### PR TITLE
Fix bug in cmd_change_bios.py

### DIFF
--- a/idrac_ctl/bios/cmd_change_bios.py
+++ b/idrac_ctl/bios/cmd_change_bios.py
@@ -254,7 +254,7 @@ class BiosChangeSettings(
             )
         registry = cmd_result.data[IDRAC_JSON.RegistryEntries]
 
-        if IDRAC_JSON.Attributes not in cmd_result.data:
+        if IDRAC_JSON.Attributes not in registry:
             return CommandResult(
                 {
                     "Status": "Failed fetch attributes from bios registry"


### PR DESCRIPTION
Small mistake making `bios-change` fail on valid `BiosRegistry` responses