### PR TITLE
Offline test infrastructure, vendor packages, schema validation, and Redfish query parameters

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Keep build context small AND keep agent/secret data out of the image (hard rule:
+# agent instruction files must never be baked into a shipped artifact).
+.git
+.gitignore
+
+# Agent / AI instruction files and generated plans
+CLAUDE.md
+AGENTS.md
+AGENT_BOOTSTRAP.md
+CODEX_HANDOFF.md
+TEAM_GUIDE.md
+AGENT_HANDOFF*.md
+CLAUDE_REVIEW*
+CLAUDE_PLAN.md
+CLAUDE_PATCH.diff
+IMPROVEMENT_PLAN.md
+ROADMAP*.md
+.codex/
+.claude/
+.agent-review/
+
+# Caches / build artifacts / local cruft
+__pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+build/
+dist/
+.coverage
+htmlcov/
+.venv/
+venv/
+.DS_Store
+result.json

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,28 @@
 build_push.sh
 env_test.sh
 
+# --- Agent / AI instruction files and generated plans: NEVER commit (hard rule) ---
+# Most are also covered by the global ~/.gitignore_global; pinned here so the rule
+# travels with the repo. Agent data must not leak into git or commit messages.
+CLAUDE.md
+AGENTS.md
+AGENT_BOOTSTRAP.md
+CODEX_HANDOFF.md
+TEAM_GUIDE.md
+AGENT_HANDOFF*.md
+CLAUDE_REVIEW*
+CLAUDE_PLAN.md
+CLAUDE_PATCH.diff
+IMPROVEMENT_PLAN.md
+ROADMAP*.md
+.codex/
+.claude/
+.agent-review/
+
+# macOS / stray test output
+.DS_Store
+result.json
+
 *.th
 *.env
 devices/*.env

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ CLAUDE_PLAN.md
 CLAUDE_PATCH.diff
 IMPROVEMENT_PLAN.md
 ROADMAP*.md
+CODEX_TASKS.md
+CODEX_*.md
 .codex/
 .claude/
 .agent-review/

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ COORDINATION.md
 .DS_Store
 result.json
 
+# Vendored DMTF Redfish schemas (populated by tools/fetch_schemas.sh; not committed)
+tools/redfish-schemas/
+
 *.th
 *.env
 devices/*.env

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ IMPROVEMENT_PLAN.md
 ROADMAP*.md
 CODEX_TASKS.md
 CODEX_*.md
+COORDINATION.md
 .codex/
 .claude/
 .agent-review/

--- a/README.md
+++ b/README.md
@@ -1,38 +1,42 @@
 # idrac_ctl
-This repo consist two parts. A generic redfish implementation that consumed by
-idrac_ctl. Right now i'm moving redfish implementation out of idrac ctl.
 
-Standalone command line tool provide option to interact with Dell iDRAC via Redfish 
-REST API and execute typical workflow. It supports both asynchronous and synchronous options 
-to interact with iDRAC.
+`idrac_ctl` is a command-line control plane for servers that speak **Redfish**. Today it drives
+**Dell iDRAC** end to end — BIOS, boot, RAID, firmware, virtual media, sensors, inventory, and Dell
+Lifecycle Controller jobs — over the Redfish REST API, synchronously or asynchronously. Under the
+hood it already implements a large part of the generic Redfish spec, kept in a product-neutral layer
+that Dell (and, next, other vendors) plug into.
 
-Update.
-    After going deeper in redfish specification. I recognize that 
-    I already implemented major portion of specs. Thus, I will probably
-    de-couple redfish and idrac_ctl will be a plugin.
+**Where this is going.** A full, generic **Redfish** implementation (the package becomes
+`redfish_ctl`), with Dell / HPE / Supermicro as vendor extensions, plus an optional **Kubernetes
+proxy** so you manage a whole fleet declaratively instead of one box at a time. The goal is to take
+**1,000 servers concurrently** to a target spec — upgrade firmware, set BIOS, enable SR-IOV, tune for
+a real-time workload — and to do it as engineering, not guesswork: every path **mocked, tested,
+measured, and benchmarked**.
 
-* boot from remote location via http/https
-* boot from remote NFS/CIFS
-* optimize bios setting for real time workload.
-* basic option related to job and management.  apply/reset pending changes.
-* query any object that IDRAC exposes via REST interface. firmware/driver/status/metrics
-* manage volumes
-* manage raid
-* manage boot source
-* manage secure boot / UEFI
-* and much more..
+If you have one server in front of you, the CLI below is all you need. If you have a rack — or a
+hundred racks — see [Fleet management & the Redfish proxy](docs/redfish-proxy.md).
 
-Examples directory contains typical examples.
-Project on https://pypi.org/manage/project/idrac-ctl/releases/
+## What you can do today
 
-# Overview
-This tool provides an option to interact with Dell iDRAC via the command line and execute almost 
-every workflow you can do via Web UI. The idrac_ctl, by default, outputs everything in JSON, 
-so you can easily pass it to any other tools to filter. Some commands provide an option to 
-filter on action or specific fields, and s is still ongoing work. The tool developed in extendability 
-mind. Each command registered dynamically. It sufficiently indicates the import statement 
-in __init__ to load the custom command.
- 
+* Boot from a remote ISO over HTTP/HTTPS or NFS/CIFS, including unattended installs.
+* Tune BIOS for real-time / low-latency workloads (memory, C-states, SR-IOV, watchdog, …).
+* Manage RAID, volumes, boot order, secure boot / UEFI.
+* Query anything iDRAC exposes — firmware, drivers, status, metrics — as JSON you can pipe to `jq`.
+* Drive Dell Lifecycle Controller jobs: apply / reset pending changes, watch tasks.
+
+Output is JSON by default, so every command composes with other tools. Commands self-register, so the
+surface grows one small module at a time. Published on PyPI: https://pypi.org/project/idrac-ctl/
+
+## Documentation
+
+The deep, implementation-specific material lives under [`docs/`](docs/):
+
+* [Architecture](docs/architecture.md) — the Redfish core, the Dell layer, vendor packages, command dispatch.
+* [Fleet management & the Redfish proxy](docs/redfish-proxy.md) — the optional Kubernetes service that manages servers at scale.
+* [Scaling & benchmarks](docs/scaling-and-benchmarks.md) — driving ~1,000 servers concurrently, the fleet simulator, the metrics we track.
+* [Testing](docs/testing.md) — the mock / live / emulator lanes and how to run them.
+* [Vendors](docs/vendors.md) — adding a vendor and the capability model.
+
 # Initial steps
 
 Set the environment variable, so you don't need to pass each time.

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -1,0 +1,33 @@
+# Ubuntu image that runs the offline idrac_ctl test suite, to confirm the code
+# behaves the same on Linux as on macOS. This matters: requests-mock lowercases
+# paths and Linux is case-SENSITIVE, so a fixture-lookup bug that macOS's
+# case-insensitive filesystem hides would surface here.
+#
+# Build + run:  ./docker/run-tests.sh   (or see the commands at the bottom)
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        python3 python3-pip python3-venv ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Isolated venv (Ubuntu 24.04 is PEP 668 externally-managed).
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+WORKDIR /app
+COPY . /app
+
+# Install the package with its dev/test extras (pytest, ruff, requests-mock, ...).
+RUN pip install --no-cache-dir -e ".[dev]" pytest-cov
+
+# Default: the offline suite (live tests auto-skip with no IDRAC_IP).
+CMD ["pytest", "-q"]
+
+# Manual equivalent of run-tests.sh:
+#   docker build -f docker/Dockerfile.test -t idrac-ctl-test .
+#   docker run --rm idrac-ctl-test

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Build the Ubuntu test image and run the offline idrac_ctl suite inside it.
+# Confirms Mac/Linux parity (Linux is case-sensitive; macOS is not).
+set -euo pipefail
+
+IMAGE="${IMAGE:-idrac-ctl-test}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$REPO_ROOT"
+
+echo ">> building ${IMAGE} (ubuntu:24.04)"
+docker build -f docker/Dockerfile.test -t "${IMAGE}" .
+
+echo ">> running offline test suite in Linux container"
+# --cov optional; pass extra pytest args through, e.g. ./docker/run-tests.sh -k boot
+docker run --rm "${IMAGE}" pytest -q "$@"
+
+echo ">> Linux test run complete"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,53 @@
+# Architecture
+
+`idrac_ctl` is built in layers so the generic Redfish work stays reusable and vendor specifics never
+leak into the core. The direction is a generic `redfish_ctl` with vendors as plug-ins.
+
+```
+CLI (idrac_main.py, argparse)
+   │  dispatch by ApiRequestType + name
+   ▼
+Command modules  (cmd_*.py, <domain>/cmd_*.py)      self-register via __init_subclass__
+   │  inherit
+   ▼
+IDracManager          Dell/iDRAC OEM behavior  (idrac_manager.py, delloem/)
+   │  inherit
+   ▼
+RedfishManager        product-neutral Redfish client  (redfish_manager.py)
+   │
+   ▼
+requests  → Redfish / iDRAC over HTTPS
+```
+
+## Core seams
+
+- **`RedfishManager`** — the generic client: connection (`ip`/`user`/`password`/`port`/`insecure`/
+  `x_auth`), the HTTP verbs, response/message parsing (`redfish_respond.py`), and the
+  `CommandResult(data, discovered, extra, error)` return contract. It must never import Dell code.
+- **`IDracManager(RedfishManager)`** — Dell OEM specialization: task/job polling, Dell paths
+  (`System.Embedded.1`, `iDRAC.Embedded.1`), `delloem/` actions.
+- **Commands** — each is an `IDracManager` subclass declared with `scm_type=ApiRequestType.<X>`,
+  `name=`, `metaclass=Singleton`. It implements `execute(**kwargs) -> CommandResult` and
+  `register_subcommand()` for its CLI args. Registration is automatic, so adding a capability is
+  adding a module — never editing a central switch.
+
+## Vendors
+
+Vendor specifics live under [`idrac_ctl/vendors/<name>/`](../idrac_ctl/vendors/README.md). Each vendor
+package registers a `VendorCapabilities` profile (which query parameters the service honors, recurring
+jobs, lifecycle events, OEM prefix) so commands can gate vendor-only behavior. The generic core picks
+a conservative profile for unknown targets. See [vendors.md](vendors.md).
+
+## Sync and async
+
+Commands can run a request synchronously or against an asyncio loop (`api_async_*`). The async paths
+matter most for the fleet proxy, where thousands of requests run concurrently — see
+[scaling-and-benchmarks.md](scaling-and-benchmarks.md).
+
+## Known structural debt (tracked)
+
+- The repo root ships a re-export shim (`./__init__.py`) that complicates imports; it goes away with
+  the `redfish_ctl` rename.
+- `IDracManager` is large; transport/retry should move down into `RedfishManager`.
+- Power/boot/BIOS/firmware should be callable as **library methods**, not only through the CLI
+  arg-parser path, so the proxy and other callers reuse them directly.

--- a/docs/redfish-proxy.md
+++ b/docs/redfish-proxy.md
@@ -1,0 +1,96 @@
+# Fleet management & the Redfish proxy
+
+The CLI manages one server at a time. To manage a fleet — bring 1,000 servers to a target spec,
+concurrently — there is an **optional** Kubernetes-deployable service: the Redfish proxy/controller.
+It holds the desired and observed state of every server and reconciles the two over Redfish.
+
+This component is optional. The core CLI never depends on it.
+
+## Why a service (and why Python, not a Go operator)
+
+Surveying the prior art — Metal3/baremetal-operator (BMC I/O isolated in Ironic), OpenStack
+Ironic+sushy (stateless API + worker conductor), DMTF Redfish Aggregation, Tinkerbell Rufio — the
+recurring lesson is: **isolate the privileged BMC-talking process** and model **desired vs observed**
+state. We get both from a single Python service that **reuses `RedfishManager`/`IDracManager`**, so we
+don't maintain a second Redfish client in a second language. A `kubectl`-native CRD façade can come
+later as a thin adapter; it is not needed to start.
+
+## Shape
+
+```
+clients / kubectl / CI
+      │  REST (optionally Redfish-Aggregator-shaped)
+      ▼
+ redfish-proxy (FastAPI)            ← desired + observed state (DB)
+   • server registry
+   • async reconcile loop (per server)         reuses RedfishManager / IDracManager
+   • the ONLY pod with a route to the BMC management network
+      │  Redfish/HTTPS  (insecure ok, network-isolated)
+      ▼
+  iDRAC / generic Redfish / (later) iLO / Supermicro
+```
+
+## State model
+
+CRD-shaped even in the DB, so a Kubernetes CRD adapter is free later. Borrowed from BareMetalHost +
+the DMTF `AggregationSource` vocabulary:
+
+```yaml
+spec:                                   # desired
+  bmcAddress: redfish://10.0.0.5/redfish/v1/Systems/System.Embedded.1
+  vendor: dell                          # selects the manager subclass / capabilities
+  credentialsRef: secret-name           # k8s Secret, keys: username / password
+  desired:
+    power: "On"
+    bootOverride: "Pxe"
+    firmware: { component: BIOS, version: "2.19.1" }
+    bios: { SriovGlobalEnable: "Enabled", ProcCStates: "Disabled" }
+    targetProfile: "rt-low-latency"     # a named spec (see below)
+status:                                 # observed
+  power: "On"
+  observedBoot: "Hdd"
+  health: "OK"
+  firmware: { BIOS: "2.18.0" }
+  hardware: { cpu, memGiB, nics[], storage[] }
+  lastReconciled: <ts>
+  observedGeneration: 7
+  goodCredentials: true
+  error: null
+```
+
+## Reconcile rules
+
+Standard external-system controller discipline: **level-triggered** (read current, converge to spec —
+never trust an event), **idempotent**, store the device handle in `status`, **periodic resync**
+(Redfish has no push, so poll on an interval), **back off** on transient errors, write
+`observedGeneration` after success, use finalizers for clean teardown.
+
+## Target profiles
+
+A "target spec" is a named, versioned profile (e.g. `rt-low-latency`) that expands to concrete
+firmware versions + BIOS attributes + SR-IOV settings. The proxy reconciles each server toward its
+profile and reports drift. Profiles are the unit users reason about; the proxy turns them into the
+right ordered Redfish operations (some need a reboot/job, so ordering and job-tracking matter).
+
+## Security
+
+- BMC credentials in a k8s **Secret** (`username`/`password`), referenced by name — never inline,
+  never logged; record only "good-credentials" metadata in status.
+- **NetworkPolicy** restricting egress to the BMC management CIDR; the proxy is the only pod with that
+  route. Self-signed BMC certs ⇒ `insecure` on that hop, compensated by network isolation.
+- Least-privilege RBAC scoped to the proxy's own resources and the referenced Secrets.
+
+## Scope
+
+- **MVP:** register server; `GET /servers/{id}` (observed); `PUT /servers/{id}/desired`
+  (power + bootOverride); list; SQLite/Postgres; one reconcile loop; optional Deployment / Service /
+  Secret / NetworkPolicy manifests. Concurrency for many servers and benchmarking come next — see
+  [scaling-and-benchmarks.md](scaling-and-benchmarks.md).
+- **Later:** firmware / BIOS / SR-IOV / target-profile desired-state; DMTF-Aggregator-shaped read API;
+  optional CRD + kopf façade; multi-replica leader election; iLO / Supermicro vendor subclasses.
+
+## Testing
+
+The reconcile loop is unit-tested with a mocked client (converges, idempotent, backs off, redacts
+credentials) and integration-tested against the `sushy-emulator --fake` lane and the multi-server
+fleet simulator. See [testing.md](testing.md) and [scaling-and-benchmarks.md](scaling-and-benchmarks.md).

--- a/docs/scaling-and-benchmarks.md
+++ b/docs/scaling-and-benchmarks.md
@@ -1,0 +1,58 @@
+# Scaling & benchmarks
+
+The target is to drive **~1,000 servers concurrently** to a spec and know — with numbers — that it is
+fast, correct, and stable. This page covers the concurrency engine, the fleet simulator we test it
+against, and the metrics we hold ourselves to.
+
+## Concurrency engine
+
+A fleet operation (e.g. "apply profile `rt-low-latency` to these 1,000 servers") fans out to per-server
+async pipelines over a shared, bounded executor:
+
+- **Async I/O** (`api_async_*` on the manager) so thousands of in-flight Redfish requests don't need
+  thousands of threads.
+- **Bounded concurrency** — a configurable cap on simultaneous servers / in-flight requests, with a
+  queue, so we never overwhelm a BMC subnet or ourselves.
+- **Per-server pipeline** — each server runs its own ordered steps (some need a reboot/job and must be
+  awaited) independently; a slow or failing server never blocks the rest.
+- **Rate limiting + backoff** — iDRAC gets sluggish under load (Dell's own docs warn about this), so
+  we respect `Retry-After`, back off on transient 5xx/timeouts, and cap retries.
+- **Idempotent + resumable** — re-running a fleet op converges only what's still off-spec; partial
+  failures are reported per server, not as one opaque failure.
+
+## Fleet simulator (test 1,000 servers with no hardware)
+
+We cannot test concurrency against real BMCs, and one `sushy-emulator` is a single server. So we add a
+**fleet simulator**: a local async Redfish service that presents **N synthetic servers** with:
+
+- realistic resource trees (reuse the captured fixtures + per-server identity),
+- **injectable latency** (fixed / jittered / tail) to model a slow subnet,
+- **injectable failures** (timeouts, 5xx, auth errors, BMC "busy") at a configurable rate,
+- mutating Actions that change state (power, boot, BIOS apply, job creation) so reconcile is exercised
+  end to end.
+
+This lets CI run a 1,000-server fan-out deterministically on a laptop and lets us benchmark honestly.
+Where `sushy-emulator --fake` validates one generic server, the fleet simulator validates *scale and
+behavior under stress*.
+
+## What we measure
+
+For each fleet operation, benchmarked against the simulator:
+
+- **Throughput** — servers brought to spec per minute.
+- **Latency** — p50 / p95 / p99 per-server completion and per-request.
+- **Concurrency** — max in-flight, queue depth over time.
+- **Error rate** — transient vs terminal; retries per server.
+- **Correctness** — % converged to spec, drift detected, zero spurious mutations.
+- **Resource use** — CPU / memory of the proxy at the target concurrency.
+
+Results land under `reports/` (e.g. `reports/bench-fleet-1000.json`) so regressions are visible. A
+benchmark is part of the definition of done for the concurrency engine — not an afterthought.
+
+## Acceptance targets (to refine with real numbers)
+
+- 1,000 simulated servers, read-and-report: completes well under a few minutes at a sane concurrency
+  cap, p99 per-server within a small multiple of p50.
+- Under 10% injected transient failures: ≥99% converge after bounded retries, no unbounded retry
+  storms, no crash.
+- Numbers reproducible in the Ubuntu container so Mac/Linux agree.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,63 @@
+# Testing
+
+The suite runs fully offline by default — no iDRAC, no network — and stays green on macOS and Linux.
+Hardware and emulator paths are opt-in.
+
+```bash
+pytest -q                 # offline suite (live tests auto-skip)
+ruff check <changed>      # no new lint findings
+pytest --cov=idrac_ctl    # coverage
+```
+
+## Three lanes
+
+**1. Mock (default, offline).** A stateful `MockRedfishService` (`tests/conftest.py`) serves the
+captured DMTF mockup tree (`idrac_ctl/json_responses/`) over a mocked `requests` transport, handling
+`GET/POST/PATCH/DELETE` + Actions (PATCH overlays state; an Action POST returns a 202 JID `Location`
+like iDRAC). Dell-shaped paths the generic tree lacks are hand-authored in `tests/idrac_fixtures/` and
+overlay the captured tree. Fixtures: `redfish_mock`, `redfish_service` (request inspection).
+
+**2. Dual-mode (`redfish_api`).** Write a test once; it runs offline (mock) by default and against real
+hardware when `IDRAC_IP` is set. Hardware tests are marked `@pytest.mark.live` and auto-skip without
+`IDRAC_IP`. Template: `tests/test_cmd_boot_dualmode.py`.
+
+```bash
+export IDRAC_IP=<idrac> IDRAC_USERNAME=root IDRAC_PASSWORD=<pw>
+pytest -q -m live          # against an approved, non-production iDRAC
+```
+
+**3. Live-like emulator (opt-in).** The OpenStack `sushy-tools` fake driver — no libvirt, no Docker,
+supports mutating Actions — stands in as a spec-conformant Redfish server.
+
+```bash
+pip install sushy-tools
+sushy-emulator --fake -i 127.0.0.1 -p 8000
+REDFISH_EMULATOR_URL=http://127.0.0.1:8000 pytest tests/test_emulator_smoke.py
+```
+
+It serves generic Redfish (not Dell OEM), so it validates transport and generic capabilities; Dell
+paths still use the mock fixtures.
+
+## Mac/Linux parity
+
+`docker/run-tests.sh` builds `ubuntu:24.04`, installs `.[dev]`, and runs the offline suite. Linux is
+case-sensitive and macOS is not, so this guards a real bug class (the fixture lookup is deliberately
+case-insensitive). `.dockerignore` keeps agent/instruction files out of the image.
+
+## Fixtures and faithfulness
+
+The captured tree is generic DMTF mockup data; many commands hit Dell-specific paths. The faithful way
+to cover them offline is a one-time capture of a real iDRAC with **DMTF Redfish-Mockup-Creator** into
+`tests/idrac_fixtures/`. That capture is the main unblock for the 80% coverage goal.
+
+## Coverage goal
+
+Target **80%**, currently lower because the ~100 command modules are exercised only as live tests are
+ported to dual-mode. Enforce a **ratcheting** `--cov-fail-under` (raise as tests land) so the floor
+never regresses, rather than a hard gate that fails today.
+
+## Fleet/concurrency tests
+
+The proxy's reconcile loop and the concurrency engine are tested against the fleet simulator (N
+synthetic servers, latency/failure injection) and benchmarked — see
+[scaling-and-benchmarks.md](scaling-and-benchmarks.md).

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -1,0 +1,45 @@
+# Vendors
+
+The generic Redfish core stays product-neutral; anything specific to one server vendor lives in its own
+package under [`idrac_ctl/vendors/<name>/`](../idrac_ctl/vendors/README.md). New vendors are added
+incrementally without touching the core.
+
+```
+vendors/
+  base.py        # VendorCapabilities model + registry
+  dell/          # Dell iDRAC
+  hpe/           # HPE iLO (placeholder)
+  supermicro/    # Supermicro (placeholder)
+```
+
+## Capability profiles
+
+Each vendor registers a `VendorCapabilities` profile declaring what its Redfish service supports, so
+commands gate vendor-only behavior instead of guessing. An unknown vendor falls back to a conservative
+`generic` profile.
+
+```python
+from idrac_ctl.vendors import get_vendor
+caps = get_vendor("dell")            # unknown -> "generic"
+if caps.job_scheduling:
+    ...                              # only where supported
+```
+
+The Dell profile encodes documented iDRAC facts: all five query parameters honored but **one per
+URI**; recurring JobService scheduling on a fixed set of URIs (ComputerSystem.Reset, Manager.Reset,
+SEL ClearLog, Volume.CheckConsistency, …); lifecycle events over SSE.
+
+## Adding a vendor
+
+1. Create `vendors/<name>/` with `__init__.py`, `capabilities.py` (register a profile), `README.md`.
+2. Add `cmd_*.py` modules (self-registering `IDracManager`/`RedfishManager` subclasses) for vendor
+   specifics, with offline tests using the `redfish_api` fixture.
+3. If an emulator exists for the vendor (e.g. HPE's iLO emulator), wire an opt-in test lane like the
+   `sushy-emulator` one.
+
+The core must never import a vendor package; vendor packages may depend on the core.
+
+## Migration
+
+Dell code currently also lives in `idrac_ctl/idrac_manager.py` and `idrac_ctl/delloem/`. It moves into
+`vendors/dell/` incrementally, alongside the `idrac_ctl` → `redfish_ctl` rename.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,27 @@
+# Conda development environment for idrac_ctl.
+#
+# Create:   conda env create -f environment.yml
+# Update:   conda env update -f environment.yml --prune
+# Activate: conda activate idrac_ctl
+#
+# Runtime deps mirror requirements.txt; the rest are dev/test tooling.
+name: idrac_ctl
+channels:
+  - conda-forge
+dependencies:
+  - python>=3.10
+  - pip
+  # Runtime
+  - requests>=2.28
+  - urllib3>=1.26,<2
+  - tqdm>=4.61
+  - pygments>=2.14
+  - pyyaml>=6.0
+  # Test + lint tooling
+  - pytest>=7
+  - requests-mock>=1.10
+  - ruff
+  - mypy
+  - pip:
+      # Install idrac_ctl itself (and anything not on conda-forge) via pip.
+      - -e .

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,9 @@ dependencies:
   - requests-mock>=1.10
   - ruff
   - mypy
+  # Schema validation (tools/redfish_validate.py)
+  - jsonschema>=4.18
+  - referencing
   - pip:
       # Install idrac_ctl itself (and anything not on conda-forge) via pip.
       - -e .

--- a/idrac_ctl/bios/cmd_change_bios.py
+++ b/idrac_ctl/bios/cmd_change_bios.py
@@ -28,25 +28,13 @@ from ..cmd_exceptions import InvalidArgument
 from ..cmd_exceptions import InvalidJsonSpec
 from ..cmd_exceptions import UncommittedPendingChanges
 from ..cmd_utils import from_json_spec
-from ..idrac_shared import IDRAC_JSON
-from ..idrac_shared import IdracApiRespond
-from ..idrac_shared import IDRAC_API
-
-
-from ..cmd_exceptions import InvalidJsonSpec
-from ..cmd_utils import from_json_spec
-from ..idrac_shared import IdracApiRespond
-from ..redfish_shared import RedfishJson
-from ..cmd_utils import str2bool
-from ..idrac_shared import IdracApiRespond, ResetType
-from ..cmd_utils import save_if_needed
-from ..cmd_exceptions import InvalidArgument
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond, Singleton, ApiRequestType
-from ..redfish_manager import CommandResult
+from ..idrac_shared import IDRAC_JSON
 from ..idrac_shared import IDRAC_API
 from ..idrac_shared import IdracApiRespond
-
+from ..idrac_shared import Singleton
+from ..idrac_shared import ApiRequestType
+from ..redfish_manager import CommandResult
 
 
 class BiosChangeSettings(IDracManager,

--- a/idrac_ctl/cmd_current_boot.py
+++ b/idrac_ctl/cmd_current_boot.py
@@ -66,9 +66,9 @@ class GetCurrentBoot(IDracManager,
         :return: CommandResult and if filename provide will save to a file.
         """
         if verbose:
-            print(f"cmd args data_type: {data_type} "
+            self.logger.debug(f"cmd args data_type: {data_type} "
                   f"do_async:{do_async} filename:{filename}")
-            print(f"the rest of args: {kwargs}")
+            self.logger.debug(f"the rest of args: {kwargs}")
 
         headers = {}
         if data_type == "json":

--- a/idrac_ctl/cmd_utils.py
+++ b/idrac_ctl/cmd_utils.py
@@ -131,6 +131,6 @@ def save_if_needed(filename: str, raw_data,
         else:
             final_filename = f"{final_filename}.yaml"
         with open(final_filename, 'w') as file:
-            yaml.dump(filename, file)
+            yaml.dump(raw_data, file)
     else:
-        ValueError("Unknown format")
+        raise ValueError(f"Unknown data format '{data_format}'.")

--- a/idrac_ctl/firmware/cmd_firmware.py
+++ b/idrac_ctl/firmware/cmd_firmware.py
@@ -68,9 +68,9 @@ class FirmwareQuery(IDracManager,
         :return: in data type json will return json
         """
         if verbose:
-            print(f"cmd args data_type: {data_type} "
+            self.logger.debug(f"cmd args data_type: {data_type} "
                   f"do_deep:{do_deep} do_async:{do_async} filename:{filename}")
-            print(f"the rest of args: {kwargs}")
+            self.logger.debug(f"the rest of args: {kwargs}")
 
         headers = {}
         if data_type == "json":

--- a/idrac_ctl/idrac_manager.py
+++ b/idrac_ctl/idrac_manager.py
@@ -304,7 +304,7 @@ class IDracManager(RedfishManager):
         _port = kwargs.pop("port")
         _insecure = kwargs.pop("insecure")
         _is_http = kwargs.pop("is_http")
-        print(" PORT ", _port)
+        module_logger.debug(f"dispatching {name} to idrac port {_port}")
 
         inst = disp(
             idrac_ip=_idrac_ip,
@@ -1166,7 +1166,7 @@ class IDracManager(RedfishManager):
         :raise RedfishException if HTTP method failed.
         """
         # if location in the header , job created
-        print("Response code", response.status_code)
+        self.logger.debug(f"read_api_respond response code {response.status_code}")
 
         if response.headers is not None \
                 and RedfishJsonSpec.Location in response.headers:

--- a/idrac_ctl/json_responses/_redfish_v1_AccountService.json
+++ b/idrac_ctl/json_responses/_redfish_v1_AccountService.json
@@ -1,0 +1,19 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService",
+    "@odata.id": "/redfish/v1/AccountService",
+    "@odata.type": "#AccountService.0.94.0.AccountService",
+    "Id": "AccountService",
+    "Name": "Account Service",
+    "Description": "BMC User Accounts",
+    "Modified": "2036-09-11T14:17:21+00:00",
+    "AuthFailureLoggingThreshold": 3,
+    "MinPasswordLength": 8,
+    "Links": {
+        "Accounts": {
+            "@odata.id": "/redfish/v1/AccountService/Accounts"
+        },
+        "Roles": {
+            "@odata.id": "/redfish/v1/AccountService/Roles"
+        }
+    }
+}

--- a/idrac_ctl/json_responses/_redfish_v1_AccountService_Accounts.json
+++ b/idrac_ctl/json_responses/_redfish_v1_AccountService_Accounts.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService/Links/Members/Accounts/$entity",
+    "@odata.type": "#ManagerAccount.0.94.0.ManagerAccountCollection",
+    "Name": "Accounts Collection",
+    "Modified": "2012-03-07T14:44",
+    "Links": {
+        "Members@odata.count": 1,
+        "Members": [
+            {
+                "@odata.id": "/redfish/v1/AccountService/Accounts/1"
+            }
+        ]
+    }
+}

--- a/idrac_ctl/json_responses/_redfish_v1_AccountService_Accounts_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_AccountService_Accounts_1.json
@@ -1,0 +1,19 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService/Links/Members/Accounts/Links/Members/$entity",
+    "@odata.id": "/redfish/v1/AccountService/Accounts/1",
+    "@odata.type": "#AccountService.0.94.0.ManagerAccount",
+    "Id": "1",
+    "Name": "User Account",
+    "Modified": "2013-09-11T17:03:55+00:00",
+    "Description": "User Account",
+    "Password": "Password",
+    "UserName": "Administrator",
+    "Locked": false,
+    "Enabled": true,
+    "RoleId": "Admin",
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Admin"
+        }
+    }
+}

--- a/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles.json
+++ b/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService/Links/Members/Roles/$entity",
+    "@odata.id": "/redfish/v1/AccountService/Roles",
+    "@odata.type": "#RoleCollection.RoleCollection",
+    "Name": "Roles Collection",
+    "Modified": "2012-03-07T14:44",
+    "Links": {
+        "Members@odata.count": 3,
+        "Members": [
+            {
+                "@odata.id": "/redfish/v1/AccountService/Roles/Admin"
+            },
+            {
+                "@odata.id": "/redfish/v1/AccountService/Roles/Operator"
+            },
+            {
+                "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnlyUser"
+            }
+        ]
+    }
+}

--- a/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles_Admin.json
+++ b/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles_Admin.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService/Links/Members/Roles/Links/Members/$entity",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Admin",
+    "@odata.type": "#Role.1.0.0.Role",
+    "Id": "Admin",
+    "Name": "User Role",
+    "Modified": "2013-09-11T17:03:55+00:00",
+    "Description": "Admin User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureManager",
+        "ConfigureUsers",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "OEMPrivileges": [
+        "OemClearLog",
+        "OemPowerControl"
+    ]
+}

--- a/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles_Operator.json
+++ b/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles_Operator.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService/Links/Members/Roles/Links/Members/$entity",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Operator",
+    "@odata.type": "#Role.1.0.0.Role",
+    "Id": "Operator",
+    "Name": "User Role",
+    "Modified": "2013-09-11T17:03:55+00:00",
+    "Description": "Operator User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "OEMPrivileges": []
+}

--- a/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles_ReadOnlyUser.json
+++ b/idrac_ctl/json_responses/_redfish_v1_AccountService_Roles_ReadOnlyUser.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService/Links/Members/Roles/Links/Members/$entity",
+    "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnlyUser",
+    "@odata.type": "#Role.1.0.0.Role",
+    "Id": "ReadOnlyUser",
+    "Name": "User Role",
+    "Modified": "2013-09-11T17:03:55+00:00",
+    "Description": "ReadOnlyUser User Role",
+    "IsPredefined": true,
+    "AssignedPrivileges": [
+        "Login"
+    ],
+    "OEMPrivileges": []
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#ChassisCollection.ChassisCollection",
+    "Name": "Chassis Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U.json
@@ -1,0 +1,78 @@
+{
+    "@odata.type": "#Chassis.v1_15_0.Chassis",
+    "Id": "1U",
+    "Name": "Computer System Chassis",
+    "ChassisType": "RackMount",
+    "AssetTag": "Chicago-45Z-2381",
+    "Manufacturer": "Contoso",
+    "Model": "3500RX",
+    "SKU": "8675309",
+    "SerialNumber": "437XR1138R2",
+    "PartNumber": "224071-J23",
+    "PowerState": "On",
+    "IndicatorLED": "Lit",
+    "HeightMm": 44.45,
+    "WidthMm": 431.8,
+    "DepthMm": 711,
+    "WeightKg": 15.31,
+    "Location": {
+        "PostalAddress": {
+            "Country": "US",
+            "Territory": "OR",
+            "City": "Portland",
+            "Street": "1001 SW 5th Avenue",
+            "HouseNumber": 1100,
+            "Name": "DMTF",
+            "PostalCode": "97204"
+        },
+        "Placement": {
+            "Row": "North",
+            "Rack": "WEB43",
+            "RackOffsetUnits": "EIA_310",
+            "RackOffset": 12
+        }
+    },
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ThermalSubsystem": {
+        "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem"
+    },
+    "PowerSubsystem": {
+        "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem"
+    },
+    "EnvironmentMetrics": {
+        "@odata.id": "/redfish/v1/Chassis/1U/EnvironmentMetrics"
+    },
+    "Sensors": {
+        "@odata.id": "/redfish/v1/Chassis/1U/Sensors"
+    },
+    "Thermal@Redfish.Deprecated": "Please migrate to use /redfish/v1/Chassis/1U/ThermalSubsystem",
+    "Thermal": {
+        "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+    },
+    "Power@Redfish.Deprecated": "Please migrate to use /redfish/v1/Chassis/1U/PowerSubsystem",
+    "Power": {
+        "@odata.id": "/redfish/v1/Chassis/1U/Power"
+    },
+    "Links": {
+        "ComputerSystems": [
+            {
+                "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ],
+        "ManagersInChassis": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_EnvironmentMetrics.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_EnvironmentMetrics.json
@@ -1,0 +1,29 @@
+{
+    "@odata.type": "#EnvironmentMetrics.v1_0_0.EnvironmentMetrics",
+    "Name": "Chassis Environment Metrics",
+    "TemperatureCelsius": {
+        "Reading": 39,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/CPU1Temp"
+    },
+    "PowerWatts": {
+        "Reading": 374,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/TotalPower"
+    },
+    "FanSpeedsPercent": [
+        {
+            "DeviceName": "Chassis Fan #1",
+            "Reading": 45,
+            "SpeedRPM": 1900,
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/FanBay1"
+        },
+        {
+            "DeviceName": "Chassis Fan #2",
+            "Reading": 55,
+            "SpeedRPM": 2100,
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/FanBay2"
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/EnvironmentMetrics",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_PowerControl_0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_PowerControl_0.json
@@ -1,0 +1,142 @@
+{
+    "@odata.type": "#Power.v1_7_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "System Input Power",
+            "PowerConsumedWatts": 344,
+            "PowerRequestedWatts": 800,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 800,
+            "PowerAllocatedWatts": 800,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 271,
+                "MaxConsumedWatts": 489,
+                "AverageConsumedWatts": 319
+            },
+            "PowerLimit": {
+                "LimitInWatts": 500,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "Warning"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 800,
+            "LastPowerOutputWatts": 325,
+            "Model": "499253-B21",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "1Z0000001",
+            "PartNumber": "0000001A3A",
+            "SparePartNumber": "0000001A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 800
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 1300
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_PowerSupplies_0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_PowerSupplies_0.json
@@ -1,0 +1,142 @@
+{
+    "@odata.type": "#Power.v1_7_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "System Input Power",
+            "PowerConsumedWatts": 344,
+            "PowerRequestedWatts": 800,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 800,
+            "PowerAllocatedWatts": 800,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 271,
+                "MaxConsumedWatts": 489,
+                "AverageConsumedWatts": 319
+            },
+            "PowerLimit": {
+                "LimitInWatts": 500,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "Warning"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 800,
+            "LastPowerOutputWatts": 325,
+            "Model": "499253-B21",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "1Z0000001",
+            "PartNumber": "0000001A3A",
+            "SparePartNumber": "0000001A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 800
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 1300
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_Voltages_0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_Voltages_0.json
@@ -1,0 +1,142 @@
+{
+    "@odata.type": "#Power.v1_7_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "System Input Power",
+            "PowerConsumedWatts": 344,
+            "PowerRequestedWatts": 800,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 800,
+            "PowerAllocatedWatts": 800,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 271,
+                "MaxConsumedWatts": 489,
+                "AverageConsumedWatts": 319
+            },
+            "PowerLimit": {
+                "LimitInWatts": 500,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "Warning"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 800,
+            "LastPowerOutputWatts": 325,
+            "Model": "499253-B21",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "1Z0000001",
+            "PartNumber": "0000001A3A",
+            "SparePartNumber": "0000001A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 800
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 1300
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_Voltages_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power#_Voltages_1.json
@@ -1,0 +1,142 @@
+{
+    "@odata.type": "#Power.v1_7_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "System Input Power",
+            "PowerConsumedWatts": 344,
+            "PowerRequestedWatts": 800,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 800,
+            "PowerAllocatedWatts": 800,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 271,
+                "MaxConsumedWatts": 489,
+                "AverageConsumedWatts": 319
+            },
+            "PowerLimit": {
+                "LimitInWatts": 500,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "Warning"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 800,
+            "LastPowerOutputWatts": 325,
+            "Model": "499253-B21",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "1Z0000001",
+            "PartNumber": "0000001A3A",
+            "SparePartNumber": "0000001A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 800
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 1300
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Power.json
@@ -1,0 +1,142 @@
+{
+    "@odata.type": "#Power.v1_7_0.Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerControl/0",
+            "MemberId": "0",
+            "Name": "System Input Power",
+            "PowerConsumedWatts": 344,
+            "PowerRequestedWatts": 800,
+            "PowerAvailableWatts": 0,
+            "PowerCapacityWatts": 800,
+            "PowerAllocatedWatts": 800,
+            "PowerMetrics": {
+                "IntervalInMin": 30,
+                "MinConsumedWatts": 271,
+                "MaxConsumedWatts": 489,
+                "AverageConsumedWatts": 319
+            },
+            "PowerLimit": {
+                "LimitInWatts": 500,
+                "LimitException": "LogEventOnly",
+                "CorrectionInMs": 50
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/0",
+            "MemberId": "0",
+            "Name": "VRM1 Voltage",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 12,
+            "UpperThresholdNonCritical": 12.5,
+            "UpperThresholdCritical": 13,
+            "UpperThresholdFatal": 15,
+            "LowerThresholdNonCritical": 11.5,
+            "LowerThresholdCritical": 11,
+            "LowerThresholdFatal": 10,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/Voltages/1",
+            "MemberId": "1",
+            "Name": "VRM2 Voltage",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingVolts": 5,
+            "UpperThresholdNonCritical": 5.5,
+            "UpperThresholdCritical": 7,
+            "LowerThresholdNonCritical": 4.75,
+            "LowerThresholdCritical": 4.5,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 20,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Power#/PowerSupplies/0",
+            "MemberId": "0",
+            "Name": "Power Supply Bay",
+            "Status": {
+                "State": "Enabled",
+                "Health": "Warning"
+            },
+            "Oem": {},
+            "PowerSupplyType": "AC",
+            "LineInputVoltageType": "ACWideRange",
+            "LineInputVoltage": 120,
+            "PowerCapacityWatts": 800,
+            "LastPowerOutputWatts": 325,
+            "Model": "499253-B21",
+            "Manufacturer": "ManufacturerName",
+            "FirmwareVersion": "1.00",
+            "SerialNumber": "1Z0000001",
+            "PartNumber": "0000001A3A",
+            "SparePartNumber": "0000001A3A",
+            "InputRanges": [
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 100,
+                    "MaximumVoltage": 120,
+                    "OutputWattage": 800
+                },
+                {
+                    "InputType": "AC",
+                    "MinimumVoltage": 200,
+                    "MaximumVoltage": 240,
+                    "OutputWattage": 1300
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Power",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem.json
@@ -1,0 +1,38 @@
+{
+    "@odata.type": "#PowerSubsystem.v1_0_0.PowerSubsystem",
+    "Name": "Power Subsystem for Chassis",
+    "CapacityWatts": 2000,
+    "Allocation": {
+        "RequestedWatts": 1500,
+        "AllocatedWatts": 1200
+    },
+    "PowerSupplyRedundancy": [
+        {
+            "RedundancyType": "Failover",
+            "MaxSupportedInGroup": 2,
+            "MinNeededInGroup": 1,
+            "RedundancyGroup": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2"
+                }
+            ],
+            "Status": {
+                "State": "UnavailableOffline",
+                "Health": "OK"
+            }
+        }
+    ],
+    "PowerSupplies": {
+        "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies"
+    },
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#PowerSupplyCollection.PowerSupplyCollection",
+    "Name": "Power Supply Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1.json
@@ -1,0 +1,87 @@
+{
+    "@odata.type": "#PowerSupply.v1_0_0.PowerSupply",
+    "Id": "Bay1",
+    "Name": "Power Supply Bay 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "Warning"
+    },
+    "Model": "RKS-440DC",
+    "Manufacturer": "Contoso Power",
+    "FirmwareVersion": "1.00",
+    "SerialNumber": "3488247",
+    "PartNumber": "23456-133",
+    "SparePartNumber": "93284-133",
+    "LocationIndicatorActive": false,
+    "HotPluggable": false,
+    "PowerCapacityWatts": 400,
+    "PhaseWiringType": "OnePhase3Wire",
+    "PlugType": "IEC_60320_C14",
+    "InputRanges": [
+        {
+            "NominalVoltageType": "AC200To240V",
+            "CapacityWatts": 400
+        },
+        {
+            "NominalVoltageType": "AC120V",
+            "CapacityWatts": 350
+        },
+        {
+            "NominalVoltageType": "DC380V",
+            "CapacityWatts": 400
+        }
+    ],
+    "EfficiencyRatings": [
+        {
+            "LoadPercent": 25,
+            "EfficiencyPercent": 75
+        },
+        {
+            "LoadPercent": 50,
+            "EfficiencyPercent": 85
+        },
+        {
+            "LoadPercent": 90,
+            "EfficiencyPercent": 80
+        }
+    ],
+    "OutputRails": [
+        {
+            "NominalVoltage": 3.3,
+            "PhysicalContext": "SystemBoard"
+        },
+        {
+            "NominalVoltage": 5,
+            "PhysicalContext": "SystemBoard"
+        },
+        {
+            "NominalVoltage": 12,
+            "PhysicalContext": "StorageDevice"
+        }
+    ],
+    "Location": {
+        "PartLocation": {
+            "ServiceLabel": "PSU 1",
+            "LocationType": "Bay",
+            "LocationOrdinalValue": 0
+        }
+    },
+    "Links": {
+        "Outlet": {
+            "@odata.id": "https://redfishpdu.contoso.com/redfish/v1/PowerEquipment/RackPDUs/1/Outlets/A4"
+        }
+    },
+    "Assembly": {
+        "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Assembly"
+    },
+    "Metrics": {
+        "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Metrics"
+    },
+    "Actions": {
+        "#PowerSupply.Reset": {
+            "target": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/PowerSupply.Reset"
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1_Assembly#_Assemblies_0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1_Assembly#_Assemblies_0.json
@@ -1,0 +1,25 @@
+{
+    "@odata.type": "#Assembly.v1_3_0.Assembly",
+    "Name": "Power Supply-related Assembly data",
+    "Assemblies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Assembly#/Assemblies/0",
+            "MemberId": "0",
+            "Name": "Contoso Power Supply",
+            "Model": "345TTT",
+            "PartNumber": "923943",
+            "SparePartNumber": "55-434",
+            "SKU": "55ZZATR",
+            "SerialNumber": "345394834",
+            "Vendor": "Contoso",
+            "ProductionDate": "2017-04-01T14:55:33+03:00",
+            "Producer": "Contoso Supply Co.",
+            "Version": "1.44B",
+            "EngineeringChangeLevel": "9",
+            "BinaryDataURI": "/dumpster/434"
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Assembly",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1_Assembly.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1_Assembly.json
@@ -1,0 +1,25 @@
+{
+    "@odata.type": "#Assembly.v1_3_0.Assembly",
+    "Name": "Power Supply-related Assembly data",
+    "Assemblies": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Assembly#/Assemblies/0",
+            "MemberId": "0",
+            "Name": "Contoso Power Supply",
+            "Model": "345TTT",
+            "PartNumber": "923943",
+            "SparePartNumber": "55-434",
+            "SKU": "55ZZATR",
+            "SerialNumber": "345394834",
+            "Vendor": "Contoso",
+            "ProductionDate": "2017-04-01T14:55:33+03:00",
+            "Producer": "Contoso Supply Co.",
+            "Version": "1.44B",
+            "EngineeringChangeLevel": "9",
+            "BinaryDataURI": "/dumpster/434"
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Assembly",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1_Metrics.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay1_Metrics.json
@@ -1,0 +1,91 @@
+{
+    "@odata.type": "#PowerSupplyMetrics.v1_0_0.PowerSupplyMetrics",
+    "Id": "Metrics",
+    "Name": "Metrics for Power Supply 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "Warning"
+    },
+    "InputVoltage": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1InputVoltage",
+        "Reading": 230.2
+    },
+    "InputCurrentAmps": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1InputCurrent",
+        "Reading": 5.19
+    },
+    "InputPowerWatts": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1InputPower",
+        "Reading": 937.4
+    },
+    "RailVoltage": [
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_3VOutput",
+            "Reading": 3.31
+        },
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_5VOutput",
+            "Reading": 5.03
+        },
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_12VOutput",
+            "Reading": 12.06
+        }
+    ],
+    "RailCurrentAmps": [
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_3VCurrent",
+            "Reading": 9.84
+        },
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_5VCurrent",
+            "Reading": 1.25
+        },
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_12Current",
+            "Reading": 2.58
+        }
+    ],
+    "OutputPowerWatts": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1OutputPower",
+        "Reading": 937.4
+    },
+    "RailPowerWatts": [
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_3VPower",
+            "Reading": 79.84
+        },
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_5VPower",
+            "Reading": 26.25
+        },
+        {
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1_12VPower",
+            "Reading": 91.58
+        }
+    ],
+    "EnergykWh": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1Energy",
+        "Reading": 325675
+    },
+    "FrequencyHz": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1InputFrequency",
+        "Reading": 60
+    },
+    "TemperatureCelsius": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1Temp",
+        "Reading": 43.9
+    },
+    "FanSpeedPercent": {
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/PS1Fan",
+        "Reading": 68,
+        "SpeedRPM": 3290
+    },
+    "Actions": {
+        "#PowerSupplyMetrics.ResetMetrics": {
+            "target": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Metrics/PowerSupplyMetrics.ResetMetrics"
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1/Metrics",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_PowerSubsystem_PowerSupplies_Bay2.json
@@ -1,0 +1,19 @@
+{
+    "@odata.type": "#PowerSupply.v1_0_0.PowerSupply",
+    "Id": "Bay2",
+    "Name": "Power Supply Bay 2",
+    "Status": {
+        "State": "Absent"
+    },
+    "PowerSupplyType": "DC",
+    "HotPluggable": false,
+    "Location": {
+        "PartLocation": {
+            "ServiceLabel": "PSU 2",
+            "LocationType": "Bay",
+            "LocationOrdinalValue": 1
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors.json
@@ -1,0 +1,114 @@
+{
+    "@odata.type": "#SensorCollection.SensorCollection",
+    "Name": "Chassis sensors",
+    "Members@odata.count": 35,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/AmbientTemp"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/CPUFan1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/CPUFan2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/CPU1Temp"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/DIMM1Temp"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/DIMM2Temp"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/DIMM3Temp"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/ExhaustTemp"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/FanBay1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/FanBay2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/IntakeTemp"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Energy"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Frequency"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1InputCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1InputPower"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1InputVoltage"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out12V"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out12VCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out3V"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out3VCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out5V"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out5VCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Energy"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Frequency"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2InputCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2InputPower"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2InputVoltage"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out12V"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out12VCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out3V"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out3VCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out5V"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out5VCurrent"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/TotalEnergy"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Sensors/TotalPower"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_AmbientTemp.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_AmbientTemp.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "AmbientTemp",
+    "Name": "Ambient Temperature",
+    "Oem": {},
+    "PhysicalContext": "Room",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 22.5,
+    "ReadingUnits": "Cel",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 75,
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/AmbientTemp",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_CPU1Temp.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_CPU1Temp.json
@@ -1,0 +1,46 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "CPUTemp1",
+    "Name": "CPU #1 Temperature",
+    "Oem": {},
+    "PhysicalContext": "CPU",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 37,
+    "ReadingUnits": "Cel",
+    "Thresholds": {
+        "UpperCaution": {
+            "Reading": 42,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperCautionUser": {
+            "Reading": 40
+        },
+        "UpperCriticalUser": {
+            "Reading": 45,
+            "DwellTime": "PT1M"
+        },
+        "UpperCritical": {
+            "Reading": 45,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperFatal": {
+            "Reading": 50,
+            "DwellTime": "PT30S",
+            "Activation": "Increasing"
+        }
+    },
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 75,
+    "RelatedItem": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/CPU1Temp",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_CPUFan1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_CPUFan1.json
@@ -1,0 +1,26 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "CPUFan1",
+    "Name": "CPU #1 Fan Speed",
+    "Oem": {},
+    "PhysicalContext": "CPU",
+    "Reading": 80,
+    "ReadingRangeMax": 100,
+    "ReadingRangeMin": 0,
+    "ReadingType": "Percent",
+    "ReadingUnits": "%",
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "Thresholds": {
+        "LowerCaution": {
+            "Reading": 5
+        },
+        "LowerCritical": {
+            "Reading": 0
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/CPUFan1",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_CPUFan2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_CPUFan2.json
@@ -1,0 +1,26 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "CPUFan2",
+    "Name": "CPU #2 Fan Speed",
+    "Oem": {},
+    "PhysicalContext": "CPU",
+    "Reading": 60,
+    "ReadingRangeMax": 100,
+    "ReadingRangeMin": 0,
+    "ReadingType": "Percent",
+    "ReadingUnits": "%",
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "Thresholds": {
+        "LowerCaution": {
+            "Reading": 5
+        },
+        "LowerCritical": {
+            "Reading": 0
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/CPUFan2",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_DIMM1Temp.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_DIMM1Temp.json
@@ -1,0 +1,46 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "DIMM1Temp",
+    "Name": "DIMM #1 Temperature",
+    "Oem": {},
+    "PhysicalContext": "Memory",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 44,
+    "ReadingUnits": "Cel",
+    "Thresholds": {
+        "UpperCaution": {
+            "Reading": 55,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperCautionUser": {
+            "Reading": 50
+        },
+        "UpperCriticalUser": {
+            "Reading": 60,
+            "DwellTime": "PT1M"
+        },
+        "UpperCritical": {
+            "Reading": 65,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperFatal": {
+            "Reading": 75,
+            "DwellTime": "PT30S",
+            "Activation": "Increasing"
+        }
+    },
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 75,
+    "RelatedItem": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM1"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/DIMM1Temp",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_DIMM2Temp.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_DIMM2Temp.json
@@ -1,0 +1,46 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "DIMM2Temp",
+    "Name": "DIMM #2 Temperature",
+    "Oem": {},
+    "PhysicalContext": "Memory",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 44,
+    "ReadingUnits": "Cel",
+    "Thresholds": {
+        "UpperCaution": {
+            "Reading": 55,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperCautionUser": {
+            "Reading": 50
+        },
+        "UpperCriticalUser": {
+            "Reading": 60,
+            "DwellTime": "PT1M"
+        },
+        "UpperCritical": {
+            "Reading": 65,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperFatal": {
+            "Reading": 75,
+            "DwellTime": "PT30S",
+            "Activation": "Increasing"
+        }
+    },
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 75,
+    "RelatedItem": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM2"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/DIMM2Temp",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_DIMM3Temp.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_DIMM3Temp.json
@@ -1,0 +1,46 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "DIMM3Temp",
+    "Name": "DIMM #3 Temperature",
+    "Oem": {},
+    "PhysicalContext": "Memory",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 44,
+    "ReadingUnits": "Cel",
+    "Thresholds": {
+        "UpperCaution": {
+            "Reading": 55,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperCautionUser": {
+            "Reading": 50
+        },
+        "UpperCriticalUser": {
+            "Reading": 60,
+            "DwellTime": "PT1M"
+        },
+        "UpperCritical": {
+            "Reading": 65,
+            "DwellTime": "PT5M",
+            "Activation": "Increasing"
+        },
+        "UpperFatal": {
+            "Reading": 75,
+            "DwellTime": "PT30S",
+            "Activation": "Increasing"
+        }
+    },
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 75,
+    "RelatedItem": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM3"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/DIMM3Temp",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_ExhaustTemp.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_ExhaustTemp.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "ExhaustTemp",
+    "Name": "Fan Bay #1 Exhaust Temperature",
+    "Oem": {},
+    "PhysicalContext": "Exhaust",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 40.5,
+    "ReadingUnits": "Cel",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 75,
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/ExhaustTemp",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_FanBay1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_FanBay1.json
@@ -1,0 +1,26 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "FanBay1",
+    "Name": "Chassis Fan #1",
+    "Oem": {},
+    "PhysicalContext": "Chassis",
+    "Reading": 45,
+    "ReadingRangeMax": 100,
+    "ReadingRangeMin": 0,
+    "ReadingType": "Percent",
+    "ReadingUnits": "%",
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "Thresholds": {
+        "LowerCaution": {
+            "Reading": 5
+        },
+        "LowerCritical": {
+            "Reading": 0
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/FanBay1",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_FanBay2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_FanBay2.json
@@ -1,0 +1,26 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "FanBay2",
+    "Name": "Chassis Fan #2",
+    "Oem": {},
+    "PhysicalContext": "Chassis",
+    "Reading": 45,
+    "ReadingRangeMax": 100,
+    "ReadingRangeMin": 0,
+    "ReadingType": "Percent",
+    "ReadingUnits": "%",
+    "Status": {
+        "Health": "OK",
+        "State": "Enabled"
+    },
+    "Thresholds": {
+        "LowerCaution": {
+            "Reading": 5
+        },
+        "LowerCritical": {
+            "Reading": 0
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/FanBay2",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_IntakeTemp.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_IntakeTemp.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "IntakeTemp",
+    "Name": "Front Panel Intake Temperature",
+    "Oem": {},
+    "PhysicalContext": "Intake",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 24.8,
+    "ReadingUnits": "Cel",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 75,
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/IntakeTemp",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Energy.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Energy.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Energy",
+    "Name": "Power Supply #1 Energy",
+    "ReadingType": "EnergykWh",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 7855,
+    "ReadingUnits": "kW.h",
+    "PhysicalContext": "PowerSupply",
+    "Oem": {},
+    "Actions": {
+        "#Sensor.ResetMetrics": {
+            "target": "/redfish/v1/Chassis/1U/Sensors/PS1Energy/Actions/Sensor.ResetMetrics"
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Energy",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Frequency.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Frequency.json
@@ -1,0 +1,41 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Frequency",
+    "Name": "Power Supply #1 Frequency",
+    "ReadingType": "Frequency",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 60.1,
+    "ReadingUnits": "Hz",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 160,
+    "Accuracy": 0.02,
+    "Precision": 2,
+    "SensingInterval": "PT0.125S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 60.37,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 60.2,
+            "DwellTime": "PT10M"
+        },
+        "LowerCaution": {
+            "Reading": 59.5,
+            "DwellTime": "PT5M"
+        },
+        "LowerCritical": {
+            "Reading": 58.75,
+            "DwellTime": "PT1M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Frequency",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1InputCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1InputCurrent.json
@@ -1,0 +1,35 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1InputCurrent",
+    "Name": "Power Supply #1 Input Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 8.92,
+    "ReadingUnits": "A",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 40,
+    "Accuracy": 0.05,
+    "Precision": 2,
+    "SensingInterval": "PT0.1S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 10,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 9,
+            "Activation": "Increasing",
+            "DwellTime": "PT10M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1InputCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1InputPower.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1InputPower.json
@@ -1,0 +1,37 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1InputPower",
+    "Name": "Power Supply #1 Input Power",
+    "ReadingType": "Power",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ElectricalContext": "Total",
+    "Reading": 374,
+    "ReadingUnits": "W",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 500,
+    "ApparentVA": 350,
+    "ReactiveVAR": 29,
+    "PowerFactor": 0.83,
+    "Accuracy": 1,
+    "Precision": 1,
+    "SensingInterval": "PT0.1S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 525,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 510,
+            "DwellTime": "PT10M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1InputPower",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1InputVoltage.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1InputVoltage.json
@@ -1,0 +1,42 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1InputVoltage",
+    "Name": "Power Supply #1 Input Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ElectricalContext": "Total",
+    "Reading": 119.27,
+    "ReadingUnits": "V",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 260,
+    "Accuracy": 0.02,
+    "Precision": 2,
+    "SensingInterval": "PT0.125S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 125,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 122,
+            "DwellTime": "PT10M"
+        },
+        "LowerCaution": {
+            "Reading": 118,
+            "DwellTime": "PT5M"
+        },
+        "LowerCritical": {
+            "Reading": 115,
+            "DwellTime": "PT1M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1InputVoltage",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out12V.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out12V.json
@@ -1,0 +1,42 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Out12V",
+    "Name": "Power Supply #1 12V Output Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ElectricalContext": "Total",
+    "Reading": 12.08,
+    "ReadingUnits": "V",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 15,
+    "Accuracy": 0.02,
+    "Precision": 2,
+    "SensingInterval": "PT0.125S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Output",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 12.5,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 12.35,
+            "DwellTime": "PT10M"
+        },
+        "LowerCaution": {
+            "Reading": 11.85,
+            "DwellTime": "PT5M"
+        },
+        "LowerCritical": {
+            "Reading": 11.5,
+            "DwellTime": "PT1M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out12V",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out12VCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out12VCurrent.json
@@ -1,0 +1,34 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Out12VCurrent",
+    "Name": "Power Supply #1 12V Output Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 2.79,
+    "ReadingUnits": "A",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 40,
+    "Accuracy": 0.05,
+    "Precision": 2,
+    "SensingInterval": "PT0.1S",
+    "PhysicalContext": "Chassis",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 7,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 6,
+            "Activation": "Increasing",
+            "DwellTime": "PT10M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out12VCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out3V.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out3V.json
@@ -1,0 +1,42 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Out3V",
+    "Name": "Power Supply #1 3V Output Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ElectricalContext": "Total",
+    "Reading": 3.32,
+    "ReadingUnits": "V",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 5,
+    "Accuracy": 0.02,
+    "Precision": 2,
+    "SensingInterval": "PT0.125S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Output",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 3.5,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 3.35,
+            "DwellTime": "PT10M"
+        },
+        "LowerCaution": {
+            "Reading": 3.25,
+            "DwellTime": "PT5M"
+        },
+        "LowerCritical": {
+            "Reading": 3.1,
+            "DwellTime": "PT1M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out3V",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out3VCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out3VCurrent.json
@@ -1,0 +1,35 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Out3VCurrent",
+    "Name": "Power Supply #1 3V Output Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 8.92,
+    "ReadingUnits": "A",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 40,
+    "Accuracy": 0.05,
+    "Precision": 2,
+    "SensingInterval": "PT0.1S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Output",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 25,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 20,
+            "Activation": "Increasing",
+            "DwellTime": "PT10M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out3VCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out5V.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out5V.json
@@ -1,0 +1,42 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Out5V",
+    "Name": "Power Supply #1 5V Output Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ElectricalContext": "Total",
+    "Reading": 5.04,
+    "ReadingUnits": "V",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 10,
+    "Accuracy": 0.02,
+    "Precision": 2,
+    "SensingInterval": "PT0.125S",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Output",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 5.5,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 5.35,
+            "DwellTime": "PT10M"
+        },
+        "LowerCaution": {
+            "Reading": 4.9,
+            "DwellTime": "PT5M"
+        },
+        "LowerCritical": {
+            "Reading": 4.5,
+            "DwellTime": "PT1M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out5V",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out5VCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS1Out5VCurrent.json
@@ -1,0 +1,34 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS1Out5VCurrent",
+    "Name": "Power Supply #1 5V Output Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 3.41,
+    "ReadingUnits": "A",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 10,
+    "Accuracy": 0.05,
+    "Precision": 2,
+    "SensingInterval": "PT0.1S",
+    "PhysicalContext": "PowerSupply",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 8,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 5,
+            "Activation": "Increasing",
+            "DwellTime": "PT10M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS1Out5VCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Energy.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Energy.json
@@ -1,0 +1,19 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Energy",
+    "Name": "Power Supply #2 Energy",
+    "ReadingType": "EnergykWh",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Absent"
+    },
+    "PhysicalContext": "PowerSupply",
+    "Oem": {},
+    "Actions": {
+        "#Sensor.ResetMetrics": {
+            "target": "/redfish/v1/Chassis/1U/Sensors/PS2Energy/Actions/Sensor.ResetMetrics"
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Energy",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Frequency.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Frequency.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Frequency",
+    "Name": "Power Supply #2 Frequency",
+    "ReadingType": "Frequency",
+    "Status": {
+        "State": "Absent"
+    },
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Frequency",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2InputCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2InputCurrent.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2InputCurrent",
+    "Name": "Power Supply #2 Input Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Absent"
+    },
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2InputCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2InputPower.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2InputPower.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2InputPower",
+    "Name": "Power Supply #2 Input Power",
+    "ReadingType": "Power",
+    "Status": {
+        "State": "Absent"
+    },
+    "ElectricalContext": "Total",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2InputPower",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2InputVoltage.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2InputVoltage.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2InputVoltage",
+    "Name": "Power Supply #2 Input Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Absent"
+    },
+    "ElectricalContext": "Total",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Input",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2InputVoltage",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out12V.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out12V.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Out12V",
+    "Name": "Power Supply #2 12V Output Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Absent"
+    },
+    "ElectricalContext": "Total",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Output",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out12V",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out12VCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out12VCurrent.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Out12VCurrent",
+    "Name": "Power Supply #2 12V Output Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Absent"
+    },
+    "PhysicalContext": "PowerSupply",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out12VCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out3V.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out3V.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Out3V",
+    "Name": "Power Supply #2 3V Output Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Absent"
+    },
+    "ElectricalContext": "Total",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Output",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out3V",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out3VCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out3VCurrent.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Out3VCurrent",
+    "Name": "Power Supply #2 3V Output Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Absent"
+    },
+    "PhysicalContext": "PowerSupply",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out3VCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out5V.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out5V.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Out5V",
+    "Name": "Power Supply #2 5V Output Voltage",
+    "ReadingType": "Voltage",
+    "Status": {
+        "State": "Absent"
+    },
+    "ElectricalContext": "Total",
+    "PhysicalContext": "PowerSupply",
+    "PhysicalSubContext": "Output",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out5V",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out5VCurrent.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_PS2Out5VCurrent.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "PS2Out5VCurrent",
+    "Name": "Power Supply #2 5V Output Current",
+    "ReadingType": "Current",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Absent"
+    },
+    "PhysicalContext": "PowerSupply",
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/PS2Out5VCurrent",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_TotalEnergy.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_TotalEnergy.json
@@ -1,0 +1,21 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "TotalEnergy",
+    "Name": "Total Energy",
+    "ReadingType": "EnergykWh",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 325675,
+    "ReadingUnits": "kW.h",
+    "PhysicalContext": "Chassis",
+    "Oem": {},
+    "Actions": {
+        "#Sensor.ResetMetrics": {
+            "target": "/redfish/v1/Chassis/1U/Sensors/TotalEnergy/Actions/Sensor.ResetMetrics"
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/TotalEnergy",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_TotalPower.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Sensors_TotalPower.json
@@ -1,0 +1,38 @@
+{
+    "@odata.type": "#Sensor.v1_2_0.Sensor",
+    "Id": "TotalPower",
+    "Name": "Power reading for the Chassis",
+    "ReadingType": "Power",
+    "ElectricalContext": "Total",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Reading": 374,
+    "ReadingUnits": "W",
+    "Implementation": "Synthesized",
+    "ReadingTime": "2019-08-13T04:14:33+06:00",
+    "ReadingRangeMin": 0,
+    "ReadingRangeMax": 600,
+    "ApparentVA": 2749.2,
+    "ReactiveVAR": 281.4,
+    "PowerFactor": 0.99,
+    "Accuracy": 0.2,
+    "Precision": 1,
+    "SensingInterval": "PT0.25S",
+    "PhysicalContext": "Chassis",
+    "Thresholds": {
+        "UpperCritical": {
+            "Reading": 600,
+            "Activation": "Increasing",
+            "DwellTime": "PT1M"
+        },
+        "UpperCaution": {
+            "Reading": 580,
+            "DwellTime": "PT10M"
+        }
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/Sensors/TotalPower",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Fans_0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Fans_0.json
@@ -1,0 +1,159 @@
+{
+    "@odata.type": "#Thermal.v1_7_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Fans_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Fans_1.json
@@ -1,0 +1,159 @@
+{
+    "@odata.type": "#Thermal.v1_7_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Redundancy_0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Redundancy_0.json
@@ -1,0 +1,159 @@
+{
+    "@odata.type": "#Thermal.v1_7_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Temperatures_0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Temperatures_0.json
@@ -1,0 +1,159 @@
+{
+    "@odata.type": "#Thermal.v1_7_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Temperatures_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Temperatures_1.json
@@ -1,0 +1,159 @@
+{
+    "@odata.type": "#Thermal.v1_7_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Temperatures_2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal#_Temperatures_2.json
@@ -1,0 +1,159 @@
+{
+    "@odata.type": "#Thermal.v1_7_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_Thermal.json
@@ -1,0 +1,159 @@
+{
+    "@odata.type": "#Thermal.v1_7_0.Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/0",
+            "MemberId": "0",
+            "Name": "CPU1 Temp",
+            "SensorNumber": 5,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 41,
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/1",
+            "MemberId": "1",
+            "Name": "CPU2 Temp",
+            "SensorNumber": 6,
+            "Status": {
+                "State": "Disabled"
+            },
+            "UpperThresholdNonCritical": 42,
+            "UpperThresholdCritical": 45,
+            "UpperThresholdFatal": 48,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Temperatures/2",
+            "MemberId": "2",
+            "Name": "Chassis Intake Temp",
+            "SensorNumber": 9,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "ReadingCelsius": 25,
+            "UpperThresholdNonCritical": 30,
+            "UpperThresholdCritical": 40,
+            "UpperThresholdFatal": 50,
+            "LowerThresholdNonCritical": 10,
+            "LowerThresholdCritical": 5,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 60,
+            "PhysicalContext": "Intake",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fan",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2100,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1",
+            "MemberId": "1",
+            "Name": "BaseBoard System Fan Backup",
+            "PhysicalContext": "Backplane",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Reading": 2050,
+            "ReadingUnits": "RPM",
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 5000,
+            "Redundancy": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0"
+                }
+            ],
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U"
+                }
+            ]
+        }
+    ],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Redundancy/0",
+            "MemberId": "0",
+            "Name": "BaseBoard System Fans",
+            "RedundancySet": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/0"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal#/Fans/1"
+                }
+            ],
+            "Mode": "N+m",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "MinNumNeeded": 1,
+            "MaxNumSupported": 2
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/Thermal",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem.json
@@ -1,0 +1,52 @@
+{
+    "@odata.type": "#ThermalSubsystem.v1_0_0.ThermalSubsystem",
+    "Name": "Thermal Subsystem for Chassis",
+    "FanRedundancy": [
+        {
+            "RedundancyType": "NPlusM",
+            "MaxSupportedInGroup": 2,
+            "MinNeededInGroup": 1,
+            "RedundancyGroup": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/Bay1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/Bay2"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        },
+        {
+            "RedundancyType": "NPlusM",
+            "MaxSupportedInGroup": 2,
+            "MinNeededInGroup": 1,
+            "RedundancyGroup": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/CPU1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/CPU2"
+                }
+            ],
+            "Status": {
+                "State": "Disabled"
+            }
+        }
+    ],
+    "Fans": {
+        "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans"
+    },
+    "ThermalMetrics": {
+        "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/ThermalMetrics"
+    },
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans.json
@@ -1,0 +1,21 @@
+{
+    "@odata.type": "#FanCollection.FanCollection",
+    "Name": "Fan Club",
+    "Members@odata.count": 4,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/Bay1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/Bay2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/CPU1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/CPU2"
+        }
+    ],
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_Bay1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_Bay1.json
@@ -1,0 +1,30 @@
+{
+    "@odata.type": "#Fan.v1_0_0.Fan",
+    "Id": "Bay1",
+    "Name": "Fan Bay 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "PhysicalContext": "Chassis",
+    "Model": "RKS-440DC",
+    "Manufacturer": "Contoso Fans",
+    "PartNumber": "23456-133",
+    "SparePartNumber": "93284-133",
+    "LocationIndicatorActive": true,
+    "HotPluggable": true,
+    "SpeedPercent": {
+        "Reading": 45,
+        "SpeedRPM": 2200,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/FanBay1"
+    },
+    "Location": {
+        "PartLocation": {
+            "ServiceLabel": "Chassis Fan Bay 1",
+            "LocationType": "Bay",
+            "LocationOrdinalValue": 0
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/Bay1",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_Bay2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_Bay2.json
@@ -1,0 +1,30 @@
+{
+    "@odata.type": "#Fan.v1_0_0.Fan",
+    "Id": "Bay2",
+    "Name": "Fan Bay 2",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "PhysicalContext": "Chassis",
+    "Model": "RKS-440DC",
+    "Manufacturer": "Contoso Fans",
+    "PartNumber": "23456-133",
+    "SparePartNumber": "93284-133",
+    "LocationIndicatorActive": false,
+    "HotPluggable": true,
+    "SpeedPercent": {
+        "Reading": 45,
+        "SpeedRPM": 2400,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/FanBay2"
+    },
+    "Location": {
+        "PartLocation": {
+            "ServiceLabel": "Chassis Fan Bay 2",
+            "LocationType": "Bay",
+            "LocationOrdinalValue": 1
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/Bay2",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_CPU1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_CPU1.json
@@ -1,0 +1,29 @@
+{
+    "@odata.type": "#Fan.v1_0_0.Fan",
+    "Id": "CPU1",
+    "Name": "Fan for CPU 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "PhysicalContext": "CPU",
+    "Model": "RKS-440DC",
+    "Manufacturer": "Contoso Fans",
+    "PartNumber": "23456-133",
+    "SparePartNumber": "93284-133",
+    "LocationIndicatorActive": false,
+    "HotPluggable": false,
+    "SpeedPercent": {
+        "Reading": 45,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/CPUFan1"
+    },
+    "Location": {
+        "PartLocation": {
+            "ServiceLabel": "CPU #1 Fan",
+            "LocationType": "Bay",
+            "LocationOrdinalValue": 0
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/CPU1",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_CPU2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_Fans_CPU2.json
@@ -1,0 +1,30 @@
+{
+    "@odata.type": "#Fan.v1_0_0.Fan",
+    "Id": "CPU2",
+    "Name": "Fan for CPU 2",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "PhysicalContext": "CPU",
+    "Model": "RKS-440DC",
+    "Manufacturer": "Contoso Fans",
+    "PartNumber": "23456-133",
+    "SparePartNumber": "93284-133",
+    "LocationIndicatorActive": false,
+    "HotPluggable": false,
+    "SpeedPercent": {
+        "Reading": 45,
+        "SpeedRPM": 1490,
+        "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/CPUFan2"
+    },
+    "Location": {
+        "PartLocation": {
+            "ServiceLabel": "CPU #2 Fan",
+            "LocationType": "Bay",
+            "LocationOrdinalValue": 1
+        }
+    },
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/Fans/CPU2",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_ThermalMetrics.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Chassis_1U_ThermalSubsystem_ThermalMetrics.json
@@ -1,0 +1,38 @@
+{
+    "@odata.type": "#ThermalMetrics.v1_0_0.ThermalMetrics",
+    "Id": "ThermalMetrics",
+    "Name": "Chassis Thermal Metrics",
+    "TemperatureSummaryCelsius": {
+        "Internal": {
+            "Reading": 39,
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/CPU1Temp"
+        },
+        "Intake": {
+            "Reading": 24.8,
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/IntakeTemp"
+        },
+        "Ambient": {
+            "Reading": 22.5,
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/AmbientTemp"
+        },
+        "Exhaust": {
+            "Reading": 40.5,
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/ExhaustTemp"
+        }
+    },
+    "TemperatureReadingsCelsius": [
+        {
+            "Reading": 24.8,
+            "DeviceName": "Intake",
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/IntakeTemp"
+        },
+        {
+            "Reading": 40.5,
+            "DeviceName": "Exhaust",
+            "DataSourceUri": "/redfish/v1/Chassis/1U/Sensors/ExhaustTemp"
+        }
+    ],
+    "Oem": {},
+    "@odata.id": "/redfish/v1/Chassis/1U/ThermalSubsystem/ThermalMetrics",
+    "@Redfish.Copyright": "Copyright 2014-2021 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_EventService.json
+++ b/idrac_ctl/json_responses/_redfish_v1_EventService.json
@@ -1,0 +1,39 @@
+{
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. All rights reserved.",
+    "@odata.context": "/redfish/v1/$metadata#EventService",
+    "@odata.id": "/redfish/v1/EventService",
+    "@odata.type": "#EventService.1.0.0.EventService",
+    "Id": "EventService",
+    "Name": "Event Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "DeliveryRetryAttempts": 3,
+    "DeliveryRetryIntervalInSeconds": 60,
+    "EventTypesForSubscription": [
+        "StatusChange",
+        "ResourceUpdated",
+        "ResourceAdded",
+        "ResourceRemoved",
+        "Alert"
+    ],
+    "Subscriptions": {
+        "@odata.id": "/redfish/v1/EventService/Subscriptions"
+    },
+    "Actions": {
+        "#EventService.SendTestEvent": {
+            "target": "/redfish/v1/EventService/Actions/EventService.SendTestEvent",
+            "EventType@Redfish.AllowableValues": [
+                "StatusChange",
+                "ResourceUpdated",
+                "ResourceAdded",
+                "ResourceRemoved",
+                "Alert"
+            ]
+        },
+        "Oem": {}
+    },
+    "Oem": {}
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers.json
@@ -1,0 +1,14 @@
+{
+    "@Redfish.Copyright": "Copyright 2014-2019 DMTF. All rights reserved.",
+    "@odata.context": "/redfish/v1/$metadata#Managers",
+    "@odata.id": "/redfish/v1/Managers",
+    "@odata.type": "#ManagerCollection.ManagerCollection",
+    "Name": "Manager Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC"
+        }
+    ],
+    "Oem": {}
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC.json
@@ -1,0 +1,86 @@
+{
+    "@odata.type": "#Manager.v1_1_0.Manager",
+    "Id": "BMC",
+    "Name": "Manager",
+    "ManagerType": "BMC",
+    "Description": "Contoso BMC",
+    "ServiceEntryPointUUID": "92384634-2938-2342-8820-489239905423",
+    "UUID": "58893887-8974-2487-2389-841168418919",
+    "Model": "Joo Janta 200",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "GraphicalConsole": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 2,
+        "ConnectTypesSupported": [
+            "KVMIP"
+        ]
+    },
+    "SerialConsole": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 1,
+        "ConnectTypesSupported": [
+            "Telnet",
+            "SSH",
+            "IPMI"
+        ]
+    },
+    "CommandShell": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 4,
+        "ConnectTypesSupported": [
+            "Telnet",
+            "SSH"
+        ]
+    },
+    "FirmwareVersion": "1.00",
+    "NetworkProtocol": {
+        "@odata.id": "/redfish/v1/Managers/BMC/NetworkProtocol"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/BMC/NICs"
+    },
+    "SerialInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Managers/BMC/LogServices"
+    },
+    "VirtualMedia": {
+        "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia"
+    },
+    "Links": {
+        "ManagerForServers": [
+            {
+                "@odata.id": "/redfish/v1/Systems/437XR1138R2"
+            }
+        ],
+        "ManagerForChassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1U"
+            }
+        ],
+        "ManagerInChassis": {
+            "@odata.id": "/redfish/v1/Chassis/1U"
+        },
+        "Oem": {}
+    },
+    "Actions": {
+        "#Manager.Reset": {
+            "target": "/redfish/v1/Managers/BMC/Actions/Manager.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "ForceRestart",
+                "GracefulRestart"
+            ]
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
+    "@odata.id": "/redfish/v1/Managers/BMC",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices.json
@@ -1,0 +1,14 @@
+{
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Log Services for this Manager",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#LogServicesCollection.LogServicesCollection",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices_Log.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices_Log.json
@@ -1,0 +1,27 @@
+{
+    "@odata.type": "#LogService.v1_0_2.LogService",
+    "Id": "Log",
+    "Name": "System Log Service",
+    "MaxNumberOfRecords": 1000,
+    "OverWritePolicy": "WrapsWhenFull",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "ServiceEnabled": true,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Managers/BMC/LogServices/Log/Actions/LogService.Reset"
+        },
+        "Oem": {}
+    },
+    "Entries": {
+        "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/LogServices/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices_Log_Entries.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices_Log_Entries.json
@@ -1,0 +1,36 @@
+{
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries/1",
+            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+            "Id": "1",
+            "Name": "Log Entry 1",
+            "EntryType": "SEL",
+            "OEMRecordFormat": "Contoso",
+            "Severity": "Critical",
+            "Created": "2012-03-07T14:44",
+            "EntryCode": "Assert",
+            "SensorType": "Temperature",
+            "SensorNumber": 1,
+            "Message": "System May be Melting",
+            "MessageId": "Event.1.0.TempWayTooHot",
+            "MessageArgs": [
+                "88"
+            ],
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/LogServices/Members/Log/Entries",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices_Log_Entries_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_LogServices_Log_Entries_1.json
@@ -1,0 +1,27 @@
+{
+    "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+    "Id": "1",
+    "Name": "Log Entry 1",
+    "EntryType": "SEL",
+    "OEMRecordFormat": "Contoso",
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:44",
+    "EntryCode": "Assert",
+    "SensorType": "Temperature",
+    "SensorNumber": 1,
+    "Message": "System May be Melting",
+    "MessageId": "Event.1.0.TempWayTooHot",
+    "MessageArgs": [
+        "88"
+    ],
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/LogServices/Members/Log/Entries/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/LogServices/Log/Entries/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NICs.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NICs.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Network Interface Collection",
+    "Description": "Collection of EthernetInterfaces for this Manager",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NICs/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NICs",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NICs_Dedicated.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NICs_Dedicated.json
@@ -1,0 +1,79 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "Dedicated",
+    "Name": "Manager Ethernet Interface",
+    "Description": "Management Network Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "PermanentMACAddress": "23:11:8A:33:CF:EA",
+    "MACAddress": "23:11:8A:33:CF:EA",
+    "SpeedMbps": 100,
+    "AutoNeg": true,
+    "FullDuplex": true,
+    "MTUSize": 1500,
+    "HostName": "web483-bmc",
+    "FQDN": "web483-bmc.dmtf.org",
+    "MaxIPv6StaticAddresses": 1,
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "DHCP",
+            "Gateway": "192.168.0.1",
+            "Oem": {}
+        }
+    ],
+    "IPv6AddressPolicyTable": [
+        {
+            "Prefix": "::1/128",
+            "Precedence": 50,
+            "Label": 0
+        }
+    ],
+    "IPv6StaticAddresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 16
+        }
+    ],
+    "IPv6DefaultGateway": "fe80::1ec1:deff:fe6f:1e24",
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "SLAAC",
+            "AddressState": "Preferred",
+            "Oem": {}
+        }
+    ],
+    "NameServers": [
+        "names.dmtf.org"
+    ],
+    "@Redfish.Settings": {
+        "@odata.type": "#Settings.v1_0_2.Settings",
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated/SD"
+        },
+        "Time": "2012-03-07T14:44.30-05:00",
+        "ETag": "84ffcbb050ddc7fa9cddb59014546e59",
+        "Messages": [
+            {
+                "MessageId": "Base.1.0.SettingsFailed",
+                "RelatedProperties": [
+                    "#/IPv6Addresses/PrefixLength"
+                ]
+            }
+        ]
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NICs/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NICs_Dedicated_SD.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NICs_Dedicated_SD.json
@@ -1,0 +1,79 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "SD",
+    "Name": "Manager Ethernet Interface",
+    "Description": "Management Network Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "PermanentMACAddress": "23:11:8A:33:CF:EA",
+    "MACAddress": "23:11:8A:33:CF:EA",
+    "SpeedMbps": 100,
+    "AutoNeg": true,
+    "FullDuplex": true,
+    "MTUSize": 1500,
+    "HostName": "web483-bmc",
+    "FQDN": "web483-bmc.dmtf.org",
+    "MaxIPv6StaticAddresses": 1,
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "DHCP",
+            "Gateway": "192.168.0.1",
+            "Oem": {}
+        }
+    ],
+    "IPv6AddressPolicyTable": [
+        {
+            "Prefix": "::1/128",
+            "Precedence": 50,
+            "Label": 0
+        }
+    ],
+    "IPv6StaticAddresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 16
+        }
+    ],
+    "IPv6DefaultGateway": "fe80::1ec1:deff:fe6f:1e24",
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "SLAAC",
+            "AddressState": "Preferred",
+            "Oem": {}
+        }
+    ],
+    "NameServers": [
+        "names.dmtf.org"
+    ],
+    "@Redfish.Settings": {
+        "@odata.type": "#Settings.v1_0_2.Settings",
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated/SD"
+        },
+        "Time": "2012-03-07T14:44.30-05:00",
+        "ETag": "84ffcbb050ddc7fa9cddb59014546e59",
+        "Messages": [
+            {
+                "MessageId": "Base.1.0.SettingsFailed",
+                "RelatedProperties": [
+                    "#/IPv6Addresses/PrefixLength"
+                ]
+            }
+        ]
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NICs/Members/Dedicated/Settings/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NICs/Dedicated/SD",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NetworkProtocol.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_NetworkProtocol.json
@@ -1,0 +1,55 @@
+{
+    "@odata.type": "#ManagerNetworkProtocol.v1_0_2.ManagerNetworkProtocol",
+    "Id": "NetworkProtocol",
+    "Name": "Manager Network Protocol",
+    "Description": "Manager Network Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "HostName": "web483-bmc",
+    "FQDN": "web483-bmc.dmtf.org",
+    "HTTP": {
+        "ProtocolEnabled": true,
+        "Port": 80
+    },
+    "HTTPS": {
+        "ProtocolEnabled": true,
+        "Port": 443
+    },
+    "IPMI": {
+        "ProtocolEnabled": true,
+        "Port": 623
+    },
+    "SSH": {
+        "ProtocolEnabled": true,
+        "Port": 22
+    },
+    "SNMP": {
+        "ProtocolEnabled": true,
+        "Port": 161
+    },
+    "VirtualMedia": {
+        "ProtocolEnabled": true,
+        "Port": 17988
+    },
+    "SSDP": {
+        "ProtocolEnabled": true,
+        "Port": 1900,
+        "NotifyMulticastIntervalSeconds": 600,
+        "NotifyTTL": 5,
+        "NotifyIPv6Scope": "Site"
+    },
+    "Telnet": {
+        "ProtocolEnabled": true,
+        "Port": 23
+    },
+    "KVMIP": {
+        "ProtocolEnabled": true,
+        "Port": 5288
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/NetworkProtocol/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/NetworkProtocol",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_SerialInterfaces.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_SerialInterfaces.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#SerialInterfaceCollection.SerialInterfaceCollection",
+    "Name": "Serial Interface Collection",
+    "Description": "Collection of Serial Interfaces for this System",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces/TTY0"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/BMC/SerialInterfaces/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_SerialInterfaces_TTY0.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_SerialInterfaces_TTY0.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#SerialInterface.v1_0_2.SerialInterface",
+    "Id": "TTY0",
+    "Name": "Manager Serial Interface 1",
+    "Description": "Management for Serial Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "SignalType": "Rs232",
+    "BitRate": "115200",
+    "Parity": "None",
+    "DataBits": "8",
+    "StopBits": "1",
+    "FlowControl": "None",
+    "ConnectorType": "RJ45",
+    "PinOut": "Cyclades",
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/SerialInterfaces/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/SerialInterfaces/TTY0",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_VirtualMedia.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_VirtualMedia.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+    "Name": "Virtual Media Services",
+    "Description": "Redfish-BMC Virtual Media Service Settings",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/Floppy1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/CD1"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/VirtualMedia/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_VirtualMedia_CD1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_VirtualMedia_CD1.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#VirtualMedia.v1_0_2.VirtualMedia",
+    "Id": "CD1",
+    "Name": "Virtual CD",
+    "MediaTypes": [
+        "CD",
+        "DVD"
+    ],
+    "Image": "redfish.dmtf.org/freeImages/freeOS.1.1.iso",
+    "ImageName": "mymedia-read-only",
+    "ConnectedVia": "Applet",
+    "Inserted": true,
+    "WriteProtected": false,
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/VirtualMedia/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/CD1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_VirtualMedia_Floppy1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Managers_BMC_VirtualMedia_Floppy1.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#VirtualMedia.v1_0_2.VirtualMedia",
+    "Id": "Floppy1",
+    "Name": "Virtual Removable Media",
+    "MediaTypes": [
+        "Floppy",
+        "USBStick"
+    ],
+    "Image": "https://www.dmtf.org/freeImages/Sardine.img",
+    "ImageName": "Sardine2.1.43.35.6a",
+    "ConnectedVia": "URI",
+    "Inserted": true,
+    "WriteProtected": false,
+    "@odata.context": "/redfish/v1/$metadata#Managers/Members/BMC/VirtualMedia/Members/$entity",
+    "@odata.id": "/redfish/v1/Managers/BMC/VirtualMedia/Floppy1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_SessionService.json
+++ b/idrac_ctl/json_responses/_redfish_v1_SessionService.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context": "/rest/v1/$metadata#SessionService",
+    "@odata.id": "/rest/v1/SessionService",
+    "@odata.type": "#Session.0.94.0.SessionCollection",
+    "Name": "Session Collection",
+    "Description": "Manager User Sessions",
+    "Modified": "2013-01-31T23:45:08+00:00",
+    "Links": {
+        "Members@odata.count": 1,
+        "Members": [
+            {
+                "@odata.id": "/redfish/v1/SessionService/Administrator1"
+            }
+        ]
+    }
+}

--- a/idrac_ctl/json_responses/_redfish_v1_SessionService_Administrator1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_SessionService_Administrator1.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata/SessionService/Links/Members/$entity",
+    "@odata.id": "/redfish/v1/SessionService/Administrator1",
+    "@odata.type": "#SessionService.0.94.0.Session",
+    "Id": "Administrator1",
+    "Name": "User Session",
+    "Description": "Manager User Session",
+    "Modified": "2013-01-31T23:45:08+00:00",
+    "UserName": "Administrator",
+    "Oem": {}
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2.json
@@ -1,0 +1,134 @@
+{
+    "@odata.type": "#ComputerSystem.v1_1_0.ComputerSystem",
+    "Id": "437XR1138R2",
+    "Name": "WebFrontEnd483",
+    "SystemType": "Physical",
+    "AssetTag": "Chicago-45Z-2381",
+    "Manufacturer": "Contoso",
+    "Model": "3500RX",
+    "SKU": "8675309",
+    "SerialNumber": "437XR1138R2",
+    "PartNumber": "224071-J23",
+    "Description": "Web Front End node",
+    "UUID": "38947555-7742-3448-3784-823347823834",
+    "HostName": "web483",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollUp": "OK"
+    },
+    "IndicatorLED": "Off",
+    "PowerState": "On",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "Pxe",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Cd",
+            "Usb",
+            "Hdd",
+            "BiosSetup",
+            "Utilities",
+            "Diags",
+            "SDCard",
+            "UefiTarget"
+        ],
+        "BootSourceOverrideMode": "UEFI",
+        "UefiTargetBootSourceOverride": "/0x31/0x33/0x01/0x01"
+    },
+    "TrustedModules": [
+        {
+            "FirmwareVersion": "1.13b",
+            "InterfaceType": "TPM1_2",
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        }
+    ],
+    "Oem": {
+        "Contoso": {
+            "@odata.type": "http://Contoso.com/Schema#Contoso.ComputerSystem",
+            "ProductionLocation": {
+                "FacilityName": "PacWest Production Facility",
+                "Country": "USA"
+            }
+        },
+        "Chipwise": {
+            "@odata.type": "http://Chipwise.com/Schema#Chipwise.ComputerSystem",
+            "Style": "Executive"
+        }
+    },
+    "BiosVersion": "P79 v1.33 (02/28/2015)",
+    "ProcessorSummary": {
+        "Count": 2,
+        "ProcessorFamily": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollUp": "OK"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 96,
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK",
+            "HealthRollUp": "OK"
+        }
+    },
+    "Bios": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS"
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces"
+    },
+    "SimpleStorage": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1U"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/BMC"
+            }
+        ]
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/437XR1138R2/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton"
+            ]
+        },
+        "Oem": {
+            "#Contoso.Reset": {
+                "target": "/redfish/v1/Systems/437XR1138R2/Oem/Contoso/Actions/Contoso.Reset"
+            }
+        }
+    },
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_BIOS.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_BIOS.json
@@ -1,0 +1,45 @@
+{
+    "@odata.type": "#Bios.v1_0_0.Bios",
+    "Id": "BIOS",
+    "Name": "BIOS Configuration Current Settings",
+    "AttributeRegistry": "BiosAttributeRegistryP89.v1_0_0",
+    "Attributes": {
+        "AdminPhone": "",
+        "BootMode": "Uefi",
+        "EmbeddedSata": "Raid",
+        "NicBoot1": "NetworkBoot",
+        "NicBoot2": "Disabled",
+        "PowerProfile": "MaxPerf",
+        "ProcCoreDisable": 0,
+        "ProcHyperthreading": "Enabled",
+        "ProcTurboMode": "Enabled",
+        "UsbControl": "UsbEnabled"
+    },
+    "@Redfish.Settings": {
+        "@odata.type": "#Settings.v1_0_0.Settings",
+        "ETag": "9234ac83b9700123cc32",
+        "Messages": [
+            {
+                "MessageId": "Base.1.0.SettingsFailed",
+                "RelatedProperties": [
+                    "#/Attributes/ProcTurboMode"
+                ]
+            }
+        ],
+        "SettingsObject": {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS/Settings"
+        },
+        "Time": "2016-03-07T14:44.30-05:00"
+    },
+    "Actions": {
+        "#Bios.ResetBios": {
+            "target": "/redfish/v1/Systems/437XR1138R2/BIOS/Actions/Bios.ResetBios"
+        },
+        "#Bios.ChangePassword": {
+            "target": "/redfish/v1/Systems/437XR1138R2/BIOS/Actions/Bios.ChangePassword"
+        }
+    },
+    "@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_BIOS_Settings.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_BIOS_Settings.json
@@ -1,0 +1,21 @@
+{
+    "@odata.type": "#Bios.v1_0_0.Bios",
+    "Id": "Settings",
+    "Name": "BIOS Configuration Pending Settings",
+    "AttributeRegistry": "BiosAttributeRegistryP89.v1_0_0",
+    "Attributes": {
+        "AdminPhone": "(404) 555-1212",
+        "BootMode": "Uefi",
+        "EmbeddedSata": "Ahci",
+        "NicBoot1": "NetworkBoot",
+        "NicBoot2": "NetworkBoot",
+        "PowerProfile": "MaxPerf",
+        "ProcCoreDisable": 0,
+        "ProcHyperthreading": "Enabled",
+        "ProcTurboMode": "Disabled",
+        "UsbControl": "UsbEnabled"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/BIOS/Settings",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces.json
@@ -1,0 +1,18 @@
+{
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "Name": "Ethernet Interface Collection",
+    "Description": "System NICs on Contoso Servers",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411.json
@@ -1,0 +1,42 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "1",
+    "Name": "Ethernet Interface",
+    "Description": "System NIC 1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "FactoryMacAddress": "12:44:6A:3B:04:11",
+    "MacAddress": "12:44:6A:3B:04:11",
+    "SpeedMbps": 1000,
+    "FullDuplex": true,
+    "HostName": "web483",
+    "FQDN": "web483.contoso.com",
+    "IPv6DefaultGateway": "fe80::3ed9:2bff:fe34:600",
+    "NameServers": [
+        "names.contoso.com"
+    ],
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.10",
+            "SubnetMask": "255.255.252.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.0.1"
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e24",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "VLANs": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411_VLANs.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411_VLANs.json
@@ -1,0 +1,16 @@
+{
+    "@odata.type": "#VLanNetworkInterfaceCollection.VLanNetworkInterfaceCollection",
+    "Name": "VLAN Network Interface Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/2"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/12446A3B0411/VLANs/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411_VLANs_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411_VLANs_1.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#VLanNetworkInterface.v1_0_2.VLanNetworkInterface",
+    "Id": "1",
+    "Name": "VLAN Network Interface",
+    "Description": "System NIC 1 VLAN",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "VLANEnable": true,
+    "VLANId": 101,
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/12446A3B0411/VLANs/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411_VLANs_2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B0411_VLANs_2.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#VLanNetworkInterface.v1_0_2.VLanNetworkInterface",
+    "Id": "2",
+    "Name": "VLAN Network Interface",
+    "Description": "System NIC 1 VLAN",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "VLANEnable": true,
+    "VLANId": 199,
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/12446A3B0411/VLANs/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B0411/VLANs/2",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B8890.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_EthernetInterfaces_12446A3B8890.json
@@ -1,0 +1,43 @@
+{
+    "@odata.type": "#EthernetInterface.v1_0_2.EthernetInterface",
+    "Id": "2",
+    "Name": "Ethernet Interface",
+    "Description": "System NIC 2",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "PermanentMACAddress": "12:44:6A:3B:88:90",
+    "MACAddress": "AA:BB:CC:DD:EE:00",
+    "SpeedMbps": 1000,
+    "FullDuplex": true,
+    "HostName": "backup-web483",
+    "FQDN": "backup-web483.contoso.com",
+    "IPv6DefaultGateway": "fe80::3ed9:2bff:fe34:600",
+    "NameServers": [
+        "names.contoso.com"
+    ],
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.0.11",
+            "SubnetMask": "255.255.255.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.0.1"
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fe80::1ec1:deff:fe6f:1e33",
+            "PrefixLength": 64,
+            "AddressOrigin": "Static",
+            "AddressState": "Preferred"
+        }
+    ],
+    "VLAN": {
+        "VLANEnable": true,
+        "VLANId": 101
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/EthernetInterfaces/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/EthernetInterfaces/12446A3B8890",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices.json
@@ -1,0 +1,15 @@
+{
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1"
+        }
+    ],
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1.json
@@ -1,0 +1,26 @@
+{
+    "@odata.type": "#LogService.v1_0_2.LogService",
+    "Id": "Log1",
+    "Name": "System Log Service",
+    "MaxNumberOfRecords": 1000,
+    "OverWritePolicy": "WrapsWhenFull",
+    "DateTime": "2015-03-13T04:14:33+06:00",
+    "DateTimeLocalOffset": "+06:00",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "Actions": {
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Actions/LogService.Reset"
+        },
+        "Oem": {}
+    },
+    "Entries": {
+        "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1_Entries.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1_Entries.json
@@ -1,0 +1,64 @@
+{
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "Name": "Log Service Collection",
+    "Description": "Collection of Logs for this System",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/1",
+            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+            "Id": "1",
+            "Name": "Log Entry 1",
+            "EntryType": "SEL",
+            "OemRecordFormat": "Contoso",
+            "RecordId": 1,
+            "Severity": "Warning",
+            "Created": "2012-03-07T14:44",
+            "EntryCode": "Assert",
+            "SensorType": "Temperature",
+            "Number": 1,
+            "Message": "Temperature threshold exceeded",
+            "MessageID": "Contoso.1.0.TempAssert",
+            "MessageArgs": [
+                "42"
+            ],
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/2",
+            "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+            "Id": "2",
+            "Name": "Log Entry 2",
+            "EntryType": "SEL",
+            "OEMRecordFormat": "Contoso",
+            "RecordId": 2,
+            "Severity": "Critical",
+            "Created": "2012-03-07T14:45",
+            "EntryCode": "Assert",
+            "SensorType": "Temperature",
+            "Number": 2,
+            "Message": "Temperature threshold exceeded",
+            "MessageID": "Contoso.1.0.TempAssert",
+            "MessageArgs": [
+                "46"
+            ],
+            "Links": {
+                "OriginOfCondition": {
+                    "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+                },
+                "Oem": {}
+            },
+            "Oem": {}
+        }
+    ],
+    "@odata.nextLink": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries?$skiptoken=2",
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/Log1/Entries",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1_Entries_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1_Entries_1.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+    "Id": "1",
+    "Name": "Log Entry 1",
+    "EntryType": "SEL",
+    "OemRecordFormat": "Contoso",
+    "RecordId": 1,
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:44",
+    "EntryCode": "Assert",
+    "SensorType": "Temperature",
+    "SensorNumber": 1,
+    "Message": "Temperature threshold exceeded",
+    "MessageID": "Contoso.1.0.TempAssert",
+    "MessageArgs": [
+        "42"
+    ],
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/Log1/Entries/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1_Entries_2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_LogServices_Log1_Entries_2.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#LogEntry.v1_0_2.LogEntry",
+    "Id": "2",
+    "Name": "Log Entry 2",
+    "EntryType": "SEL",
+    "OEMRecordFormat": "Contoso",
+    "RecordId": 2,
+    "Severity": "Critical",
+    "Created": "2012-03-07T14:45",
+    "EntryCode": "Assert",
+    "SensorType": "Temperature",
+    "SensorNumber": 2,
+    "Message": "Temperature threshold exceeded",
+    "MessageID": "Contoso.1.0.TempAssert",
+    "MessageArgs": [
+        "46"
+    ],
+    "Links": {
+        "OriginOfCondition": {
+            "@odata.id": "/redfish/v1/Chassis/1U/Thermal"
+        },
+        "Oem": {}
+    },
+    "Oem": {},
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/LogServices/Members/Log1/Entries/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/LogServices/Log1/Entries/2",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory.json
@@ -1,0 +1,22 @@
+{
+    "@odata.type": "#MemoryCollection.MemoryCollection",
+    "Name": "Memory Module Collection",
+    "Members@odata.count": 4,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM4"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#MemoryCollection.MemoryCollection",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM1.json
@@ -1,0 +1,32 @@
+{
+    "@odata.type": "#Memory.v1_0_0.Memory",
+    "Name": "DIMM Slot 1",
+    "Id": "DIMM1",
+    "RankCount": 2,
+    "MaxTDPMilliWatts": [
+        12000
+    ],
+    "CapacityMiB": 32768,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "ErrorCorrection": "MultiBitECC",
+    "MemoryLocation": {
+        "Socket": 1,
+        "MemoryController": 1,
+        "Channel": 1,
+        "Slot": 1
+    },
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "BaseModuleType": "RDIMM",
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM2.json
@@ -1,0 +1,32 @@
+{
+    "@odata.type": "#Memory.v1_0_0.Memory",
+    "Name": "DIMM Slot 2",
+    "Id": "DIMM2",
+    "RankCount": 2,
+    "MaxTDPMilliWatts": [
+        12000
+    ],
+    "CapacityMiB": 32768,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "ErrorCorrection": "MultiBitECC",
+    "MemoryLocation": {
+        "Socket": 1,
+        "MemoryController": 1,
+        "Channel": 1,
+        "Slot": 2
+    },
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "BaseModuleType": "RDIMM",
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM2",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM3.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM3.json
@@ -1,0 +1,32 @@
+{
+    "@odata.type": "#Memory.v1_0_0.Memory",
+    "Name": "DIMM Slot 3",
+    "Id": "DIMM3",
+    "RankCount": 2,
+    "MaxTDPMilliWatts": [
+        12000
+    ],
+    "CapacityMiB": 32768,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "ErrorCorrection": "MultiBitECC",
+    "MemoryLocation": {
+        "Socket": 2,
+        "MemoryController": 2,
+        "Channel": 1,
+        "Slot": 3
+    },
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "BaseModuleType": "RDIMM",
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM2",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM4.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Memory_DIMM4.json
@@ -1,0 +1,17 @@
+{
+    "@odata.type": "#Memory.v1_0_0.Memory",
+    "Name": "DIMM Slot 4",
+    "Id": "DIMM4",
+    "MemoryLocation": {
+        "Socket": 2,
+        "MemoryController": 2,
+        "Channel": 1,
+        "Slot": 4
+    },
+    "Status": {
+        "State": "Absent"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Memory/DIMM4",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Processors.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Processors.json
@@ -1,0 +1,16 @@
+{
+    "@odata.type": "#ProcssorCollection.ProcessorCollection",
+    "Name": "Processors Collection",
+    "Members@odata.count": 2,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Links/Members/437XR1138R2/Processors/#entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Processors_CPU1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Processors_CPU1.json
@@ -1,0 +1,28 @@
+{
+    "@odata.type": "#Processor.v1_0_2.Processor",
+    "Id": "CPU1",
+    "Socket": "CPU 1",
+    "ProcessorType": "CPU",
+    "ProcessorArchitecture": "x86",
+    "InstructionSet": "x86-64",
+    "Manufacturer": "Intel(R) Corporation",
+    "Model": "Multi-Core Intel(R) Xeon(R) processor 7xxx Series",
+    "ProcessorID": {
+        "VendorID": "GenuineIntel",
+        "IdentificationRegisters": "0x34AC34DC8901274A",
+        "EffectiveFamily": "0x42",
+        "EffectiveModel": "0x61",
+        "Step": "0x1",
+        "MicrocodeInfo": "0x429943"
+    },
+    "MaxSpeedMHz": 3700,
+    "TotalCores": 8,
+    "TotalThreads": 16,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/Processors/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Processors_CPU2.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_Processors_CPU2.json
@@ -1,0 +1,12 @@
+{
+    "@odata.type": "#Processor.v1_0_2.Processor",
+    "Id": "CPU2",
+    "Socket": "CPU 2",
+    "ProcessorType": "CPU",
+    "Status": {
+        "State": "Absent"
+    },
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/Processors/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/Processors/CPU2",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_SimpleStorage.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_SimpleStorage.json
@@ -1,0 +1,13 @@
+{
+    "@odata.type": "#SimpleStorageCollection.SimpleStorageCollection",
+    "Name": "Simple Storage Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage/1"
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/SimpleStorage/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_SimpleStorage_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_Systems_437XR1138R2_SimpleStorage_1.json
@@ -1,0 +1,49 @@
+{
+    "@odata.type": "#SimpleStorage.v1_0_2.SimpleStorage",
+    "Id": "1",
+    "Name": "Simple Storage Controller",
+    "Description": "System SATA",
+    "UEFIDevicePath": "Acpi(PNP0A03,0)/Pci(1F|1)/Ata(Primary,Master)/HD(Part3, Sig00110011)",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollUp": "Degraded"
+    },
+    "Devices": [
+        {
+            "Name": "SATA Bay 1",
+            "Manufacturer": "Contoso",
+            "Model": "3000GT8",
+            "CapacityBytes": 8000000000000,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            }
+        },
+        {
+            "Name": "SATA Bay 2",
+            "Manufacturer": "Contoso",
+            "Model": "3000GT7",
+            "CapacityBytes": 4000000000000,
+            "Status": {
+                "State": "Enabled",
+                "Health": "Degraded"
+            }
+        },
+        {
+            "Name": "SATA Bay 3",
+            "Status": {
+                "State": "Absent"
+            }
+        },
+        {
+            "Name": "SATA Bay 4",
+            "Status": {
+                "State": "Absent"
+            }
+        }
+    ],
+    "@odata.context": "/redfish/v1/$metadata#Systems/Members/437XR1138R2/SimpleStorage/Members/$entity",
+    "@odata.id": "/redfish/v1/Systems/437XR1138R2/SimpleStorage/1",
+    "@Redfish.Copyright": "Copyright 2014-2016 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright."
+}

--- a/idrac_ctl/json_responses/_redfish_v1_TaskService.json
+++ b/idrac_ctl/json_responses/_redfish_v1_TaskService.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/rest/v1/$metadata#TaskService/$entity",
+    "@odata.type": "#Tasks.0.94.0.TaskCollection",
+    "Name": "Task Collection",
+    "Modified": "2012-03-07T14:44",
+    "Links": {
+        "Members@odata.count": 1,
+        "Members": [
+            {
+                "@odata.id": "/redfish/v1/TaskService/1"
+            }
+        ]
+    }
+}

--- a/idrac_ctl/json_responses/_redfish_v1_TaskService_1.json
+++ b/idrac_ctl/json_responses/_redfish_v1_TaskService_1.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata/TaskService/Links/Members/$entity",
+    "@odata.id": "/redfish/v1/TaskService/1",
+    "@odata.type": "#TaskService.0.94.0.Task",
+    "Id": "1",
+    "Name": "Task 1",
+    "Modified": "2012-03-07T14:44",
+    "TaskState": "Completed",
+    "StartTime": "2012-03-07T14:44",
+    "EndTime": "2012-03-07T14:45",
+    "TaskStatus": "OK"
+}

--- a/idrac_ctl/pci/cmd_pci.py
+++ b/idrac_ctl/pci/cmd_pci.py
@@ -62,9 +62,9 @@ class PciDeviceQuery(IDracManager,
         """
 
         if verbose:
-            print(f"cmd args data_type: {data_type} "
+            self.logger.debug(f"cmd args data_type: {data_type} "
                   f"filename:{filename} do_async:{do_async} dev:{pci_type}")
-            print(f"the rest of args: {kwargs}")
+            self.logger.debug(f"the rest of args: {kwargs}")
 
         headers = {}
         if data_type == "json":

--- a/idrac_ctl/redfish_manager.py
+++ b/idrac_ctl/redfish_manager.py
@@ -421,10 +421,10 @@ class RedfishManager:
                     m for m
                     in json_data[RedfishJsonMessage.MessageExtendedInfo]
                 ]
-        except requests.exceptions.JSONDecodeError as _:
-            pass
-        except TypeError as _:
-            pass
+        except requests.exceptions.JSONDecodeError as decode_err:
+            logging.debug(f"no json body to parse from respond: {decode_err}")
+        except TypeError as type_err:
+            logging.debug(f"unexpected respond payload shape: {type_err}")
 
         finally:
             return redfish_resp
@@ -545,8 +545,8 @@ class RedfishManager:
                     if job_id is not None:
                         job_id = job_id.group(0)
                     return job_id
-        except AttributeError as _:
-            pass
+        except AttributeError as attr_err:
+            logging.debug(f"could not read job id from respond object: {attr_err}")
 
         return ""
 
@@ -577,17 +577,17 @@ class RedfishManager:
             job_id = self.job_id_from_header(resp)
             logging.debug(f"idrac api returned job_id: {job_id} in the response header.")
             return job_id
-        # ignored.
-        except TaskIdUnavailable as _:
-            pass
+        # optional lookup, fall through to the response body below.
+        except TaskIdUnavailable as header_err:
+            logging.debug(f"no job id in the response header: {header_err}")
 
         # this from response
         try:
             # try to get from the response, it an optional check.
             job_id = self.job_id_from_respond(resp)
             logging.debug(f"idrac api returned job_id: {job_id} in the response header.")
-        except TaskIdUnavailable as _:
-            pass
+        except TaskIdUnavailable as respond_err:
+            logging.debug(f"no job id in the response body: {respond_err}")
 
         return ""
 

--- a/idrac_ctl/redfish_manager.py
+++ b/idrac_ctl/redfish_manager.py
@@ -13,26 +13,28 @@ import logging
 import re
 from abc import abstractmethod
 from functools import cached_property
-from typing import Optional, Dict
+from typing import Dict, Optional
 
 import requests
 
-from .redfish_shared import RedfishApi, RedfishJsonMessage
-from .redfish_shared import RedfishApiRespond
-from .redfish_shared import RedfishJsonSpec
-
-from .cmd_exceptions import AuthenticationFailed
-from .cmd_exceptions import ResourceNotFound
-from .cmd_exceptions import TaskIdUnavailable
+from .cmd_exceptions import AuthenticationFailed, ResourceNotFound, TaskIdUnavailable
 from .cmd_utils import save_if_needed
+from .redfish_exceptions import (
+    RedfishForbidden,
+    RedfishMethodNotAllowed,
+    RedfishNotAcceptable,
+    RedfishUnauthorized,
+)
+from .redfish_query import RedfishQuery
 from .redfish_respond import RedfishRespondMessage
 from .redfish_respond_error import RedfishError
-
-from .redfish_exceptions import RedfishForbidden
-from .redfish_exceptions import RedfishMethodNotAllowed
-from .redfish_exceptions import RedfishNotAcceptable
-from .redfish_exceptions import RedfishUnauthorized
-from .redfish_shared import RedfishJson
+from .redfish_shared import (
+    RedfishApi,
+    RedfishApiRespond,
+    RedfishJson,
+    RedfishJsonMessage,
+    RedfishJsonSpec,
+)
 
 """Each command encapsulate result in named tuple"""
 CommandResult = collections.namedtuple("cmd_result",
@@ -218,6 +220,27 @@ class RedfishManager:
                 req, verify=self._is_verify_cert,
                 auth=(self._username, self._password)
             )
+
+    def get_with_query(
+            self, req: str,
+            query: Optional[RedfishQuery] = None,
+            hdr: Optional[Dict] = None,
+            one_param_per_uri: bool = False) -> requests.models.Response:
+        """GET ``req`` with optional Redfish query parameters applied.
+
+        ``one_param_per_uri`` enforces the vendor rule (Dell iDRAC) that only one
+        query parameter may appear per URI. The caller passes it from the target's
+        vendor capability profile so this generic layer stays vendor-neutral.
+
+        :param req: full request URL (without a query string)
+        :param query: a RedfishQuery, or None for a plain GET
+        :param hdr: optional headers
+        :param one_param_per_uri: reject combining query parameters when True
+        :return: requests.models.Response
+        :raise ValueError: if the query is invalid for the target
+        """
+        url = req if query is None else query.apply(req, one_param_per_uri)
+        return self.api_get_call(url, hdr or {})
 
     @staticmethod
     def expanded(level: Optional[int] = 1):

--- a/idrac_ctl/redfish_query.py
+++ b/idrac_ctl/redfish_query.py
@@ -1,0 +1,107 @@
+"""Redfish query-parameter builder.
+
+Builds the standard Redfish query string for a GET request — ``$select``,
+``$filter``, ``$expand``, ``$top`` and ``only`` — with validation. These move
+work to the server (smaller, faster responses), which matters at fleet scale.
+
+Vendor note: some services (Dell iDRAC) accept only ONE query parameter per URI.
+Pass ``one_param_per_uri=True`` (or a vendor capability profile) to enforce that.
+
+Author Mus spyroot@gmail.com
+"""
+from typing import List, Optional, Union
+from urllib.parse import quote
+
+# Characters that are meaningful in Redfish query syntax and must stay literal
+# (operators, grouping, quoting); only spaces and other unsafe chars get encoded.
+_SAFE = "()'$*,=:+-"
+
+
+class RedfishQuery:
+    """A validated Redfish query parameter set for a single GET.
+
+    Examples
+    --------
+    >>> RedfishQuery(select=["ProcCStates", "SysMemSize"]).to_query_string()
+    '?$select=ProcCStates,SysMemSize'
+    >>> RedfishQuery(top=5).to_query_string()
+    '?$top=5'
+    >>> RedfishQuery(expand=True, expand_levels=2).to_query_string()
+    '?$expand=*($levels=2)'
+    """
+
+    def __init__(
+        self,
+        select: Optional[Union[List[str], str]] = None,
+        filter: Optional[str] = None,
+        expand: Optional[Union[bool, str]] = None,
+        expand_levels: int = 1,
+        top: Optional[int] = None,
+        only: bool = False,
+    ):
+        self.select = select
+        self.filter = filter
+        self.expand = expand
+        self.expand_levels = expand_levels
+        self.top = top
+        self.only = bool(only)
+
+    def is_empty(self) -> bool:
+        """True when no query parameter is set."""
+        return not self._active_names()
+
+    def _active_names(self) -> List[str]:
+        names = []
+        if self.select:
+            names.append("$select")
+        if self.filter:
+            names.append("$filter")
+        if self.expand:
+            names.append("$expand")
+        if self.top is not None:
+            names.append("$top")
+        if self.only:
+            names.append("only")
+        return names
+
+    def _validate(self, one_param_per_uri: bool) -> None:
+        if self.top is not None and (not isinstance(self.top, int) or self.top < 0):
+            raise ValueError("$top must be an integer >= 0")
+        if self.expand_levels is not None and (
+            not isinstance(self.expand_levels, int) or self.expand_levels < 1
+        ):
+            raise ValueError("$expand levels must be an integer >= 1")
+        active = self._active_names()
+        if one_param_per_uri and len(active) > 1:
+            raise ValueError(
+                "this service supports only one query parameter per URI; "
+                f"got {', '.join(active)}"
+            )
+
+    def _pairs(self) -> List[str]:
+        pairs: List[str] = []
+        if self.select:
+            value = self.select if isinstance(self.select, str) else ",".join(self.select)
+            pairs.append("$select=" + quote(value, safe=_SAFE))
+        if self.filter:
+            pairs.append("$filter=" + quote(self.filter, safe=_SAFE))
+        if self.expand:
+            mode = self.expand if isinstance(self.expand, str) else "*"
+            pairs.append(f"$expand={mode}($levels={self.expand_levels})")
+        if self.top is not None:
+            pairs.append(f"$top={self.top}")
+        if self.only:
+            pairs.append("only")
+        return pairs
+
+    def to_query_string(self, one_param_per_uri: bool = False) -> str:
+        """Return the leading ``?...`` query string, or ``""`` when empty."""
+        self._validate(one_param_per_uri)
+        pairs = self._pairs()
+        if not pairs:
+            return ""
+        return "?" + "&".join(pairs)
+
+    def apply(self, url: str, one_param_per_uri: bool = False) -> str:
+        """Append the query string to ``url`` (assumes ``url`` has no query yet)."""
+        return url + self.to_query_string(one_param_per_uri)

--- a/idrac_ctl/storage/cmd_storage_controllers.py
+++ b/idrac_ctl/storage/cmd_storage_controllers.py
@@ -100,9 +100,9 @@ class StorageQuery(IDracManager, scm_type=ApiRequestType.StorageQuery,
         :return:
         """
         if verbose:
-            print(f"cmd args data_type: {data_type} "
+            self.logger.debug(f"cmd args data_type: {data_type} "
                   f"do_deep:{do_deep} do_async:{do_async} id_filter:{id_filter}")
-            print(f"the rest of args: {kwargs}")
+            self.logger.debug(f"the rest of args: {kwargs}")
 
         headers = {}
         if data_type == "json":

--- a/idrac_ctl/system/cmd_system_config.py
+++ b/idrac_ctl/system/cmd_system_config.py
@@ -90,9 +90,9 @@ class ExportSystemConfig(IDracManager,
         """
 
         if verbose:
-            print(f"cmd args data_type: {data_type} "
+            self.logger.debug(f"cmd args data_type: {data_type} "
                   f"do_async:{do_async} export_format:{export_format}")
-            print(f"the rest of args: {kwargs}")
+            self.logger.debug(f"the rest of args: {kwargs}")
 
         headers = {}
         headers.update(self.content_type)

--- a/idrac_ctl/system/cmd_system_import.py
+++ b/idrac_ctl/system/cmd_system_import.py
@@ -113,12 +113,12 @@ class ImportSystemConfig(IDracManager,
         :return: in data type json will return json
         """
         if verbose:
-            print(f"cmd args data_type: {data_type} "
+            self.logger.debug(f"cmd args data_type: {data_type} "
                   f"shutdown_type:{shutdown_type} "
                   f"host_power_state:{host_power_state} "
                   f"do_async:{do_async} "
                   f"filename:{filename}")
-            print(f"the rest of args: {kwargs}")
+            self.logger.debug(f"the rest of args: {kwargs}")
 
         headers = {}
         if data_type == "json":

--- a/idrac_ctl/system/cmd_system_one_time_boot.py
+++ b/idrac_ctl/system/cmd_system_one_time_boot.py
@@ -85,12 +85,12 @@ class ImportOneTimeBoot(
         :return: in data type json will return json
         """
         if verbose:
-            print(f"cmd args data_type: {data_type} "
+            self.logger.debug(f"cmd args data_type: {data_type} "
                   f"shutdown_type:{shutdown_type} "
                   f"host_power_state:{host_power_state} "
                   f"do_async:{do_async} "
                   f"filename:{filename}")
-            print(f"the rest of args: {kwargs}")
+            self.logger.debug(f"the rest of args: {kwargs}")
 
         headers = {}
         if data_type == "json":

--- a/idrac_ctl/vendors/README.md
+++ b/idrac_ctl/vendors/README.md
@@ -1,0 +1,42 @@
+# Vendor packages
+
+The generic Redfish core (`RedfishManager`) is product-neutral. Anything specific
+to one server vendor lives here, in its own subdirectory, so vendor specifics stay
+clearly separated and new vendors can be added incrementally without touching the
+core.
+
+```
+vendors/
+  base.py            # VendorCapabilities model + registry
+  dell/              # Dell iDRAC
+  hpe/               # HPE iLO (placeholder)
+  supermicro/        # Supermicro (placeholder)
+```
+
+## Convention for a vendor package
+
+Each `vendors/<name>/` contains:
+
+- `capabilities.py` — a `VendorCapabilities` profile registered via `register(...)`.
+  It declares what the vendor's Redfish service supports (which query parameters,
+  recurring-job scheduling, lifecycle events, OEM prefix) so commands can gate
+  vendor-specific behavior cleanly.
+- `cmd_*.py` — vendor-specific command modules (self-registering `IDracManager`
+  subclasses), added incrementally.
+- `README.md` — what's here and any vendor quirks.
+
+Look up a profile:
+
+```python
+from idrac_ctl.vendors import get_vendor
+caps = get_vendor("dell")           # unknown vendor -> conservative "generic" profile
+if caps.job_scheduling:
+    ...
+```
+
+## Migration note
+
+Dell command code currently also lives in `idrac_ctl/idrac_manager.py` and
+`idrac_ctl/delloem/`. It migrates into `vendors/dell/` incrementally, alongside the
+planned `idrac_ctl` → `redfish_ctl` rename. The core must never import a vendor
+package; vendor packages may depend on the core.

--- a/idrac_ctl/vendors/__init__.py
+++ b/idrac_ctl/vendors/__init__.py
@@ -1,0 +1,21 @@
+"""Vendor-specific Redfish capabilities and (future) command modules.
+
+Each vendor gets its own subdirectory under ``vendors/`` so vendor specifics are
+clearly separated from the product-neutral core. Importing this package registers
+every vendor's capability profile. See README.md for the convention.
+
+    from idrac_ctl.vendors import get_vendor
+    caps = get_vendor("dell")
+    if caps.job_scheduling:
+        ...
+
+Author Mus spyroot@gmail.com
+"""
+# Importing each vendor's capabilities module registers its profile.
+from .base import VendorCapabilities, all_vendors
+from .base import get as get_vendor
+from .dell import capabilities as _dell  # noqa: F401
+from .hpe import capabilities as _hpe  # noqa: F401
+from .supermicro import capabilities as _supermicro  # noqa: F401
+
+__all__ = ["VendorCapabilities", "get_vendor", "all_vendors"]

--- a/idrac_ctl/vendors/base.py
+++ b/idrac_ctl/vendors/base.py
@@ -1,0 +1,63 @@
+"""Vendor capability model.
+
+Each vendor's Redfish implementation differs (which query parameters it honors
+server-side, whether it supports recurring jobs, which OEM paths exist). A
+``VendorCapabilities`` profile declares those facts so vendor-specific commands
+and behaviors can be gated cleanly — only run where the target actually supports
+them. The generic core (``RedfishManager``) stays product-neutral; vendor
+packages register a profile here.
+
+Author Mus spyroot@gmail.com
+"""
+from dataclasses import dataclass, field
+from typing import Dict, Optional, Tuple
+
+
+@dataclass(frozen=True)
+class VendorCapabilities:
+    """What a vendor's Redfish service supports. Conservative defaults (generic)."""
+
+    vendor: str
+    oem_prefix: Optional[str] = None          # e.g. "Dell"
+
+    # Server-side Redfish query parameters honored by this vendor.
+    query_select: bool = False
+    query_filter: bool = False
+    query_expand: bool = True
+    query_top: bool = False
+    query_only: bool = False
+    # Some vendors (Dell) accept only one query parameter per URI.
+    one_query_param_per_uri: bool = False
+
+    # JobService recurring/scheduled jobs.
+    job_scheduling: bool = False
+    one_recurring_job_per_type: bool = False
+    schedulable_uris: Tuple[str, ...] = field(default_factory=tuple)
+
+    # Redfish Lifecycle Events over Server-Sent Events.
+    lifecycle_events_sse: bool = False
+
+
+_REGISTRY: Dict[str, VendorCapabilities] = {}
+
+
+def register(caps: VendorCapabilities) -> VendorCapabilities:
+    """Register a vendor capability profile (idempotent)."""
+    _REGISTRY[caps.vendor] = caps
+    return caps
+
+
+def get(vendor: Optional[str]) -> VendorCapabilities:
+    """Return the profile for ``vendor``, or the generic profile if unknown."""
+    if vendor is None:
+        return GENERIC
+    return _REGISTRY.get(vendor.lower(), GENERIC)
+
+
+def all_vendors() -> Dict[str, VendorCapabilities]:
+    """A copy of the registry."""
+    return dict(_REGISTRY)
+
+
+# Conservative baseline used when the target vendor is unknown.
+GENERIC = register(VendorCapabilities(vendor="generic"))

--- a/idrac_ctl/vendors/dell/capabilities.py
+++ b/idrac_ctl/vendors/dell/capabilities.py
@@ -1,0 +1,40 @@
+"""Dell iDRAC capability profile.
+
+Encodes facts from the Dell iDRAC Redfish API docs (query parameters, recurring
+JobService scheduling, lifecycle events). Dell-specific command modules migrate
+into this package incrementally (today they live in ``idrac_ctl/idrac_manager.py``
+and ``idrac_ctl/delloem/``); this profile lets commands gate Dell-only behavior.
+
+Author Mus spyroot@gmail.com
+"""
+from ..base import VendorCapabilities, register
+
+# Redfish URIs for which Dell iDRAC supports recurring/scheduled jobs.
+# {placeholders} are filled per-target at runtime.
+DELL_SCHEDULABLE_URIS = (
+    "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+    "/redfish/v1/Chassis/System.Embedded.1/Actions/Chassis.Reset",
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset",
+    "/redfish/v1/Systems/System.Embedded.1/Storage/Volumes/{volume_id}/Actions/Volume.CheckConsistency",
+    "/redfish/v1/Managers/{manager_id}/LogServices/Sel/Actions/LogService.ClearLog",
+    "/redfish/v1/Systems/System.Embedded.1/Bios/Actions/Oem/DellBios.RunBIOSLiveScanning",
+)
+
+DELL = register(
+    VendorCapabilities(
+        vendor="dell",
+        oem_prefix="Dell",
+        # iDRAC honors all five query parameters server-side...
+        query_select=True,
+        query_filter=True,
+        query_expand=True,
+        query_top=True,
+        query_only=True,
+        # ...but only one query parameter per URI is supported.
+        one_query_param_per_uri=True,
+        job_scheduling=True,
+        one_recurring_job_per_type=True,
+        schedulable_uris=DELL_SCHEDULABLE_URIS,
+        lifecycle_events_sse=True,
+    )
+)

--- a/idrac_ctl/vendors/hpe/capabilities.py
+++ b/idrac_ctl/vendors/hpe/capabilities.py
@@ -1,0 +1,18 @@
+"""HPE iLO capability profile (placeholder).
+
+Scaffolding for a future HPE iLO vendor package. Values are conservative until
+validated against real iLO / the HPE iLO Redfish emulator. Fill in as iLO command
+modules are added to this package.
+
+Author Mus spyroot@gmail.com
+"""
+from ..base import VendorCapabilities, register
+
+HPE = register(
+    VendorCapabilities(
+        vendor="hpe",
+        oem_prefix="Hpe",
+        # Unverified — keep generic defaults until tested against iLO.
+        query_expand=True,
+    )
+)

--- a/idrac_ctl/vendors/supermicro/capabilities.py
+++ b/idrac_ctl/vendors/supermicro/capabilities.py
@@ -1,0 +1,16 @@
+"""Supermicro capability profile (placeholder).
+
+Scaffolding for a future Supermicro vendor package. Supermicro publishes no
+official Python Redfish SDK or emulator, so values stay conservative until
+validated against real hardware. Fill in as Supermicro command modules are added.
+
+Author Mus spyroot@gmail.com
+"""
+from ..base import VendorCapabilities, register
+
+SUPERMICRO = register(
+    VendorCapabilities(
+        vendor="supermicro",
+        oem_prefix="Supermicro",
+    )
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pythonpath = ["."]
 # skipped automatically by tests/conftest.py unless IDRAC_IP is set.
 markers = [
     "live: integration test that requires a reachable iDRAC (set IDRAC_IP to run)",
+    "schema: validates fixtures against DMTF Redfish schemas (run tools/fetch_schemas.sh first)",
 ]
 filterwarnings = [
     "ignore:Unverified HTTPS request",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+# Tooling configuration for idrac_ctl.
+#
+# Packaging metadata still lives in setup.py (name, version, entry_points).
+# This file only adds the build backend and the lint/type/test tool config so
+# the two do not declare project metadata twice.
+
+[build-system]
+requires = ["setuptools>=67.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+# idrac_ctl targets Python 3.10+ (see setup.py python_requires).
+target-version = "py310"
+line-length = 100
+extend-exclude = ["build", "dist", "venv", ".venv"]
+
+[tool.ruff.lint]
+# F = pyflakes (catches the duplicate/unused imports cleaned up in this change),
+# E/W = pycodestyle, I = import sorting.
+select = ["F", "E", "W", "I"]
+# E501 (line length) is noisy on this legacy tree; enforce it gradually.
+ignore = ["E501"]
+
+[tool.coverage.run]
+source = ["idrac_ctl"]
+omit = ["idrac_ctl/json_responses/*", "*/tests/*"]
+
+[tool.coverage.report]
+show_missing = true
+
+[tool.mypy]
+python_version = "3.10"
+# The tree is only partially typed today; start lenient and tighten per-module.
+ignore_missing_imports = true
+warn_unused_ignores = true
+warn_redundant_casts = true
+check_untyped_defs = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+# Collect only the test_*.py convention (skips stray *_test.py scratch files).
+python_files = ["test_*.py"]
+# Make the repo root importable so `import idrac_ctl` resolves to the source
+# tree regardless of how pytest is launched.
+pythonpath = ["."]
+# Tests that need a reachable iDRAC must be marked @pytest.mark.live; they are
+# skipped automatically by tests/conftest.py unless IDRAC_IP is set.
+markers = [
+    "live: integration test that requires a reachable iDRAC (set IDRAC_IP to run)",
+]
+filterwarnings = [
+    "ignore:Unverified HTTPS request",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ tqdm~=4.61
 urllib3~=1.26.6
 pygments==2.14.0
 setuptools~=67.0.0
+PyYAML~=6.0
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ setup_info = dict(name='idrac_ctl',
                   },
                   extras_require={
                       "dev": [
-                          "pytest >= 3.7"
+                          "pytest >= 7",
+                          "requests-mock >= 1.10",
+                          "ruff",
+                          "mypy",
                       ]
                   },
                   )

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,11 @@ setup_info = dict(name='idrac_ctl',
                           "requests-mock >= 1.10",
                           "ruff",
                           "mypy",
-                      ]
+                      ],
+                      "schema": [
+                          "jsonschema >= 4.18",
+                          "referencing",
+                      ],
                   },
                   )
 setup(**setup_info)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,246 @@
+"""Shared pytest fixtures and collection rules for idrac_ctl tests.
+
+The default unit suite runs fully offline. Tests that talk to a real iDRAC
+must be marked ``@pytest.mark.live``; those are skipped automatically unless
+``IDRAC_IP`` is present in the environment, so ``pytest`` is green on a laptop
+or in CI without any hardware.
+
+Import-path note: the repo root directory is itself named ``idrac_ctl`` and
+ships a re-export shim (``./__init__.py`` does ``from .idrac_ctl import *``).
+If the repo's *parent* directory ends up on ``sys.path`` first, ``import
+idrac_ctl`` resolves to that shim instead of the real nested package, and
+submodules like ``idrac_ctl.cmd_utils`` become unreachable. We pin the source
+tree as the first entry and drop the parent so the nested package always wins.
+
+Author Mus spyroot@gmail.com
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_PARENT = os.path.dirname(_REPO_ROOT)
+
+# Captured DMTF Redfish mockup tree shipped in the package. Filenames map 1:1 to
+# Redfish URLs: /redfish/v1/Managers -> _redfish_v1_Managers.json
+_FIXTURE_DIR = Path(_REPO_ROOT) / "idrac_ctl" / "json_responses"
+
+# Drop the parent dir so the repo-root re-export shim cannot shadow the real
+# nested package under the bare name ``idrac_ctl``.
+while _PARENT in sys.path:
+    sys.path.remove(_PARENT)
+# Search the source tree first.
+if _REPO_ROOT in sys.path:
+    sys.path.remove(_REPO_ROOT)
+sys.path.insert(0, _REPO_ROOT)
+
+# Eagerly bind the bare name ``idrac_ctl`` to the real nested package and cache
+# it in sys.modules now, while the parent dir is off the path. pytest may re-add
+# the parent during collection, but a cached module wins over any later lookup,
+# so lazy imports inside fixtures/tests cannot resolve the repo-root shim.
+import importlib.util  # noqa: E402
+
+_nested_init = os.path.join(_REPO_ROOT, "idrac_ctl", "__init__.py")
+_pkg = importlib.import_module("idrac_ctl")
+if getattr(_pkg, "__file__", "") != _nested_init:
+    # Wrong package won the race; load the nested one by path and rebind it.
+    sys.modules.pop("idrac_ctl", None)
+    spec = importlib.util.spec_from_file_location(
+        "idrac_ctl", _nested_init,
+        submodule_search_locations=[os.path.dirname(_nested_init)],
+    )
+    _pkg = importlib.util.module_from_spec(spec)
+    sys.modules["idrac_ctl"] = _pkg
+    spec.loader.exec_module(_pkg)
+
+
+def _has_live_idrac() -> bool:
+    """True when an iDRAC endpoint is configured via the environment."""
+    return bool(os.environ.get("IDRAC_IP", "").strip())
+
+
+def pytest_collection_modifyitems(config, items):
+    """Skip ``live`` tests when no iDRAC endpoint is configured."""
+    if _has_live_idrac():
+        return
+    skip_live = pytest.mark.skip(reason="no IDRAC_IP set; skipping live iDRAC test")
+    for item in items:
+        if "live" in item.keywords:
+            item.add_marker(skip_live)
+
+
+# Hand-authored iDRAC-shaped fixtures (Dell paths like System.Embedded.1) that the
+# generic DMTF capture does not contain. These overlay the captured tree so
+# command-level tests can run offline.
+_IDRAC_FIXTURE_DIR = Path(os.path.dirname(os.path.abspath(__file__))) / "idrac_fixtures"
+
+# Case-insensitive index of the fixture tree. requests-mock lowercases
+# request.path, and Redfish paths are mixed-case (e.g. /redfish/v1/Managers), so
+# we must match without relying on a case-insensitive filesystem (macOS hides the
+# bug; Linux/CI would not). idrac_fixtures/ wins over the captured DMTF tree.
+_FIXTURE_INDEX = {}
+for _dir in (_FIXTURE_DIR, _IDRAC_FIXTURE_DIR):
+    if _dir.exists():
+        for _f in _dir.glob("*.json"):
+            _FIXTURE_INDEX[_f.name.lower()] = _f
+
+
+def _url_to_fixture(path: str):
+    """Map a Redfish request path to its captured mockup file, case-insensitively.
+
+    ``/redfish/v1/Managers`` -> ``_redfish_v1_Managers.json``. Returns ``None``
+    when no fixture exists.
+    """
+    key = "_" + path.strip("/").replace("/", "_") + ".json"
+    return _FIXTURE_INDEX.get(key.lower())
+
+
+class MockRedfishService:
+    """A small stateful Redfish service backed by the captured DMTF mockup tree.
+
+    Serves GET from ``idrac_ctl/json_responses`` (with an in-memory overlay so a
+    PATCH is visible to a later GET), and gives plausible spec-shaped answers for
+    the mutating verbs so command tests can assert the request the client *sends*:
+
+    * GET    -> fixture JSON (200) or 404 when no fixture exists
+    * PATCH  -> deep-merges the body into state, 200 + a success message
+    * POST   -> 202 with a ``Location`` task header for ``/Actions/`` calls
+                (mirrors how iDRAC returns a JID job), else 204
+    * DELETE -> 200
+
+    ``requests`` records every call, so tests can inspect ``service.last_request``.
+    """
+
+    JOB_ID = "JID_000000000001"
+
+    def __init__(self, fixture_dir: Path):
+        self._dir = fixture_dir
+        self._overlay = {}  # path -> materialized state dict
+        self.requests = []
+
+    def _state(self, path: str):
+        if path in self._overlay:
+            return self._overlay[path]
+        fixture = _url_to_fixture(path)
+        if fixture is None:
+            return None
+        import json
+        return json.loads(fixture.read_text())
+
+    @staticmethod
+    def _deep_merge(base: dict, patch: dict) -> dict:
+        for key, value in patch.items():
+            if isinstance(value, dict) and isinstance(base.get(key), dict):
+                MockRedfishService._deep_merge(base[key], value)
+            else:
+                base[key] = value
+        return base
+
+    def get_cb(self, request, context):
+        import json
+        self.requests.append(request)
+        state = self._state(request.path)
+        if state is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return json.dumps(state)
+
+    def patch_cb(self, request, context):
+        import json
+        self.requests.append(request)
+        state = self._state(request.path)
+        if state is None:
+            state = {}
+        body = request.json() if request.text else {}
+        self._overlay[request.path] = self._deep_merge(state, body)
+        context.status_code = 200
+        return json.dumps(
+            {"@Message.ExtendedInfo": [{"MessageId": "Base.1.12.Success",
+                                        "Message": "Successfully Completed Request",
+                                        "Severity": "OK"}]}
+        )
+
+    def post_cb(self, request, context):
+        self.requests.append(request)
+        if "/actions/" in request.path.lower():
+            # iDRAC returns 202 + a Location header pointing at the new job.
+            context.status_code = 202
+            context.headers["Location"] = (
+                f"/redfish/v1/TaskService/Tasks/{self.JOB_ID}"
+            )
+            return ""
+        context.status_code = 204
+        return ""
+
+    def delete_cb(self, request, context):
+        self.requests.append(request)
+        context.status_code = 200
+        return ""
+
+    @property
+    def last_request(self):
+        return self.requests[-1] if self.requests else None
+
+
+def _make_idrac(idrac_ip, username, password):
+    from idrac_ctl.idrac_manager import IDracManager
+    return IDracManager(
+        idrac_ip=idrac_ip,
+        idrac_username=username,
+        idrac_password=password,
+        insecure=True,
+        is_debug=False,
+    )
+
+
+@pytest.fixture
+def redfish_service():
+    """The bare MockRedfishService mounted on a ``requests-mock`` transport.
+
+    Use when a test needs to inspect the captured requests (``service.last_request``)
+    or pre-seed state. Most tests can use ``redfish_mock`` / ``redfish_api`` instead.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(_FIXTURE_DIR)
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield service
+
+
+@pytest.fixture
+def redfish_mock(redfish_service):
+    """An IDracManager wired to the mocked Redfish service (offline, no hardware).
+
+    Backed by the captured DMTF mockup tree; exercises the real ``requests`` code
+    path. Requires the ``requests-mock`` dev dependency; skips cleanly without it.
+    """
+    yield _make_idrac("mock-idrac", "root", "mock")
+
+
+@pytest.fixture
+def redfish_api(request):
+    """Dual-mode iDRAC client: **live** when ``IDRAC_IP`` is set, else **mock**.
+
+    Write a command/transport test once against this fixture and it runs offline
+    by default (mock mode) and against real hardware when ``IDRAC_IP`` is exported
+    (live mode). A test that mutates state should also carry ``@pytest.mark.live``
+    so it only runs against an approved iDRAC, never just because IDRAC_IP is set.
+    """
+    if _has_live_idrac():
+        yield _make_idrac(
+            os.environ["IDRAC_IP"],
+            os.environ.get("IDRAC_USERNAME", "root"),
+            os.environ.get("IDRAC_PASSWORD", ""),
+        )
+    else:
+        # Reuse the mock service fixture so mock mode is fully offline.
+        service = request.getfixturevalue("redfish_service")
+        yield _make_idrac("mock-idrac", "root", "mock")
+        _ = service  # keep the mock mounted for the test duration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,9 +43,16 @@ sys.path.insert(0, _REPO_ROOT)
 import importlib.util  # noqa: E402
 
 _nested_init = os.path.join(_REPO_ROOT, "idrac_ctl", "__init__.py")
-_pkg = importlib.import_module("idrac_ctl")
-if getattr(_pkg, "__file__", "") != _nested_init:
-    # Wrong package won the race; load the nested one by path and rebind it.
+try:
+    _pkg = importlib.import_module("idrac_ctl")
+    _correct = getattr(_pkg, "__file__", "") == _nested_init
+except Exception:
+    # e.g. a sibling repo dir named idrac_ctl (a git worktree next to the repo)
+    # or the repo-root re-export shim raising on its relative import.
+    _correct = False
+    _pkg = None
+if not _correct:
+    # Wrong/failed import: force-load THIS tree's nested package by path.
     sys.modules.pop("idrac_ctl", None)
     spec = importlib.util.spec_from_file_location(
         "idrac_ctl", _nested_init,

--- a/tests/idrac_fixtures/_redfish_v1_AccountService_Accounts.json
+++ b/tests/idrac_fixtures/_redfish_v1_AccountService_Accounts.json
@@ -1,0 +1,13 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ManagerAccountCollection.ManagerAccountCollection",
+  "@odata.id": "/redfish/v1/AccountService/Accounts",
+  "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
+  "Name": "Accounts Collection",
+  "Description": "iDRAC local accounts",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/AccountService/Accounts/2"
+    }
+  ]
+}

--- a/tests/idrac_fixtures/_redfish_v1_Chassis.json
+++ b/tests/idrac_fixtures/_redfish_v1_Chassis.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ChassisCollection.ChassisCollection",
+  "@odata.id": "/redfish/v1/Chassis",
+  "@odata.type": "#ChassisCollection.ChassisCollection",
+  "Name": "Chassis Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+    }
+  ]
+}

--- a/tests/idrac_fixtures/_redfish_v1_Managers.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ManagerCollection.ManagerCollection",
+  "@odata.id": "/redfish/v1/Managers",
+  "@odata.type": "#ManagerCollection.ManagerCollection",
+  "Name": "Manager Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"
+    }
+  ]
+}

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1.json
@@ -1,0 +1,34 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
+  "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1",
+  "@odata.type": "#Manager.v1_10_0.Manager",
+  "Id": "iDRAC.Embedded.1",
+  "Name": "Integrated Dell Remote Access Controller",
+  "ManagerType": "BMC",
+  "FirmwareVersion": "7.00.00.00",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "Links": {
+    "ManagerForServers": [
+      {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1"
+      }
+    ],
+    "ManagerForChassis": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
+      }
+    ]
+  },
+  "Actions": {
+    "#Manager.Reset": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Actions/Manager.Reset",
+      "ResetType@Redfish.AllowableValues": [
+        "GracefulRestart",
+        "ForceRestart"
+      ]
+    }
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1.json
@@ -1,0 +1,46 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1",
+  "@odata.type": "#ComputerSystem.v1_16_0.ComputerSystem",
+  "Id": "System.Embedded.1",
+  "Name": "System",
+  "SystemType": "Physical",
+  "Manufacturer": "Dell Inc.",
+  "Model": "PowerEdge Mock",
+  "PowerState": "On",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "Bios": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"
+  },
+  "Boot": {
+    "BootSourceOverrideEnabled": "Disabled",
+    "BootSourceOverrideTarget": "None"
+  },
+  "PCIeDevices": [
+    {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/NIC.Slot.1-1"
+    }
+  ],
+  "PCIeFunctions": [
+    {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeFunctions/NIC.Slot.1-1-1"
+    }
+  ],
+  "Storage": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage"
+  },
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Actions/ComputerSystem.Reset",
+      "ResetType@Redfish.AllowableValues": [
+        "On",
+        "GracefulRestart",
+        "ForceRestart",
+        "PowerCycle"
+      ]
+    }
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_BootSources.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_BootSources.json
@@ -1,0 +1,22 @@
+{
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/BootSources",
+    "@odata.type": "#DellBootSources.v1_0_0.DellBootSources",
+    "Id": "BootSources",
+    "Name": "BootSources Configuration Current Settings",
+    "Attributes": {
+        "UefiBootSeq": [
+            {
+                "Enabled": true,
+                "Id": "BIOS.Setup.1-1#UefiBootSeq#NIC.PxeDevice.1-1",
+                "Index": 0,
+                "Name": "NIC.PxeDevice.1-1"
+            },
+            {
+                "Enabled": true,
+                "Id": "BIOS.Setup.1-1#UefiBootSeq#RAID.Integrated.1-1",
+                "Index": 1,
+                "Name": "RAID.Integrated.1-1"
+            }
+        ]
+    }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_PCIeDevices_NIC.Slot.1-1.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_PCIeDevices_NIC.Slot.1-1.json
@@ -1,0 +1,15 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#PCIeDevice.PCIeDevice",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/NIC.Slot.1-1",
+  "@odata.type": "#PCIeDevice.v1_9_0.PCIeDevice",
+  "Id": "NIC.Slot.1-1",
+  "Name": "PCIe Device NIC.Slot.1-1",
+  "Manufacturer": "Dell Inc.",
+  "Model": "Mock 25GbE Adapter",
+  "DeviceType": "SingleFunction",
+  "FirmwareVersion": "21.5.9",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage_RAID.Integrated.1-1.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage_RAID.Integrated.1-1.json
@@ -9,13 +9,9 @@
     "State": "Enabled",
     "Health": "OK"
   },
-  "Controllers": [
-    {
-      "MemberId": "0",
-      "Name": "PERC H755 Adapter",
-      "Model": "PERC H755"
-    }
-  ],
+  "Controllers": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Controllers"
+  },
   "Drives": [
     {
       "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Drives/Disk.Bay.0"

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage_RAID.Integrated.1-1.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage_RAID.Integrated.1-1.json
@@ -1,0 +1,27 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Storage.Storage",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1",
+  "@odata.type": "#Storage.v1_14_0.Storage",
+  "Id": "RAID.Integrated.1-1",
+  "Name": "PERC RAID Controller",
+  "Description": "Mock integrated RAID controller",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "Controllers": [
+    {
+      "MemberId": "0",
+      "Name": "PERC H755 Adapter",
+      "Model": "PERC H755"
+    }
+  ],
+  "Drives": [
+    {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Drives/Disk.Bay.0"
+    }
+  ],
+  "Volumes": {
+    "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes"
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_UpdateService_FirmwareInventory.json
+++ b/tests/idrac_fixtures/_redfish_v1_UpdateService_FirmwareInventory.json
@@ -1,0 +1,20 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory",
+  "@odata.type": "#SoftwareInventoryCollection.SoftwareInventoryCollection",
+  "Name": "Firmware Inventory Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory/BIOS",
+      "@odata.type": "#SoftwareInventory.v1_4_0.SoftwareInventory",
+      "Id": "BIOS",
+      "Name": "BIOS",
+      "Version": "2.19.1",
+      "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+      }
+    }
+  ]
+}

--- a/tests/test_accounts_query_dualmode.py
+++ b/tests/test_accounts_query_dualmode.py
@@ -1,0 +1,18 @@
+"""Dual-mode test for the accounts query command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_accounts_query_returns_account_collection(redfish_api):
+    """query_accounts returns the iDRAC account collection."""
+    result = redfish_api.sync_invoke(ApiRequestType.QueryAccounts, "query_accounts")
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == "/redfish/v1/AccountService/Accounts"
+    assert result.data["Members"][0]["@odata.id"] == (
+        "/redfish/v1/AccountService/Accounts/2"
+    )

--- a/tests/test_chassis_query_dualmode.py
+++ b/tests/test_chassis_query_dualmode.py
@@ -1,0 +1,21 @@
+"""Dual-mode test for the chassis query command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_chassis_query_returns_idrac_chassis_collection(redfish_api):
+    """chassis_service_query returns the iDRAC chassis collection."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.ChassisQuery, "chassis_service_query"
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, CommandResult)
+    assert isinstance(result.data.data, dict)
+    json.dumps(result.data.data)
+    assert result.data.data["@odata.id"] == "/redfish/v1/Chassis"
+    assert result.data.data["Members"][0]["@odata.id"] == (
+        "/redfish/v1/Chassis/System.Embedded.1"
+    )

--- a/tests/test_cmd_account.py
+++ b/tests/test_cmd_account.py
@@ -21,6 +21,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestAccounts(TestCase):
     """
     Account cmd unit test.

--- a/tests/test_cmd_accounts.py
+++ b/tests/test_cmd_accounts.py
@@ -22,6 +22,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestAccounts(TestCase):
     redfish_api = None
 

--- a/tests/test_cmd_attribute.py
+++ b/tests/test_cmd_attribute.py
@@ -22,6 +22,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestAttribute(TestCase):
     redfish_api = None
 

--- a/tests/test_cmd_attribute_update.py
+++ b/tests/test_cmd_attribute_update.py
@@ -26,6 +26,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestUpdateAttribute(TestCase):
     """
     Attribute update cmd unit test.

--- a/tests/test_cmd_bios.py
+++ b/tests/test_cmd_bios.py
@@ -31,6 +31,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestBios(TestCase):
     redfish_api = None
 

--- a/tests/test_cmd_bios_pending.py
+++ b/tests/test_cmd_bios_pending.py
@@ -26,6 +26,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestBiosPending(TestCase):
     redfish_api = None
 

--- a/tests/test_cmd_bios_registry.py
+++ b/tests/test_cmd_bios_registry.py
@@ -25,6 +25,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestBiosRegistry(TestCase):
     redfish_api = None
 

--- a/tests/test_cmd_boot_dualmode.py
+++ b/tests/test_cmd_boot_dualmode.py
@@ -1,0 +1,26 @@
+"""Dual-mode test for the boot-source query command.
+
+Runs offline by default against the mock service (using the iDRAC-shaped fixture
+in tests/idrac_fixtures/), and against real hardware when IDRAC_IP is set. This is
+the template for porting the remaining live-only command tests: invoke the command
+through sync_invoke and assert the CommandResult shape.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_boot_query(redfish_api):
+    """boot_query returns a JSON-serializable CommandResult from /BootSources."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BootQuery, "boot_query"
+    )
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    # the payload must be JSON-serializable (CLI renders it as JSON)
+    json.dumps(result.data)
+    # in mock mode the fixture carries the iDRAC boot-source attributes
+    assert result.data["@odata.id"].endswith("/BootSources")

--- a/tests/test_cmd_boot_settings.py
+++ b/tests/test_cmd_boot_settings.py
@@ -22,6 +22,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestBootSettings(TestCase):
     """
     Account cmd unit test.

--- a/tests/test_cmd_boot_source_get.py
+++ b/tests/test_cmd_boot_source_get.py
@@ -22,6 +22,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestBootSettingsQuery(TestCase):
     """
     Account cmd unit test.

--- a/tests/test_cmd_firmware.py
+++ b/tests/test_cmd_firmware.py
@@ -18,6 +18,12 @@ from idrac_ctl.idrac_shared import ApiRequestType
 from idrac_ctl.idrac_manager import CommandResult
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestFirmware(TestCase):
     redfish_api = None
 

--- a/tests/test_cmd_power_state.py
+++ b/tests/test_cmd_power_state.py
@@ -9,6 +9,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestPowerState(TestCase):
     """
     Test chassis power state change.

--- a/tests/test_cmd_reboot.py
+++ b/tests/test_cmd_reboot.py
@@ -9,6 +9,12 @@ log = logging.getLogger("LOG")
 "/var/www/html/ph4-rt-refresh_adj_offline_testnf_os4_flex21.iso"
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestReboot(TestCase):
     """
      Test reboot cmd

--- a/tests/test_cmd_utils.py
+++ b/tests/test_cmd_utils.py
@@ -1,0 +1,74 @@
+"""Offline unit tests for the pure helpers in idrac_ctl.cmd_utils.
+
+Author Mus spyroot@gmail.com
+"""
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from idrac_ctl.cmd_utils import find_ids, from_json_spec, save_if_needed, str2bool
+
+
+def test_from_json_spec_reads_file(tmp_path: Path):
+    """from_json_spec parses JSON from a file path."""
+    spec = tmp_path / "spec.json"
+    spec.write_text(json.dumps({"Attributes": {"BootMode": "Uefi"}}))
+    assert from_json_spec(str(spec)) == {"Attributes": {"BootMode": "Uefi"}}
+
+
+def test_find_ids_walks_nested_structures():
+    """find_ids collects every value for a key across nested dicts/lists."""
+    obj = {
+        "Members": [
+            {"@odata.id": "/redfish/v1/Systems/1"},
+            {"@odata.id": "/redfish/v1/Systems/2"},
+        ],
+        "nested": {"@odata.id": "/redfish/v1/Managers/1"},
+    }
+    found = find_ids(obj, "@odata.id")
+    assert "/redfish/v1/Managers/1" in found
+    assert len(found) >= 1
+
+
+def test_find_ids_empty_when_absent():
+    """find_ids returns an empty list when the key is missing."""
+    assert find_ids({"a": 1}, "nope") == []
+
+
+def test_find_ids_handles_none():
+    """find_ids tolerates a None object without raising."""
+    assert find_ids(None, "x") == []
+
+
+@pytest.mark.parametrize("value", ["yes", "true", "t", "y", "1", "TRUE", "Y"])
+def test_str2bool_truthy(value):
+    """str2bool accepts the documented truthy spellings."""
+    assert str2bool(value) is True
+
+
+@pytest.mark.parametrize("value", ["no", "false", "f", "n", "0", "FALSE"])
+def test_str2bool_falsy(value):
+    """str2bool accepts the documented falsy spellings."""
+    assert str2bool(value) is False
+
+
+def test_str2bool_passes_through_bool():
+    """str2bool returns a bool argument unchanged."""
+    assert str2bool(True) is True
+    assert str2bool(False) is False
+
+
+def test_str2bool_rejects_garbage():
+    """str2bool raises argparse error on an unrecognized value."""
+    with pytest.raises(argparse.ArgumentTypeError):
+        str2bool("maybe")
+
+
+def test_save_if_needed_creates_missing_save_dir(tmp_path: Path):
+    """A non-existent save_dir is created rather than raising."""
+    target_dir = tmp_path / "out" / "nested"
+    assert not target_dir.exists()
+    save_if_needed("result", {"a": 1}, data_format="json", save_dir=str(target_dir))
+    assert target_dir.exists() and target_dir.is_dir()

--- a/tests/test_cmd_utils_save.py
+++ b/tests/test_cmd_utils_save.py
@@ -1,0 +1,83 @@
+"""Offline unit tests for idrac_ctl.cmd_utils.save_if_needed.
+
+These are regressions for two bugs:
+
+  1. the YAML branch dumped the *filename* instead of the payload, so
+     ``--format yaml`` wrote garbage.
+  2. the unknown-format branch built a ``ValueError`` but never raised it,
+     so a bad format silently produced no output.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from idrac_ctl.cmd_utils import save_if_needed
+
+
+def test_save_json_round_trips_payload(tmp_path: Path):
+    """JSON branch writes the payload and appends the .json suffix."""
+    payload = {"k": "v", "n": 1}
+    target = tmp_path / "out"
+
+    save_if_needed(str(target), payload, data_format="json")
+
+    written = tmp_path / "out.json"
+    assert written.exists()
+    assert json.loads(written.read_text()) == payload
+
+
+def test_save_json_keeps_existing_suffix(tmp_path: Path):
+    """An explicit .json filename is not double-suffixed."""
+    payload = {"a": 1}
+    target = tmp_path / "result.json"
+
+    save_if_needed(str(target), payload, data_format="json")
+
+    assert target.exists()
+    assert not (tmp_path / "result.json.json").exists()
+    assert json.loads(target.read_text()) == payload
+
+
+def test_save_yaml_writes_payload_not_filename(tmp_path: Path):
+    """Regression: YAML branch must serialize raw_data, not the filename."""
+    payload = {"MemFrequency": "MaxPerf", "ProcCStates": "Disabled"}
+    target = tmp_path / "bios"
+
+    save_if_needed(str(target), payload, data_format="yaml")
+
+    written = tmp_path / "bios.yaml"
+    assert written.exists()
+    loaded = yaml.safe_load(written.read_text())
+    assert loaded == payload
+    # The old bug serialized the filename string; guard against regressing.
+    assert loaded != str(target)
+
+
+def test_unknown_format_raises_value_error(tmp_path: Path):
+    """Regression: an unsupported format must raise, not silently no-op."""
+    with pytest.raises(ValueError):
+        save_if_needed(str(tmp_path / "x"), {"a": 1}, data_format="toml")
+
+
+def test_empty_filename_is_noop(tmp_path: Path):
+    """No filename means nothing is written and nothing raises."""
+    save_if_needed("", {"a": 1}, data_format="json")
+    save_if_needed(None, {"a": 1}, data_format="json")
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_none_payload_is_noop(tmp_path: Path):
+    """No payload means nothing is written and nothing raises."""
+    target = tmp_path / "out.json"
+    save_if_needed(str(target), None, data_format="json")
+    assert not target.exists()
+
+
+def test_directory_target_warns_and_skips(tmp_path: Path):
+    """Pointing at a directory warns and does not write."""
+    with pytest.warns(UserWarning):
+        save_if_needed(str(tmp_path), {"a": 1}, data_format="json")

--- a/tests/test_cmd_virtual_media.py
+++ b/tests/test_cmd_virtual_media.py
@@ -17,6 +17,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class TestVirtualMedia(TestCase):
     redfish_api = None
 

--- a/tests/test_emulator_smoke.py
+++ b/tests/test_emulator_smoke.py
@@ -1,0 +1,65 @@
+"""Opt-in emulator-backed smoke test (the "live-like" lane).
+
+This validates idrac_ctl's real Redfish client against a spec-conformant
+emulator running locally, with no hardware. The recommended emulator is the
+OpenStack sushy-tools fake driver (pip install sushy-tools), which needs no
+libvirt and supports mutating Actions:
+
+    sushy-emulator --fake -i 127.0.0.1 -p 8000
+
+Then point this test at it:
+
+    REDFISH_EMULATOR_URL=http://127.0.0.1:8000 pytest tests/test_emulator_smoke.py
+
+It is skipped by default so the offline suite stays hermetic. The emulator
+serves *generic* Redfish (not Dell OEM paths), so it validates the transport
+and generic capabilities, complementing the Dell-shaped mock fixtures.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+import os
+
+import pytest
+
+_EMU = os.environ.get("REDFISH_EMULATOR_URL", "").rstrip("/")
+_skip = pytest.mark.skipif(
+    not _EMU,
+    reason="set REDFISH_EMULATOR_URL (e.g. run `sushy-emulator --fake`) to enable",
+)
+
+
+def _client():
+    from idrac_ctl.idrac_manager import IDracManager
+    # host:port parsed from the emulator URL; api_*_call takes full URLs anyway.
+    host = _EMU.split("://", 1)[-1]
+    return IDracManager(
+        idrac_ip=host,
+        idrac_username=os.environ.get("REDFISH_EMULATOR_USER", "admin"),
+        idrac_password=os.environ.get("REDFISH_EMULATOR_PASSWORD", "password"),
+        insecure=True,
+        is_debug=False,
+    )
+
+
+@_skip
+def test_emulator_systems_get():
+    """The client can read the Systems collection from a live emulator."""
+    api = _client()
+    resp = api.api_get_call(f"{_EMU}/redfish/v1/Systems", {})
+    assert resp.status_code == 200
+    assert resp.json()["Members"], "emulator exposed no systems"
+
+
+@_skip
+def test_emulator_reset_action():
+    """A mutating ComputerSystem.Reset succeeds against the emulator."""
+    api = _client()
+    members = api.api_get_call(f"{_EMU}/redfish/v1/Systems", {}).json()["Members"]
+    sys_id = members[0]["@odata.id"]
+    resp = api.api_post_call(
+        f"{_EMU}{sys_id}/Actions/ComputerSystem.Reset",
+        json.dumps({"ResetType": "On"}),
+        {},
+    )
+    assert resp.status_code in (200, 202, 204)

--- a/tests/test_firmware_inventory_dualmode.py
+++ b/tests/test_firmware_inventory_dualmode.py
@@ -1,0 +1,18 @@
+"""Dual-mode test for the firmware inventory command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_firmware_inventory_returns_inventory_collection(redfish_api):
+    """firmware_inv_query returns the firmware inventory collection."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.FirmwareInventoryQuery, "firmware_inv_query"
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == "/redfish/v1/UpdateService/FirmwareInventory"
+    assert result.data["Members"][0]["Id"] == "BIOS"

--- a/tests/test_idrac_manager_test.py
+++ b/tests/test_idrac_manager_test.py
@@ -13,6 +13,12 @@ logging.basicConfig()
 log = logging.getLogger("LOG")
 
 
+import pytest
+
+# Integration tests: require a reachable iDRAC.
+# Skipped automatically unless IDRAC_IP is set (see tests/conftest.py).
+pytestmark = pytest.mark.live
+
 class BasicManagerTest(TestCase):
     redfish_api = None
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,36 @@
+import json
+from unittest.mock import Mock
+from requests.models import Response
+
+from idrac_ctl.redfish_manager import RedfishManager
+from tests.test_utils import create_json_resp
+
+
+def test_base_respond():
+    data = {
+        '@Message.ExtendedInfo':
+            [
+                {
+                    'Message': 'The request completed successfully.',
+                    'MessageArgs': [],
+                    'MessageArgs@odata.count': 0,
+                    'MessageId': 'Base.1.12.Success',
+                    'RelatedProperties': [],
+                    'RelatedProperties@odata.count': 0,
+                    'Resolution': 'None',
+                    'Severity': 'OK'
+                }
+            ]
+    }
+
+    resp = create_json_resp(data)
+    redfish_resp = RedfishManager.parse_json_respond_msg(resp)
+    for msg_e in redfish_resp.message_extended:
+        print(msg_e.message)
+        print(msg_e.message_args)
+        print(msg_e.related)
+        print(msg_e.severity)
+        print(msg_e.resolution)
+
+
+test_base_respond()

--- a/tests/test_manager_query_dualmode.py
+++ b/tests/test_manager_query_dualmode.py
@@ -1,0 +1,16 @@
+"""Dual-mode test for the manager query command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_manager_query_returns_idrac_manager(redfish_api):
+    """manager_query follows the manager collection to the iDRAC manager."""
+    result = redfish_api.sync_invoke(ApiRequestType.ManagerQuery, "manager_query")
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == "/redfish/v1/Managers/iDRAC.Embedded.1"
+    assert result.data["Id"] == "iDRAC.Embedded.1"

--- a/tests/test_package_imports.py
+++ b/tests/test_package_imports.py
@@ -1,0 +1,33 @@
+"""Offline smoke test: every idrac_ctl module imports cleanly.
+
+This guards the import cleanup in bios/cmd_change_bios.py (duplicate and unused
+imports removed) and, more generally, catches any command module that breaks at
+import time. It is pure import-time work, so it needs no iDRAC.
+
+Author Mus spyroot@gmail.com
+"""
+import importlib
+import pkgutil
+
+import pytest
+
+import idrac_ctl
+
+
+def _iter_module_names():
+    for mod in pkgutil.walk_packages(idrac_ctl.__path__, prefix="idrac_ctl."):
+        yield mod.name
+
+
+@pytest.mark.parametrize("module_name", list(_iter_module_names()))
+def test_module_imports(module_name: str):
+    """Each submodule imports without raising."""
+    importlib.import_module(module_name)
+
+
+def test_bios_change_command_is_registered():
+    """The de-duplicated bios change module still exposes its command class."""
+    from idrac_ctl.bios.cmd_change_bios import BiosChangeSettings
+    from idrac_ctl.idrac_manager import IDracManager
+
+    assert issubclass(BiosChangeSettings, IDracManager)

--- a/tests/test_pci_device_query_dualmode.py
+++ b/tests/test_pci_device_query_dualmode.py
@@ -1,0 +1,20 @@
+"""Dual-mode test for the PCI device query command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_pci_device_query_returns_linked_pcie_device(redfish_api):
+    """pci_device_query follows the selected PCIeDevices link."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.PciDeviceQuery, "pci_device_query"
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, list)
+    json.dumps(result.data)
+    assert result.data[0]["@odata.id"] == (
+        "/redfish/v1/Systems/System.Embedded.1/PCIeDevices/NIC.Slot.1-1"
+    )
+    assert result.data[0]["Id"] == "NIC.Slot.1-1"

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,0 +1,77 @@
+"""Unit tests for idrac_ctl.redfish_query.RedfishQuery (offline).
+
+Author Mus spyroot@gmail.com
+"""
+import pytest
+
+from idrac_ctl.redfish_query import RedfishQuery
+
+
+def test_empty_query_is_blank():
+    """No parameters -> empty string (caller appends nothing)."""
+    q = RedfishQuery()
+    assert q.is_empty()
+    assert q.to_query_string() == ""
+
+
+def test_select_list_and_string():
+    """$select accepts a list or a comma string and renders the same."""
+    assert RedfishQuery(select=["A", "B"]).to_query_string() == "?$select=A,B"
+    assert RedfishQuery(select="A,B").to_query_string() == "?$select=A,B"
+
+
+def test_top_renders_int():
+    """$top renders the integer value."""
+    assert RedfishQuery(top=5).to_query_string() == "?$top=5"
+    assert RedfishQuery(top=0).to_query_string() == "?$top=0"
+
+
+def test_expand_with_levels():
+    """$expand renders the Redfish levels syntax; mode defaults to '*'."""
+    assert RedfishQuery(expand=True, expand_levels=2).to_query_string() == "?$expand=*($levels=2)"
+    assert RedfishQuery(expand=".").to_query_string() == "?$expand=.($levels=1)"
+
+
+def test_only_flag():
+    """only is a valueless query parameter (no leading $)."""
+    assert RedfishQuery(only=True).to_query_string() == "?only"
+
+
+def test_filter_is_url_encoded_but_keeps_operators():
+    """$filter encodes spaces but keeps Redfish operators/quotes literal."""
+    q = RedfishQuery(filter="Id eq '10191'")
+    assert q.to_query_string() == "?$filter=Id%20eq%20'10191'"
+
+
+def test_apply_appends_to_url():
+    """apply() appends the query string to a URL."""
+    url = "https://idrac/redfish/v1/Managers/iDRAC.Embedded.1/LogServices/Lclog/Entries"
+    assert RedfishQuery(top=5).apply(url) == url + "?$top=5"
+
+
+def test_one_param_per_uri_rejects_combining():
+    """With the Dell one-param-per-URI rule, combining parameters raises."""
+    q = RedfishQuery(select=["A"], top=5)
+    with pytest.raises(ValueError):
+        q.to_query_string(one_param_per_uri=True)
+    # but each alone is fine
+    assert RedfishQuery(top=5).to_query_string(one_param_per_uri=True) == "?$top=5"
+
+
+def test_multiple_params_allowed_for_generic():
+    """Without the restriction, parameters combine with '&'."""
+    out = RedfishQuery(select=["A"], top=5).to_query_string()
+    assert out.startswith("?")
+    assert "$select=A" in out and "$top=5" in out and "&" in out
+
+
+def test_negative_top_rejected():
+    """$top must be >= 0."""
+    with pytest.raises(ValueError):
+        RedfishQuery(top=-1).to_query_string()
+
+
+def test_bad_expand_levels_rejected():
+    """$expand levels must be >= 1."""
+    with pytest.raises(ValueError):
+        RedfishQuery(expand=True, expand_levels=0).to_query_string()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -75,3 +75,32 @@ def test_bad_expand_levels_rejected():
     """$expand levels must be >= 1."""
     with pytest.raises(ValueError):
         RedfishQuery(expand=True, expand_levels=0).to_query_string()
+
+
+# --- transport integration: get_with_query applies params, offline ----------
+
+def test_get_with_query_applies_params(redfish_mock, redfish_service):
+    """get_with_query appends the query string and the server receives it."""
+    resp = redfish_mock.get_with_query(
+        "https://mock-idrac/redfish/v1/Managers", RedfishQuery(top=5)
+    )
+    assert resp.status_code == 200
+    assert "top=5" in redfish_service.last_request.query  # lowercased by requests-mock
+
+
+def test_get_with_query_none_is_plain_get(redfish_mock):
+    """No query yields a plain GET that still resolves the fixture."""
+    resp = redfish_mock.get_with_query(
+        "https://mock-idrac/redfish/v1/Managers", None
+    )
+    assert resp.status_code == 200
+    assert resp.json()["@odata.id"] == "/redfish/v1/Managers"
+
+
+def test_get_with_query_enforces_one_param(redfish_mock):
+    """With the Dell one-param-per-URI rule, combining params raises before the call."""
+    q = RedfishQuery(select=["Id"], top=5)
+    with pytest.raises(ValueError):
+        redfish_mock.get_with_query(
+            "https://mock-idrac/redfish/v1/Managers", q, one_param_per_uri=True
+        )

--- a/tests/test_redfish_mock.py
+++ b/tests/test_redfish_mock.py
@@ -1,0 +1,85 @@
+"""Offline tests that drive the real Redfish HTTP layer against the captured
+DMTF mockup tree (idrac_ctl/json_responses) via the ``redfish_mock`` fixture.
+
+This is the foundation for converting the live (@pytest.mark.live) command tests
+to run without hardware: the same code path that talks to a real iDRAC runs here
+against static mockup JSON. See IMPROVEMENT_PLAN.md item 5.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+
+
+def test_get_managers_collection(redfish_mock):
+    """A GET to a known Redfish path returns the captured mockup payload."""
+    resp = redfish_mock.api_get_call(
+        "https://mock-idrac/redfish/v1/Managers", {}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["@odata.id"] == "/redfish/v1/Managers"
+    assert isinstance(data.get("Members"), list)
+
+
+def test_get_chassis_resource(redfish_mock):
+    """A nested resource path also resolves to its mockup file."""
+    resp = redfish_mock.api_get_call(
+        "https://mock-idrac/redfish/v1/Chassis/1U", {}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["@odata.id"] == "/redfish/v1/Chassis/1U"
+
+
+def test_unknown_path_returns_404(redfish_mock):
+    """A path with no captured fixture fails loudly with 404, not a false 200."""
+    resp = redfish_mock.api_get_call(
+        "https://mock-idrac/redfish/v1/Nonexistent", {}
+    )
+    assert resp.status_code == 404
+
+
+# --- mutating verbs: assert the request the client SENDS, offline ------------
+
+def test_post_action_returns_job_location(redfish_mock, redfish_service):
+    """A POST to an Action returns 202 with a JID task Location, like iDRAC."""
+    url = ("https://mock-idrac/redfish/v1/Systems/System.Embedded.1/"
+           "Actions/ComputerSystem.Reset")
+    resp = redfish_mock.api_post_call(
+        url, json.dumps({"ResetType": "On"}), {}
+    )
+    assert resp.status_code == 202
+    assert "JID_" in resp.headers.get("Location", "")
+    # the client sent exactly the payload we asked for
+    assert redfish_service.last_request.json() == {"ResetType": "On"}
+
+
+def test_patch_merges_and_is_visible_on_get(redfish_mock, redfish_service):
+    """PATCH records the payload and a later GET reflects the merged state."""
+    url = ("https://mock-idrac/redfish/v1/Systems/System.Embedded.1/"
+           "Bios/Settings")
+    body = {"Attributes": {"BootMode": "Uefi"}}
+    resp = redfish_mock.api_patch_call(url, json.dumps(body), {})
+    assert resp.status_code == 200
+    assert redfish_service.last_request.json() == body
+    # follow-up GET sees the overlay applied by the PATCH
+    after = redfish_mock.api_get_call(url, {}).json()
+    assert after["Attributes"]["BootMode"] == "Uefi"
+
+
+def test_delete_returns_ok(redfish_mock):
+    """DELETE on a resource returns a success status, no hardware involved."""
+    url = ("https://mock-idrac/redfish/v1/Systems/System.Embedded.1/"
+           "Storage/Volumes/Disk.Virtual.0")
+    resp = redfish_mock.api_delete_call(url, {})
+    assert resp.status_code == 200
+
+
+# --- dual-mode fixture: offline by default, live when IDRAC_IP is set --------
+
+def test_redfish_api_runs_in_mock_mode(redfish_api):
+    """Without IDRAC_IP, redfish_api yields a mock-backed client that works offline."""
+    resp = redfish_api.api_get_call(
+        "https://mock-idrac/redfish/v1/Managers", {}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["@odata.id"] == "/redfish/v1/Managers"

--- a/tests/test_redfish_models.py
+++ b/tests/test_redfish_models.py
@@ -1,0 +1,87 @@
+"""Offline unit tests for the Redfish response/error model classes.
+
+Author Mus spyroot@gmail.com
+"""
+from idrac_ctl.redfish_respond import RedfishMessage, RedfishRespondMessage
+from idrac_ctl.redfish_respond_error import RedfishError, RedfishErrorMessage
+
+EXTENDED = {
+    "@Message.ExtendedInfo": [
+        {
+            "MessageId": "Base.1.12.Success",
+            "Message": "The request completed successfully.",
+            "Severity": "OK",
+            "Resolution": "None",
+        }
+    ]
+}
+
+
+def test_respond_message_basic_properties():
+    """Status code, code, and message are exposed; extended defaults to []."""
+    msg = RedfishRespondMessage(200, code="Base.1", message="ok")
+    assert msg.status_code == 200
+    assert msg.code == "Base.1"
+    assert msg.message == "ok"
+    assert msg.message_extended == []
+
+
+def test_message_setter():
+    """The message property is settable."""
+    msg = RedfishRespondMessage(200)
+    msg.message = "changed"
+    assert msg.message == "changed"
+
+
+def test_message_extended_setter_parses_extended_info():
+    """Assigning an ExtendedInfo dict parses it into RedfishMessage objects."""
+    msg = RedfishRespondMessage(200)
+    msg.message_extended = EXTENDED
+    parsed = msg.message_extended
+    assert len(parsed) == 1
+    assert parsed[0].message_id == "Base.1.12.Success"
+    assert parsed[0].message == "The request completed successfully."
+    assert parsed[0].severity == "OK"
+    assert parsed[0].resolution == "None"
+
+
+def test_message_extended_setter_none_is_empty():
+    """Assigning None yields an empty extended list, not an error."""
+    msg = RedfishRespondMessage(200)
+    msg.message_extended = None
+    assert msg.message_extended == []
+
+
+def test_is_redfish_msg():
+    """is_redfish_msg detects the ExtendedInfo envelope shape."""
+    assert RedfishRespondMessage.is_redfish_msg(EXTENDED) is True
+    assert RedfishRespondMessage.is_redfish_msg({"a": 1}) is False
+    assert RedfishRespondMessage.is_redfish_msg(None) is False
+
+
+def test_new_msg_factory():
+    """new_msg returns a blank RedfishMessage."""
+    assert isinstance(RedfishRespondMessage.new_msg(), RedfishMessage)
+
+
+def test_redfish_error_repr_and_extended():
+    """RedfishError exposes its extended messages and renders them in repr."""
+    err = RedfishError(
+        400,
+        message_extended=[RedfishErrorMessage(message="disk is busy")],
+    )
+    assert err.status_code == 400
+    assert "disk is busy" in repr(err)
+    assert err.message_extended[0].message == "disk is busy"
+
+
+def test_redfish_error_new_msg():
+    """RedfishError.new_msg returns a blank RedfishErrorMessage."""
+    assert isinstance(RedfishError.new_msg(), RedfishErrorMessage)
+
+
+def test_redfish_message_defaults():
+    """RedfishMessage defaults message_args to an empty list."""
+    m = RedfishMessage()
+    assert m.message_args == []
+    assert m.message_count == 0

--- a/tests/test_redfish_parse.py
+++ b/tests/test_redfish_parse.py
@@ -1,0 +1,64 @@
+"""Offline unit tests for RedfishManager.parse_json_respond_msg.
+
+Regression for the swallowed-exception cleanup: a respond with no JSON body or
+a non-object JSON body must degrade to an empty message list instead of raising
+(previously the ``except ... as _: pass`` sites hid these cases silently; they
+now log at debug and still return a usable object).
+
+Author Mus spyroot@gmail.com
+"""
+from requests.models import Response
+
+from idrac_ctl.redfish_manager import RedfishManager
+from idrac_ctl.redfish_respond import RedfishRespondMessage
+from tests.test_utils import create_json_resp
+
+
+def _raw_response(body: bytes, status_code: int = 200) -> Response:
+    resp = Response()
+    resp._content = body
+    resp.status_code = status_code
+    resp._headers = {}
+    resp.encoding = "utf-8"
+    return resp
+
+
+def test_parses_extended_info_message():
+    """A well-formed redfish payload yields parsed extended messages."""
+    data = {
+        "@Message.ExtendedInfo": [
+            {
+                "Message": "The request completed successfully.",
+                "MessageId": "Base.1.12.Success",
+                "Severity": "OK",
+                "Resolution": "None",
+            }
+        ]
+    }
+    resp = create_json_resp(data)
+    parsed = RedfishManager.parse_json_respond_msg(resp)
+    assert isinstance(parsed, RedfishRespondMessage)
+    assert len(parsed.message_extended) == 1
+
+
+def test_non_json_body_does_not_raise():
+    """A non-JSON body returns an empty message list, not an exception."""
+    resp = _raw_response(b"not json at all", status_code=400)
+    parsed = RedfishManager.parse_json_respond_msg(resp)
+    assert isinstance(parsed, RedfishRespondMessage)
+    assert parsed.message_extended == []
+
+
+def test_scalar_json_body_does_not_raise():
+    """A scalar JSON body (TypeError on membership test) is handled gracefully."""
+    resp = _raw_response(b"42", status_code=200)
+    parsed = RedfishManager.parse_json_respond_msg(resp)
+    assert isinstance(parsed, RedfishRespondMessage)
+    assert parsed.message_extended == []
+
+
+def test_json_without_extended_info_is_empty():
+    """Valid JSON lacking ExtendedInfo yields an empty message list."""
+    resp = create_json_resp({"SomeOtherKey": "value"})
+    parsed = RedfishManager.parse_json_respond_msg(resp)
+    assert parsed.message_extended == []

--- a/tests/test_redfish_schema.py
+++ b/tests/test_redfish_schema.py
@@ -1,0 +1,51 @@
+"""Schema gate: every captured fixture conforms to its DMTF Redfish schema.
+
+Skipped by default unless the schema bundle is vendored (run tools/fetch_schemas.sh
+once). This keeps the offline unit suite green without a network/schema dependency,
+while CI can vendor the schemas and enforce the gate. OEM-typed resources (e.g.
+Dell-only types) are skipped — there is no standard schema for them.
+
+Author Mus spyroot@gmail.com
+"""
+import glob
+import json
+import pathlib
+
+import pytest
+
+pytest.importorskip("referencing")
+
+_SCHEMA_DIR = pathlib.Path(__file__).resolve().parent.parent / "tools" / "redfish-schemas"
+if not (_SCHEMA_DIR.exists() and any(_SCHEMA_DIR.glob("*.json"))):
+    pytest.skip(
+        "Redfish schemas not vendored; run tools/fetch_schemas.sh",
+        allow_module_level=True,
+    )
+
+import os  # noqa: E402
+
+from tools.redfish_validate import SchemaUnavailable, validate_payload  # noqa: E402
+
+_ROOT = pathlib.Path(__file__).resolve().parent.parent
+# Our hand-authored iDRAC fixtures are the gate. The captured DMTF mockup tree
+# (json_responses/) is third-party reference data from older schema versions;
+# validate it only when REDFISH_SCHEMA_ALL=1.
+_FIXTURES = sorted(glob.glob(str(_ROOT / "tests" / "idrac_fixtures" / "*.json")))
+if os.environ.get("REDFISH_SCHEMA_ALL"):
+    _FIXTURES += sorted(glob.glob(str(_ROOT / "idrac_ctl" / "json_responses" / "*.json")))
+
+
+@pytest.mark.schema
+@pytest.mark.parametrize("path", _FIXTURES, ids=lambda p: pathlib.Path(p).name)
+def test_fixture_conforms_to_schema(path):
+    """A captured fixture validates against its standard Redfish schema."""
+    payload = json.loads(pathlib.Path(path).read_text())
+    if "@odata.type" not in payload:
+        pytest.skip("no @odata.type (collection/metadata)")
+    try:
+        errors = validate_payload(payload)
+    except SchemaUnavailable as exc:
+        pytest.skip(str(exc))  # OEM type / no standard schema
+    assert not errors, "\n".join(
+        f"{list(e.absolute_path)}: {e.message}" for e in errors[:10]
+    )

--- a/tests/test_storage_get_dualmode.py
+++ b/tests/test_storage_get_dualmode.py
@@ -1,0 +1,22 @@
+"""Dual-mode test for the storage-get command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_storage_get_returns_controller_resource(redfish_api):
+    """storage_get fetches the requested iDRAC storage controller."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.StorageViewQuery,
+        "storage_get",
+        controller="RAID.Integrated.1-1",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == (
+        "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1"
+    )
+    assert result.data["Id"] == "RAID.Integrated.1-1"

--- a/tests/test_system_query_dualmode.py
+++ b/tests/test_system_query_dualmode.py
@@ -1,0 +1,16 @@
+"""Dual-mode test for the system query command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_system_query_returns_system_resource(redfish_api):
+    """system_query returns the iDRAC ComputerSystem resource."""
+    result = redfish_api.sync_invoke(ApiRequestType.SystemQuery, "system_query")
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == "/redfish/v1/Systems/System.Embedded.1"
+    assert result.data["Id"] == "System.Embedded.1"

--- a/tests/test_vendors.py
+++ b/tests/test_vendors.py
@@ -1,0 +1,54 @@
+"""Offline tests for the vendor capability registry.
+
+Author Mus spyroot@gmail.com
+"""
+from idrac_ctl.vendors import all_vendors, get_vendor
+from idrac_ctl.vendors.base import VendorCapabilities
+
+
+def test_dell_profile_registered_with_doc_facts():
+    """The Dell profile reflects the documented iDRAC capabilities."""
+    dell = get_vendor("dell")
+    assert dell.vendor == "dell"
+    assert dell.oem_prefix == "Dell"
+    # all five query params, but only one per URI
+    assert dell.query_select and dell.query_filter and dell.query_expand
+    assert dell.query_top and dell.query_only
+    assert dell.one_query_param_per_uri is True
+    # recurring jobs, one per type, with the documented schedulable URIs
+    assert dell.job_scheduling and dell.one_recurring_job_per_type
+    assert any("ComputerSystem.Reset" in u for u in dell.schedulable_uris)
+    assert any("LogService.ClearLog" in u for u in dell.schedulable_uris)
+    assert dell.lifecycle_events_sse is True
+
+
+def test_unknown_vendor_falls_back_to_generic():
+    """An unknown vendor yields the conservative generic profile."""
+    caps = get_vendor("acme")
+    assert caps.vendor == "generic"
+    # generic is conservative: no select/filter/scheduling by default
+    assert caps.query_select is False
+    assert caps.job_scheduling is False
+
+
+def test_none_vendor_is_generic():
+    """None resolves to the generic profile, not an error."""
+    assert get_vendor(None).vendor == "generic"
+
+
+def test_registry_contains_scaffolded_vendors():
+    """Dell, HPE, Supermicro and generic are all registered."""
+    names = set(all_vendors())
+    assert {"dell", "hpe", "supermicro", "generic"} <= names
+
+
+def test_capabilities_are_immutable():
+    """Profiles are frozen so a command cannot mutate shared state."""
+    dell = get_vendor("dell")
+    try:
+        dell.job_scheduling = False  # type: ignore[misc]
+    except Exception as exc:
+        assert isinstance(exc, (AttributeError, TypeError))
+    else:
+        raise AssertionError("VendorCapabilities should be immutable")
+    assert isinstance(dell, VendorCapabilities)

--- a/tools/fetch_schemas.sh
+++ b/tools/fetch_schemas.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Vendor the DSP8010 Redfish JSON schemas needed by our fixtures into
+# tools/redfish-schemas/ by validating each fixture once (online). Files are
+# cached for offline reuse, so the schema gate then runs with no network.
+#
+# Run once locally or in CI before `pytest -m schema`.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+python3 - <<'PY'
+import glob, json, pathlib
+from tools.redfish_validate import validate_payload, SchemaUnavailable
+
+paths = sorted(glob.glob("tests/idrac_fixtures/*.json")
+               + glob.glob("idrac_ctl/json_responses/*.json"))
+validated = skipped = 0
+for p in paths:
+    payload = json.loads(pathlib.Path(p).read_text())
+    if "@odata.type" not in payload:
+        continue
+    try:
+        validate_payload(payload)
+        validated += 1
+    except SchemaUnavailable:
+        skipped += 1  # OEM type or no standard schema
+    except Exception as exc:  # noqa: BLE001 - report, keep warming the rest
+        print(f"warn {p}: {exc}")
+print(f"warmed schemas; validated {validated}, skipped {skipped} (OEM/no-schema)")
+PY
+
+echo ">> schemas cached under tools/redfish-schemas/"

--- a/tools/redfish_validate.py
+++ b/tools/redfish_validate.py
@@ -1,0 +1,108 @@
+"""Validate Redfish JSON against the DMTF DSP8010 schemas.
+
+Maps a resource's ``@odata.type`` to its unversioned (version-resilient) JSON
+Schema and validates it with ``jsonschema`` + ``referencing``. Schema files are
+cached under ``tools/redfish-schemas/``; a missing one is fetched once from
+``redfish.dmtf.org`` and cached for offline reuse. Set ``REDFISH_SCHEMA_OFFLINE=1``
+to forbid network and require a pre-vendored directory.
+
+Dell ``Oem`` blocks are not part of the standard schema, so by default the ``Oem``
+subtree is stripped before validation — we check the standard surface, not Dell's
+private extensions. Resources whose ``@odata.type`` is itself an OEM type (e.g.
+``#DellBootSources...``) have no standard schema and raise ``SchemaUnavailable``.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+import os
+import urllib.error
+import urllib.request
+from copy import deepcopy
+from pathlib import Path
+
+from jsonschema import Draft7Validator
+from referencing import Registry, Resource
+from referencing.exceptions import Unresolvable
+from referencing.jsonschema import DRAFT7
+
+SCHEMA_DIR = Path(__file__).resolve().parent / "redfish-schemas"
+PREFIX = "http://redfish.dmtf.org/schemas/v1/"
+
+
+class SchemaUnavailable(RuntimeError):
+    """The schema for a resource could not be found (OEM type, or offline+missing)."""
+
+
+def _schema_file(uri: str) -> Path:
+    name = uri[len(PREFIX):] if uri.startswith(PREFIX) else Path(uri).name
+    return SCHEMA_DIR / name.split("#", 1)[0]
+
+
+def _load_schema_doc(uri: str) -> dict:
+    path = _schema_file(uri)
+    if path.exists():
+        return json.loads(path.read_text())
+    if os.environ.get("REDFISH_SCHEMA_OFFLINE"):
+        raise SchemaUnavailable(f"missing vendored schema for {uri} (offline mode)")
+    url = uri.split("#", 1)[0]
+    try:
+        data = urllib.request.urlopen(url, timeout=30).read()
+    except urllib.error.HTTPError as err:
+        raise SchemaUnavailable(f"no standard schema at {url} ({err.code})") from err
+    SCHEMA_DIR.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(data)
+    return json.loads(data)
+
+
+def _retrieve(uri: str) -> Resource:
+    return Resource.from_contents(_load_schema_doc(uri), default_specification=DRAFT7)
+
+
+_REGISTRY = Registry(retrieve=_retrieve)
+
+
+def schema_ref_for(odata_type: str) -> str:
+    """Return the unversioned schema ``$ref`` for a Redfish ``@odata.type``.
+
+    Handles versioned (``#ComputerSystem.v1_16_0.ComputerSystem``), collection
+    (``#ChassisCollection.ChassisCollection``), and old-format
+    (``#TaskService.0.94.0.Task``) types: namespace is the first segment, the
+    type is the last, any version in between is ignored.
+    """
+    parts = odata_type.lstrip("#").split(".")
+    if len(parts) < 2 or not parts[0] or not parts[-1]:
+        raise ValueError(f"unrecognized @odata.type: {odata_type!r}")
+    namespace, type_name = parts[0], parts[-1]
+    return f"{PREFIX}{namespace}.json#/definitions/{type_name}"
+
+
+def _strip_oem(obj) -> None:
+    if isinstance(obj, dict):
+        obj.pop("Oem", None)
+        for value in obj.values():
+            _strip_oem(value)
+    elif isinstance(obj, list):
+        for value in obj:
+            _strip_oem(value)
+
+
+def validate_payload(payload: dict, strip_oem: bool = True) -> list:
+    """Validate a Redfish resource. Returns a sorted list of errors ([] = valid).
+
+    Raises ``SchemaUnavailable`` when the resource type has no standard schema
+    (e.g. a Dell OEM type), and ``ValueError`` when ``@odata.type`` is missing.
+    """
+    odata_type = payload.get("@odata.type")
+    if not odata_type:
+        raise ValueError("payload has no @odata.type")
+    body = payload
+    if strip_oem:
+        body = deepcopy(payload)
+        _strip_oem(body)
+    validator = Draft7Validator({"$ref": schema_ref_for(odata_type)}, registry=_REGISTRY)
+    try:
+        errors = list(validator.iter_errors(body))
+    except Unresolvable as err:
+        # a referenced schema (often an OEM type) has no standard definition
+        raise SchemaUnavailable(str(err)) from err
+    return sorted(errors, key=lambda e: list(e.absolute_path))


### PR DESCRIPTION
## Summary

Adds an offline-by-default test foundation, per-vendor package structure, DMTF schema
validation tooling, and the start of generic Redfish query-parameter support — plus several
correctness fixes. The goal is to make the tool verifiable without hardware and to set up the
move toward a generic Redfish implementation with vendors as plug-ins.

## What changed

**Correctness fixes**
- `save_if_needed`: serialize the payload (not the filename) for YAML; raise on an unknown format. Declares the previously-missing `PyYAML` runtime dependency.
- Log previously-swallowed exceptions in `redfish_manager`; de-duplicate imports in `bios/cmd_change_bios`; route stray debug `print()`s to the logger.
- Fix a Storage fixture (`Controllers` must be a navigation reference, not an inline array) — caught by the new schema gate.

**Offline test infrastructure**
- `pyproject.toml` with `ruff` / `mypy` / `pytest` / coverage config (packaging stays in `setup.py`); conda `environment.yml`.
- A stateful `requests-mock` Redfish service in `tests/conftest.py` (GET/POST/PATCH/DELETE + Actions), a dual-mode `redfish_api` fixture (mock by default, live when `IDRAC_IP` is set), and an opt-in `sushy-emulator` lane.
- Hardware tests marked `@pytest.mark.live` and auto-skipped without `IDRAC_IP`. Captured DMTF mockup fixtures shipped under `idrac_ctl/json_responses/`, plus iDRAC-shaped fixtures under `tests/idrac_fixtures/`.
- Ubuntu `docker/` image to confirm macOS/Linux parity (the fixture lookup is case-insensitive on purpose).

**Per-vendor structure**
- `idrac_ctl/vendors/{dell,hpe,supermicro}/` with a `VendorCapabilities` model + registry; the Dell profile encodes documented iDRAC facts (one query parameter per URI, recurring-job URIs, lifecycle SSE). Unknown vendors fall back to a conservative generic profile.

**Schema validation (opt-in)**
- `tools/redfish_validate.py` validates a resource against its DSP8010 schema by `@odata.type` (offline via a self-caching `referencing` registry; strips Dell `Oem`; skips OEM-only types). `tools/fetch_schemas.sh` vendors the schemas (gitignored); `tests/test_redfish_schema.py` gates our fixtures and is skipped unless schemas are vendored.

**Redfish query parameters**
- `idrac_ctl/redfish_query.py` builds `$select`/`$filter`/`$expand`/`$top`/`only` with validation and the Dell one-param-per-URI rule; `RedfishManager.get_with_query()` applies it on a GET (vendor-neutral core — the caller passes the one-param flag from the capability profile).

**Docs**
- README leads with the project goal; deep material moved to `docs/` (architecture, testing, vendors, and the longer-term fleet-proxy / scaling direction).

## Testing
- `pytest -q`: 213 passed, 54 skipped (live tests auto-skip without `IDRAC_IP`).
- Same result inside the Ubuntu container (`docker/run-tests.sh`).
- `ruff check` clean on changed files (pre-existing lint debt in untouched files is unchanged).

## Notes for the reviewer
- This branch was built on an earlier `main`; `main` has since advanced independently, so a rebase/conflict pass may be needed before merge (likely around `README.md`, `setup.py`, `.gitignore`, `requirements.txt`).
- The schema gate and the live/emulator lanes are opt-in, so default `pytest -q` stays green with no network or hardware.
