### PR TITLE
Harden bios-change (supersedes #5) + dual-mode test batches

### DIFF
--- a/idrac_ctl/bios/cmd_change_bios.py
+++ b/idrac_ctl/bios/cmd_change_bios.py
@@ -24,16 +24,10 @@ import json
 from abc import abstractmethod
 from typing import Optional
 
-from ..cmd_exceptions import InvalidArgument
-from ..cmd_exceptions import InvalidJsonSpec
-from ..cmd_exceptions import UncommittedPendingChanges
+from ..cmd_exceptions import InvalidArgument, InvalidJsonSpec, UncommittedPendingChanges
 from ..cmd_utils import from_json_spec
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IDRAC_JSON
-from ..idrac_shared import IDRAC_API
-from ..idrac_shared import IdracApiRespond
-from ..idrac_shared import Singleton
-from ..idrac_shared import ApiRequestType
+from ..idrac_shared import IDRAC_API, IDRAC_JSON, ApiRequestType, IdracApiRespond, Singleton
 from ..redfish_manager import CommandResult
 
 
@@ -238,50 +232,50 @@ class BiosChangeSettings(IDracManager,
         :param start_date:
         :return: CommandResult and if filename provide will save to a file.
         """
-        target_api = f"{self.idrac_manage_servers}{IDRAC_API.BiosRegistry}"
-        cmd_result = self.base_query(
-            target_api, filename=filename,
-            do_async=do_async, do_expanded=False
-        )
-        if verbose:
-            self.default_json_printer(cmd_result.data)
-
-        if IDRAC_JSON.RegistryEntries not in cmd_result.data:
-            return CommandResult(
-                {
-                    "Status": "Failed fetch bios registry"
-                }, None, None, None
-            )
-        registry = cmd_result.data[IDRAC_JSON.RegistryEntries]
-
-        if IDRAC_JSON.Attributes not in cmd_result.data:
-            return CommandResult(
-                {
-                    "Status": "Failed fetch attributes from bios registry"
-                }, None, None, None
-            )
-        attribute_data = registry[IDRAC_JSON.Attributes]
-
-        # we read either from a file or form args
-        # comma seperated.
+        # We read changes either from a JSON spec file or build them from
+        # --attr_name/--attr_value. A spec file is self-contained, so the BIOS
+        # registry is only fetched (and validated) on the args path.
         try:
             if from_spec is not None and len(from_spec) > 0:
                 payload = from_json_spec(from_spec)
             else:
+                target_api = f"{self.idrac_manage_servers}{IDRAC_API.BiosRegistry}"
+                cmd_result = self.base_query(
+                    target_api, filename=filename,
+                    do_async=do_async, do_expanded=False
+                )
+                if verbose:
+                    self.default_json_printer(cmd_result.data)
+
+                if cmd_result is None or not isinstance(cmd_result.data, dict):
+                    return CommandResult(
+                        {"Status": "Failed fetch bios registry"}, None, None, None
+                    )
+                registry = cmd_result.data.get(IDRAC_JSON.RegistryEntries)
+                if not isinstance(registry, dict) \
+                        or IDRAC_JSON.Attributes not in registry:
+                    return CommandResult(
+                        {"Status": "Failed fetch attributes from bios registry"},
+                        None, None, None
+                    )
+                attribute_data = registry[IDRAC_JSON.Attributes]
+                if not isinstance(attribute_data, list):
+                    return CommandResult(
+                        {"Status": "Bios registry attributes are malformed"},
+                        None, None, None
+                    )
                 payload = self.crete_bios_config(
                     attribute_data, attr_name, attr_value
                 )
             if len(payload) == 0:
                 return CommandResult(
-                    {
-                        "Status": "Empty bios spec."
-                    },
-                    None, None, None
+                    {"Status": "Empty bios spec."}, None, None, None
                 )
         except json.decoder.JSONDecodeError as jde:
             raise InvalidJsonSpec(
-                "It looks like your JSON spec is invalid. "
-                "JSONlint the file and check..".format(str(jde)))
+                f"It looks like your JSON spec is invalid. "
+                f"JSONlint the file and check: {jde}"
+            )
 
         job_req_payload = self.create_apply_time_req(
             apply, start_time, start_date, default_duration)
@@ -325,7 +319,7 @@ class BiosChangeSettings(IDracManager,
             cmd_result.data['task_id'] = task_id
         elif api_resp.Success or api_resp.Ok:
             if do_commit:
-                self.logger.info(f"Commit changes and rebooting.")
+                self.logger.info("Commit changes and rebooting.")
                 # we commit with a reboot
                 cmd_apply = self.sync_invoke(
                     ApiRequestType.JobApply,

--- a/tests/idrac_fixtures/_redfish_v1_AccountService_Accounts_2.json
+++ b/tests/idrac_fixtures/_redfish_v1_AccountService_Accounts_2.json
@@ -1,0 +1,17 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#ManagerAccount.ManagerAccount",
+  "@odata.id": "/redfish/v1/AccountService/Accounts/2",
+  "@odata.type": "#ManagerAccount.v1_8_0.ManagerAccount",
+  "Id": "2",
+  "Name": "User Account",
+  "Description": "iDRAC local user account",
+  "Enabled": true,
+  "Locked": false,
+  "RoleId": "Administrator",
+  "UserName": "root",
+  "Links": {
+    "Role": {
+      "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
+    }
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1.json
@@ -17,7 +17,20 @@
   },
   "Boot": {
     "BootSourceOverrideEnabled": "Disabled",
-    "BootSourceOverrideTarget": "None"
+    "BootSourceOverrideTarget": "None",
+    "BootSourceOverrideTarget@Redfish.AllowableValues": [
+      "None",
+      "Pxe",
+      "Cd",
+      "Usb",
+      "Hdd",
+      "BiosSetup",
+      "Utilities",
+      "Diags",
+      "SDCard",
+      "UefiTarget",
+      "UefiHttp"
+    ]
   },
   "PCIeDevices": [
     {

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios_BiosRegistry.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios_BiosRegistry.json
@@ -4,6 +4,9 @@
   "@odata.type": "#AttributeRegistry.v1_3_0.AttributeRegistry",
   "Id": "BiosAttributeRegistry",
   "Name": "BIOS Attribute Registry",
+  "Language": "en",
+  "RegistryVersion": "1.0.0",
+  "OwningEntity": "Dell",
   "RegistryEntries": {
     "Attributes": [
       {

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios_BiosRegistry.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios_BiosRegistry.json
@@ -1,0 +1,48 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#AttributeRegistry.AttributeRegistry",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios/BiosRegistry",
+  "@odata.type": "#AttributeRegistry.v1_3_0.AttributeRegistry",
+  "Id": "BiosAttributeRegistry",
+  "Name": "BIOS Attribute Registry",
+  "RegistryEntries": {
+    "Attributes": [
+      {
+        "AttributeName": "ProcCStates",
+        "CurrentValue": "Disabled",
+        "DisplayName": "Processor C States",
+        "ReadOnly": false,
+        "Type": "Enumeration",
+        "Value": [
+          {
+            "ValueName": "Enabled"
+          },
+          {
+            "ValueName": "Disabled"
+          }
+        ]
+      },
+      {
+        "AttributeName": "SriovGlobalEnable",
+        "CurrentValue": "Enabled",
+        "DisplayName": "SR-IOV Global Enable",
+        "ReadOnly": false,
+        "Type": "Enumeration",
+        "Value": [
+          {
+            "ValueName": "Enabled"
+          },
+          {
+            "ValueName": "Disabled"
+          }
+        ]
+      },
+      {
+        "AttributeName": "SysMemSize",
+        "CurrentValue": "768 GB",
+        "DisplayName": "System Memory Size",
+        "ReadOnly": true,
+        "Type": "String"
+      }
+    ]
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios_Settings.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios_Settings.json
@@ -1,0 +1,13 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios/Settings",
+  "@odata.type": "#Bios.v1_2_0.Bios",
+  "Id": "Settings",
+  "Name": "BIOS Pending Settings",
+  "Attributes": {
+    "BootMode": "Uefi",
+    "ProcCStates": "Disabled",
+    "SriovGlobalEnable": "Enabled",
+    "SysMemSize": "768 GB"
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_VirtualMedia.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_VirtualMedia.json
@@ -1,0 +1,71 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#VirtualMediaCollection.VirtualMediaCollection",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia",
+  "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+  "Name": "Virtual Media Collection",
+  "Description": "Mock iDRAC virtual media collection",
+  "Members@odata.count": 2,
+  "Members": [
+    {
+      "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1",
+      "@odata.type": "#VirtualMedia.v1_6_0.VirtualMedia",
+      "Id": "1",
+      "Name": "VirtualMedia Instance 1",
+      "Description": "iDRAC Virtual Media Instance",
+      "ConnectedVia": "NotConnected",
+      "Image": null,
+      "ImageName": null,
+      "Inserted": false,
+      "MediaTypes": [
+        "CD",
+        "DVD",
+        "USBStick"
+      ],
+      "MediaTypes@odata.count": 3,
+      "Password": null,
+      "TransferMethod": null,
+      "TransferProtocolType": null,
+      "UserName": null,
+      "WriteProtected": true,
+      "Actions": {
+        "#VirtualMedia.InsertMedia": {
+          "target": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1/Actions/VirtualMedia.InsertMedia"
+        },
+        "#VirtualMedia.EjectMedia": {
+          "target": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/1/Actions/VirtualMedia.EjectMedia"
+        }
+      }
+    },
+    {
+      "@odata.context": "/redfish/v1/$metadata#VirtualMedia.VirtualMedia",
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/2",
+      "@odata.type": "#VirtualMedia.v1_6_0.VirtualMedia",
+      "Id": "2",
+      "Name": "VirtualMedia Instance 2",
+      "Description": "iDRAC Virtual Media Instance",
+      "ConnectedVia": "URI",
+      "Image": "http://example.test/installer.iso",
+      "ImageName": "installer.iso",
+      "Inserted": true,
+      "MediaTypes": [
+        "CD",
+        "DVD"
+      ],
+      "MediaTypes@odata.count": 2,
+      "Password": null,
+      "TransferMethod": "Stream",
+      "TransferProtocolType": "HTTP",
+      "UserName": null,
+      "WriteProtected": true,
+      "Actions": {
+        "#VirtualMedia.InsertMedia": {
+          "target": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/2/Actions/VirtualMedia.InsertMedia"
+        },
+        "#VirtualMedia.EjectMedia": {
+          "target": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/2/Actions/VirtualMedia.EjectMedia"
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_account_query_dualmode.py
+++ b/tests/test_account_query_dualmode.py
@@ -1,0 +1,21 @@
+"""Dual-mode tests for the individual account query command."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_account_query_returns_manager_account(redfish_api):
+    """query_account returns the requested ManagerAccount resource."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.QueryAccount,
+        "query_account",
+        account="2",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == "/redfish/v1/AccountService/Accounts/2"
+    assert result.data["Id"] == "2"
+    assert result.data["UserName"]

--- a/tests/test_bios_dualmode.py
+++ b/tests/test_bios_dualmode.py
@@ -1,0 +1,65 @@
+"""Dual-mode tests for BIOS pending and registry commands."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_bios_pending_returns_pending_attributes(redfish_api):
+    """bios_query_pending unwraps Attributes from the pending BIOS settings resource."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BiosQueryPending,
+        "bios_query_pending",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["BootMode"] == "Uefi"
+    assert result.data["SriovGlobalEnable"] == "Enabled"
+
+
+def test_bios_pending_filter_returns_single_attribute_value(redfish_api):
+    """bios_query_pending returns the selected pending BIOS attribute value."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BiosQueryPending,
+        "bios_query_pending",
+        data_filter="SriovGlobalEnable",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == "Enabled"
+
+
+def test_bios_registry_returns_registry_entries(redfish_api):
+    """bios_registry returns BIOS registry attributes."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BiosRegistry,
+        "bios_registry",
+        is_registry_only=True,
+        is_value_only=False,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, list)
+    json.dumps(result.data)
+    assert result.data[0]["AttributeName"] == "ProcCStates"
+    assert result.data[0]["ReadOnly"] is False
+
+
+def test_bios_registry_filters_attribute_names(redfish_api):
+    """bios_registry filters registry entries by requested attribute name."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BiosRegistry,
+        "bios_registry",
+        attr_name="SriovGlobalEnable",
+        is_value_only=False,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert len(result.data) == 1
+    assert result.data[0]["AttributeName"] == "SriovGlobalEnable"
+    assert result.data[0]["Value"] == [
+        {"ValueName": "Enabled"},
+        {"ValueName": "Disabled"},
+    ]

--- a/tests/test_cmd_boot_dualmode.py
+++ b/tests/test_cmd_boot_dualmode.py
@@ -9,7 +9,8 @@ Author Mus spyroot@gmail.com
 """
 import json
 
-from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.compute.cmd_power_state import RebootHost
+from idrac_ctl.idrac_shared import IDRAC_API, ApiRequestType
 from idrac_ctl.redfish_manager import CommandResult
 
 
@@ -24,3 +25,78 @@ def test_boot_query(redfish_api):
     json.dumps(result.data)
     # in mock mode the fixture carries the iDRAC boot-source attributes
     assert result.data["@odata.id"].endswith("/BootSources")
+
+
+def test_current_boot_query_returns_boot_settings(redfish_api):
+    """current_boot_query returns the ComputerSystem Boot object."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.CurrentBoot, "current_boot_query"
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["BootSourceOverrideEnabled"] in {
+        "Disabled",
+        "Once",
+        "Continuous",
+    }
+    allowable_targets = result.data["BootSourceOverrideTarget@Redfish.AllowableValues"]
+    assert isinstance(allowable_targets, list)
+    assert "Pxe" in allowable_targets
+    assert result.data["BootSourceOverrideTarget"] in allowable_targets
+
+
+def test_boot_one_shot_patches_requested_target_in_mock_mode(
+    redfish_mock, redfish_service
+):
+    """boot_one_shot validates the target and PATCHes the system Boot payload."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="Pxe",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["Status"] == "ok"
+    request = redfish_service.last_request
+    assert request.method == "PATCH"
+    assert request.path.lower() == "/redfish/v1/systems/system.embedded.1"
+    assert request.json() == {"Boot": {"BootSourceOverrideTarget": "Pxe"}}
+
+    current = redfish_mock.sync_invoke(
+        ApiRequestType.CurrentBoot, "current_boot_query"
+    )
+    assert current.data["BootSourceOverrideTarget"] == "Pxe"
+
+
+def test_reboot_posts_reset_action_payload_in_mock_mode(
+    redfish_mock, redfish_service, monkeypatch
+):
+    """reboot POSTs the requested ResetType and records the generated task."""
+    task_state = {"TaskState": "Completed", "TaskStatus": "OK"}
+
+    def fetch_task(self, task_id):
+        assert task_id == redfish_service.JOB_ID
+        return task_state
+
+    monkeypatch.setattr(
+        IDRAC_API, "COMPUTE_RESET", "/Actions/ComputerSystem.Reset", raising=False
+    )
+    monkeypatch.setattr(RebootHost, "fetch_task", fetch_task)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.ComputerSystemReset,
+        "reboot",
+        reset_type="PowerCycle",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["task_id"] == redfish_service.JOB_ID
+    assert result.data["task_state"] == task_state
+    request = redfish_service.last_request
+    assert request.method == "POST"
+    assert request.path.lower() == (
+        "/redfish/v1/systems/system.embedded.1/actions/computersystem.reset"
+    )
+    assert request.json() == {"ResetType": "PowerCycle"}

--- a/tests/test_cmd_change_bios_guards.py
+++ b/tests/test_cmd_change_bios_guards.py
@@ -1,0 +1,105 @@
+"""Regression tests for cmd_change_bios.execute() registry-guard hardening.
+
+Covers the corner cases around fetching the BIOS registry: missing/None data,
+a non-dict RegistryEntries, missing Attributes (the original PR #5 bug fix),
+a non-list Attributes, the JSON-spec short-circuit, and that an invalid spec
+surfaces the decoder detail.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+
+import pytest
+
+from idrac_ctl.bios.cmd_change_bios import BiosChangeSettings
+from idrac_ctl.cmd_exceptions import InvalidJsonSpec
+from idrac_ctl.redfish_manager import CommandResult
+
+
+@pytest.fixture
+def bios_cmd():
+    """A BiosChangeSettings command instance (offline; no iDRAC contacted)."""
+    return BiosChangeSettings(
+        idrac_ip="mock-idrac", idrac_username="root",
+        idrac_password="mock", insecure=True, is_debug=False,
+    )
+
+
+def _serve_registry(monkeypatch, cmd, data):
+    """Make the command's registry query return ``data``."""
+    monkeypatch.setattr(
+        cmd, "base_query", lambda *a, **k: CommandResult(data, None, None, None)
+    )
+
+
+def test_none_registry_data_fails_gracefully(bios_cmd, monkeypatch):
+    """No data from the registry query -> graceful failure, not a TypeError."""
+    _serve_registry(monkeypatch, bios_cmd, None)
+    result = bios_cmd.execute(attr_name="MemTest", attr_value="Disabled", do_show=True)
+    assert result.data["Status"] == "Failed fetch bios registry"
+
+
+def test_missing_registry_entries(bios_cmd, monkeypatch):
+    """Response without RegistryEntries -> attribute fetch failure."""
+    _serve_registry(monkeypatch, bios_cmd, {"@odata.id": "/x"})
+    result = bios_cmd.execute(attr_name="MemTest", attr_value="Disabled", do_show=True)
+    assert result.data["Status"] == "Failed fetch attributes from bios registry"
+
+
+def test_registry_entries_not_a_dict(bios_cmd, monkeypatch):
+    """RegistryEntries that is a list -> graceful failure (no crash on indexing)."""
+    _serve_registry(monkeypatch, bios_cmd, {"RegistryEntries": ["nope"]})
+    result = bios_cmd.execute(attr_name="MemTest", attr_value="Disabled", do_show=True)
+    assert result.data["Status"] == "Failed fetch attributes from bios registry"
+
+
+def test_missing_attributes_is_the_pr5_path(bios_cmd, monkeypatch):
+    """RegistryEntries present but no Attributes -> the original PR #5 failure path."""
+    _serve_registry(monkeypatch, bios_cmd, {"RegistryEntries": {"Menus": []}})
+    result = bios_cmd.execute(attr_name="MemTest", attr_value="Disabled", do_show=True)
+    assert result.data["Status"] == "Failed fetch attributes from bios registry"
+
+
+def test_attributes_not_a_list(bios_cmd, monkeypatch):
+    """Attributes present but not a list -> malformed, not a downstream crash."""
+    _serve_registry(monkeypatch, bios_cmd, {"RegistryEntries": {"Attributes": None}})
+    result = bios_cmd.execute(attr_name="MemTest", attr_value="Disabled", do_show=True)
+    assert result.data["Status"] == "Bios registry attributes are malformed"
+
+
+def test_valid_registry_builds_payload(bios_cmd, monkeypatch):
+    """A valid registry yields the requested change (the PR #5 fix actually works)."""
+    registry = {"RegistryEntries": {"Attributes": [
+        {"AttributeName": "MemTest", "Type": "Enumeration"},
+    ]}}
+    _serve_registry(monkeypatch, bios_cmd, registry)
+    monkeypatch.setattr(bios_cmd, "create_apply_time_req", lambda *a, **k: {})
+    result = bios_cmd.execute(attr_name="MemTest", attr_value="Disabled", do_show=True)
+    assert result.data["Attributes"]["MemTest"] == "Disabled"
+
+
+def test_from_spec_skips_registry_fetch(bios_cmd, monkeypatch, tmp_path):
+    """With --from_spec, the BIOS registry is not fetched at all."""
+    calls = {"n": 0}
+
+    def _spy(*a, **k):
+        calls["n"] += 1
+        return CommandResult({}, None, None, None)
+
+    monkeypatch.setattr(bios_cmd, "base_query", _spy)
+    monkeypatch.setattr(bios_cmd, "create_apply_time_req", lambda *a, **k: {})
+    spec = tmp_path / "bios.json"
+    spec.write_text(json.dumps({"Attributes": {"MemTest": "Disabled"}}))
+    result = bios_cmd.execute(from_spec=str(spec), do_show=True)
+    assert calls["n"] == 0
+    assert result.data["Attributes"]["MemTest"] == "Disabled"
+
+
+def test_invalid_spec_surfaces_decoder_detail(bios_cmd, monkeypatch, tmp_path):
+    """An invalid JSON spec raises InvalidJsonSpec with the decoder detail."""
+    monkeypatch.setattr(bios_cmd, "create_apply_time_req", lambda *a, **k: {})
+    spec = tmp_path / "bad.json"
+    spec.write_text("{not valid json")
+    with pytest.raises(InvalidJsonSpec) as exc:
+        bios_cmd.execute(from_spec=str(spec), do_show=True)
+    assert "JSONlint" in str(exc.value)

--- a/tests/test_virtual_media_dualmode.py
+++ b/tests/test_virtual_media_dualmode.py
@@ -1,0 +1,150 @@
+"""Dual-mode tests for virtual-media commands."""
+import json
+
+from idrac_ctl.idrac_manager import IDracManager
+from idrac_ctl.idrac_shared import ApiRequestType, IdracApiRespond
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_virtual_media_query_returns_collection(redfish_api):
+    """virtual_disk_query returns the expanded virtual-media collection."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.VirtualMediaGet, "virtual_disk_query"
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == (
+        "/redfish/v1/Systems/System.Embedded.1/VirtualMedia"
+    )
+    assert result.data["Members@odata.count"] == 2
+    assert [member["Id"] for member in result.data["Members"]] == ["1", "2"]
+
+
+def test_virtual_media_query_filters_by_device_id(redfish_api):
+    """device_id returns the matching virtual-media member."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.VirtualMediaGet,
+        "virtual_disk_query",
+        device_id="2",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["Id"] == "2"
+    assert result.data["Inserted"] is True
+    assert result.data["Image"] == "http://example.test/installer.iso"
+
+
+def test_virtual_media_query_filter_key_returns_member_value(redfish_api):
+    """filter_key narrows a device response to one field."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.VirtualMediaGet,
+        "virtual_disk_query",
+        device_id="2",
+        filter_key="Image",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == "http://example.test/installer.iso"
+
+
+def test_virtual_media_query_filter_key_reports_missing_key(redfish_api):
+    """filter_key returns a status payload when the requested field is absent."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.VirtualMediaGet,
+        "virtual_disk_query",
+        device_id="1",
+        filter_key="MissingField",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {"Status": "key MissingField not found"}
+
+
+def test_virtual_media_query_reports_missing_device(redfish_api):
+    """unknown device_id returns a status payload instead of a member."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.VirtualMediaGet,
+        "virtual_disk_query",
+        device_id="99",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {"Status": "device id 99 not found"}
+
+
+def test_virtual_media_insert_posts_action_payload(
+    redfish_mock, redfish_service, monkeypatch
+):
+    """virtual_disk_insert POSTs to the member InsertMedia action target."""
+    monkeypatch.setattr(
+        IDracManager,
+        "fetch_task",
+        lambda self, task_id: {"TaskState": "Completed"},
+    )
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.VirtualMediaInsert,
+        "virtual_disk_insert",
+        uri_path="http://example.test/new.iso",
+        device_id="1",
+        remote_username="media-user",
+        remote_password="media-pass",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["task_id"] == redfish_service.JOB_ID
+    assert result.data["task_state"] == {"TaskState": "Completed"}
+    assert redfish_service.last_request.path == (
+        "/redfish/v1/systems/system.embedded.1/virtualmedia/1/"
+        "actions/virtualmedia.insertmedia"
+    )
+    assert redfish_service.last_request.json() == {
+        "Image": "http://example.test/new.iso",
+        "Inserted": True,
+        "WriteProtected": True,
+        "UserName": "media-user",
+        "Password": "media-pass",
+    }
+
+
+def test_virtual_media_eject_posts_action_payload(
+    redfish_mock, redfish_service, monkeypatch
+):
+    """virtual_disk_eject POSTs an empty body to the member EjectMedia target."""
+    monkeypatch.setattr(
+        IDracManager,
+        "fetch_task",
+        lambda self, task_id: {"TaskState": "Completed"},
+    )
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.VirtualMediaEject,
+        "virtual_disk_eject",
+        device_id="2",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["task_id"] == redfish_service.JOB_ID
+    assert result.data["task_state"] == {"TaskState": "Completed"}
+    assert redfish_service.last_request.path == (
+        "/redfish/v1/systems/system.embedded.1/virtualmedia/2/"
+        "actions/virtualmedia.ejectmedia"
+    )
+    assert redfish_service.last_request.json() == {}
+
+
+def test_virtual_media_eject_skips_post_when_device_is_already_empty(
+    redfish_mock, redfish_service
+):
+    """non-strict eject returns Ok without POSTing when media is not inserted."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.VirtualMediaEject,
+        "virtual_disk_eject",
+        device_id="1",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {"Status": IdracApiRespond.Ok}
+    assert redfish_service.last_request.method == "GET"


### PR DESCRIPTION
## Summary

Follow-ups on top of the converged `main`: hardens `bios-change` (supersedes #5 with the surrounding
corner cases + tests) and folds in four offline dual-mode test batches.

## BIOS-change hardening (supersedes #5)
- Check `Attributes` inside `RegistryEntries`, not the top-level response (the fix from #5 — thanks
  @fahhem), so `bios-change` works on valid `BiosRegistry` responses.
- Fail gracefully on missing/`None` data, a non-dict `RegistryEntries`, or a non-list `Attributes`
  instead of throwing.
- Skip the registry fetch entirely when `--from_spec` is given; surface the JSON decoder detail on an
  invalid spec (was silently dropped by a `.format` with no placeholder).
- 8 regression tests covering each case (`tests/test_cmd_change_bios_guards.py`).

## Dual-mode test batches (offline, no hardware)
Read/mutating command tests that run against the mock Redfish service, with iDRAC-shaped fixtures:
- account query, virtual media, BIOS, and additional boot tests (current-boot, one-shot, reboot).
- Fixed the `BiosRegistry` fixture to satisfy the DMTF `AttributeRegistry` schema (added the required
  `Language` / `RegistryVersion` / `OwningEntity` fields — caught by the schema gate).

## Testing
- `pytest -q`: **241 passed, 54 skipped** (live tests auto-skip without `IDRAC_IP`).
- Schema gate green; `ruff` clean on changed files.

You can close #5 as superseded once this lands.
