### PR TITLE
Fold in jobs/tasks + storage-volume dual-mode tests; collection schema validation

### DIFF
--- a/tests/idrac_fixtures/_redfish_v1_JobService.json
+++ b/tests/idrac_fixtures/_redfish_v1_JobService.json
@@ -1,0 +1,16 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#JobService.JobService",
+  "@odata.id": "/redfish/v1/JobService",
+  "@odata.type": "#JobService.v1_0_0.JobService",
+  "Id": "JobService",
+  "Name": "Job Service",
+  "ServiceEnabled": true,
+  "ServiceCapabilities": {
+    "MaxJobs": 256,
+    "MaxSteps": 1,
+    "Scheduling": true
+  },
+  "Jobs": {
+    "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Jobs"
+  }
+}

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Jobs.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Jobs.json
@@ -1,0 +1,33 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#JobCollection.JobCollection",
+  "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Jobs",
+  "@odata.type": "#JobCollection.JobCollection",
+  "Name": "Job Queue",
+  "Members@odata.count": 2,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/JID_000000000001",
+      "@odata.type": "#DellJob.v1_0_0.DellJob",
+      "Id": "JID_000000000001",
+      "Name": "Completed BIOS configuration job",
+      "JobState": "Completed",
+      "JobType": "BIOSConfiguration",
+      "StartTime": "2026-06-28T10:00:00+00:00",
+      "ActualRunningStartTime": "2026-06-28T10:00:00+00:00",
+      "PercentComplete": 100,
+      "Message": "Job completed successfully."
+    },
+    {
+      "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/JID_000000000002",
+      "@odata.type": "#DellJob.v1_0_0.DellJob",
+      "Id": "JID_000000000002",
+      "Name": "Running firmware update job",
+      "JobState": "Running",
+      "JobType": "FirmwareUpdate",
+      "StartTime": "2026-06-28T10:05:00+00:00",
+      "ActualRunningStartTime": "2026-06-28T10:05:00+00:00",
+      "PercentComplete": 40,
+      "Message": "Job is running."
+    }
+  ]
+}

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_Jobs_JID_000000000001.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_Jobs_JID_000000000001.json
@@ -1,0 +1,14 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#DellJob.DellJob",
+  "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/JID_000000000001",
+  "@odata.type": "#DellJob.v1_0_0.DellJob",
+  "Id": "JID_000000000001",
+  "Name": "Completed BIOS configuration job",
+  "JobState": "Completed",
+  "JobType": "BIOSConfiguration",
+  "StartTime": "2026-06-28T10:00:00+00:00",
+  "ActualRunningStartTime": "2026-06-28T10:00:00+00:00",
+  "EndTime": "2026-06-28T10:02:00+00:00",
+  "PercentComplete": 100,
+  "Message": "Job completed successfully."
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#StorageCollection.StorageCollection",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage",
+  "@odata.type": "#StorageCollection.StorageCollection",
+  "Name": "Storage Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1"
+    }
+  ]
+}

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage_RAID.Integrated.1-1_Volumes.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Storage_RAID.Integrated.1-1_Volumes.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#VolumeCollection.VolumeCollection",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes",
+  "@odata.type": "#VolumeCollection.VolumeCollection",
+  "Name": "Volume Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes/Disk.Virtual.0:RAID.Integrated.1-1"
+    }
+  ]
+}

--- a/tests/idrac_fixtures/_redfish_v1_TaskService_Tasks.json
+++ b/tests/idrac_fixtures/_redfish_v1_TaskService_Tasks.json
@@ -1,0 +1,25 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
+  "@odata.id": "/redfish/v1/TaskService/Tasks",
+  "@odata.type": "#TaskCollection.TaskCollection",
+  "Name": "Task Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/TaskService/Tasks/JID_000000000001",
+      "@odata.type": "#Task.v1_7_0.Task",
+      "Id": "JID_000000000001",
+      "Name": "Completed BIOS configuration task",
+      "TaskState": "Completed",
+      "TaskStatus": "OK",
+      "StartTime": "2026-06-28T10:00:00+00:00",
+      "EndTime": "2026-06-28T10:02:00+00:00",
+      "PercentComplete": 100,
+      "Actions": {
+        "#Task.Cancel": {
+          "target": "/redfish/v1/TaskService/Tasks/JID_000000000001/Actions/Task.Cancel"
+        }
+      }
+    }
+  ]
+}

--- a/tests/idrac_fixtures/_redfish_v1_TaskService_Tasks_JID_000000000001.json
+++ b/tests/idrac_fixtures/_redfish_v1_TaskService_Tasks_JID_000000000001.json
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Task.Task",
+  "@odata.id": "/redfish/v1/TaskService/Tasks/JID_000000000001",
+  "@odata.type": "#Task.v1_7_0.Task",
+  "Id": "JID_000000000001",
+  "Name": "Completed BIOS configuration task",
+  "TaskState": "Completed",
+  "TaskStatus": "OK",
+  "StartTime": "2026-06-28T10:00:00+00:00",
+  "EndTime": "2026-06-28T10:02:00+00:00",
+  "PercentComplete": 100
+}

--- a/tests/test_jobs_tasks_dualmode.py
+++ b/tests/test_jobs_tasks_dualmode.py
@@ -1,0 +1,107 @@
+"""Dual-mode tests for job and task read commands."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+JOB_ID = "JID_000000000001"
+
+
+def test_jobs_list_returns_expanded_job_members(redfish_api):
+    """jobs_sources_query returns expanded Dell job resources offline."""
+    result = redfish_api.sync_invoke(ApiRequestType.Jobs, "jobs_sources_query")
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, list)
+    json.dumps(result.data)
+    assert [job["Id"] for job in result.data] == [
+        "JID_000000000002",
+        JOB_ID,
+    ]
+    assert result.data[0]["JobState"] == "Running"
+
+
+def test_jobs_list_can_return_only_job_ids(redfish_api):
+    """jobs_sources_query can project the expanded job collection to IDs."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.Jobs,
+        "jobs_sources_query",
+        job_ids=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == ["JID_000000000002", JOB_ID]
+
+
+def test_job_get_returns_dell_oem_job(redfish_api):
+    """job_query returns one Dell OEM job by job ID."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.JobGet,
+        "job_query",
+        job_id=JOB_ID,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == (
+        f"/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/Jobs/{JOB_ID}"
+    )
+    assert result.data["Id"] == JOB_ID
+    assert result.data["JobState"] == "Completed"
+
+
+def test_job_service_returns_service_capabilities(redfish_api):
+    """job_service_query returns the Redfish JobService resource."""
+    result = redfish_api.sync_invoke(ApiRequestType.JobServices, "job_service_query")
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, CommandResult)
+    assert isinstance(result.data.data, dict)
+    json.dumps(result.data.data)
+    assert result.data.data["@odata.id"] == "/redfish/v1/JobService"
+    assert result.data.data["ServiceCapabilities"]["MaxJobs"] == 256
+    assert result.data.data["Jobs"]["@odata.id"] == (
+        "/redfish/v1/Managers/iDRAC.Embedded.1/Jobs"
+    )
+
+
+def test_tasks_list_returns_task_collection_and_actions(redfish_api):
+    """chassis_service_query for TasksList returns expanded task members."""
+    result = redfish_api.sync_invoke(ApiRequestType.TasksList, "chassis_service_query")
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, CommandResult)
+    assert isinstance(result.data.data, dict)
+    json.dumps(result.data.data)
+    assert result.data.data["@odata.id"] == "/redfish/v1/TaskService/Tasks"
+    assert result.data.data["Members"][0]["Id"] == JOB_ID
+    assert "Cancel" in result.discovered
+
+
+def test_task_get_returns_one_task_resource(redfish_api):
+    """task-get returns one TaskService task by task ID."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.TaskGet,
+        "chassis_service_query",
+        task_id=JOB_ID,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, CommandResult)
+    assert isinstance(result.data.data, dict)
+    json.dumps(result.data.data)
+    assert result.data.data["@odata.id"] == f"/redfish/v1/TaskService/Tasks/{JOB_ID}"
+    assert result.data.data["TaskState"] == "Completed"
+
+
+def test_get_task_returns_completed_job_state_without_polling(redfish_api):
+    """task_query returns the completed job state before polling TaskService."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.GetTask,
+        "task_query",
+        job_id=JOB_ID,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data.value == "Completed"

--- a/tests/test_storage_volume_dualmode.py
+++ b/tests/test_storage_volume_dualmode.py
@@ -1,0 +1,54 @@
+"""Dual-mode tests for storage collection and volume collection commands."""
+import json
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_storage_list_returns_storage_collection(redfish_api):
+    """storage_list fetches the iDRAC system storage collection."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.StorageListQuery,
+        "storage_list",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == "/redfish/v1/Systems/System.Embedded.1/Storage"
+    assert result.data["Members"][0]["@odata.id"].endswith("/RAID.Integrated.1-1")
+
+
+def test_storage_query_filters_controller_ids(redfish_api):
+    """storage_query returns filtered controller IDs and matching Redfish URIs."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.StorageQuery,
+        "storage_query",
+        id_filter="RAID",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == ["RAID.Integrated.1-1"]
+    assert result.discovered == [
+        "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1"
+    ]
+
+
+def test_volume_query_returns_controller_volume_collection(redfish_api):
+    """vol_query fetches the volume collection under the selected controller."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.VolumeQuery,
+        "vol_query",
+        dev_id="RAID.Integrated.1-1",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data)
+    assert result.data["@odata.id"] == (
+        "/redfish/v1/Systems/System.Embedded.1/Storage/RAID.Integrated.1-1/Volumes"
+    )
+    assert result.data["Members"][0]["@odata.id"].endswith(
+        "/Volumes/Disk.Virtual.0:RAID.Integrated.1-1"
+    )
+    assert result.discovered == {}

--- a/tools/redfish_validate.py
+++ b/tools/redfish_validate.py
@@ -86,6 +86,23 @@ def _strip_oem(obj) -> None:
             _strip_oem(value)
 
 
+def _reduce_collection_members(obj: dict) -> None:
+    """Reduce a collection's ``Members`` to references for validation.
+
+    Redfish collection schemas type ``Members`` as references (``{@odata.id}``).
+    Real services (notably Dell iDRAC, and any ``$expand`` response) inline the
+    full member objects. We validate the collection's reference structure here;
+    each inlined member is validated on its own as its individual resource.
+    """
+    members = obj.get("Members")
+    if isinstance(members, list):
+        obj["Members"] = [
+            {"@odata.id": m["@odata.id"]}
+            if isinstance(m, dict) and "@odata.id" in m else m
+            for m in members
+        ]
+
+
 def validate_payload(payload: dict, strip_oem: bool = True) -> list:
     """Validate a Redfish resource. Returns a sorted list of errors ([] = valid).
 
@@ -95,10 +112,10 @@ def validate_payload(payload: dict, strip_oem: bool = True) -> list:
     odata_type = payload.get("@odata.type")
     if not odata_type:
         raise ValueError("payload has no @odata.type")
-    body = payload
+    body = deepcopy(payload)
     if strip_oem:
-        body = deepcopy(payload)
         _strip_oem(body)
+    _reduce_collection_members(body)
     validator = Draft7Validator({"$ref": schema_ref_for(odata_type)}, registry=_REGISTRY)
     try:
         errors = list(validator.iter_errors(body))


### PR DESCRIPTION
Two more offline dual-mode test batches (jobs/tasks, storage-volume) with iDRAC-shaped fixtures, plus a schema-gate improvement: collection Members are validated as references so the gate tolerates the inlined/expanded members that Dell iDRAC actually returns. pytest -q: 257 passed, 55 skipped; ruff clean.