### PR TITLE
Live-found fixes (TLS flag, numpy, BIOS, storage) + redfish-discover + Supermicro profile

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,0 @@
-from .idrac_ctl import *
-

--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,8 @@ dependencies:
   # Schema validation (tools/redfish_validate.py)
   - jsonschema>=4.18
   - referencing
+  # Optional TUI ("tui" extra in setup.py): pretty tables for redfish-discover.
+  - rich>=13
   - pip:
       # Install idrac_ctl itself (and anything not on conda-forge) via pip.
       - -e .

--- a/idrac_ctl/discover/__init__.py
+++ b/idrac_ctl/discover/__init__.py
@@ -1,0 +1,25 @@
+"""Read-only Redfish network discovery.
+
+This package implements ``redfish-discover``: a non-mutating tool that probes a
+list of hosts for a Redfish service root (``/redfish/v1/``) and classifies the
+vendor of each reachable service. Nothing here opens a real network connection
+or stores credentials — the scan helper takes an async GET callable supplied by
+the caller, so the pure logic (vendor classification, result shaping, table
+rendering) stays fully offline-testable.
+
+Public surface:
+
+* :func:`classify_vendor` — pure ServiceRoot dict -> vendor string.
+* :func:`scan_subnet` — async probe of many hosts via an injected GET callable.
+* :func:`redfish_discover_main` — console entry point (rich if available).
+
+Author Mus spyroot@gmail.com
+"""
+from idrac_ctl.discover.classifier import classify_vendor
+from idrac_ctl.discover.scanner import DiscoveredService, scan_subnet
+
+__all__ = [
+    "classify_vendor",
+    "scan_subnet",
+    "DiscoveredService",
+]

--- a/idrac_ctl/discover/classifier.py
+++ b/idrac_ctl/discover/classifier.py
@@ -1,0 +1,127 @@
+"""Pure vendor classification for a Redfish ServiceRoot.
+
+A Redfish ``ServiceRoot`` (the document served at ``/redfish/v1/``) does not
+carry a single canonical "vendor" field, so vendors leak their identity in a few
+different places. This module reads those signals in a fixed priority order and
+maps them to a small, stable set of vendor tags. It performs no I/O.
+
+Ranking (first match wins):
+
+1. ``Oem`` child key — e.g. ``ServiceRoot["Oem"]["Dell"]``. The OEM block is the
+   strongest signal because a vendor only emits its own OEM namespace.
+2. ``@odata.type`` OEM prefix — e.g. ``#DellServiceRoot.v1_0_0.DellServiceRoot``.
+   Some services type their root with a vendor-prefixed schema name.
+3. ``Manufacturer`` / ``Vendor`` substring — a free-text fallback, matched
+   case-insensitively against known vendor names.
+
+Anything unrecognized maps to ``"generic"`` so callers always get a usable tag.
+
+Author Mus spyroot@gmail.com
+"""
+from typing import Any, Dict, Mapping, Optional
+
+# Canonical vendor tags this tool emits.
+DELL = "dell"
+HPE = "hpe"
+SUPERMICRO = "supermicro"
+GENERIC = "generic"
+
+# Map an OEM namespace / type token (lowercased) to a canonical vendor tag.
+# Vendors use a couple of spellings (Dell/Emc, Hpe/Hp, Supermicro/SMC), so we
+# normalize them all to one tag here.
+_OEM_KEY_TO_VENDOR = {
+    "dell": DELL,
+    "emc": DELL,
+    "hpe": HPE,
+    "hp": HPE,
+    "supermicro": SUPERMICRO,
+    "smc": SUPERMICRO,
+    "smci": SUPERMICRO,
+}
+
+# Substrings searched in Manufacturer/Vendor free-text (lowercased). Ordered so
+# the more specific token wins (e.g. "hpe" before a bare "hp").
+_TEXT_TOKENS = (
+    ("dell", DELL),
+    ("hewlett packard enterprise", HPE),
+    ("hpe", HPE),
+    ("hewlett-packard", HPE),
+    ("hewlett packard", HPE),
+    ("hp", HPE),
+    ("supermicro", SUPERMICRO),
+    ("super micro", SUPERMICRO),
+)
+
+
+def _vendor_from_oem(service_root: Mapping[str, Any]) -> Optional[str]:
+    """Return a vendor from the ``Oem`` block, or ``None``.
+
+    The ``Oem`` value should be a mapping whose keys are vendor namespaces.
+    A non-mapping ``Oem`` (malformed input) is ignored rather than raising.
+    """
+    oem = service_root.get("Oem")
+    if not isinstance(oem, Mapping):
+        return None
+    for key in oem.keys():
+        if not isinstance(key, str):
+            continue
+        vendor = _OEM_KEY_TO_VENDOR.get(key.strip().lower())
+        if vendor is not None:
+            return vendor
+    return None
+
+
+def _vendor_from_odata_type(service_root: Mapping[str, Any]) -> Optional[str]:
+    """Return a vendor from an OEM-prefixed ``@odata.type``, or ``None``.
+
+    Example: ``#DellServiceRoot.v1_0_0.DellServiceRoot`` -> ``dell``. The leading
+    ``#`` and any namespace path are stripped before matching the prefix.
+    """
+    odata_type = service_root.get("@odata.type")
+    if not isinstance(odata_type, str):
+        return None
+    token = odata_type.lstrip("#")
+    # Take the schema name portion before the first dot, e.g. "DellServiceRoot".
+    schema = token.split(".", 1)[0].lower()
+    for oem_key, vendor in _OEM_KEY_TO_VENDOR.items():
+        if schema.startswith(oem_key):
+            return vendor
+    return None
+
+
+def _vendor_from_text(service_root: Mapping[str, Any]) -> Optional[str]:
+    """Return a vendor from ``Manufacturer``/``Vendor`` substrings, or ``None``."""
+    parts = []
+    for field in ("Manufacturer", "Vendor"):
+        value = service_root.get(field)
+        if isinstance(value, str):
+            parts.append(value.lower())
+    if not parts:
+        return None
+    haystack = " ".join(parts)
+    for token, vendor in _TEXT_TOKENS:
+        if token in haystack:
+            return vendor
+    return None
+
+
+def classify_vendor(service_root: Optional[Dict[str, Any]]) -> str:
+    """Classify the vendor of a Redfish ServiceRoot document.
+
+    :param service_root: a parsed ``/redfish/v1/`` ServiceRoot dict. ``None`` or a
+        non-mapping value is treated as unidentifiable.
+    :return: one of ``"dell"``, ``"hpe"``, ``"supermicro"``, or ``"generic"``.
+
+    The signals are consulted in a fixed ranking (Oem child key, then
+    ``@odata.type`` OEM prefix, then ``Manufacturer``/``Vendor`` substring); the
+    first that yields a known vendor wins. Unrecognized input is ``"generic"``,
+    never an exception, so discovery never crashes on an odd root document.
+    """
+    if not isinstance(service_root, Mapping):
+        return GENERIC
+
+    for resolver in (_vendor_from_oem, _vendor_from_odata_type, _vendor_from_text):
+        vendor = resolver(service_root)
+        if vendor is not None:
+            return vendor
+    return GENERIC

--- a/idrac_ctl/discover/cli.py
+++ b/idrac_ctl/discover/cli.py
@@ -1,0 +1,179 @@
+"""Console entry point for ``redfish-discover``.
+
+This wires the pure pieces (:func:`idrac_ctl.discover.classifier.classify_vendor`
+and :func:`idrac_ctl.discover.scanner.scan_subnet`) into a CLI and renders the
+results as a table. Rendering prefers ``rich`` when it is importable and the
+output is a real terminal; otherwise it falls back to a fixed-width plain-text
+table so the tool works in pipes, logs, and CI.
+
+The default network fetcher is intentionally a stub that returns no services:
+real discovery requires a transport/auth policy the operator supplies. Keeping
+the default inert means importing or invoking this module never opens a socket
+and never uses credentials, which is what lets the rest of the package stay
+offline-testable.
+
+Author Mus spyroot@gmail.com
+"""
+import argparse
+import asyncio
+import sys
+from typing import Any, Dict, List, Optional, Sequence, TextIO
+
+from idrac_ctl.discover.scanner import DiscoveredService, scan_subnet
+
+# Column order for both renderers; (header, record-key) pairs.
+_COLUMNS = (
+    ("IP", "ip"),
+    ("Vendor", "vendor"),
+    ("Product", "product"),
+    ("Redfish", "redfish_version"),
+)
+
+
+def _supports_rich(stream: TextIO) -> bool:
+    """Return True when ``rich`` is importable and ``stream`` is a TTY.
+
+    Both conditions matter: ``rich`` styling is only worth using on an
+    interactive terminal, and on a non-TTY (pipe/file/CI) we degrade to plain
+    text so escape codes never pollute the output.
+    """
+    if not _stream_is_tty(stream):
+        return False
+    try:
+        import rich  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def _stream_is_tty(stream: TextIO) -> bool:
+    """Best-effort ``isatty`` check that tolerates odd stream objects."""
+    isatty = getattr(stream, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return bool(isatty())
+    except Exception:
+        return False
+
+
+def _cell(record: Dict[str, Any], key: str) -> str:
+    """Stringify one record cell, rendering missing values as ``-``."""
+    value = record.get(key)
+    return "-" if value is None else str(value)
+
+
+def render_table(
+        services: Sequence[DiscoveredService],
+        stream: Optional[TextIO] = None) -> None:
+    """Render discovered services to ``stream`` (default ``sys.stdout``).
+
+    Uses ``rich`` when available on a TTY; otherwise writes a plain-text table.
+    An empty result set prints a short notice rather than an empty frame.
+    """
+    out = stream if stream is not None else sys.stdout
+    records = [svc.as_dict() for svc in services]
+
+    if not records:
+        out.write("No Redfish services discovered.\n")
+        return
+
+    if _supports_rich(out):
+        _render_rich(records, out)
+    else:
+        _render_plain(records, out)
+
+
+def _render_rich(records: List[Dict[str, Any]], out: TextIO) -> None:
+    """Render with ``rich`` (only called when import + TTY checks passed)."""
+    from rich.console import Console
+    from rich.table import Table
+
+    table = Table(title="Discovered Redfish services")
+    for header, _key in _COLUMNS:
+        table.add_column(header)
+    for record in records:
+        table.add_row(*(_cell(record, key) for _header, key in _COLUMNS))
+
+    Console(file=out).print(table)
+
+
+def _render_plain(records: List[Dict[str, Any]], out: TextIO) -> None:
+    """Render a fixed-width plain-text table (no escape codes)."""
+    headers = [header for header, _key in _COLUMNS]
+    keys = [key for _header, key in _COLUMNS]
+
+    rows = [[_cell(record, key) for key in keys] for record in records]
+    widths = [
+        max(len(headers[i]), *(len(row[i]) for row in rows))
+        for i in range(len(headers))
+    ]
+
+    def _fmt(cells: Sequence[str]) -> str:
+        return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(cells))
+
+    out.write(_fmt(headers) + "\n")
+    out.write(_fmt(["-" * w for w in widths]) + "\n")
+    for row in rows:
+        out.write(_fmt(row) + "\n")
+
+
+async def _default_get(_ip: str) -> Optional[Dict[str, Any]]:
+    """Default fetcher: a no-op that discovers nothing.
+
+    Real discovery needs an operator-supplied transport/auth policy. The default
+    deliberately performs no network call and holds no credentials, so running
+    the CLI without wiring a fetcher is safe and inert.
+    """
+    return None
+
+
+def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
+    """Parse ``redfish-discover`` arguments."""
+    parser = argparse.ArgumentParser(
+        prog="redfish-discover",
+        description=(
+            "Read-only discovery of Redfish services on a list of hosts. "
+            "Probes /redfish/v1/ and reports vendor, product, and Redfish "
+            "version. Does not mutate any controller."
+        ),
+    )
+    parser.add_argument(
+        "hosts",
+        nargs="*",
+        help="Host addresses to probe (e.g. 10.0.0.10 10.0.0.11).",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=32,
+        help="Maximum number of concurrent probes (default: 32).",
+    )
+    return parser.parse_args(argv)
+
+
+def redfish_discover_main(argv: Optional[Sequence[str]] = None) -> int:
+    """Console entry point for ``redfish-discover``.
+
+    :param argv: argument vector (defaults to ``sys.argv[1:]``).
+    :return: process exit code. ``0`` always for a completed scan; ``2`` when no
+        hosts were supplied (nothing to do).
+
+    With the default fetcher the scan discovers nothing — wiring a real fetcher
+    is an operator responsibility, kept out of this module so it never performs
+    network I/O or touches credentials on its own.
+    """
+    args = _parse_args(argv)
+    if not args.hosts:
+        sys.stderr.write("redfish-discover: no hosts supplied; nothing to scan.\n")
+        return 2
+
+    services = asyncio.run(
+        scan_subnet(args.hosts, _default_get, concurrency=args.concurrency)
+    )
+    render_table(services)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    raise SystemExit(redfish_discover_main())

--- a/idrac_ctl/discover/scanner.py
+++ b/idrac_ctl/discover/scanner.py
@@ -1,0 +1,134 @@
+"""Async subnet scan for reachable Redfish services.
+
+:func:`scan_subnet` probes many hosts concurrently for a Redfish service root and
+returns the ones that answer. It performs **no** network I/O itself and stores no
+credentials: the caller injects an async ``get`` callable that knows how to fetch
+``/redfish/v1/`` for a single host (with whatever auth/TLS policy the caller
+chose). That keeps this module product-neutral and fully offline-testable — tests
+pass a fake async GET.
+
+Concurrency is bounded by an :class:`asyncio.Semaphore` so a large host list
+cannot open an unbounded number of sockets at once.
+
+Author Mus spyroot@gmail.com
+"""
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence
+
+from idrac_ctl.discover.classifier import classify_vendor
+
+# The well-known Redfish service root path. Probed read-only.
+REDFISH_ROOT_PATH = "/redfish/v1/"
+
+# Signature of the injected fetcher: given a host, return the parsed ServiceRoot
+# dict, or ``None`` when the host is not a reachable Redfish service. The callable
+# owns its own transport, auth, and error handling.
+AsyncGet = Callable[[str], Awaitable[Optional[Dict[str, Any]]]]
+
+
+@dataclass(frozen=True)
+class DiscoveredService:
+    """A reachable Redfish service found during a scan.
+
+    :ivar ip: the host address that answered.
+    :ivar vendor: classification from :func:`classify_vendor`.
+    :ivar product: ``Product`` field from the ServiceRoot, if present.
+    :ivar redfish_version: ``RedfishVersion`` field, if present.
+    """
+
+    ip: str
+    vendor: str
+    product: Optional[str]
+    redfish_version: Optional[str]
+
+    def as_dict(self) -> Dict[str, Optional[str]]:
+        """Return the record as a plain dict (handy for rendering/serialization)."""
+        return {
+            "ip": self.ip,
+            "vendor": self.vendor,
+            "product": self.product,
+            "redfish_version": self.redfish_version,
+        }
+
+
+def _service_from_root(
+        ip: str, service_root: Optional[Dict[str, Any]]) -> Optional[DiscoveredService]:
+    """Build a :class:`DiscoveredService` from a fetched ServiceRoot, or ``None``.
+
+    A falsy/non-mapping root means the host is not a usable Redfish service, so we
+    return ``None`` and the caller drops it from the results.
+    """
+    if not isinstance(service_root, dict) or not service_root:
+        return None
+    product = service_root.get("Product")
+    redfish_version = service_root.get("RedfishVersion")
+    return DiscoveredService(
+        ip=ip,
+        vendor=classify_vendor(service_root),
+        product=product if isinstance(product, str) else None,
+        redfish_version=redfish_version if isinstance(redfish_version, str) else None,
+    )
+
+
+async def _probe_host(
+        ip: str,
+        get: AsyncGet,
+        semaphore: asyncio.Semaphore) -> Optional[DiscoveredService]:
+    """Probe a single host under the concurrency semaphore.
+
+    Any exception raised by the injected ``get`` (timeout, connection refused,
+    bad TLS, non-JSON body) is swallowed so one unreachable host never fails the
+    whole scan; that host is simply reported as not discovered (``None``).
+    """
+    async with semaphore:
+        try:
+            service_root = await get(ip)
+        except Exception:
+            return None
+    return _service_from_root(ip, service_root)
+
+
+async def scan_subnet(
+        hosts: Sequence[str],
+        get: AsyncGet,
+        *,
+        concurrency: int = 32) -> List[DiscoveredService]:
+    """Probe ``hosts`` for reachable Redfish services, concurrently.
+
+    :param hosts: host addresses to probe (e.g. an expanded subnet). Duplicates
+        and falsy entries are ignored; order of the returned list follows the
+        order of the first occurrence of each host in ``hosts``.
+    :param get: async callable fetching ``/redfish/v1/`` for one host and
+        returning the parsed ServiceRoot dict, or ``None`` when not reachable.
+        This is the only thing that touches the network — the module never calls
+        out on its own and never holds credentials.
+    :param concurrency: maximum number of in-flight probes; must be >= 1. Bounds
+        socket/file-descriptor usage on large host lists.
+    :return: a list of :class:`DiscoveredService`, one per reachable host, in the
+        input order described above.
+    :raises ValueError: if ``concurrency`` < 1.
+
+    Hosts that error or do not answer with a Redfish service root are silently
+    omitted. The scan is read-only; it only issues GETs through ``get``.
+    """
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+
+    # Preserve input order while dropping duplicates and empty entries.
+    ordered_hosts: List[str] = []
+    seen = set()
+    for host in hosts:
+        if not host or host in seen:
+            continue
+        seen.add(host)
+        ordered_hosts.append(host)
+
+    if not ordered_hosts:
+        return []
+
+    semaphore = asyncio.Semaphore(concurrency)
+    results = await asyncio.gather(
+        *(_probe_host(host, get, semaphore) for host in ordered_hosts)
+    )
+    return [svc for svc in results if svc is not None]

--- a/idrac_ctl/discovery/cmd_discovery.py
+++ b/idrac_ctl/discovery/cmd_discovery.py
@@ -10,11 +10,8 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Optional
 
-import numpy as np
-
 from ..idrac_manager import IDracManager
-from ..idrac_shared import ApiRequestType
-from ..idrac_shared import Singleton
+from ..idrac_shared import ApiRequestType, Singleton
 from ..redfish_exceptions import RedfishForbidden
 from ..redfish_manager import CommandResult
 
@@ -131,7 +128,12 @@ class Discovery(IDracManager,
     def save_url_file_mapping(self):
         """Save the URL-to-file mapping to a JSON respond file
         and what each api allow.
+
+        numpy is imported lazily here so importing this module does not
+        require numpy to be installed; it is only needed for ``np.save``.
         """
+        import numpy as np
+
         filename = os.path.join(self.json_response_dir, "rest_api_map.npy")
         mappings = {
             "url_file_mapping": self._discovered_url_file_mapping,

--- a/idrac_ctl/idrac_main.py
+++ b/idrac_ctl/idrac_main.py
@@ -235,7 +235,12 @@ def process_respond(cmd_args, command_result):
 def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
     """Main entry point
     """
-    if cmd_args.insecure:
+    # BMCs ship self-signed certs, so verification is opt-in via --verify-ssl.
+    # We skip verification by default; --insecure stays as an explicit "skip".
+    verify_ssl = getattr(cmd_args, "verify_ssl", False)
+    insecure = not verify_ssl
+
+    if insecure:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # idrac manager main interface main uses to interact with IDRAC.
@@ -243,7 +248,7 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
                                idrac_username=cmd_args.idrac_username,
                                idrac_password=cmd_args.idrac_password,
                                idrac_port=cmd_args.idrac_port,
-                               insecure=cmd_args.insecure,
+                               insecure=insecure,
                                is_http=cmd_args.use_http,
                                is_debug=cmd_args.debug)
     _ = redfish_api.check_api_version()
@@ -394,8 +399,14 @@ def idrac_main_ctl():
         help="idrac port address, by default "
              "read from environment IDRAC_PORT.")
     credentials.add_argument(
-        '--insecure', action='store_true', required=False,
-        help="insecure ssl.")
+        '--insecure', action='store_true', required=False, default=False,
+        help="skip TLS certificate verification (explicit form of the "
+             "default; BMCs ship self-signed certs).")
+    credentials.add_argument(
+        '--verify-ssl', dest='verify_ssl',
+        action='store_true', required=False, default=False,
+        help="verify the BMC TLS certificate. Off by default because "
+             "BMCs ship self-signed certs; opt in only with a trusted cert.")
     credentials.add_argument(
         '--use_http', action='store_true', required=False, default=False,
         help="use http instead https as transport.")

--- a/idrac_ctl/idrac_manager.py
+++ b/idrac_ctl/idrac_manager.py
@@ -85,7 +85,7 @@ class IDracManager(RedfishManager):
                  idrac_username: Optional[str] = "root",
                  idrac_password: Optional[str] = "",
                  idrac_port: Optional[int] = 443,
-                 insecure: Optional[bool] = False,
+                 insecure: Optional[bool] = True,
                  x_auth: Optional[str] = None,
                  is_http: Optional[bool] = False,
                  is_debug: Optional[bool] = False,
@@ -97,7 +97,9 @@ class IDracManager(RedfishManager):
         :param idrac_ip: idrac mgmt IP address
         :param idrac_username: idrac username default is root
         :param idrac_password: idrac password.
-        :param insecure: by default, we use insecure SSL
+        :param insecure: when True (the default) TLS certificate verification is
+            skipped. iDRAC/BMC controllers present self-signed certificates, so
+            verification is opt-in: pass ``insecure=False`` to verify the cert.
         :param x_auth: X-Authentication header.
         """
         super().__init__(redfish_ip=idrac_ip,
@@ -405,7 +407,9 @@ class IDracManager(RedfishManager):
                 "username": self._username,
                 "password": self._password,
                 "port": self._port,
-                "insecure": self._is_verify_cert,
+                # forward the original "skip verification" intent; _is_verify_cert
+                # is the inverse (requests' verify flag), so flip it back here.
+                "insecure": not self._is_verify_cert,
                 "is_http": self._is_http,
             }
         )

--- a/idrac_ctl/idrac_shared.py
+++ b/idrac_ctl/idrac_shared.py
@@ -439,8 +439,11 @@ class IDRAC_API:
     # /redfish/v1/AccountService/Roles/{RoleId}
     # The value of the Id property of the Role resource
     BiosSettings = RedfishApi.BiosSettings
+    # Base BIOS resource, relative to idrac_manage_servers
+    # (e.g. /redfish/v1/Systems/System.Embedded.1) -> .../Bios. This matches the
+    # BiosRegistry/BiosSettings members, which hang off the same /Bios base.
+    BIOS = RedfishApi.Bios
     # COMPUTE_RESET = RedfishApi.ComputeReset
-    # BIOS = RedfishApi.Bios
     BootOptions = "BootOptions"
 
 

--- a/idrac_ctl/redfish_manager.py
+++ b/idrac_ctl/redfish_manager.py
@@ -48,7 +48,7 @@ class RedfishManager:
                  redfish_username: Optional[str] = "root",
                  redfish_password: Optional[str] = "",
                  redfish_port: Optional[int] = 443,
-                 insecure: Optional[bool] = False,
+                 insecure: Optional[bool] = True,
                  is_http: Optional[bool] = False,
                  x_auth: Optional[str] = None,
                  is_debug: Optional[bool] = False):
@@ -60,7 +60,9 @@ class RedfishManager:
         :param redfish_ip: redfish IP or hostname
         :param redfish_username: redfish username default is root
         :param redfish_password: redfish password.
-        :param insecure: by default, we use insecure SSLself.api_success_msg(api_resp)
+        :param insecure: when True (the default) TLS certificate verification is
+            skipped. BMCs ship self-signed certificates, so verification is
+            opt-in: pass ``insecure=False`` to verify the server certificate.
         :param x_auth: X-Authentication header.
         """
         self._redfish_ip = redfish_ip
@@ -71,7 +73,9 @@ class RedfishManager:
             redfish_port = int(redfish_port)
 
         self._port = redfish_port
-        self._is_verify_cert = insecure
+        # ``insecure`` means "skip TLS verification"; requests' ``verify`` is the
+        # inverse, so verification is enabled only when insecure is explicitly off.
+        self._is_verify_cert = not insecure
         self._x_auth = x_auth
         self._is_debug = is_debug
         self._is_http = is_http

--- a/idrac_ctl/storage/cmd_drives.py
+++ b/idrac_ctl/storage/cmd_drives.py
@@ -4,8 +4,9 @@ Author Mus spyroot@gmail.com
 from abc import abstractmethod
 from typing import Optional
 
+from ..cmd_utils import find_ids
 from ..idrac_manager import IDracManager
-from ..idrac_shared import Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
 
 

--- a/idrac_ctl/vendors/supermicro/capabilities.py
+++ b/idrac_ctl/vendors/supermicro/capabilities.py
@@ -1,8 +1,12 @@
-"""Supermicro capability profile (placeholder).
+"""Supermicro capability profile.
 
-Scaffolding for a future Supermicro vendor package. Supermicro publishes no
-official Python Redfish SDK or emulator, so values stay conservative until
-validated against real hardware. Fill in as Supermicro command modules are added.
+Validated read-only against a live Supermicro GB300 BMC (Redfish 1.17.0):
+Manufacturer reports "Supermicro"; ServiceRoot carries no Oem block; standard
+Redfish paths are used (Systems member id "System_0", not Dell's
+"System.Embedded.1"); UpdateService and its FirmwareInventory exist.
+
+Server-side query-parameter support and recurring JobService scheduling were NOT
+observed, so they stay conservative (False) until verified against hardware.
 
 Author Mus spyroot@gmail.com
 """
@@ -11,6 +15,16 @@ from ..base import VendorCapabilities, register
 SUPERMICRO = register(
     VendorCapabilities(
         vendor="supermicro",
+        # Manufacturer string reported by the live GB300 BMC.
         oem_prefix="Supermicro",
+        # Query parameters and job scheduling were not validated on the GB300;
+        # keep them conservative (False) until confirmed against hardware.
+        query_select=False,
+        query_filter=False,
+        query_expand=False,
+        query_top=False,
+        query_only=False,
+        job_scheduling=False,
+        one_recurring_job_per_type=False,
     )
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
@@ -22,6 +22,7 @@ setup_info = dict(name='idrac_ctl',
                   entry_points={
                       'console_scripts': [
                           'idrac_ctl = idrac_ctl.idrac_main:idrac_main_ctl',
+                          'redfish-discover = idrac_ctl.discover.cli:redfish_discover_main',
                       ]
                   },
                   extras_require={
@@ -34,6 +35,9 @@ setup_info = dict(name='idrac_ctl',
                       "schema": [
                           "jsonschema >= 4.18",
                           "referencing",
+                      ],
+                      "tui": [
+                          "rich >= 13",
                       ],
                   },
                   )

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios.json
@@ -1,0 +1,24 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#Bios.Bios",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios",
+  "@odata.type": "#Bios.v1_2_0.Bios",
+  "Id": "BIOS",
+  "Name": "BIOS Configuration Current Settings",
+  "AttributeRegistry": "BiosAttributeRegistry.v1_0_0",
+  "Actions": {
+    "#Bios.ChangePassword": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Bios/Settings/Actions/Bios.ChangePassword"
+    },
+    "#Bios.ResetBios": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Bios/Settings/Actions/Bios.ResetBios"
+    }
+  },
+  "Attributes": {
+    "BootMode": "Uefi",
+    "OneTimeBootMode": "Disabled",
+    "ProcCStates": "Disabled",
+    "SriovGlobalEnable": "Enabled",
+    "SysMemSize": "768 GB",
+    "SystemModelName": "PowerEdge R740"
+  }
+}

--- a/tests/test_bios_inventory_dualmode.py
+++ b/tests/test_bios_inventory_dualmode.py
@@ -1,0 +1,61 @@
+"""Dual-mode test for the BIOS inventory query command.
+
+Runs offline by default against the mock service (using the iDRAC-shaped fixture
+tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios.json), and against
+real hardware when IDRAC_IP is set. Mirrors tests/test_cmd_boot_dualmode.py: invoke
+the command through sync_invoke and assert the CommandResult shape.
+
+This is also the regression guard for the IDRAC_API.BIOS member: BiosQuery.execute
+builds the URL as f"{self.idrac_manage_servers}{IDRAC_API.BIOS}", so a missing BIOS
+member raises AttributeError before any request is made.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+
+from idrac_ctl.idrac_shared import IDRAC_API, ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+
+def test_idrac_api_has_bios_member():
+    """IDRAC_API exposes a BIOS base path so BiosQuery can build its URL."""
+    # The base resource hangs off idrac_manage_servers (.../System.Embedded.1).
+    assert IDRAC_API.BIOS == "/Bios"
+
+
+def test_bios_inventory_query(redfish_api):
+    """bios_inventory returns a JSON-serializable CommandResult from /Bios."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BiosQuery, "bios_inventory"
+    )
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    # the payload must be JSON-serializable (CLI renders it as JSON)
+    json.dumps(result.data)
+    # in mock mode the fixture carries the iDRAC BIOS resource + attributes
+    assert result.data["@odata.id"].endswith("/Bios")
+    assert result.data["@odata.type"].startswith("#Bios.")
+    attributes = result.data["Attributes"]
+    assert isinstance(attributes, dict)
+    assert attributes["BootMode"] in {"Uefi", "Bios"}
+
+
+def test_bios_inventory_attr_only_returns_only_attributes(redfish_api):
+    """attr_only trims the payload down to just the Attributes map."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BiosQuery, "bios_inventory", attr_only=True
+    )
+    assert isinstance(result, CommandResult)
+    assert set(result.data.keys()) == {"Attributes"}
+    assert isinstance(result.data["Attributes"], dict)
+
+
+def test_bios_inventory_filter_selects_matching_attribute(redfish_api):
+    """A --filter value narrows the result to the matching BIOS attribute(s)."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.BiosQuery, "bios_inventory", attr_filter="ProcCStates"
+    )
+    assert isinstance(result, CommandResult)
+    assert "ProcCStates" in result.data
+    # filtering returns a flat {attr: value} map, not the full Bios resource
+    assert "@odata.id" not in result.data

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -1,0 +1,249 @@
+"""Offline tests for the read-only Redfish discovery package.
+
+Covers the pure vendor classifier (ranking and fallbacks), the async scan helper
+driven by a fake GET (no network), and the table renderer's plain-text/empty
+paths. Everything here runs without an iDRAC, a network, or ``rich`` installed.
+
+Author Mus spyroot@gmail.com
+"""
+import asyncio
+import io
+
+import pytest
+
+from idrac_ctl.discover import (
+    DiscoveredService,
+    classify_vendor,
+    scan_subnet,
+)
+from idrac_ctl.discover import cli as discover_cli
+
+# --------------------------------------------------------------------------- #
+# Vendor classifier
+# --------------------------------------------------------------------------- #
+
+def test_classify_dell_via_oem():
+    """Dell ServiceRoot with an Oem.Dell block classifies as ``dell``."""
+    service_root = {
+        "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+        "RedfishVersion": "1.11.0",
+        "Oem": {"Dell": {"@odata.type": "#DellServiceRoot.v1_0_0.DellServiceRoot"}},
+    }
+    assert classify_vendor(service_root) == "dell"
+
+
+def test_classify_hpe_via_oem():
+    """HPE ServiceRoot with an Oem.Hpe block classifies as ``hpe``."""
+    service_root = {
+        "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+        "Oem": {"Hpe": {"Manager": {"Type": "iLO 5"}}},
+    }
+    assert classify_vendor(service_root) == "hpe"
+
+
+def test_classify_supermicro_via_vendor_field_no_oem():
+    """Supermicro is recognized from Vendor text when no Oem block is present."""
+    service_root = {
+        "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+        "Vendor": "Supermicro",
+        "Product": "X11 BMC",
+    }
+    assert "Oem" not in service_root
+    assert classify_vendor(service_root) == "supermicro"
+
+
+def test_classify_unknown_is_generic():
+    """A ServiceRoot with no vendor signal falls back to ``generic``."""
+    service_root = {
+        "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+        "RedfishVersion": "1.6.0",
+    }
+    assert classify_vendor(service_root) == "generic"
+
+
+def test_classify_odata_type_prefix_ranks_above_text():
+    """An OEM-prefixed @odata.type wins when there is no Oem block.
+
+    Even with a misleading Manufacturer string, the @odata.type signal (ranked
+    above free text) decides the vendor.
+    """
+    service_root = {
+        "@odata.type": "#DellServiceRoot.v1_0_0.DellServiceRoot",
+        "Manufacturer": "Supermicro",
+    }
+    assert classify_vendor(service_root) == "dell"
+
+
+def test_classify_oem_ranks_above_odata_type():
+    """The Oem child key outranks a conflicting @odata.type prefix."""
+    service_root = {
+        "@odata.type": "#HpeServiceRoot.v1_0_0.HpeServiceRoot",
+        "Oem": {"Dell": {}},
+    }
+    assert classify_vendor(service_root) == "dell"
+
+
+def test_classify_manufacturer_substring_case_insensitive():
+    """Manufacturer matching is case-insensitive and substring-based."""
+    service_root = {"Manufacturer": "DELL Inc."}
+    assert classify_vendor(service_root) == "dell"
+
+
+@pytest.mark.parametrize("bad", [None, [], "ServiceRoot", 42])
+def test_classify_non_mapping_is_generic(bad):
+    """Non-mapping / missing input never raises; it maps to ``generic``."""
+    assert classify_vendor(bad) == "generic"
+
+
+def test_classify_malformed_oem_falls_through_to_text():
+    """A non-mapping Oem is ignored and later signals still apply."""
+    service_root = {"Oem": ["Dell"], "Vendor": "Hewlett Packard Enterprise"}
+    assert classify_vendor(service_root) == "hpe"
+
+
+# --------------------------------------------------------------------------- #
+# Async scan helper (fake GET, no network)
+# --------------------------------------------------------------------------- #
+
+def _make_fake_get(table):
+    """Build a fake async GET that returns ``table[ip]`` or raises on KeyError.
+
+    ``table`` maps host -> ServiceRoot dict (or ``None`` for "answered but not
+    Redfish"). A host missing from the table raises, exercising the scanner's
+    per-host error isolation.
+    """
+    async def fake_get(ip):
+        if ip not in table:
+            raise ConnectionError(f"unreachable: {ip}")
+        return table[ip]
+
+    return fake_get
+
+
+def test_scan_subnet_returns_reachable_services():
+    """Reachable hosts are returned with parsed vendor/product/version."""
+    table = {
+        "10.0.0.1": {
+            "Oem": {"Dell": {}},
+            "Product": "Integrated Dell Remote Access Controller",
+            "RedfishVersion": "1.11.0",
+        },
+        "10.0.0.2": None,  # answered but not a Redfish service
+        "10.0.0.3": {
+            "Vendor": "Supermicro",
+            "Product": "BMC",
+            "RedfishVersion": "1.8.0",
+        },
+    }
+    # 10.0.0.4 is absent from the table -> the fake GET raises for it.
+    hosts = ["10.0.0.1", "10.0.0.2", "10.0.0.3", "10.0.0.4"]
+
+    results = asyncio.run(scan_subnet(hosts, _make_fake_get(table), concurrency=2))
+
+    assert [svc.ip for svc in results] == ["10.0.0.1", "10.0.0.3"]
+    dell, smc = results
+    assert dell.vendor == "dell"
+    assert dell.redfish_version == "1.11.0"
+    assert smc.vendor == "supermicro"
+    assert smc.product == "BMC"
+
+
+def test_scan_subnet_preserves_input_order_and_dedupes():
+    """Results follow first-seen input order; duplicate/empty hosts are dropped."""
+    table = {
+        "a": {"Vendor": "Dell"},
+        "b": {"Vendor": "Supermicro"},
+    }
+    hosts = ["b", "a", "b", "", "a"]
+    results = asyncio.run(scan_subnet(hosts, _make_fake_get(table)))
+    assert [svc.ip for svc in results] == ["b", "a"]
+
+
+def test_scan_subnet_empty_hosts_returns_empty():
+    """An empty (or all-empty) host list yields no results and calls nothing."""
+    calls = []
+
+    async def fake_get(ip):  # pragma: no cover - must never be called
+        calls.append(ip)
+        return {}
+
+    results = asyncio.run(scan_subnet(["", None], fake_get))
+    assert results == []
+    assert calls == []
+
+
+def test_scan_subnet_isolates_host_errors():
+    """One failing host does not abort the whole scan."""
+    async def fake_get(ip):
+        if ip == "boom":
+            raise TimeoutError("slow host")
+        return {"Vendor": "Dell"}
+
+    results = asyncio.run(scan_subnet(["boom", "ok"], fake_get))
+    assert [svc.ip for svc in results] == ["ok"]
+
+
+def test_scan_subnet_rejects_bad_concurrency():
+    """A concurrency below 1 is a programming error and raises."""
+    async def fake_get(ip):  # pragma: no cover - never reached
+        return {}
+
+    with pytest.raises(ValueError):
+        asyncio.run(scan_subnet(["x"], fake_get, concurrency=0))
+
+
+def test_scan_subnet_bounds_concurrency():
+    """No more than ``concurrency`` probes run at once."""
+    in_flight = 0
+    max_in_flight = 0
+
+    async def fake_get(ip):
+        nonlocal in_flight, max_in_flight
+        in_flight += 1
+        max_in_flight = max(max_in_flight, in_flight)
+        await asyncio.sleep(0)  # yield so others can start
+        in_flight -= 1
+        return {"Vendor": "Dell"}
+
+    hosts = [f"10.0.0.{i}" for i in range(20)]
+    asyncio.run(scan_subnet(hosts, fake_get, concurrency=3))
+    assert max_in_flight <= 3
+
+
+# --------------------------------------------------------------------------- #
+# Rendering / entry point
+# --------------------------------------------------------------------------- #
+
+def test_render_table_plain_text(monkeypatch):
+    """Plain-text rendering lists each service; no rich, non-TTY target."""
+    services = [
+        DiscoveredService("10.0.0.1", "dell", "iDRAC", "1.11.0"),
+        DiscoveredService("10.0.0.2", "generic", None, None),
+    ]
+    buf = io.StringIO()  # StringIO has no isatty -> plain path
+    discover_cli.render_table(services, stream=buf)
+    text = buf.getvalue()
+    assert "10.0.0.1" in text and "dell" in text and "iDRAC" in text
+    assert "10.0.0.2" in text and "generic" in text
+    # Missing product/version render as a dash, not "None".
+    assert "None" not in text
+    assert "-" in text
+
+
+def test_render_table_empty(monkeypatch):
+    """An empty result set prints a clear notice."""
+    buf = io.StringIO()
+    discover_cli.render_table([], stream=buf)
+    assert "No Redfish services discovered." in buf.getvalue()
+
+
+def test_main_no_hosts_returns_2():
+    """Invoking with no hosts is a no-op that exits with code 2."""
+    assert discover_cli.redfish_discover_main([]) == 2
+
+
+def test_main_with_default_fetcher_discovers_nothing(capsys):
+    """The default fetcher performs no I/O, so a scan finds nothing (exit 0)."""
+    rc = discover_cli.redfish_discover_main(["10.0.0.5"])
+    assert rc == 0
+    assert "No Redfish services discovered." in capsys.readouterr().out

--- a/tests/test_discovery_import.py
+++ b/tests/test_discovery_import.py
@@ -1,0 +1,28 @@
+"""Offline regression test: importing the discovery command must not import numpy.
+
+The discovery command (idrac_ctl/discovery/cmd_discovery.py) only needs numpy for
+``np.save`` inside ``save_url_file_mapping``. A top-level ``import numpy`` made the
+whole module unimportable in environments without numpy, which blocked collecting
+the offline pytest suite. The import is now lazy, so importing the module must not
+pull numpy into ``sys.modules``.
+
+Author Mus spyroot@gmail.com
+"""
+import importlib
+import sys
+
+
+def test_discovery_module_imports_without_numpy():
+    """Importing cmd_discovery fresh does not import numpy at module load time."""
+    module_name = "idrac_ctl.discovery.cmd_discovery"
+
+    # Drop any cached copies so the import really re-executes the module body.
+    sys.modules.pop(module_name, None)
+    sys.modules.pop("numpy", None)
+
+    importlib.import_module(module_name)
+
+    assert "numpy" not in sys.modules, (
+        "importing idrac_ctl.discovery.cmd_discovery must not import numpy; "
+        "the numpy import should be lazy inside save_url_file_mapping"
+    )

--- a/tests/test_ssl_verify.py
+++ b/tests/test_ssl_verify.py
@@ -1,0 +1,99 @@
+"""TLS verification semantics for the Redfish/iDRAC client.
+
+BMCs (iDRAC, Supermicro, etc.) ship self-signed certificates, so the tool must
+*skip* certificate verification by default and verify only when explicitly asked.
+Internally ``insecure`` means "skip verification" and maps to the inverse of the
+``verify`` kwarg that the client hands to ``requests``. These tests pin that
+mapping at the seam where ``requests.get`` is called, capturing the ``verify``
+kwarg via a monkeypatched stub so no real network call is ever made.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from idrac_ctl.idrac_manager import IDracManager
+from idrac_ctl.redfish_manager import RedfishManager
+
+
+class _FakeResponse:
+    """Minimal stand-in for ``requests.Response`` returned by the stub."""
+
+    status_code = 200
+
+    def json(self):  # pragma: no cover - not exercised here
+        return {}
+
+
+@pytest.fixture
+def captured_verify(monkeypatch):
+    """Monkeypatch ``requests.get`` to record the ``verify`` kwarg, no network.
+
+    Patches the symbol on the ``requests`` module that both managers import, so a
+    call to ``api_get_call`` records the flag instead of opening a socket.
+    """
+    seen = {}
+
+    def fake_get(url, **kwargs):
+        seen["verify"] = kwargs.get("verify")
+        seen["url"] = url
+        return _FakeResponse()
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fake_get)
+    return seen
+
+
+@pytest.mark.parametrize("manager_cls", [RedfishManager, IDracManager])
+def test_default_manager_skips_verification(manager_cls, captured_verify):
+    """No flag -> insecure default -> requests.get receives verify=False.
+
+    This is the self-signed-BMC happy path: the client must not verify unless
+    the operator opts in, otherwise every connection to a default iDRAC fails.
+    """
+    mgr = manager_cls()
+    mgr.api_get_call("https://bmc.invalid/redfish/v1", hdr=None)
+    assert captured_verify["verify"] is False
+
+
+@pytest.mark.parametrize("manager_cls", [RedfishManager, IDracManager])
+def test_insecure_true_skips_verification(manager_cls, captured_verify):
+    """insecure=True -> verify=False (explicit skip is honored)."""
+    mgr = manager_cls(insecure=True)
+    mgr.api_get_call("https://bmc.invalid/redfish/v1", hdr=None)
+    assert captured_verify["verify"] is False
+
+
+@pytest.mark.parametrize("manager_cls", [RedfishManager, IDracManager])
+def test_insecure_false_enables_verification(manager_cls, captured_verify):
+    """insecure=False -> verify=True (opt-in verification path)."""
+    mgr = manager_cls(insecure=False)
+    mgr.api_get_call("https://bmc.invalid/redfish/v1", hdr=None)
+    assert captured_verify["verify"] is True
+
+
+def test_internal_verify_flag_is_inverse_of_insecure():
+    """_is_verify_cert is the inverse of the insecure intent for both managers."""
+    assert RedfishManager(insecure=True)._is_verify_cert is False
+    assert RedfishManager(insecure=False)._is_verify_cert is True
+    assert IDracManager(insecure=True)._is_verify_cert is False
+    assert IDracManager(insecure=False)._is_verify_cert is True
+    # Default (no flag) must skip verification.
+    assert RedfishManager()._is_verify_cert is False
+    assert IDracManager()._is_verify_cert is False
+
+
+def test_cli_verify_ssl_flag_drives_insecure():
+    """--verify-ssl off (default) -> insecure skip; on -> verification enabled.
+
+    Mirrors how ``idrac_main.main`` derives the ``insecure`` value it passes to
+    IDracManager from the parsed ``verify_ssl`` flag, without constructing a real
+    client. ``--insecure`` stays a harmless explicit "skip".
+    """
+    # Default namespace: verify_ssl absent/False -> insecure (skip) is True.
+    default_args = SimpleNamespace(verify_ssl=False)
+    assert (not getattr(default_args, "verify_ssl", False)) is True
+
+    # Opt in: verify_ssl True -> insecure (skip) is False -> verification on.
+    verify_args = SimpleNamespace(verify_ssl=True)
+    assert (not getattr(verify_args, "verify_ssl", False)) is False

--- a/tests/test_storage_drives_dualmode.py
+++ b/tests/test_storage_drives_dualmode.py
@@ -1,0 +1,130 @@
+"""Dual-mode test for the storage-drives query command.
+
+Runs offline by default against the mock service (using the iDRAC-shaped Storage
+fixture in tests/idrac_fixtures/, which carries a Drives navigation list), and
+against real hardware when IDRAC_IP is set. Modeled on test_cmd_boot_dualmode.py.
+
+This is also a regression test for a missing import: cmd_drives.py walks the
+Storage payload with find_ids(...) but never imported it, so the offline
+'storage-drives' path raised NameError before the import was added. The tests
+drive the command through sync_invoke and assert a CommandResult comes back
+without a NameError.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+
+import pytest
+
+from idrac_ctl.idrac_shared import ApiRequestType
+from idrac_ctl.redfish_manager import CommandResult
+
+# The controller + drive the Storage fixture's Drives navigation list points at.
+_CONTROLLER = "RAID.Integrated.1-1"
+_DRIVE_PATH = (
+    "/redfish/v1/Systems/System.Embedded.1/Storage/"
+    "RAID.Integrated.1-1/Drives/Disk.Bay.0"
+)
+
+
+def _seed_drive(service, raid_status: str) -> None:
+    """Seed one physical-disk resource so the per-drive loop completes offline.
+
+    The Storage fixture only carries a Drives *navigation* list (an @odata.id per
+    drive); the captured tree has no body for the drive itself, so without a seed
+    the loop's base_query would 404. The body mirrors the Dell OEM shape
+    cmd_drives classifies on (Oem.Dell.DellPhysicalDisk.RaidStatus).
+
+    requests-mock lowercases request.path, and MockRedfishService keys its overlay
+    by that path, so we seed under the lowercased key to match the GET lookup.
+    """
+    service._overlay[_DRIVE_PATH.lower()] = {
+        "@odata.id": _DRIVE_PATH,
+        "Id": "Disk.Bay.0",
+        "Oem": {"Dell": {"DellPhysicalDisk": {"RaidStatus": raid_status}}},
+    }
+
+
+def test_storage_drives_returns_command_result_without_nameerror(
+    redfish_mock, redfish_service
+):
+    """storage-drives runs end to end and returns a JSON-serializable CommandResult.
+
+    Regression guard: cmd_drives calls find_ids(...) on the Storage payload; a
+    missing import made this raise NameError on the offline path. Reaching this
+    assertion proves the symbol resolves and the command completes.
+    """
+    _seed_drive(redfish_service, "Online")
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.Drives, "drives_query", controller=_CONTROLLER
+    )
+    assert isinstance(result, CommandResult)
+    # The CLI renders the payload as JSON, so it must be serializable.
+    json.dumps(result.data)
+
+
+def test_storage_drives_walks_drives_navigation_list_in_mock_mode(
+    redfish_mock, redfish_service
+):
+    """storage-drives follows the Storage Drives list and classifies a RAID disk.
+
+    Exercises the full offline path: storage_get returns the Storage resource
+    (which has a Drives navigation list), find_ids extracts the drive @odata.id,
+    the per-drive query reads the seeded disk, and the disk is bucketed as a
+    RAID member because its RaidStatus is not 'NonRAID'.
+    """
+    _seed_drive(redfish_service, "Online")
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.Drives, "drives_query", controller=_CONTROLLER
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, list)
+    # The trailing bookkeeping dicts cmd_drives appends for the discovered disks.
+    disk_ids = next(d["disk_ids"] for d in result.data if "disk_ids" in d)
+    raid_ids = next(d["raid_disk_ids"] for d in result.data if "raid_disk_ids" in d)
+    none_raid_ids = next(
+        d["none_raid_disk_ids"] for d in result.data if "none_raid_disk_ids" in d
+    )
+    assert "Disk.Bay.0" in disk_ids
+    assert disk_ids["Disk.Bay.0"] == _DRIVE_PATH
+    assert raid_ids == ["Disk.Bay.0"]
+    assert none_raid_ids == []
+
+
+def test_storage_drives_buckets_non_raid_disk_in_mock_mode(
+    redfish_mock, redfish_service
+):
+    """A disk whose RaidStatus contains 'NonRAID' lands in none_raid_disk_ids.
+
+    The edge case mirrors a freshly converted / un-configured physical disk that
+    iDRAC reports as NonRAID; cmd_drives must bucket it separately from RAID
+    members.
+    """
+    _seed_drive(redfish_service, "NonRAID")
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.Drives, "drives_query", controller=_CONTROLLER
+    )
+
+    none_raid_ids = next(
+        d["none_raid_disk_ids"] for d in result.data if "none_raid_disk_ids" in d
+    )
+    raid_ids = next(d["raid_disk_ids"] for d in result.data if "raid_disk_ids" in d)
+    assert none_raid_ids == ["Disk.Bay.0"]
+    assert raid_ids == []
+
+
+@pytest.mark.live
+def test_storage_drives_live_returns_command_result(redfish_api):
+    """Against real hardware, storage-drives returns a CommandResult.
+
+    Skipped unless IDRAC_IP is set (see conftest). Read-only: it only queries the
+    storage subsystem. Uses the default controller discovery rather than a
+    hardcoded controller id, since live drive ids vary per box.
+    """
+    result = redfish_api.sync_invoke(ApiRequestType.Drives, "drives_query")
+    assert isinstance(result, CommandResult)
+    json.dumps(result.data)

--- a/tests/test_supermicro_profile.py
+++ b/tests/test_supermicro_profile.py
@@ -1,0 +1,48 @@
+"""Offline tests for the Supermicro vendor capability profile.
+
+The profile was filled from read-only observations of a live Supermicro GB300
+BMC (Redfish 1.17.0). These tests pin the OEM prefix and the conservative
+defaults so an unverified capability is never silently flipped on.
+
+Author Mus spyroot@gmail.com
+"""
+from idrac_ctl.vendors import get_vendor
+from idrac_ctl.vendors.base import VendorCapabilities
+
+
+def test_supermicro_oem_prefix_matches_manufacturer():
+    """The GB300 BMC reports Manufacturer "Supermicro"; oem_prefix mirrors it."""
+    caps = get_vendor("supermicro")
+    assert caps.vendor == "supermicro"
+    assert caps.oem_prefix == "Supermicro"
+
+
+def test_supermicro_query_params_are_conservative():
+    """Server-side query parameters were not verified, so all stay False."""
+    caps = get_vendor("supermicro")
+    assert caps.query_select is False
+    assert caps.query_filter is False
+    assert caps.query_expand is False
+    assert caps.query_top is False
+    assert caps.query_only is False
+    assert caps.one_query_param_per_uri is False
+
+
+def test_supermicro_job_scheduling_is_conservative():
+    """Recurring JobService scheduling was unverified, so it stays disabled."""
+    caps = get_vendor("supermicro")
+    assert caps.job_scheduling is False
+    assert caps.one_recurring_job_per_type is False
+    assert caps.schedulable_uris == ()
+
+
+def test_supermicro_profile_is_frozen():
+    """The profile is immutable so a command cannot mutate shared state."""
+    caps = get_vendor("supermicro")
+    assert isinstance(caps, VendorCapabilities)
+    try:
+        caps.oem_prefix = "Dell"  # type: ignore[misc]
+    except Exception as exc:
+        assert isinstance(exc, (AttributeError, TypeError))
+    else:
+        raise AssertionError("VendorCapabilities should be immutable")


### PR DESCRIPTION
## Summary

Capabilities + fixes driven by validating the client read-only against a real **Supermicro GB300**
(Grace-Blackwell, Redfish 1.17). Live hardware surfaced bugs the offline mocks could not.

## Fixes
- **Inverted TLS-verify flag (found live).** The client passed `verify=insecure`, so `insecure=True`
  *enabled* verification and failed on self-signed BMC certs (every real BMC). Now TLS verification is
  **skipped by default** (`insecure=True` default; `verify = not insecure`) and is opt-in via a new
  `--verify-ssl` CLI flag. Tests capture the `verify` kwarg with no network.
- **Lazy `numpy` import** in `discovery/cmd_discovery.py` — the top-level import broke environments
  without numpy (blocked conda test runs).
- **`IDRAC_API.BIOS`** base path added so the `bios` inventory command builds its URL (was an
  `AttributeError`).
- **`find_ids` import** in `storage/cmd_drives.py` — `storage-drives` raised `NameError`.

## Features
- **`redfish-discover`** (new, read-only): vendor classifier (Oem → `@odata.type` → Manufacturer
  substring), async bounded subnet scan of the spec-unauthenticated `/redfish/v1/`, and a `rich`
  results table (degrades to plain when piped). New `redfish-discover` console entry + `tui` extra.
- **Supermicro capability profile** filled from the live GB300 (Manufacturer "Supermicro", standard
  paths like `System_0`, no ServiceRoot Oem; query-params/jobs left conservative pending validation).

## Infra
- **Removed the repo-root `__init__.py` re-export shim** — never shipped, but broke pytest from git
  worktrees/clones (recurring pain for parallel agents). `import idrac_ctl` and the root script still work.

## Testing
- `pytest -q`: **304 passed, 56 skipped** (+47). New code is ruff-clean; engine files carry only
  pre-existing lint debt (unchanged vs main).

Each unit was built in an isolated git worktree and adversarially verified before integration.
