### PR TITLE
Dedup and bound the Redfish discovery walker

### DIFF
--- a/idrac_ctl/discovery/cmd_discovery.py
+++ b/idrac_ctl/discovery/cmd_discovery.py
@@ -15,6 +15,12 @@ from ..idrac_shared import ApiRequestType, Singleton
 from ..redfish_exceptions import RedfishForbidden
 from ..redfish_manager import CommandResult
 
+# Upper bound on how deep recursive_discovery will walk below a top-level
+# resource. Real Redfish trees are far shallower than this; the bound exists
+# purely to guarantee termination even if normalization/dedup ever misses a
+# cyclic back-reference.
+DEFAULT_DISCOVERY_MAX_DEPTH = 32
+
 
 class Discovery(IDracManager,
                 scm_type=ApiRequestType.Discovery,
@@ -78,20 +84,62 @@ class Discovery(IDracManager,
             for item in data:
                 yield from self.extract_odata_ids(item)
 
-    def recursive_discovery(self, resource_path):
-        """Recursive walk and discover
-        :param resource_path:
+    @staticmethod
+    def normalize_resource_path(resource_path: str) -> str:
+        """Canonicalize a Redfish resource path so URI variants map to one key.
+
+        Redfish hands back the same logical resource under several spellings:
+        a trailing slash (``.../Managers/``), a query string from an ``$expand``
+        / ``$select`` / ``$ref`` request, or duplicate slashes from a naive
+        string join (``/redfish//v1``). Keying ``visited_urls`` on the raw
+        string would treat each spelling as a new resource and re-walk it, so we
+        collapse them to a single canonical form first.
+
+        :param resource_path: a raw ``@odata.id`` / ``Uri`` value
+        :return: the path with any query string dropped, duplicate slashes
+                 collapsed, and a trailing slash removed (never reduced to "")
+        """
+        if not resource_path:
+            return resource_path
+        # Drop any query string ($expand, $select, $ref, odata.id fragments...).
+        path = resource_path.split("?", 1)[0]
+        path = path.split("#", 1)[0]
+        # Collapse duplicate slashes ("/redfish//v1/Managers" -> "/redfish/v1/Managers").
+        while "//" in path:
+            path = path.replace("//", "/")
+        # Strip trailing slash(es), but never collapse the path away entirely.
+        if len(path) > 1:
+            path = path.rstrip("/") or path
+        return path
+
+    def recursive_discovery(self,
+                            resource_path,
+                            depth: int = 0,
+                            max_depth: int = DEFAULT_DISCOVERY_MAX_DEPTH):
+        """Recursively walk and discover Redfish resources from ``resource_path``.
+
+        URI variants of the same resource (trailing slash, query string,
+        duplicate slashes) are normalized to one key before the visited check,
+        so each logical resource is fetched exactly once. Recursion stops once
+        ``depth`` exceeds ``max_depth`` so a missed back-reference can never spin
+        forever.
+
+        :param resource_path: a Redfish resource path (raw ``@odata.id``)
+        :param depth: current recursion depth; callers start at 0
+        :param max_depth: maximum depth to walk below the starting resource
         :return:
         """
+        if depth > max_depth:
+            return
+
+        resource_path = self.normalize_resource_path(resource_path)
+
         for query_filter in self.default_query_filter:
             if query_filter in resource_path:
                 self.visited_urls[resource_path] = True
                 return
 
         if resource_path in self.visited_urls or not resource_path.startswith("/redfish/v1"):
-            return
-
-        if resource_path in self.visited_urls:
             return
 
         try:
@@ -117,13 +165,13 @@ class Discovery(IDracManager,
             odata_ids = list(self.extract_odata_ids(result.data))
 
             for r in odata_ids:
-                self.recursive_discovery(r)
+                self.recursive_discovery(r, depth + 1, max_depth)
         except RedfishForbidden as e:
             self.visited_urls[resource_path] = True
             print("Forbidden: {}".format(e))
         except Exception as other_err:
             self.visited_urls[resource_path] = True
-            print("Forbidden: {}".format(other_err))
+            print("Discovery error at {}: {}".format(resource_path, other_err))
 
     def save_url_file_mapping(self):
         """Save the URL-to-file mapping to a JSON respond file
@@ -169,8 +217,10 @@ class Discovery(IDracManager,
                                  do_async=do_async,
                                  do_expanded=do_expanded)
 
-        self.visited_urls["/redfish/v1/"] = True
-        self.visited_urls["/redfish/v1/CompositionService"] = True
+        # Seed normalized keys so a child link back to the root (e.g. the
+        # bare "/redfish/v1") matches and is not re-walked.
+        self.visited_urls[self.normalize_resource_path("/redfish/v1/")] = True
+        self.visited_urls[self.normalize_resource_path("/redfish/v1/CompositionService")] = True
         odata_ids = list(self.extract_odata_ids(result.data))
         for r in odata_ids:
             self.recursive_discovery(r)

--- a/tests/test_discovery_walker.py
+++ b/tests/test_discovery_walker.py
@@ -1,0 +1,310 @@
+"""Offline tests for the recursive Redfish discovery walker.
+
+These exercise ``Discovery.recursive_discovery`` against a small synthetic
+Redfish graph, with no live iDRAC and no network. The walker's HTTP fetch
+(``base_query``) is replaced by an in-memory graph server that counts how many
+times each logical resource is requested, so we can assert:
+
+* URI variants of one resource (trailing slash, ``$expand``/``$ref`` query
+  string, duplicate slashes) collapse to a single fetch;
+* a reference cycle (A -> B -> A) terminates and fetches each node once;
+* recursion stops once it passes the requested ``max_depth``.
+
+The walker is driven on an instance built with ``__init__`` bypassed: it only
+touches a handful of plain attributes plus ``base_query``, so a real network
+client is never constructed. The whole module runs green with no IDRAC_IP set.
+
+Author Mus spyroot@gmail.com
+"""
+import pytest
+
+from idrac_ctl.discovery.cmd_discovery import (
+    DEFAULT_DISCOVERY_MAX_DEPTH,
+    Discovery,
+)
+from idrac_ctl.redfish_exceptions import RedfishForbidden, RedfishNotFound
+from idrac_ctl.redfish_manager import CommandResult
+
+
+class _FakeGraph:
+    """In-memory Redfish service backed by a ``normalized path -> payload`` map.
+
+    Stands in for ``Discovery.base_query``: the walker normalizes a path and
+    calls this with the canonical form, so the map is keyed on canonical paths.
+    Each call is tallied in :attr:`fetch_counts` so a test can prove a logical
+    resource was fetched exactly once even when its links spell it many ways.
+    A path absent from the graph raises ``RedfishNotFound`` to mimic a 404.
+    """
+
+    def __init__(self, graph):
+        self.graph = graph
+        self.fetch_counts = {}
+
+    def base_query(self, resource_path, *args, **kwargs):
+        self.fetch_counts[resource_path] = self.fetch_counts.get(resource_path, 0) + 1
+        if resource_path not in self.graph:
+            raise RedfishNotFound(resource_path)
+        # extra="GET" -> the Allow header the walker records as allowed methods.
+        return CommandResult(self.graph[resource_path], None, "GET", None)
+
+
+def _make_discovery(tmp_path, graph, query_filter=None):
+    """Build a Discovery whose ``base_query`` serves ``graph``, no network.
+
+    ``__init__`` (which would construct a real Redfish client) is bypassed; we
+    set only the attributes ``recursive_discovery`` actually reads. JSON dumps
+    land in ``tmp_path``. Returns ``(discovery, fake_graph)``.
+    """
+    disc = Discovery.__new__(Discovery)
+    disc.visited_urls = {}
+    disc._discovered_url_file_mapping = {}
+    disc._api_allowed_methods = {}
+    disc.default_query_filter = list(query_filter or [])
+    disc.json_response_dir = str(tmp_path)
+
+    fake = _FakeGraph(graph)
+    # Instance attribute shadows the bound method, so it is called with just
+    # the resource path (no implicit self), matching base_query's real call.
+    disc.base_query = fake.base_query
+    return disc, fake
+
+
+# --------------------------------------------------------------------------- #
+# normalize_resource_path
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("/redfish/v1/Managers", "/redfish/v1/Managers"),
+        ("/redfish/v1/Managers/", "/redfish/v1/Managers"),
+        ("/redfish/v1/Managers///", "/redfish/v1/Managers"),
+        ("/redfish/v1/Managers?$expand=*($levels=1)", "/redfish/v1/Managers"),
+        ("/redfish/v1/Managers?$select=Name", "/redfish/v1/Managers"),
+        ("/redfish/v1/Managers/?$ref", "/redfish/v1/Managers"),
+        ("/redfish//v1//Managers", "/redfish/v1/Managers"),
+        ("/redfish/v1/Managers#/Fragment", "/redfish/v1/Managers"),
+        ("/redfish/v1/", "/redfish/v1"),
+        ("/", "/"),
+        ("", ""),
+    ],
+)
+def test_normalize_resource_path_variants(raw, expected):
+    """Every URI spelling of one resource collapses to a single canonical key."""
+    assert Discovery.normalize_resource_path(raw) == expected
+
+
+def test_normalize_collapses_variants_to_one_key():
+    """The trailing-slash / query / dup-slash spellings all map to one value."""
+    base = "/redfish/v1/Systems/1"
+    variants = [
+        base,
+        base + "/",
+        base + "?$expand=*",
+        base + "/?$ref",
+        "/redfish//v1/Systems/1",
+        base + "#anchor",
+    ]
+    canonical = {Discovery.normalize_resource_path(v) for v in variants}
+    assert canonical == {base}
+
+
+# --------------------------------------------------------------------------- #
+# Cycle + URI-variant dedup
+# --------------------------------------------------------------------------- #
+
+def test_cycle_and_variants_fetch_each_resource_once(tmp_path):
+    """A -> B -> A with variant spellings fetches A and B exactly once each.
+
+    A links to B under four spellings (plain, trailing slash, query string,
+    duplicate slash) and B links back to A under two. With normalization and
+    the visited guard, neither node is re-fetched and the walk terminates.
+    """
+    graph = {
+        "/redfish/v1/A": {
+            "@odata.id": "/redfish/v1/A",
+            "Links": [
+                {"@odata.id": "/redfish/v1/B"},
+                {"@odata.id": "/redfish/v1/B/"},
+                {"@odata.id": "/redfish/v1/B?$expand=*($levels=1)"},
+                {"@odata.id": "/redfish//v1/B"},
+            ],
+        },
+        "/redfish/v1/B": {
+            "@odata.id": "/redfish/v1/B",
+            "Back": {"@odata.id": "/redfish/v1/A"},
+            "BackSlash": {"@odata.id": "/redfish/v1/A/"},
+            "BackQuery": {"@odata.id": "/redfish/v1/A?$select=Name"},
+        },
+    }
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    disc.recursive_discovery("/redfish/v1/A")
+
+    assert fake.fetch_counts == {"/redfish/v1/A": 1, "/redfish/v1/B": 1}
+    # Both logical resources recorded, keyed on the canonical path.
+    assert set(disc._discovered_url_file_mapping) == {"/redfish/v1/A", "/redfish/v1/B"}
+
+
+def test_entering_via_a_variant_still_dedupes(tmp_path):
+    """Starting the walk on a trailing-slash/query variant still keys on canon."""
+    graph = {
+        "/redfish/v1/A": {
+            "@odata.id": "/redfish/v1/A",
+            "Next": {"@odata.id": "/redfish/v1/A?$expand=*"},  # self via variant
+        },
+    }
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    disc.recursive_discovery("/redfish/v1/A/?$ref")
+
+    assert fake.fetch_counts == {"/redfish/v1/A": 1}
+
+
+# --------------------------------------------------------------------------- #
+# Depth bound
+# --------------------------------------------------------------------------- #
+
+def _linear_chain(length):
+    """Build R0 -> R1 -> ... -> R(length-1), each linking to the next node."""
+    graph = {}
+    for i in range(length):
+        node = {"@odata.id": f"/redfish/v1/R{i}"}
+        if i + 1 < length:
+            node["Next"] = {"@odata.id": f"/redfish/v1/R{i + 1}"}
+        graph[f"/redfish/v1/R{i}"] = node
+    return graph
+
+
+def test_recursion_stops_past_max_depth(tmp_path):
+    """With max_depth=2, only R0 (d0), R1 (d1), R2 (d2) are fetched."""
+    graph = _linear_chain(6)
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    disc.recursive_discovery("/redfish/v1/R0", depth=0, max_depth=2)
+
+    assert set(fake.fetch_counts) == {
+        "/redfish/v1/R0",
+        "/redfish/v1/R1",
+        "/redfish/v1/R2",
+    }
+    assert all(count == 1 for count in fake.fetch_counts.values())
+    # Anything deeper than the bound is never requested.
+    for deeper in ("/redfish/v1/R3", "/redfish/v1/R4", "/redfish/v1/R5"):
+        assert deeper not in fake.fetch_counts
+
+
+def test_max_depth_zero_fetches_only_the_root(tmp_path):
+    """A zero bound walks the entry resource and nothing below it."""
+    graph = _linear_chain(3)
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    disc.recursive_discovery("/redfish/v1/R0", depth=0, max_depth=0)
+
+    assert set(fake.fetch_counts) == {"/redfish/v1/R0"}
+
+
+def test_default_depth_walks_a_normal_tree(tmp_path):
+    """Within the default bound the whole chain is discovered."""
+    length = 8
+    assert length <= DEFAULT_DISCOVERY_MAX_DEPTH
+    graph = _linear_chain(length)
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    disc.recursive_discovery("/redfish/v1/R0")
+
+    assert len(fake.fetch_counts) == length
+    assert all(count == 1 for count in fake.fetch_counts.values())
+
+
+# --------------------------------------------------------------------------- #
+# Filters and error handling
+# --------------------------------------------------------------------------- #
+
+def test_query_filter_skips_without_fetch(tmp_path):
+    """A path matching default_query_filter is marked visited, never fetched."""
+    graph = {
+        "/redfish/v1/A": {
+            "@odata.id": "/redfish/v1/A",
+            "Log": {"@odata.id": "/redfish/v1/Managers/iDRAC/LogServices/Sel/Entries"},
+        },
+    }
+    disc, fake = _make_discovery(
+        tmp_path, graph, query_filter=["LogServices/Sel/Entries"]
+    )
+
+    disc.recursive_discovery("/redfish/v1/A")
+
+    assert fake.fetch_counts == {"/redfish/v1/A": 1}
+    assert "/redfish/v1/Managers/iDRAC/LogServices/Sel/Entries" in disc.visited_urls
+
+
+def test_non_redfish_path_is_ignored(tmp_path):
+    """A link outside /redfish/v1 is neither fetched nor recorded."""
+    graph = {
+        "/redfish/v1/A": {
+            "@odata.id": "/redfish/v1/A",
+            "External": {"@odata.id": "/some/other/path"},
+        },
+    }
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    disc.recursive_discovery("/redfish/v1/A")
+
+    assert fake.fetch_counts == {"/redfish/v1/A": 1}
+    assert "/some/other/path" not in disc.visited_urls
+
+
+def test_forbidden_marks_visited_and_reports(tmp_path, capsys):
+    """A 403 on a child is swallowed: marked visited, sibling walk continues."""
+    graph = {
+        "/redfish/v1/A": {
+            "@odata.id": "/redfish/v1/A",
+            "Denied": {"@odata.id": "/redfish/v1/Secret"},
+            "Ok": {"@odata.id": "/redfish/v1/B"},
+        },
+        "/redfish/v1/B": {"@odata.id": "/redfish/v1/B"},
+    }
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    def base_query(resource_path, *args, **kwargs):
+        fake.fetch_counts[resource_path] = fake.fetch_counts.get(resource_path, 0) + 1
+        if resource_path == "/redfish/v1/Secret":
+            raise RedfishForbidden("403 on Secret")
+        return CommandResult(graph[resource_path], None, "GET", None)
+
+    disc.base_query = base_query
+    disc.recursive_discovery("/redfish/v1/A")
+
+    assert disc.visited_urls.get("/redfish/v1/Secret") is True
+    assert fake.fetch_counts["/redfish/v1/B"] == 1
+    out = capsys.readouterr().out
+    assert "Forbidden:" in out
+
+
+def test_generic_error_is_not_mislabeled_forbidden(tmp_path, capsys):
+    """A non-403 failure reports a generic discovery error, not "Forbidden:".
+
+    Regression for the handler that printed "Forbidden:" for every Exception.
+    """
+    graph = {
+        "/redfish/v1/A": {
+            "@odata.id": "/redfish/v1/A",
+            "Broken": {"@odata.id": "/redfish/v1/Boom"},
+        },
+    }
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    def base_query(resource_path, *args, **kwargs):
+        fake.fetch_counts[resource_path] = fake.fetch_counts.get(resource_path, 0) + 1
+        if resource_path == "/redfish/v1/Boom":
+            raise RuntimeError("connection reset")
+        return CommandResult(graph[resource_path], None, "GET", None)
+
+    disc.base_query = base_query
+    disc.recursive_discovery("/redfish/v1/A")
+
+    assert disc.visited_urls.get("/redfish/v1/Boom") is True
+    out = capsys.readouterr().out
+    assert "Discovery error at /redfish/v1/Boom" in out
+    assert "Forbidden: connection reset" not in out


### PR DESCRIPTION
## What

`recursive_discovery()` in `idrac_ctl/discovery/cmd_discovery.py` keyed its `visited_urls` guard on the exact URL string, so the same logical Redfish resource returned under multiple URI spellings (trailing slash, `$expand`/`$select`/`$ref` query strings, parent back-references, duplicate slashes) was re-fetched and re-recursed. There was also no depth bound.

## Changes

- **Normalize before dedup/store** — new `normalize_resource_path()` drops the query string and fragment, collapses duplicate slashes (`/redfish//v1` → `/redfish/v1`), and strips trailing slashes (never reducing to `""`). The walker normalizes the path before the visited check and before using it as the storage/`visited_urls` key, so all variant spellings collapse to one key. The root seeds in `execute()` are normalized too, so a child link back to the bare `/redfish/v1` matches.
- **Depth bound** — `recursive_discovery(resource_path, depth=0, max_depth=DEFAULT_DISCOVERY_MAX_DEPTH)` stops recursing past `max_depth` (default 32), guaranteeing termination even if a back-reference is ever missed.
- **Removed dead code** — deleted the duplicate `if resource_path in self.visited_urls: return` block.
- **Fixed misleading handler** — the generic `except Exception` now prints `"Discovery error at {path}: {err}"` instead of falsely labeling everything `"Forbidden:"`. The real `RedfishForbidden` branch still prints `"Forbidden:"`.

## Tests

New offline suite `tests/test_discovery_walker.py` (21 tests, no live iDRAC, no network) drives the walker against a synthetic in-memory Redfish graph with a fetch counter:

- normalization unit tests (trailing slash, query strings, dup slashes, fragments, root, empty);
- a reference cycle `A -> B -> A` with variant spellings — asserts each node is fetched exactly once;
- depth-bound tests (`max_depth=2`, `max_depth=0`, default bound);
- filter-skip, non-`/redfish/v1` ignore, `RedfishForbidden` handling, and a regression test that a generic error is **not** mislabeled `"Forbidden:"`.

## Verification

- `pytest -q` (no `IDRAC_IP`): 360 passed, 62 skipped (live)
- `ruff check` on both changed files: clean