### PR TITLE
Guard discovery walker against non-string @odata.id/Uri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,11 @@ ROADMAP*.md
 CODEX_TASKS.md
 CODEX_*.md
 COORDINATION.md
+FLASH_BRAIN.md
 .codex/
 .claude/
 .agent-review/
+.internal/
 
 # macOS / stray test output
 .DS_Store

--- a/idrac_ctl/discovery/cmd_discovery.py
+++ b/idrac_ctl/discovery/cmd_discovery.py
@@ -64,20 +64,26 @@ class Discovery(IDracManager,
         return cmd_parser, "discovery", help_text
 
     def extract_odata_ids(self, data):
-        """Extract odata ids
-        :param data:
-        :return:
+        """Yield Redfish reference strings (``@odata.id`` / ``Uri``) found in ``data``.
+
+        Only string values are yielded. Inside a JsonSchemas document the
+        ``@odata.id`` key is a *property definition* (e.g.
+        ``{"$ref": ".../odata-v4.json#/definitions/id"}``), not an actual
+        reference; yielding that dict would crash the downstream walk
+        (``normalize_resource_path`` / membership checks expect a path string).
+        The ``isinstance`` guard keeps discovery robust across vendors whose
+        crawl reaches schema content (seen live on Supermicro).
+
+        :param data: a parsed Redfish document (dict/list) or any nested value.
+        :return: yields reference path strings.
         """
         if isinstance(data, dict):
             odata_id = data.get("@odata.id")
-            if odata_id:
+            if isinstance(odata_id, str):
                 yield odata_id
             uri = data.get("Uri")
-            if uri:
-                print("Found uri")
+            if isinstance(uri, str):
                 yield uri
-            # target = data.get("@target")
-            # print(target)
             for value in data.values():
                 yield from self.extract_odata_ids(value)
         elif isinstance(data, list):

--- a/tests/test_discovery_walker.py
+++ b/tests/test_discovery_walker.py
@@ -308,3 +308,61 @@ def test_generic_error_is_not_mislabeled_forbidden(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "Discovery error at /redfish/v1/Boom" in out
     assert "Forbidden: connection reset" not in out
+
+
+# --------------------------------------------------------------------------- #
+# extract_odata_ids — non-string references (JsonSchemas $ref)
+# --------------------------------------------------------------------------- #
+
+
+def test_extract_odata_ids_skips_non_string_refs(tmp_path):
+    """Only string @odata.id / Uri values are yielded.
+
+    A JsonSchemas document defines the @odata.id property as a dict
+    ({"$ref": ...}); a Uri can likewise be a non-string. These must be skipped,
+    not yielded, or the downstream normalize_resource_path crashes with
+    'dict object has no attribute split'. Seen live on Supermicro GB300.
+    """
+    disc, _ = _make_discovery(tmp_path, {})
+    schema_like = {
+        "@odata.id": "/redfish/v1/JsonSchemas/AccountService",  # real string ref
+        "definitions": {
+            "AccountService": {
+                "properties": {
+                    # schema *definition* of @odata.id — a dict, must be skipped
+                    "@odata.id": {"$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"},
+                    "Uri": {"type": "object"},  # non-string Uri — must be skipped
+                }
+            }
+        },
+        "Members": [{"Uri": "/redfish/v1/Real/1"}],  # real string Uri
+    }
+
+    found = list(disc.extract_odata_ids(schema_like))
+
+    assert all(isinstance(x, str) for x in found)
+    assert "/redfish/v1/JsonSchemas/AccountService" in found
+    assert "/redfish/v1/Real/1" in found
+
+
+def test_recursive_discovery_survives_schema_doc_with_dict_odata_id(tmp_path):
+    """recursive_discovery completes when a fetched doc embeds a dict @odata.id.
+
+    Regression for the live GB300 crash: walking into a JsonSchemas payload
+    whose @odata.id is a {"$ref": ...} dict must not raise.
+    """
+    graph = {
+        "/redfish/v1/JsonSchemas/X": {
+            "@odata.id": "/redfish/v1/JsonSchemas/X",
+            "properties": {
+                "@odata.id": {"$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"},
+            },
+        },
+    }
+    disc, fake = _make_discovery(tmp_path, graph)
+
+    # Must not raise AttributeError on the dict @odata.id.
+    disc.recursive_discovery("/redfish/v1/JsonSchemas/X")
+
+    assert disc.visited_urls.get("/redfish/v1/JsonSchemas/X") is True
+    assert fake.fetch_counts.get("/redfish/v1/JsonSchemas/X") == 1


### PR DESCRIPTION
## Problem
While running a real discovery crawl against a live Supermicro GB300 (Redfish 1.17), the `discovery` command crashed:

```
AttributeError: 'dict' object has no attribute 'split'
  normalize_resource_path -> resource_path.split("?", 1)
```

`extract_odata_ids` yields every `@odata.id` / `Uri` value it finds. Inside a **JsonSchemas** document the `@odata.id` key is a *property definition* — `{"$ref": ".../odata-v4.json#/definitions/id"}` — i.e. a dict, not a reference. Yielding it crashes the downstream walk. This aborts the whole crawl on any host whose discovery reaches schema content.

## Fix
`extract_odata_ids` now yields only `str` values (`isinstance` guard on both `@odata.id` and `Uri`), and drops a stray debug `print`.

## Tests
- `test_extract_odata_ids_skips_non_string_refs` — a schema-like doc with a dict `@odata.id` and non-string `Uri`; only the real string refs are yielded.
- `test_recursive_discovery_survives_schema_doc_with_dict_odata_id` — the walk completes without raising.

Full suite: 362 passed, ruff clean. Found via live GB300 crawl (read-only).