### PR TITLE
Fix default_error_handler status tautology (+ F821 __dict__)

### DIFF
--- a/idrac_ctl/redfish_manager.py
+++ b/idrac_ctl/redfish_manager.py
@@ -470,7 +470,7 @@ class RedfishManager:
             return RedfishApiRespond.AcceptedTaskGenerated
         if response.status_code == 204:
             return RedfishApiRespond.Success
-        if response.status_code >= 200 or response.status_code < 300:
+        if 200 <= response.status_code < 300:
             return RedfishApiRespond.Success
         if response.status_code == 401:
             raise RedfishUnauthorized("Unauthorized access")

--- a/idrac_ctl/redfish_manager.py
+++ b/idrac_ctl/redfish_manager.py
@@ -567,7 +567,7 @@ class RedfishManager:
         :return: str: a job id or empty string
         """
         try:
-            if response is not None and hasattr(response, __dict__):
+            if response is not None and hasattr(response, "__dict__"):
                 response_dict = str(response.__dict__)
                 if response_dict is not None and len(response_dict) > 0:
                     job_id = re.search("JID_.+?,", response_dict)

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,0 +1,54 @@
+"""Offline tests for RedfishManager.default_error_handler status mapping.
+
+Regression for a tautology (`status_code >= 200 or status_code < 300`, true for
+every int) that returned Success for 4xx/5xx and left the 401/403/404 branches
+dead. These pin the success/raise mapping. No network.
+"""
+import pytest
+
+from idrac_ctl.cmd_exceptions import ResourceNotFound
+from idrac_ctl.redfish_exceptions import RedfishForbidden, RedfishUnauthorized
+from idrac_ctl.redfish_manager import RedfishManager
+from idrac_ctl.redfish_shared import RedfishApiRespond
+
+
+class _Resp:
+    """Minimal fake response: a status code and an empty JSON body."""
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    def json(self):
+        return {}
+
+
+@pytest.mark.parametrize(
+    "status_code, expected",
+    [
+        (200, RedfishApiRespond.Ok),
+        (202, RedfishApiRespond.AcceptedTaskGenerated),
+        (204, RedfishApiRespond.Success),
+        (201, RedfishApiRespond.Success),
+        (299, RedfishApiRespond.Success),
+    ],
+)
+def test_success_codes(status_code, expected):
+    """2xx codes map to the right RedfishApiRespond value."""
+    assert RedfishManager.default_error_handler(_Resp(status_code)) == expected
+
+
+@pytest.mark.parametrize(
+    "status_code, exception",
+    [
+        (401, RedfishUnauthorized),
+        (403, RedfishForbidden),
+        (404, ResourceNotFound),
+        (400, ResourceNotFound),
+        (500, ResourceNotFound),
+        (503, ResourceNotFound),
+    ],
+)
+def test_error_codes_raise(status_code, exception):
+    """4xx/5xx codes raise (the branches the tautology used to skip)."""
+    with pytest.raises(exception):
+        RedfishManager.default_error_handler(_Resp(status_code))


### PR DESCRIPTION
Found while live-testing discovery on a Supermicro GB300.

- `default_error_handler`: `status_code >= 200 or status_code < 300` is true for every int, so 4xx/5xx returned `Success` and the 401/403/404 branches were dead. Now a proper 2xx range check; errors raise. New `tests/test_error_handler.py` pins the mapping (11 cases).
- Cleaned a pre-existing `F821`/latent NameError: `hasattr(response, __dict__)` -> `"__dict__"`.

375 passed, ruff clean.