### PR TITLE
Multi-member Systems/Managers discovery (GB300 two-system topology)

### DIFF
--- a/idrac_ctl/idrac_manager.py
+++ b/idrac_ctl/idrac_manager.py
@@ -1696,15 +1696,39 @@ class IDracManager(RedfishManager):
         cmd_result = self.base_query(f"{IDRAC_API.IDRAC_MANAGER}", key=IDRAC_JSON.Members)
         return self.value_from_json_list(cmd_result.data, IDRAC_JSON.Data_id)
 
-    @cached_property
-    def idrac_members(self) -> str:
-        """Shared method return idrac manage members servers list as json
-        /redfish/v1/Managers/iDRAC.Embedded.1
-        after first cal , result cached all follow-up call will return cached result.
-        :return:
+    @staticmethod
+    def _member_ids(members) -> list:
+        """Extract every ``@odata.id`` from a Redfish ``Members`` list.
+
+        Tolerates a non-list / malformed payload (returns ``[]``) and skips
+        members without a string id, so a partial response never raises.
         """
-        cmd_result = self.base_query(f"{IDRAC_API.IDRAC_MANAGER}", key=IDRAC_JSON.Members)
-        return self.value_from_json_list(cmd_result.data, IDRAC_JSON.Data_id)
+        if not isinstance(members, list):
+            return []
+        return [m[IDRAC_JSON.Data_id] for m in members
+                if isinstance(m, dict) and isinstance(m.get(IDRAC_JSON.Data_id), str)]
+
+    def discover_computer_system_ids(self) -> list:
+        """Return ALL ComputerSystem ids from ``/redfish/v1/Systems``.
+
+        ``idrac_manage_servers`` resolves a single system via the manager's
+        ``ManagerForServers`` link and (through ``value_from_json_list``) returns
+        only the last member — wrong on multi-system hosts. This enumerates the
+        Systems collection so callers can pick the right one: e.g. a Supermicro
+        GB300 exposes ``/redfish/v1/Systems/System_0`` (host) and
+        ``/redfish/v1/Systems/HGX_Baseboard_0`` (NVIDIA GPU baseboard).
+        """
+        cmd_result = self.base_query(RedfishApi.Systems, key=IDRAC_JSON.Members)
+        return self._member_ids(cmd_result.data)
+
+    def discover_manager_ids(self) -> list:
+        """Return ALL Manager ids from ``/redfish/v1/Managers`` (e.g. BMC_0, HGX_BMC_0).
+
+        Companion to :meth:`discover_computer_system_ids` for boxes with more
+        than one BMC; ``idrac_members`` only yields a single (last) manager.
+        """
+        cmd_result = self.base_query(RedfishApi.Managers, key=IDRAC_JSON.Members)
+        return self._member_ids(cmd_result.data)
 
     def computer_system_id(self):
         """alias name for idrac_manage_servers to match v6.0 docs

--- a/tests/test_discover_ids.py
+++ b/tests/test_discover_ids.py
@@ -1,0 +1,84 @@
+"""Offline tests for multi-member Systems/Managers discovery.
+
+A Dell box exposes one System (System.Embedded.1) and one Manager
+(iDRAC.Embedded.1), but a Supermicro GB300 exposes two of each
+(System_0 + HGX_Baseboard_0, BMC_0 + HGX_BMC_0). These pin
+``discover_computer_system_ids`` / ``discover_manager_ids`` / ``_member_ids``
+returning ALL members so callers can stop assuming a singleton. No network.
+"""
+import pytest
+
+from idrac_ctl.idrac_manager import IDracManager
+from idrac_ctl.redfish_manager import CommandResult
+
+
+class TestMemberIds:
+    """IDracManager._member_ids extracts @odata.id from a Members list."""
+
+    def test_member_ids_extracts_all(self):
+        """A two-member list yields both ids, in order."""
+        members = [
+            {"@odata.id": "/redfish/v1/Systems/System_0"},
+            {"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0"},
+        ]
+        assert IDracManager._member_ids(members) == [
+            "/redfish/v1/Systems/System_0",
+            "/redfish/v1/Systems/HGX_Baseboard_0",
+        ]
+
+    def test_member_ids_skips_missing_key(self):
+        """A member without @odata.id is skipped, not fatal."""
+        members = [
+            {"@odata.id": "/redfish/v1/Systems/System_0"},
+            {"name": "no_id"},
+            {"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0"},
+        ]
+        assert IDracManager._member_ids(members) == [
+            "/redfish/v1/Systems/System_0",
+            "/redfish/v1/Systems/HGX_Baseboard_0",
+        ]
+
+    def test_member_ids_skips_non_string_id(self):
+        """Non-string @odata.id values are skipped."""
+        members = [
+            {"@odata.id": "/redfish/v1/Systems/System_0"},
+            {"@odata.id": 123},
+            {"@odata.id": None},
+        ]
+        assert IDracManager._member_ids(members) == ["/redfish/v1/Systems/System_0"]
+
+    @pytest.mark.parametrize("bad", [None, "x", {}, 5])
+    def test_member_ids_non_list_input(self, bad):
+        """A non-list payload returns [] rather than raising."""
+        assert IDracManager._member_ids(bad) == []
+
+
+def _manager_with(members):
+    """Build an IDracManager (no __init__) whose base_query serves ``members``."""
+    inst = IDracManager.__new__(IDracManager)
+    inst.base_query = lambda *a, **k: CommandResult(members, None, None, None)
+    return inst
+
+
+def test_discover_computer_system_ids_returns_all():
+    """discover_computer_system_ids enumerates the Systems collection."""
+    inst = _manager_with([
+        {"@odata.id": "/redfish/v1/Systems/System_0"},
+        {"@odata.id": "/redfish/v1/Systems/HGX_Baseboard_0"},
+    ])
+    assert inst.discover_computer_system_ids() == [
+        "/redfish/v1/Systems/System_0",
+        "/redfish/v1/Systems/HGX_Baseboard_0",
+    ]
+
+
+def test_discover_manager_ids_returns_all():
+    """discover_manager_ids enumerates the Managers collection (BMC_0, HGX_BMC_0)."""
+    inst = _manager_with([
+        {"@odata.id": "/redfish/v1/Managers/BMC_0"},
+        {"@odata.id": "/redfish/v1/Managers/HGX_BMC_0"},
+    ])
+    assert inst.discover_manager_ids() == [
+        "/redfish/v1/Managers/BMC_0",
+        "/redfish/v1/Managers/HGX_BMC_0",
+    ]


### PR DESCRIPTION
From the live GB300 capability analysis: this box exposes **two** ComputerSystems (System_0 host + HGX_Baseboard_0 NVIDIA baseboard) and **two** Managers (BMC_0 + HGX_BMC_0). idrac_ctl's `idrac_manage_servers`/`idrac_members` resolve only one — and via `value_from_json_list`'s last-element pick they'd choose HGX_Baseboard_0 over the host.

- Adds `discover_computer_system_ids()` / `discover_manager_ids()` that enumerate the full collections, plus a tolerant `_member_ids` helper. Additive — no existing behavior changes.
- Removes an identical duplicate `idrac_members` cached_property.
- 9 new offline tests; full suite 384 passed.

Foundation for routing the ~70 hardcoded System.Embedded.1 / 16 iDRAC.Embedded.1 call sites through discovered ids.