### PR TITLE
Fix exporter --once --push-signalfx to actually POST datapoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,30 @@ idrac_ctl exporter \
 ```
 
 SignalFx push mode uses `SPLUNK_ACCESS_TOKEN`, the ingest token read from the process environment,
-and `SPLUNK_INGEST_URL`, the ingest URL read from the process environment.
+and `SPLUNK_INGEST_URL`, the ingest URL read from the process environment. The ingest URL must be the
+**full SignalFx datapoint endpoint** ending in `/v2/datapoint` (e.g.
+`https://ingest.us1.signalfx.com/v2/datapoint`), because the exporter POSTs it verbatim; a bare host
+such as `https://ingest.us1.observability.splunkcloud.com` is rejected, since it would accept the
+request but silently drop every datapoint. Override the default with `--signalfx-ingest-url`.
+
+Without `--once`, push mode scrapes and pushes on a loop every `--interval` seconds:
 
 ```bash
 idrac_ctl exporter \
   --credential-file .internal/idrac_exporter.env \
   --vendor supermicro \
+  --output signalfx \
+  --push-signalfx
+```
+
+With `--once`, it builds the datapoints, POSTs them **exactly once**, and returns the pushed body plus
+the ingest HTTP status:
+
+```bash
+idrac_ctl exporter \
+  --credential-file .internal/idrac_exporter.env \
+  --vendor supermicro \
+  --once \
   --output signalfx \
   --push-signalfx
 ```

--- a/idrac_ctl/telemetry/cmd_exporter.py
+++ b/idrac_ctl/telemetry/cmd_exporter.py
@@ -14,10 +14,13 @@ from typing import Optional
 from ..idrac_manager import IDracManager
 from ..idrac_shared import IDRAC_API, ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
+from . import exporter
 from .exporter import (
     build_identity_dimensions,
     build_metric_samples,
     render_prometheus_text,
+    resolve_signalfx_ingest_url,
+    resolve_signalfx_token,
     run_signalfx_loop,
     serve_prometheus,
     to_signalfx_body,
@@ -175,19 +178,29 @@ class Exporter(IDracManager,
                 **kwargs) -> CommandResult:
         """Scrape once, serve Prometheus, or push SignalFx datapoints."""
         if once:
+            # Resolve and validate the push target BEFORE scraping so a missing
+            # token or a bare (non-/v2/datapoint) ingest URL fails fast.
+            if exporter_output == "signalfx" and push_signalfx:
+                token = resolve_signalfx_token(signalfx_token_env)
+                ingest_url = resolve_signalfx_ingest_url(signalfx_ingest_url)
+                samples = self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
+                body = to_signalfx_body(samples)
+                status = exporter.push_signalfx(body, token, ingest_url)
+                return CommandResult(
+                    body, None,
+                    {"sample_count": len(samples),
+                     "push_status": status,
+                     "ingest_url": ingest_url},
+                    None,
+                )
             samples = self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
             data = (to_signalfx_body(samples) if exporter_output == "signalfx"
                     else render_prometheus_text(samples))
             return CommandResult(data, None, {"sample_count": len(samples)}, None)
 
         if push_signalfx or exporter_output == "signalfx":
-            import os
-            token = os.environ.get(signalfx_token_env or "SPLUNK_ACCESS_TOKEN", "")
-            ingest_url = signalfx_ingest_url or os.environ.get("SPLUNK_INGEST_URL", "")
-            if not token:
-                raise ValueError(f"{signalfx_token_env} is not set")
-            if not ingest_url:
-                raise ValueError("SPLUNK_INGEST_URL is not set")
+            token = resolve_signalfx_token(signalfx_token_env)
+            ingest_url = resolve_signalfx_ingest_url(signalfx_ingest_url)
 
             def scrape_samples():
                 return self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)

--- a/idrac_ctl/telemetry/exporter.py
+++ b/idrac_ctl/telemetry/exporter.py
@@ -55,6 +55,9 @@ FABRIC_PROPERTY_METRICS = {
 }
 SECRET_ARG_NAMES = {"--idrac_password", "--idrac-password"}
 DIM_VALUE_OK = re.compile(r"[^A-Za-z0-9_.\-/]")
+# push_signalfx POSTs the ingest URL as-is, so it must be the full SignalFx
+# datapoint endpoint (…/v2/datapoint), never a bare host.
+SIGNALFX_DATAPOINT_PATH = "/v2/datapoint"
 
 
 @dataclass(frozen=True)
@@ -314,8 +317,53 @@ def to_signalfx_body(samples: Iterable[MetricSample]) -> dict[str, list[dict]]:
     }
 
 
+def _require_datapoint_url(ingest_url: str) -> str:
+    """Return ``ingest_url`` when it is a full SignalFx datapoint endpoint, else raise.
+
+    ``push_signalfx`` POSTs the URL as-is (it does not append a path), so a bare
+    host such as ``https://ingest.us1.observability.splunkcloud.com`` accepts the
+    request context but silently drops every datapoint. Require the full
+    ``…/v2/datapoint`` endpoint so misconfiguration fails loudly instead.
+    """
+    if SIGNALFX_DATAPOINT_PATH not in (ingest_url or ""):
+        raise ValueError(
+            "SignalFx ingest URL must be the full datapoint endpoint ending in "
+            f"{SIGNALFX_DATAPOINT_PATH} (e.g. "
+            "https://ingest.us1.signalfx.com/v2/datapoint), not a bare host like "
+            f"https://ingest.us1.observability.splunkcloud.com; got {ingest_url!r}"
+        )
+    return ingest_url
+
+
+def resolve_signalfx_token(token_env: Optional[str] = None) -> str:
+    """Return the SignalFx ingest token from ``token_env`` (default SPLUNK_ACCESS_TOKEN)."""
+    name = token_env or "SPLUNK_ACCESS_TOKEN"
+    token = os.environ.get(name, "")
+    if not token:
+        raise ValueError(f"{name} is not set")
+    return token
+
+
+def resolve_signalfx_ingest_url(ingest_url: Optional[str] = None) -> str:
+    """Return a validated SignalFx datapoint ingest URL.
+
+    Falls back to the ``SPLUNK_INGEST_URL`` environment variable and requires the
+    full ``…/v2/datapoint`` endpoint (see ``_require_datapoint_url``).
+    """
+    url = ingest_url or os.environ.get("SPLUNK_INGEST_URL", "")
+    if not url:
+        raise ValueError("SPLUNK_INGEST_URL is not set")
+    return _require_datapoint_url(url)
+
+
 def push_signalfx(body: Mapping, token: str, ingest_url: str, timeout: float = 20.0) -> int:
-    """POST a SignalFx datapoint body and return the status code."""
+    """POST a SignalFx datapoint body and return the status code.
+
+    ``ingest_url`` must be the full SignalFx datapoint endpoint (``…/v2/datapoint``);
+    it is POSTed verbatim, so a bare host silently drops every datapoint
+    (see ``_require_datapoint_url``).
+    """
+    _require_datapoint_url(ingest_url)
     data = json.dumps(body).encode()
     req = urllib.request.Request(
         ingest_url,

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -1,5 +1,8 @@
 """Offline tests for the Redfish telemetry exporter contract."""
 
+import pytest
+
+import idrac_ctl.telemetry.exporter as exporter_mod
 from idrac_ctl.idrac_shared import ApiRequestType
 from idrac_ctl.telemetry.exporter import (
     MetricSample,
@@ -8,6 +11,7 @@ from idrac_ctl.telemetry.exporter import (
     exporter_argv_uses_secret,
     load_exporter_env_file,
     render_prometheus_text,
+    resolve_signalfx_ingest_url,
     to_signalfx_body,
 )
 
@@ -232,3 +236,95 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
     assert {"hw.power", "hw.gpu.power", "hw.fabric.rx_bytes"} <= metrics
     assert all(REQUIRED_DIMS <= set(point["dimensions"]) for point in gauges)
     assert all(recorded.method != "POST" for recorded in service.requests)
+
+
+def test_once_push_signalfx_posts_body_exactly_once(redfish_mock_factory, monkeypatch):
+    """--once --push-signalfx builds the SignalFx body AND POSTs it exactly once."""
+    mgr, _service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("SPLUNK_ACCESS_TOKEN", "test-token")
+
+    calls = []
+
+    def fake_push(body, token, ingest_url, timeout=20.0):
+        calls.append({"body": body, "token": token, "ingest_url": ingest_url})
+        return 200
+
+    monkeypatch.setattr(exporter_mod, "push_signalfx", fake_push)
+
+    result = mgr.sync_invoke(
+        ApiRequestType.Exporter,
+        "exporter",
+        once=True,
+        exporter_output="signalfx",
+        push_signalfx=True,
+        signalfx_ingest_url="https://ingest.us1.signalfx.com/v2/datapoint",
+        label_bmc_ip="172.25.230.29",
+        vendor="supermicro",
+    )
+
+    # Pushed exactly once, with the same body that is returned to the caller.
+    assert len(calls) == 1
+    assert calls[0]["token"] == "test-token"
+    assert calls[0]["ingest_url"] == "https://ingest.us1.signalfx.com/v2/datapoint"
+    assert calls[0]["body"] is result.data
+    assert result.data["gauge"]
+    assert result.extra["push_status"] == 200
+    assert result.extra["sample_count"] == len(result.data["gauge"])
+
+
+def test_once_push_signalfx_rejects_bare_ingest_url(redfish_mock_factory, monkeypatch):
+    """A bare host (no /v2/datapoint) is rejected before any datapoint is pushed."""
+    mgr, _service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("SPLUNK_ACCESS_TOKEN", "test-token")
+
+    called = []
+    monkeypatch.setattr(exporter_mod, "push_signalfx",
+                        lambda *a, **k: called.append(1))
+
+    with pytest.raises(ValueError, match="v2/datapoint"):
+        mgr.sync_invoke(
+            ApiRequestType.Exporter,
+            "exporter",
+            once=True,
+            exporter_output="signalfx",
+            push_signalfx=True,
+            signalfx_ingest_url="https://ingest.us1.observability.splunkcloud.com",
+            label_bmc_ip="172.25.230.29",
+            vendor="supermicro",
+        )
+    assert called == []
+
+
+def test_once_push_signalfx_requires_ingest_url(redfish_mock_factory, monkeypatch):
+    """Missing SPLUNK_INGEST_URL (and no --signalfx-ingest-url) raises a clear error."""
+    mgr, _service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("SPLUNK_ACCESS_TOKEN", "test-token")
+    monkeypatch.delenv("SPLUNK_INGEST_URL", raising=False)
+
+    with pytest.raises(ValueError, match="SPLUNK_INGEST_URL is not set"):
+        mgr.sync_invoke(
+            ApiRequestType.Exporter,
+            "exporter",
+            once=True,
+            exporter_output="signalfx",
+            push_signalfx=True,
+            label_bmc_ip="172.25.230.29",
+            vendor="supermicro",
+        )
+
+
+def test_resolve_signalfx_ingest_url_validates_full_datapoint_endpoint(monkeypatch):
+    """The ingest URL resolver falls back to env and demands the /v2/datapoint path."""
+    monkeypatch.setenv("SPLUNK_INGEST_URL",
+                       "https://ingest.us1.signalfx.com/v2/datapoint")
+    assert (resolve_signalfx_ingest_url()
+            == "https://ingest.us1.signalfx.com/v2/datapoint")
+    assert (resolve_signalfx_ingest_url("https://custom.example/v2/datapoint")
+            == "https://custom.example/v2/datapoint")
+
+    with pytest.raises(ValueError, match="v2/datapoint"):
+        resolve_signalfx_ingest_url("https://ingest.us1.observability.splunkcloud.com")
+
+    monkeypatch.delenv("SPLUNK_INGEST_URL", raising=False)
+    with pytest.raises(ValueError, match="SPLUNK_INGEST_URL is not set"):
+        resolve_signalfx_ingest_url()


### PR DESCRIPTION
## Problem

`idrac_ctl exporter --once --output signalfx --push-signalfx` built the SignalFx datapoints but never POSTed them. In `ExporterCommand.execute()`, the `if once:` branch returned the built body **before** the push block that calls `push_signalfx`. Verified against a real GB300 BMC: `--once` built 2614 datapoints but delivered 0 to Splunk; loop mode (without `--once`) delivered correctly.

## Fix

- **`--once` now pushes.** When combined with `--output signalfx --push-signalfx`, the exporter scrapes once, builds the body, POSTs it **exactly once**, and returns the pushed body plus the ingest HTTP status (`push_status`) in `CommandResult.extra`. Plain `--once` (no push) is unchanged.
- **Ingest URL validation.** `push_signalfx` POSTs the URL verbatim (it does not append a path), so a bare host like `https://ingest.us1.observability.splunkcloud.com` is accepted by urllib but silently drops every datapoint. The URL must now be the full `/v2/datapoint` endpoint — enforced both up-front in `execute` (fails fast before scraping) and inside `push_signalfx`.
- **Shared resolution.** Token/URL resolution + validation is factored into `resolve_signalfx_token` / `resolve_signalfx_ingest_url`, used by both `--once` and loop modes.
- **Docs.** README now documents the full-endpoint requirement and the `--once` push behavior.

## Tests

Four new offline tests in `tests/test_telemetry_exporter.py`:
- `--once --push-signalfx` calls `push_signalfx` exactly once with a body identical to `result.data`, and records `push_status`
- a bare ingest URL raises before any push happens
- missing `SPLUNK_INGEST_URL` raises a clear error
- direct coverage of `resolve_signalfx_ingest_url` env-fallback + `/v2/datapoint` enforcement

Full suite: **451 passed, 55 skipped** (skipped = live-hardware tests, no `IDRAC_IP`).

Scope: telemetry exporter + its docs/tests only.