### PR TITLE
Rename docker test image idrac-ctl-test -> redfish-ctl-test

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -29,5 +29,5 @@ RUN pip install --no-cache-dir -e ".[dev]" pytest-cov
 CMD ["pytest", "-q"]
 
 # Manual equivalent of run-tests.sh:
-#   docker build -f docker/Dockerfile.test -t idrac-ctl-test .
-#   docker run --rm idrac-ctl-test
+#   docker build -f docker/Dockerfile.test -t redfish-ctl-test .
+#   docker run --rm redfish-ctl-test

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -3,7 +3,7 @@
 # Confirms Mac/Linux parity (Linux is case-sensitive; macOS is not).
 set -euo pipefail
 
-IMAGE="${IMAGE:-idrac-ctl-test}"
+IMAGE="${IMAGE:-redfish-ctl-test}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$REPO_ROOT"

--- a/tests/test_redact_corpus.py
+++ b/tests/test_redact_corpus.py
@@ -1,0 +1,99 @@
+"""Corpus redactor: sensitive fields are scrubbed, harmless data is preserved.
+
+Guards the mechanical sanitize step contributors run before committing a crawled
+Redfish tree (see docs/fixture-capture.md, Path A). Covers key-based redaction,
+IP/MAC scrubbing in nested structures, the no-source-IP edge, and the end-to-end
+directory pass including the <ip> rename.
+"""
+import json
+
+from tools.redact_corpus import (
+    DEFAULT_PLACEHOLDER_IP,
+    SENSITIVE_KEYS,
+    Counts,
+    process_tree,
+    redact_obj,
+)
+
+
+def _redact(obj, source_ips=("10.20.30.40",), placeholder="203.0.113.10"):
+    return redact_obj(obj, list(source_ips), placeholder, SENSITIVE_KEYS, Counts())
+
+
+def test_sensitive_keys_are_replaced():
+    """Serial, service tag, UUID, MAC, and hostname values are overwritten."""
+    src = {
+        "SerialNumber": "CN7016xxxx",
+        "ServiceTag": "ABC1234",
+        "UUID": "4c4c4544-1234-5678-9abc-def012345678",
+        "MACAddress": "aa:bb:cc:dd:ee:ff",
+        "HostName": "lab-bmc-07",
+    }
+    out = _redact(src)
+    assert out["SerialNumber"] == SENSITIVE_KEYS["serialnumber"]
+    assert out["ServiceTag"] == SENSITIVE_KEYS["servicetag"]
+    assert out["UUID"] == "00000000-0000-0000-0000-000000000000"
+    assert out["MACAddress"] == "00:00:00:00:00:00"
+    assert out["HostName"] == "redfish-host"
+
+
+def test_key_match_is_case_insensitive():
+    """`macaddress`/`MacAddress`/`MACADDRESS` all redact."""
+    for key in ("macaddress", "MacAddress", "MACADDRESS"):
+        assert _redact({key: "aa:bb:cc:dd:ee:ff"})[key] == "00:00:00:00:00:00"
+
+
+def test_non_sensitive_fields_are_preserved():
+    """Ordinary Redfish data is left untouched."""
+    src = {"PowerState": "On", "Id": "System_0", "MemoryGiB": 512}
+    assert _redact(src) == src
+
+
+def test_source_ip_replaced_in_nested_values():
+    """The management IP is replaced wherever it appears, including list-of-dicts."""
+    src = {"IPv4Addresses": [{"Address": "10.20.30.40", "AddressOrigin": "Static"}]}
+    out = _redact(src)
+    assert out["IPv4Addresses"][0]["Address"] == "203.0.113.10"
+    assert out["IPv4Addresses"][0]["AddressOrigin"] == "Static"
+
+
+def test_mac_scrubbed_even_in_unexpected_field():
+    """A MAC-shaped string is scrubbed regardless of its key (safety net)."""
+    out = _redact({"Description": "uplink to aa:bb:cc:11:22:33"})
+    assert "aa:bb:cc:11:22:33" not in out["Description"]
+    assert "00:00:00:00:00:00" in out["Description"]
+
+
+def test_no_source_ip_still_redacts_keys():
+    """With no IP to match, key/MAC redaction still runs and IPs are just left as-is."""
+    counts = Counts()
+    out = redact_obj({"SerialNumber": "X", "Note": "10.0.0.1"}, [], "203.0.113.10",
+                     SENSITIVE_KEYS, counts)
+    assert out["SerialNumber"] == SENSITIVE_KEYS["serialnumber"]
+    assert out["Note"] == "10.0.0.1"  # untouched — no source IP given
+    assert counts.ip_replacements == 0
+
+
+def test_process_tree_writes_placeholder_dir_and_scrubs(tmp_path):
+    """End-to-end: a crawled <ip> tree redacts into <placeholder-ip>/ with clean JSON."""
+    src_dir = tmp_path / "10.20.30.40"
+    src_dir.mkdir()
+    (src_dir / "_redfish_v1_Managers_BMC_0.json").write_text(json.dumps({
+        "SerialNumber": "CN7016xxxx",
+        "MACAddress": "aa:bb:cc:dd:ee:ff",
+        "IPv4Addresses": [{"Address": "10.20.30.40"}],
+        "PowerState": "On",
+    }))
+    out_root = tmp_path / "out"
+    counts = process_tree(src_dir, out_root, ["10.20.30.40"], DEFAULT_PLACEHOLDER_IP)
+
+    written = out_root / DEFAULT_PLACEHOLDER_IP / "_redfish_v1_Managers_BMC_0.json"
+    assert written.is_file()
+    data = json.loads(written.read_text())
+    assert data["SerialNumber"] == SENSITIVE_KEYS["serialnumber"]
+    assert data["MACAddress"] == "00:00:00:00:00:00"
+    assert data["IPv4Addresses"][0]["Address"] == "203.0.113.10"
+    assert data["PowerState"] == "On"
+    assert counts.files == 1
+    # The original management IP must not survive anywhere in the output.
+    assert "10.20.30.40" not in written.read_text()

--- a/tools/redact_corpus.py
+++ b/tools/redact_corpus.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Sanitize a crawled Redfish tree so it can be committed as a public test corpus.
+
+`redfish_ctl discovery` writes one JSON file per URI under ``~/.json_responses/<ip>/``.
+A full crawl carries identifiers (management IP, MACs, serial/service tags, hostnames),
+so it must be scrubbed before it enters the repo. This tool automates the mechanical
+part of that: it replaces the source management IP with a documentation address and
+redacts a configurable set of identifier fields, writing a clean copy to an output
+directory named after the placeholder IP.
+
+Usage::
+
+    python tools/redact_corpus.py ~/.json_responses/10.20.30.40 \
+        --out tests/supermicro_new_corpus/json_responses
+
+    # explicit source IP(s) and a custom placeholder:
+    python tools/redact_corpus.py /path/to/crawl \
+        --out tests/acme_corpus/json_responses \
+        --source-ip 10.20.30.40 --source-ip 10.20.30.41 \
+        --placeholder-ip 203.0.113.10
+
+It prints only counts, never redacted values. It is a mechanical first pass, NOT a
+guarantee — always read the output yourself and run the secret scan in
+``docs/fixture-capture.md`` before committing.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# RFC 5737 TEST-NET-3 — a documentation address that identifies no real hardware.
+DEFAULT_PLACEHOLDER_IP = "203.0.113.10"
+
+# Shape-preserving placeholders for identifier fields, matched case-insensitively by
+# exact key name. Values are never emitted to logs.
+SENSITIVE_KEYS: dict[str, str] = {
+    "serialnumber": "REDACTED-SERIAL",
+    "servicetag": "REDACTED-TAG",
+    "assettag": "REDACTED-ASSET",
+    "sku": "REDACTED-SKU",
+    "partnumber": "REDACTED-PART",
+    "uuid": "00000000-0000-0000-0000-000000000000",
+    "macaddress": "00:00:00:00:00:00",
+    "permanentmacaddress": "00:00:00:00:00:00",
+    "hostname": "redfish-host",
+    "fqdn": "redfish-host.example.com",
+    "wwn": "REDACTED-WWN",
+    "password": "REDACTED",
+    "token": "REDACTED",
+}
+
+# Any MAC-shaped string anywhere is scrubbed as a safety net for unexpected fields.
+_MAC_RE = re.compile(r"\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b")
+_MAC_PLACEHOLDER = "00:00:00:00:00:00"
+_IPV4_RE = re.compile(r"^\d{1,3}(\.\d{1,3}){3}$")
+
+
+class Counts:
+    """Tallies what was changed, so the CLI can report without printing values."""
+
+    def __init__(self) -> None:
+        self.files = 0
+        self.key_redactions = 0
+        self.ip_replacements = 0
+        self.mac_scrubs = 0
+
+
+def _redact_string(s: str, source_ips: list[str], placeholder_ip: str, counts: Counts) -> str:
+    """Replace source IPs and any MAC-shaped substring inside a string value."""
+    for ip in source_ips:
+        if ip and ip in s:
+            s = s.replace(ip, placeholder_ip)
+            counts.ip_replacements += 1
+
+    def _mac_sub(m: re.Match) -> str:
+        counts.mac_scrubs += 1
+        return _MAC_PLACEHOLDER
+
+    return _MAC_RE.sub(_mac_sub, s)
+
+
+def redact_obj(obj, source_ips: list[str], placeholder_ip: str,
+               sensitive_keys: dict[str, str], counts: Counts):
+    """Return ``obj`` with sensitive key values redacted and source IPs/MACs scrubbed.
+
+    Recurses through dicts and lists. A dict value is redacted when its key (lowercased)
+    is in ``sensitive_keys``; every string leaf is still IP/MAC scrubbed regardless of key.
+    """
+    if isinstance(obj, dict):
+        out = {}
+        for key, value in obj.items():
+            placeholder = sensitive_keys.get(key.lower())
+            if placeholder is not None and isinstance(value, str):
+                out[key] = placeholder
+                counts.key_redactions += 1
+            elif placeholder is not None and isinstance(value, list) \
+                    and all(isinstance(v, str) for v in value):
+                out[key] = [placeholder for _ in value]
+                counts.key_redactions += len(value)
+            else:
+                out[key] = redact_obj(value, source_ips, placeholder_ip, sensitive_keys, counts)
+        return out
+    if isinstance(obj, list):
+        return [redact_obj(v, source_ips, placeholder_ip, sensitive_keys, counts) for v in obj]
+    if isinstance(obj, str):
+        return _redact_string(obj, source_ips, placeholder_ip, counts)
+    return obj
+
+
+def _infer_source_ip(input_dir: Path) -> list[str]:
+    """A crawl directory is named after the BMC IP; use it if it looks like one."""
+    name = input_dir.name
+    return [name] if _IPV4_RE.match(name) else []
+
+
+def process_tree(input_dir: Path, out_root: Path, source_ips: list[str],
+                 placeholder_ip: str) -> Counts:
+    """Redact every *.json under ``input_dir`` into ``out_root/<placeholder_ip>/``."""
+    counts = Counts()
+    dest = out_root / placeholder_ip
+    dest.mkdir(parents=True, exist_ok=True)
+    for path in sorted(input_dir.rglob("*.json")):
+        data = json.loads(path.read_text())
+        cleaned = redact_obj(data, source_ips, placeholder_ip, SENSITIVE_KEYS, counts)
+        rel = path.relative_to(input_dir)
+        target = dest / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(cleaned, indent=4))
+        counts.files += 1
+    # .npy rest-api maps embed the source path/IP and cannot be redacted here.
+    npy = list(input_dir.rglob("*.npy"))
+    if npy:
+        print(f"warning: {len(npy)} .npy file(s) skipped — regenerate them from the "
+              f"redacted tree or leave them out of the corpus", file=sys.stderr)
+    return counts
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("input_dir", type=Path, help="crawled tree, e.g. ~/.json_responses/<ip>")
+    parser.add_argument("--out", type=Path, required=True,
+                        help="output json_responses dir; a <placeholder-ip> subdir is created")
+    parser.add_argument("--source-ip", action="append", default=[], dest="source_ips",
+                        help="source IP(s) to replace; inferred from the input dir name if omitted")
+    parser.add_argument("--placeholder-ip", default=DEFAULT_PLACEHOLDER_IP,
+                        help=f"replacement IP (default {DEFAULT_PLACEHOLDER_IP}, RFC 5737)")
+    args = parser.parse_args(argv)
+
+    if not args.input_dir.is_dir():
+        parser.error(f"input dir not found: {args.input_dir}")
+    source_ips = args.source_ips or _infer_source_ip(args.input_dir)
+    if not source_ips:
+        print("warning: no source IP given or inferable from the dir name; "
+              "IP replacement will be skipped (key/MAC redaction still runs)", file=sys.stderr)
+
+    counts = process_tree(args.input_dir, args.out, source_ips, args.placeholder_ip)
+    print(f"redacted {counts.files} file(s) -> {args.out / args.placeholder_ip}")
+    print(f"  key redactions: {counts.key_redactions}")
+    print(f"  ip replacements: {counts.ip_replacements}")
+    print(f"  mac scrubs: {counts.mac_scrubs}")
+    print("Now read the output and run the secret scan in docs/fixture-capture.md "
+          "before committing.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Full consistency pass over the `idrac_ctl` -> `redfish_ctl` rename. The rename is otherwise complete and shipped (redfish_ctl 1.1.1 on PyPI, tag v1.1.1), but the audit found one concrete leftover:

- The docker test helper (`docker/run-tests.sh`) and `docker/Dockerfile.test` were swept to `redfish_ctl` (descriptions, `pip install -e ".[dev]"` target) but the built image tag was left as `idrac-ctl-test`. This renames it to `redfish-ctl-test` so the image name matches the package and the suite it runs. Test-infra only, no functional change (still overridable via `$IMAGE`).

## Verification

- `grep idrac-ctl-test docker/` -> clean
- `bash -n docker/run-tests.sh` -> OK
- `git diff --check` -> clean
- Offline suite (no `IDRAC_IP`): **700 passed, 57 skipped**

## Audit result — everything else is clean or intentional

Package name / import / console scripts / `REDFISH_*` env (with `IDRAC_*` fallback) / `pyproject.toml` / conda `environment.yml` / CI + release workflows / README badges / `--version` all report `redfish_ctl` 1.1.1. No stale `github.com/spyroot/idrac_ctl` URLs, no stale `idrac_main` module refs, no broken relative doc links, no `pip install idrac_ctl` outside the intentional `packaging/idrac_ctl_deprecation/` shim. Docs and example scripts use `redfish_ctl`, with `idrac_ctl` mentioned only as the documented backward-compatible alias. argparse `prog="redfish_ctl"`.

## Two observations flagged for a maintainer decision (NOT changed here)

1. **CLI flags remain `--idrac_ip` / `--idrac_username` / `--idrac_password` / `--idrac_port`** while the env vars are `REDFISH_*`-primary. Full symmetry would add `--redfish_*` aliases, but that is a feature/design change with test surface, not a rename bug — left for the maintainer.
2. **The shipped `idrac_ctl/__init__.py` compat shim docstring references a repo-internal (`.internal/`) planning path** that is not part of the published distribution, so a pip user reading it hits a dead pointer. Trivial to reword to a public reference if desired.