### PR TITLE
Add manager network protocol command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -111,6 +111,7 @@ Safety labels:
 | `jobs-service` | Read standard Redfish JobService. | Read |
 | `logs` | Read system and manager log entries. | Read |
 | `manager` | Read manager data. | Read |
+| `manager-network` | Read BMC ManagerNetworkProtocol service state, including HTTP/HTTPS/IPMI/SSH and NTP. | Read |
 | `manager-reboot` | Reboot the BMC manager. | Write |
 | `manager-time` | Read the BMC (Manager) clock; `--now`/`--set` write `DateTime` (read-only by default, no dry-run). | Write |
 | `metric-definitions` | Read TelemetryService metric definitions. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -52,6 +52,7 @@ from .pci.cmd_pci import *
 
 # manager cmds
 from .manager.cmd_manager import *
+from .manager.cmd_manager_network import *
 from .manager.cmd_manager_reset import *
 
 

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -124,6 +124,7 @@ class ApiRequestType(Enum):
 
     # idrac manager
     ManagerQuery = auto()
+    ManagerNetworkProtocol = auto()
     ManagerReset = auto()
 
     # bios related

--- a/redfish_ctl/manager/cmd_manager_network.py
+++ b/redfish_ctl/manager/cmd_manager_network.py
@@ -1,0 +1,96 @@
+"""Read ManagerNetworkProtocol settings for every Redfish Manager."""
+from abc import abstractmethod
+from typing import Optional
+
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+
+
+class ManagerNetworkProtocol(IDracManager,
+                             scm_type=ApiRequestType.ManagerNetworkProtocol,
+                             name='manager-network',
+                             metaclass=Singleton):
+    """Read BMC network protocol enablement and NTP settings."""
+
+    def __init__(self, *args, **kwargs):
+        super(ManagerNetworkProtocol, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only manager-network subcommand."""
+        cmd_parser = cls.base_parser()
+        help_text = "command read ManagerNetworkProtocol service state"
+        return cmd_parser, "manager-network", help_text
+
+    @staticmethod
+    def _link(data, key):
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _protocol(data, key):
+        protocol = (data or {}).get(key)
+        if not isinstance(protocol, dict):
+            return {"ProtocolEnabled": None, "Port": None}
+        return {
+            "ProtocolEnabled": protocol.get("ProtocolEnabled"),
+            "Port": protocol.get("Port"),
+        }
+
+    @staticmethod
+    def _ntp(data):
+        ntp = (data or {}).get("NTP")
+        if not isinstance(ntp, dict):
+            return {"ProtocolEnabled": None, "NTPServers": []}
+        servers = ntp.get("NTPServers")
+        if not isinstance(servers, list):
+            servers = []
+        return {
+            "ProtocolEnabled": ntp.get("ProtocolEnabled"),
+            "NTPServers": servers,
+        }
+
+    def _get(self, uri, do_async):
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Read ManagerNetworkProtocol rows from every manager."""
+        rows = []
+        for manager_uri in self.discover_manager_ids():
+            manager = self._get(manager_uri, do_async)
+            network_uri = self._link(manager, "NetworkProtocol")
+            if not network_uri:
+                continue
+            network = self._get(network_uri, do_async)
+            if not network:
+                continue
+            status = network.get("Status") or {}
+            manager_id = manager.get("Id")
+            if not manager_id and "/Managers/" in network_uri:
+                manager_id = network_uri.rstrip("/").split("/")[-2]
+            if not manager_id:
+                manager_id = manager_uri.rsplit("/", 1)[-1]
+            rows.append({
+                "Manager": manager_id,
+                "HostName": network.get("HostName"),
+                "FQDN": network.get("FQDN"),
+                "HTTP": self._protocol(network, "HTTP"),
+                "HTTPS": self._protocol(network, "HTTPS"),
+                "IPMI": self._protocol(network, "IPMI"),
+                "SSH": self._protocol(network, "SSH"),
+                "NTP": self._ntp(network),
+                "Health": status.get("Health") if isinstance(status, dict) else None,
+                "State": status.get("State") if isinstance(status, dict) else None,
+            })
+        return CommandResult(rows, None, None, None)

--- a/tests/test_manager_network_dualmode.py
+++ b/tests/test_manager_network_dualmode.py
@@ -1,0 +1,72 @@
+"""Dual-mode tests for the manager-network command."""
+import json
+
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+
+def test_manager_network_reads_gb300_protocols_and_ntp(redfish_mock_factory):
+    """manager-network summarizes GB300 ManagerNetworkProtocol resources."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ManagerNetworkProtocol,
+        "manager-network",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.discovered is None
+    assert result.extra is None
+    assert result.error is None
+    json.dumps(result.data, sort_keys=True)
+
+    rows_by_manager = {row["Manager"]: row for row in result.data}
+    assert set(rows_by_manager) == {"BMC_0", "HGX_BMC_0"}
+
+    bmc = rows_by_manager["BMC_0"]
+    assert bmc["HostName"] == "GBNVL"
+    assert bmc["HTTP"] == {"ProtocolEnabled": False, "Port": None}
+    assert bmc["HTTPS"] == {"ProtocolEnabled": True, "Port": 443}
+    assert bmc["IPMI"] == {"ProtocolEnabled": True, "Port": 623}
+    assert bmc["SSH"] == {"ProtocolEnabled": True, "Port": 22}
+    assert bmc["NTP"] == {"ProtocolEnabled": True, "NTPServers": []}
+
+    hgx = rows_by_manager["HGX_BMC_0"]
+    assert hgx["HTTP"] == {"ProtocolEnabled": True, "Port": 80}
+    assert hgx["HTTPS"] == {"ProtocolEnabled": False, "Port": None}
+    assert hgx["IPMI"] == {"ProtocolEnabled": None, "Port": None}
+    assert hgx["NTP"] == {"ProtocolEnabled": None, "NTPServers": []}
+
+    assert {
+        request.method
+        for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    } == set()
+
+
+def test_manager_network_tolerates_x10_without_ntp_block(redfish_mock_factory):
+    """manager-network keeps X10 NetworkProtocol usable when NTP is absent."""
+    manager, service = redfish_mock_factory("supermicro_x10_119")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ManagerNetworkProtocol,
+        "manager-network",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert len(result.data) == 1
+
+    row = result.data[0]
+    assert row["Manager"] == "1"
+    assert row["HostName"] == "blade02"
+    assert row["HTTP"] == {"ProtocolEnabled": True, "Port": 80}
+    assert row["HTTPS"] == {"ProtocolEnabled": True, "Port": 443}
+    assert row["IPMI"] == {"ProtocolEnabled": True, "Port": 623}
+    assert row["SSH"] == {"ProtocolEnabled": True, "Port": 22}
+    assert row["NTP"] == {"ProtocolEnabled": None, "NTPServers": []}
+
+    assert {
+        request.method
+        for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    } == set()


### PR DESCRIPTION
## Summary
- add manager-network to read ManagerNetworkProtocol across all managers
- summarize HTTP, HTTPS, IPMI, SSH, and NTP state while tolerating missing protocol blocks
- document the command and cover GB300 plus X10 fixture behavior offline

## Validation
- conda run -n idrac_ctl pytest -q tests/test_manager_network_dualmode.py
- conda run -n idrac_ctl python -m redfish_ctl.redfish_main --help
- conda run -n idrac_ctl pytest -q
- conda run -n idrac_ctl ruff check redfish_ctl/idrac_shared.py redfish_ctl/manager/cmd_manager_network.py redfish_ctl/__init__.py tests/test_manager_network_dualmode.py
- git diff --check
- git diff --cached --check