### PR TITLE
Add leak detector command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -110,6 +110,7 @@ Safety labels:
 | `jobs` | Read the job collection. | Read |
 | `jobs-dell-service` | Read Dell JobService. | Read |
 | `jobs-service` | Read standard Redfish JobService. | Read |
+| `leak-detectors` | Read chassis LeakDetection detector states and linked leak policy data. | Read |
 | `logs` | Read system and manager log entries. | Read |
 | `manager` | Read manager data. | Read |
 | `manager-network` | Read BMC ManagerNetworkProtocol service state, including HTTP/HTTPS/IPMI/SSH and NTP. | Read |
@@ -171,6 +172,7 @@ redfish_ctl telemetry-triggers
 redfish_ctl thermal
 redfish_ctl power
 redfish_ctl environment-metrics
+redfish_ctl leak-detectors
 redfish_ctl network-adapters
 redfish_ctl network-ports
 redfish_ctl ethernet-interfaces

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -80,6 +80,7 @@ from .chassis.cmd_chasis_reset import *
 from .sensors.cmd_sensors import *
 from .thermal.cmd_thermal import *
 from .power.cmd_power import *
+from .thermal.cmd_leak_detectors import *
 from .environment.cmd_environment_metrics import *
 from .telemetry.cmd_metric_reports import *
 from .telemetry.cmd_metric_definitions import *

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -83,6 +83,7 @@ class ApiRequestType(Enum):
     Sensors = auto()
     Thermal = auto()
     Power = auto()
+    LeakDetectors = auto()
     EnvironmentMetrics = auto()
     MetricReports = auto()
     MetricReportDefinitions = auto()

--- a/redfish_ctl/thermal/cmd_leak_detectors.py
+++ b/redfish_ctl/thermal/cmd_leak_detectors.py
@@ -1,0 +1,258 @@
+"""Read Redfish LeakDetection and LeakDetector resources."""
+
+from abc import abstractmethod
+from typing import Optional
+
+from ..idrac_manager import IDracManager
+from ..idrac_shared import IDRAC_API, ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+
+
+class LeakDetectors(IDracManager,
+                    scm_type=ApiRequestType.LeakDetectors,
+                    name="leak-detectors",
+                    metaclass=Singleton):
+    """Read chassis leak detection state and linked leak policies."""
+
+    def __init__(self, *args, **kwargs):
+        super(LeakDetectors, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only ``leak-detectors`` subcommand."""
+        cmd_parser = cls.base_parser()
+        help_text = "command read chassis LeakDetection detector state"
+        return cmd_parser, "leak-detectors", help_text
+
+    @staticmethod
+    def _members(data):
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        value = data.get(key) if isinstance(data, dict) else None
+        if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
+            return value["@odata.id"]
+        return None
+
+    @staticmethod
+    def _nested_link(data, *keys):
+        value = data
+        for key in keys:
+            if not isinstance(value, dict):
+                return None
+            value = value.get(key)
+        if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
+            return value["@odata.id"]
+        return None
+
+    @staticmethod
+    def _status(data):
+        status = data.get("Status") if isinstance(data, dict) else None
+        return status if isinstance(status, dict) else {}
+
+    @staticmethod
+    def _chassis_id(chassis_uri):
+        return chassis_uri.rstrip("/").rsplit("/", 1)[-1]
+
+    def _query_optional(self, uri, do_async=False):
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def _read_detectors(self, chassis_id, detectors_uri, do_async=False):
+        data = self._query_optional(detectors_uri, do_async=do_async)
+        if not isinstance(data, dict):
+            return None, []
+        members = data.get("Members") or []
+        if not isinstance(members, list):
+            members = []
+        collection = {
+            "Chassis": chassis_id,
+            "Name": data.get("Name"),
+            "MemberCount": data.get("Members@odata.count", len(members)),
+            "Uri": data.get("@odata.id", detectors_uri),
+        }
+        detectors = []
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            detector_uri = member.get("@odata.id")
+            detector = member
+            if detector_uri and "DetectorState" not in detector:
+                detector = self._query_optional(
+                    detector_uri,
+                    do_async=do_async,
+                )
+            if not isinstance(detector, dict):
+                continue
+            status = self._status(detector)
+            detectors.append({
+                "Chassis": chassis_id,
+                "Id": detector.get("Id"),
+                "Name": detector.get("Name"),
+                "DetectorState": detector.get("DetectorState"),
+                "LeakDetectorType": detector.get("LeakDetectorType"),
+                "State": status.get("State"),
+                "Health": status.get("Health"),
+                "Uri": detector.get("@odata.id", detector_uri),
+            })
+        return collection, detectors
+
+    @staticmethod
+    def _is_leak_policy(policy):
+        if not isinstance(policy, dict):
+            return False
+        values = [
+            policy.get("Id"),
+            policy.get("Name"),
+            policy.get("@odata.type"),
+        ]
+        for value in values:
+            if isinstance(value, str) and "leak" in value.lower():
+                return True
+        conditions = policy.get("PolicyConditions") or []
+        if not isinstance(conditions, list):
+            return False
+        for condition in conditions:
+            if not isinstance(condition, dict):
+                continue
+            prop = condition.get("Property")
+            if isinstance(prop, str) and "leak" in prop.lower():
+                return True
+        return False
+
+    def _read_policies(self, chassis_id, policies_uri, do_async=False):
+        data = self._query_optional(policies_uri, do_async=do_async)
+        if not isinstance(data, dict):
+            return []
+        policies = []
+        for policy_uri in self._members(data):
+            policy = self._query_optional(policy_uri, do_async=do_async)
+            if not self._is_leak_policy(policy):
+                continue
+            status = self._status(policy)
+            conditions = policy.get("PolicyConditions") or []
+            if not isinstance(conditions, list):
+                conditions = []
+            reactions = policy.get("PolicyReactions") or []
+            if not isinstance(reactions, list):
+                reactions = []
+            policies.append({
+                "Chassis": chassis_id,
+                "Id": policy.get("Id"),
+                "Name": policy.get("Name"),
+                "PolicyEnabled": policy.get("PolicyEnabled"),
+                "PolicyConditionLogic": policy.get("PolicyConditionLogic"),
+                "State": status.get("State"),
+                "Health": status.get("Health"),
+                "ConditionCount": len(conditions),
+                "ReactionCount": len(reactions),
+                "Conditions": conditions,
+                "Reactions": reactions,
+                "Uri": policy.get("@odata.id", policy_uri),
+            })
+        return policies
+
+    @staticmethod
+    def _summary(chassis_count, data):
+        states = [
+            row.get("DetectorState")
+            for row in data["detectors"]
+            if row.get("DetectorState") is not None
+        ]
+        states_lower = [
+            state.lower()
+            for state in states
+            if isinstance(state, str)
+        ]
+        return {
+            "chassis": chassis_count,
+            "leak_detection_subsystems": len(data["subsystems"]),
+            "detector_collections": len(data["detector_collections"]),
+            "detectors": len(data["detectors"]),
+            "detectors_ok": states_lower.count("ok"),
+            "detectors_warning": states_lower.count("warning"),
+            "detectors_critical": states_lower.count("critical"),
+            "policies": len(data["policies"]),
+            "enabled_policies": sum(
+                1 for row in data["policies"]
+                if row.get("PolicyEnabled") is True
+            ),
+        }
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        data = {
+            "summary": {},
+            "subsystems": [],
+            "detector_collections": [],
+            "detectors": [],
+            "policies": [],
+        }
+        chassis = self.base_query(IDRAC_API.Chassis, do_async=do_async)
+        chassis_uris = self._members(chassis.data)
+
+        for chassis_uri in chassis_uris:
+            chassis_id = self._chassis_id(chassis_uri)
+            chassis_data = self._query_optional(chassis_uri, do_async=do_async)
+            thermal_uri = self._link(chassis_data, "ThermalSubsystem")
+            thermal = {}
+            if thermal_uri:
+                thermal = self._query_optional(thermal_uri, do_async=do_async)
+            leak_uri = self._link(thermal, "LeakDetection")
+            if leak_uri:
+                leak = self._query_optional(leak_uri, do_async=do_async)
+                if isinstance(leak, dict) and leak:
+                    status = self._status(leak)
+                    detectors_uri = self._link(leak, "LeakDetectors")
+                    data["subsystems"].append({
+                        "Chassis": chassis_id,
+                        "Name": leak.get("Name"),
+                        "State": status.get("State"),
+                        "Health": status.get("Health"),
+                        "HealthRollup": status.get("HealthRollup"),
+                        "Uri": leak.get("@odata.id", leak_uri),
+                        "LeakDetectorsUri": detectors_uri,
+                    })
+                    if detectors_uri:
+                        collection, detectors = self._read_detectors(
+                            chassis_id,
+                            detectors_uri,
+                            do_async=do_async,
+                        )
+                        if collection is not None:
+                            data["detector_collections"].append(collection)
+                            data["detectors"].extend(detectors)
+
+            policies_uri = self._nested_link(
+                chassis_data,
+                "Oem",
+                "Nvidia",
+                "Policies",
+            )
+            if policies_uri:
+                data["policies"].extend(
+                    self._read_policies(
+                        chassis_id,
+                        policies_uri,
+                        do_async=do_async,
+                    )
+                )
+
+        data["summary"] = self._summary(len(chassis_uris), data)
+        return CommandResult(data, None, None, None)

--- a/tests/test_leak_detectors_dualmode.py
+++ b/tests/test_leak_detectors_dualmode.py
@@ -1,0 +1,113 @@
+"""Offline coverage for the GB300 LeakDetection reader."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+
+GB300_CORPUS = (
+    Path(__file__).parent
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+GB300_INDEX = {path.name.lower(): path for path in GB300_CORPUS.glob("*.json")}
+
+
+def _fixture_for_path(path):
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def gb300_corpus_manager():
+    """Serve the committed GB300 crawl over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        manager = IDracManager(
+            idrac_ip="mock-gb300",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def test_leak_detectors_read_gb300_detection_state_and_policy(
+    gb300_corpus_manager,
+):
+    """leak-detectors walks GB300 LeakDetection resources without writes."""
+    manager, requests = gb300_corpus_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LeakDetectors,
+        "leak-detectors",
+    )
+
+    assert result.discovered is None
+    assert result.extra is None
+    assert result.error is None
+    json.dumps(result.data, sort_keys=True)
+
+    assert result.data["summary"] == {
+        "chassis": 42,
+        "leak_detection_subsystems": 1,
+        "detector_collections": 1,
+        "detectors": 4,
+        "detectors_ok": 4,
+        "detectors_warning": 0,
+        "detectors_critical": 0,
+        "policies": 1,
+        "enabled_policies": 0,
+    }
+
+    subsystem = result.data["subsystems"][0]
+    assert subsystem == {
+        "Chassis": "Chassis_0",
+        "Name": "Leak Detection Systems",
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollup": "OK",
+        "Uri": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/LeakDetection",
+        "LeakDetectorsUri": (
+            "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/"
+            "LeakDetection/LeakDetectors"
+        ),
+    }
+
+    detectors = {row["Id"]: row for row in result.data["detectors"]}
+    assert detectors["Chassis_0_LeakDetector_0_ColdPlate"] == {
+        "Chassis": "Chassis_0",
+        "Id": "Chassis_0_LeakDetector_0_ColdPlate",
+        "Name": "Chassis 0 LeakDetector 0 ColdPlate",
+        "DetectorState": "OK",
+        "LeakDetectorType": "Moisture",
+        "State": "Enabled",
+        "Health": "OK",
+        "Uri": (
+            "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/"
+            "LeakDetection/LeakDetectors/Chassis_0_LeakDetector_0_ColdPlate"
+        ),
+    }
+
+    policy = result.data["policies"][0]
+    assert policy["Chassis"] == "Chassis_0"
+    assert policy["Id"] == "LeakDetectionPolicy"
+    assert policy["PolicyEnabled"] is False
+    assert policy["PolicyConditionLogic"] == "AnyOf"


### PR DESCRIPTION
## Summary

- add a read-only `leak-detectors` command for Chassis `LeakDetection` and `LeakDetector` resources
- include linked NVIDIA leak policy state when the chassis exposes it
- document the command and cover it with a GB300 corpus-backed offline test

## Validation

- `conda run -n idrac_ctl pytest -q tests/test_leak_detectors_dualmode.py -p no:cacheprovider`
- `conda run -n idrac_ctl pytest -q -p no:cacheprovider`
- `conda run -n idrac_ctl ruff check redfish_ctl/thermal/cmd_leak_detectors.py redfish_ctl/__init__.py redfish_ctl/idrac_shared.py tests/test_leak_detectors_dualmode.py`
- `conda run -n idrac_ctl python -m redfish_ctl.redfish_main leak-detectors --help`
- `git diff --check`
- `git diff --cached --check`
