### PR TITLE
Add developer Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+SHELL := /bin/sh
+.DEFAULT_GOAL := help
+
+PYTHON ?= python
+PYTEST ?= pytest
+RUFF ?= ruff
+MYPY ?= mypy
+TWINE ?= twine
+DOCKER ?= docker
+IMAGE ?= redfish-ctl
+
+.PHONY: help test lint typecheck build docker-test docker-image k8s-sandbox clean
+
+help: ## Show available developer targets.
+	@awk 'BEGIN { \
+		FS = ":.*## "; \
+		printf "Available targets:\n"; \
+	} /^[a-zA-Z0-9_-]+:.*## / { \
+		printf "  %-14s %s\n", $$1, $$2; \
+	}' $(MAKEFILE_LIST)
+
+test: ## Run the offline pytest suite.
+	$(PYTEST) -q
+
+lint: ## Run Ruff over source and tests.
+	$(RUFF) check redfish_ctl tests
+
+typecheck: ## Run mypy over source and tests.
+	$(MYPY) redfish_ctl tests
+
+build: ## Build sdist/wheel locally and validate package metadata.
+	$(PYTHON) setup.py sdist bdist_wheel
+	$(TWINE) check dist/*
+
+docker-test: ## Build and run the Linux offline test image.
+	./docker/run-tests.sh
+
+docker-image: ## Build the production CLI image locally.
+	@test -f docker/Dockerfile || { \
+		printf '%s\n' 'docker/Dockerfile is not present yet.'; \
+		printf '%s\n' 'Add the production image definition before using this target.'; \
+		exit 2; \
+	}
+	$(DOCKER) build -f docker/Dockerfile -t $(IMAGE) .
+
+k8s-sandbox: ## Run the local Kubernetes read-path sandbox when present.
+	@test -f k8s/sandbox/kind-config.yaml || { \
+		printf '%s\n' 'k8s/sandbox/kind-config.yaml is not present yet.'; \
+		printf '%s\n' 'Add the sandbox manifests and smoke script before using this target.'; \
+		exit 2; \
+	}
+	@printf '%s\n' 'Run the sandbox smoke harness from k8s/sandbox/.'
+
+clean: ## Remove local build, test, and type-check artifacts.
+	rm -rf build dist *.egg-info .coverage htmlcov .pytest_cache .ruff_cache .mypy_cache

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -1,0 +1,59 @@
+"""Makefile contract tests for local developer validation targets."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+REQUIRED_TARGETS = {
+    "help",
+    "test",
+    "lint",
+    "typecheck",
+    "build",
+    "docker-test",
+    "docker-image",
+    "k8s-sandbox",
+    "clean",
+}
+
+
+def test_make_help_lists_required_developer_targets() -> None:
+    """The default help output should show every supported local workflow."""
+    result = subprocess.run(
+        ["make", "help"],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    for target in sorted(REQUIRED_TARGETS):
+        assert target in result.stdout
+
+
+def test_make_dry_run_uses_expected_safe_local_commands() -> None:
+    """Dry-run recipes should route to local checks and never publish artifacts."""
+    result = subprocess.run(
+        ["make", "-n", "build", "docker-test", "docker-image", "k8s-sandbox"],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "setup.py sdist bdist_wheel" in result.stdout
+    assert "twine check" in result.stdout
+    assert "docker/run-tests.sh" in result.stdout
+    assert "docker build" in result.stdout
+    assert "k8s/sandbox" in result.stdout
+
+    makefile_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "twine upload" not in makefile_text
+    assert "docker push" not in makefile_text


### PR DESCRIPTION
## Summary

- Add a root Makefile with help, test, lint, typecheck, build, docker-test, docker-image, k8s-sandbox, and clean targets.
- Keep build and image workflows local-only: package build creates sdist/wheel artifacts and runs twine check; Docker image build does not push.
- Add pytest coverage for the Makefile help output, safe dry-run commands, and no publish commands.

## Validation

- `pytest -q` -> 745 passed, 58 skipped
- `make test` -> 745 passed, 58 skipped
- `ruff check tests/test_makefile_targets.py` -> passed
- `make help` -> listed all Makefile targets
- `make -n build docker-test docker-image k8s-sandbox clean` -> printed local-only commands
- `make build PYTHON="conda run -n idrac_ctl python" TWINE="conda run -n idrac_ctl twine"` -> built sdist/wheel and twine check passed for both artifacts
- `git diff --cached --check` -> passed

## Notes

- `make lint` runs full-tree Ruff and currently reports existing findings outside this change.
