### PR TITLE
Add production Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ First-run problems are almost always the connection, not the command:
   profile examples.
 - [Vendors](docs/vendors.md) - Dell, Supermicro, HPE, and generic Redfish support.
 - [Testing](docs/testing.md) - offline mock tests, vendor corpora, emulator tests, and live-test safety.
+- [Docker](docker/README.md) - production image and Linux offline-test image usage.
 - [Fixture capture](docs/fixture-capture.md) - crawl a BMC with `discovery`, sanitize it, and contribute it as a vendor corpus.
 - [CI/CD](docs/ci.md) - the GitHub Actions test + release pipeline, the runner, and the Node.js runtime.
 - [Architecture](docs/architecture.md) - Redfish core, iDRAC layer, command registration, and known debt.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,53 @@
+# Production redfish_ctl image.
+#
+# Build:
+#   docker build -f docker/Dockerfile -t redfish-ctl .
+# One-shot CLI equivalent to `redfish_ctl system`:
+#   docker run --rm --env-file .env.redfish redfish-ctl system
+# OTLP sidecar equivalent to `redfish_ctl exporter --output otlp`:
+#   docker run --rm --env-file .env.redfish redfish-ctl exporter --output otlp --once
+FROM python:3.12-slim AS builder
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /src
+
+COPY pyproject.toml setup.py requirements.txt README.md LICENSE ./
+COPY idrac_ctl ./idrac_ctl
+COPY redfish_ctl ./redfish_ctl
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install build wheel \
+    && python -m pip wheel --no-cache-dir --wheel-dir /wheelhouse ".[otlp]"
+
+FROM python:3.12-slim AS runtime
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN groupadd --system redfish \
+    && useradd \
+        --system \
+        --gid redfish \
+        --home-dir /home/redfish \
+        --create-home \
+        redfish
+
+WORKDIR /work
+
+COPY --from=builder /wheelhouse /wheelhouse
+
+RUN python -m pip install \
+        --no-cache-dir \
+        --no-index \
+        --find-links=/wheelhouse \
+        "redfish_ctl[otlp]" \
+    && rm -rf /wheelhouse \
+    && python -m pip check
+
+USER redfish
+
+ENTRYPOINT ["redfish_ctl"]
+CMD ["--help"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,40 @@
+# Docker Images
+
+The `docker/Dockerfile` file in this directory builds the production `redfish_ctl` runtime image.
+It installs `redfish_ctl[otlp]` from a wheel built inside the image build and runs the CLI as a
+non-root user. Credentials are supplied at container runtime only; do not add them to the image.
+
+| File | Purpose | Local command |
+| --- | --- | --- |
+| `docker/Dockerfile` | Production CLI/exporter image with the OTLP extra installed. | `docker build -f docker/Dockerfile -t redfish-ctl .` |
+| `docker/Dockerfile.test` | Linux image for the offline pytest suite. | `./docker/run-tests.sh` |
+
+## Runtime Environment
+
+The `REDFISH_IP`, `REDFISH_USERNAME`, `REDFISH_PASSWORD`, and `REDFISH_PORT` variables are read by
+`redfish_ctl/redfish_main.py` when the CLI starts. Put them in a local env file outside the repository:
+
+```bash
+REDFISH_IP=192.0.2.10
+REDFISH_USERNAME=root
+REDFISH_PASSWORD=replace-me
+REDFISH_PORT=443
+```
+
+Run a one-shot read command, equivalent to `redfish_ctl system` on the host:
+
+```bash
+docker run --rm --env-file .env.redfish redfish-ctl system
+```
+
+Run the telemetry exporter with native OTLP output:
+
+```bash
+docker run --rm \
+  --env-file .env.redfish \
+  -e OTEL_EXPORTER_OTLP_ENDPOINT=http://collector.example.invalid:4317 \
+  redfish-ctl exporter --output otlp --once
+```
+
+The image entrypoint is `redfish_ctl`, so container arguments are the normal CLI subcommand and flags.
+No Docker target uploads or pushes an image; publishing is handled only by the release workflow.

--- a/tests/test_dockerfile_contract.py
+++ b/tests/test_dockerfile_contract.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
+DOCKER_README = REPO_ROOT / "docker" / "README.md"
+README = REPO_ROOT / "README.md"
+
+
+def test_production_dockerfile_installs_local_otlp_wheel_as_non_root() -> None:
+    """Production image uses a local wheel, the OTLP extra, and a non-root runtime user."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    dockerfile_lower = dockerfile.lower()
+    from_lines = [line for line in dockerfile.splitlines() if line.lower().startswith("from ")]
+
+    assert len(from_lines) >= 2
+    assert " as builder" in from_lines[0].lower()
+    assert "slim" in from_lines[-1].lower()
+    assert "--platform=linux/amd64" not in dockerfile_lower
+    assert "--platform=linux/arm64" not in dockerfile_lower
+
+    assert "pip wheel" in dockerfile_lower
+    assert "--find-links=/wheelhouse" in dockerfile
+    assert "--no-index" in dockerfile
+    assert '"redfish_ctl[otlp]"' in dockerfile
+    assert 'ENTRYPOINT ["redfish_ctl"]' in dockerfile
+    assert "USER redfish" in dockerfile
+
+
+def test_production_dockerfile_header_shows_safe_runtime_examples() -> None:
+    """Dockerfile examples cover one-shot CLI use and OTLP exporter use without baked secrets."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+    header = "\n".join(dockerfile.splitlines()[:20])
+
+    assert "redfish_ctl system" in header
+    assert "exporter --output otlp" in header
+    assert "REDFISH_PASSWORD=" not in dockerfile
+    assert "IDRAC_PASSWORD=" not in dockerfile
+    assert "DOCKERHUB_TOKEN" not in dockerfile
+
+
+def test_docker_docs_link_the_production_image_usage() -> None:
+    """Docker docs explain production-image usage and README links to the Docker guide."""
+    docker_readme = DOCKER_README.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+
+    assert "docker/Dockerfile" in docker_readme
+    assert "redfish_ctl system" in docker_readme
+    assert "exporter --output otlp" in docker_readme
+    assert "credentials" in docker_readme.lower()
+    assert "[Docker](docker/README.md)" in readme


### PR DESCRIPTION
## Summary
- Add a production multi-stage Docker image that builds a wheelhouse and installs `redfish_ctl[otlp]` in a slim runtime.
- Run the image as a non-root user with `redfish_ctl` as the entrypoint and no baked credentials.
- Document build/runtime usage and link the Docker guide from the README.

## Validation
- `pytest -q tests/test_dockerfile_contract.py -o cache_dir=/private/tmp/idrac-codex-worker-pytest-cache`
- `env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD pytest -q -o cache_dir=/private/tmp/idrac-codex-worker-pytest-cache`
- `ruff check tests/test_dockerfile_contract.py --cache-dir /private/tmp/idrac-codex-worker-ruff-cache`
- `git diff --check` and `git diff --cached --check`
- `docker build -f docker/Dockerfile -t redfish-ctl:dx2 .`
- `docker run --rm redfish-ctl:dx2 --version`

## Notes
- The image was built locally only; it was not pushed to a registry.