### PR TITLE
Add PowerSmoothing read command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,6 +132,7 @@ Safety labels:
 | `oem-net-iso-task` | Read Dell OEM OS deployment task data. | Read |
 | `pci` | Read PCI device or function data. | Read |
 | `power` | Read chassis PowerSubsystem, PowerSupplies, and Batteries resources. | Read |
+| `power-smoothing` | Read NVIDIA GPU PowerSmoothing current state, preset profiles, and admin override profile setpoints. | Read |
 | `privilege-registry` | Read the privilege registry. | Read |
 | `query` | Read an arbitrary Redfish resource path. | Read |
 | `raid` | Read RAID service data. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -80,6 +80,7 @@ from .chassis.cmd_chasis_reset import *
 from .sensors.cmd_sensors import *
 from .thermal.cmd_thermal import *
 from .power.cmd_power import *
+from .power.cmd_power_smoothing import *
 from .thermal.cmd_leak_detectors import *
 from .environment.cmd_environment_metrics import *
 from .telemetry.cmd_metric_reports import *

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -83,6 +83,7 @@ class ApiRequestType(Enum):
     Sensors = auto()
     Thermal = auto()
     Power = auto()
+    PowerSmoothing = auto()
     LeakDetectors = auto()
     EnvironmentMetrics = auto()
     MetricReports = auto()

--- a/redfish_ctl/power/cmd_power_smoothing.py
+++ b/redfish_ctl/power/cmd_power_smoothing.py
@@ -1,0 +1,267 @@
+"""Read NVIDIA PowerSmoothing resources exposed through GPU processors."""
+
+from abc import abstractmethod
+from typing import Optional
+
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+from ..redfish_shared import RedfishApi
+
+
+class PowerSmoothing(IDracManager,
+                     scm_type=ApiRequestType.PowerSmoothing,
+                     name="power-smoothing",
+                     metaclass=Singleton):
+    """Read GPU PowerSmoothing state and profile setpoints."""
+
+    def __init__(self, *args, **kwargs):
+        super(PowerSmoothing, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only ``power-smoothing`` subcommand."""
+        cmd_parser = cls.base_parser()
+        help_text = "command read NVIDIA GPU PowerSmoothing profiles"
+        return cmd_parser, "power-smoothing", help_text
+
+    @staticmethod
+    def _members(data):
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        value = data.get(key) if isinstance(data, dict) else None
+        if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
+            return value["@odata.id"]
+        return None
+
+    @staticmethod
+    def _nested_link(data, *keys):
+        value = data
+        for key in keys:
+            if not isinstance(value, dict):
+                return None
+            value = value.get(key)
+        if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
+            return value["@odata.id"]
+        return None
+
+    @staticmethod
+    def _resource_id(uri):
+        return uri.rstrip("/").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _action_target(data, key):
+        actions = data.get("Actions") if isinstance(data, dict) else None
+        action = actions.get(key) if isinstance(actions, dict) else None
+        if isinstance(action, dict) and isinstance(action.get("target"), str):
+            return action["target"]
+        return None
+
+    @staticmethod
+    def _profile(system_id, gpu_id, profile, fallback_uri):
+        return {
+            "System": system_id,
+            "GPU": gpu_id,
+            "Id": profile.get("Id"),
+            "Name": profile.get("Name"),
+            "RampDownHysteresisSeconds": profile.get(
+                "RampDownHysteresisSeconds"),
+            "RampDownWattsPerSecond": profile.get(
+                "RampDownWattsPerSecond"),
+            "RampUpWattsPerSecond": profile.get("RampUpWattsPerSecond"),
+            "TMPFloorPercent": profile.get("TMPFloorPercent"),
+            "Uri": profile.get("@odata.id", fallback_uri),
+        }
+
+    def _query_optional(self, uri, do_async=False):
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def _read_profile(self, system_id, gpu_id, profile_uri, do_async=False):
+        profile = self._query_optional(profile_uri, do_async=do_async)
+        if not isinstance(profile, dict) or not profile:
+            return None
+        return self._profile(system_id, gpu_id, profile, profile_uri)
+
+    def _read_preset_profiles(self,
+                              system_id,
+                              gpu_id,
+                              profiles_uri,
+                              do_async=False):
+        collection = self._query_optional(profiles_uri, do_async=do_async)
+        if not isinstance(collection, dict) or not collection:
+            return None, []
+        members = collection.get("Members") or []
+        if not isinstance(members, list):
+            members = []
+        collection_row = {
+            "System": system_id,
+            "GPU": gpu_id,
+            "Name": collection.get("Name"),
+            "MemberCount": collection.get(
+                "Members@odata.count",
+                len(members),
+            ),
+            "Uri": collection.get("@odata.id", profiles_uri),
+        }
+
+        profiles = []
+        for profile_uri in self._members(collection):
+            profile = self._read_profile(
+                system_id,
+                gpu_id,
+                profile_uri,
+                do_async=do_async,
+            )
+            if profile is not None:
+                profiles.append(profile)
+        return collection_row, profiles
+
+    def _append_gpu_power_smoothing(self,
+                                    data,
+                                    system_id,
+                                    gpu_id,
+                                    smoothing_uri,
+                                    do_async=False):
+        smoothing = self._query_optional(smoothing_uri, do_async=do_async)
+        if not isinstance(smoothing, dict) or not smoothing:
+            return
+
+        admin_uri = self._link(smoothing, "AdminOverrideProfile")
+        profiles_uri = self._link(smoothing, "PresetProfiles")
+        applied_uri = self._link(smoothing, "AppliedPresetProfile")
+        data["power_smoothing"].append({
+            "System": system_id,
+            "GPU": gpu_id,
+            "Name": smoothing.get("Name"),
+            "Enabled": smoothing.get("Enabled"),
+            "PowerSmoothingSupported": smoothing.get(
+                "PowerSmoothingSupported"),
+            "ImmediateRampDown": smoothing.get("ImmediateRampDown"),
+            "RampDownHysteresisSeconds": smoothing.get(
+                "RampDownHysteresisSeconds"),
+            "RampDownWattsPerSecond": smoothing.get(
+                "RampDownWattsPerSecond"),
+            "RampUpWattsPerSecond": smoothing.get("RampUpWattsPerSecond"),
+            "TMPFloorPercent": smoothing.get("TMPFloorPercent"),
+            "TMPFloorWatts": smoothing.get("TMPFloorWatts"),
+            "TMPWatts": smoothing.get("TMPWatts"),
+            "RemainingLifetimeCircuitryPercent": smoothing.get(
+                "RemainingLifetimeCircuitryPercent"),
+            "AppliedPresetProfileUri": applied_uri,
+            "AdminOverrideProfileUri": admin_uri,
+            "PresetProfilesUri": profiles_uri,
+            "ActivatePresetProfileTarget": self._action_target(
+                smoothing,
+                "#NvidiaPowerSmoothing.ActivatePresetProfile",
+            ),
+            "ApplyAdminOverridesTarget": self._action_target(
+                smoothing,
+                "#NvidiaPowerSmoothing.ApplyAdminOverrides",
+            ),
+            "Uri": smoothing.get("@odata.id", smoothing_uri),
+        })
+
+        if profiles_uri:
+            collection, profiles = self._read_preset_profiles(
+                system_id,
+                gpu_id,
+                profiles_uri,
+                do_async=do_async,
+            )
+            if collection is not None:
+                data["preset_collections"].append(collection)
+                data["preset_profiles"].extend(profiles)
+
+        if admin_uri:
+            admin_profile = self._read_profile(
+                system_id,
+                gpu_id,
+                admin_uri,
+                do_async=do_async,
+            )
+            if admin_profile is not None:
+                data["admin_override_profiles"].append(admin_profile)
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        data = {
+            "summary": {},
+            "power_smoothing": [],
+            "preset_collections": [],
+            "preset_profiles": [],
+            "admin_override_profiles": [],
+        }
+
+        systems = self._query_optional(RedfishApi.Systems, do_async=do_async)
+        system_uris = self._members(systems)
+        gpu_processors = 0
+        for system_uri in system_uris:
+            system = self._query_optional(system_uri, do_async=do_async)
+            processors_uri = self._link(system, "Processors")
+            if not processors_uri:
+                continue
+            processors = self._query_optional(
+                processors_uri,
+                do_async=do_async,
+            )
+            for processor_uri in self._members(processors):
+                processor = self._query_optional(
+                    processor_uri,
+                    do_async=do_async,
+                )
+                if processor.get("ProcessorType") != "GPU":
+                    continue
+                gpu_processors += 1
+                system_id = self._resource_id(system_uri)
+                gpu_id = processor.get("Id") or self._resource_id(
+                    processor_uri)
+                smoothing_uri = self._nested_link(
+                    processor,
+                    "Oem",
+                    "Nvidia",
+                    "PowerSmoothing",
+                )
+                if smoothing_uri:
+                    self._append_gpu_power_smoothing(
+                        data,
+                        system_id,
+                        gpu_id,
+                        smoothing_uri,
+                        do_async=do_async,
+                    )
+
+        data["summary"] = {
+            "systems": len(system_uris),
+            "gpu_processors": gpu_processors,
+            "power_smoothing_resources": len(data["power_smoothing"]),
+            "supported": sum(
+                1 for row in data["power_smoothing"]
+                if row.get("PowerSmoothingSupported") is True
+            ),
+            "enabled": sum(
+                1 for row in data["power_smoothing"]
+                if row.get("Enabled") is True
+            ),
+            "preset_collections": len(data["preset_collections"]),
+            "preset_profiles": len(data["preset_profiles"]),
+            "admin_override_profiles": len(data["admin_override_profiles"]),
+        }
+        return CommandResult(data, None, None, None)

--- a/tests/test_power_smoothing_dualmode.py
+++ b/tests/test_power_smoothing_dualmode.py
@@ -1,0 +1,185 @@
+"""Offline coverage for the GB300 NVIDIA PowerSmoothing reader."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+
+GB300_CORPUS = (
+    Path(__file__).parent
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+GB300_INDEX = {path.name.lower(): path for path in GB300_CORPUS.glob("*.json")}
+
+
+def _fixture_for_path(path):
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def gb300_corpus_manager():
+    """Serve the committed GB300 crawl over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        manager = IDracManager(
+            idrac_ip="mock-gb300",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def test_power_smoothing_reads_gb300_gpu_profiles_and_setpoints(
+    gb300_corpus_manager,
+):
+    """power-smoothing walks GB300 GPU OEM links without writes."""
+    manager, requests = gb300_corpus_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.PowerSmoothing,
+        "power-smoothing",
+    )
+
+    assert result.discovered is None
+    assert result.extra is None
+    assert result.error is None
+    json.dumps(result.data, sort_keys=True)
+
+    assert result.data["summary"] == {
+        "systems": 2,
+        "gpu_processors": 4,
+        "power_smoothing_resources": 4,
+        "supported": 4,
+        "enabled": 0,
+        "preset_collections": 4,
+        "preset_profiles": 12,
+        "admin_override_profiles": 4,
+    }
+
+    resources = {row["GPU"]: row for row in result.data["power_smoothing"]}
+    assert resources["GPU_0"] == {
+        "System": "HGX_Baseboard_0",
+        "GPU": "GPU_0",
+        "Name": "GPU_0 Power Smoothing",
+        "Enabled": False,
+        "PowerSmoothingSupported": True,
+        "ImmediateRampDown": False,
+        "RampDownHysteresisSeconds": 10.0,
+        "RampDownWattsPerSecond": 20.0,
+        "RampUpWattsPerSecond": 20.0,
+        "TMPFloorPercent": 89.990234375,
+        "TMPFloorWatts": 0.0,
+        "TMPWatts": 1459.0,
+        "RemainingLifetimeCircuitryPercent": 100.0,
+        "AppliedPresetProfileUri": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/PresetProfiles/0"
+        ),
+        "AdminOverrideProfileUri": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/AdminOverrideProfile"
+        ),
+        "PresetProfilesUri": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/PresetProfiles"
+        ),
+        "ActivatePresetProfileTarget": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/Actions/"
+            "NvidiaPowerSmoothing.ActivatePresetProfile"
+        ),
+        "ApplyAdminOverridesTarget": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/Actions/"
+            "NvidiaPowerSmoothing.ApplyAdminOverrides"
+        ),
+        "Uri": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing"
+        ),
+    }
+
+    collections = {
+        row["GPU"]: row
+        for row in result.data["preset_collections"]
+    }
+    assert collections["GPU_0"] == {
+        "System": "HGX_Baseboard_0",
+        "GPU": "GPU_0",
+        "Name": "GPU_0 PowerSmoothing PresetProfile Collection",
+        "MemberCount": 5,
+        "Uri": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/PresetProfiles"
+        ),
+    }
+
+    profiles = {
+        (row["GPU"], row["Id"]): row
+        for row in result.data["preset_profiles"]
+    }
+    assert profiles[("GPU_0", "0")] == {
+        "System": "HGX_Baseboard_0",
+        "GPU": "GPU_0",
+        "Id": "0",
+        "Name": "GPU_0 PowerSmoothing PresetProfile 0",
+        "RampDownHysteresisSeconds": 10.0,
+        "RampDownWattsPerSecond": 20.0,
+        "RampUpWattsPerSecond": 20.0,
+        "TMPFloorPercent": 89.990234375,
+        "Uri": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/PresetProfiles/0"
+        ),
+    }
+
+    admin_profiles = {
+        row["GPU"]: row
+        for row in result.data["admin_override_profiles"]
+    }
+    assert admin_profiles["GPU_0"] == {
+        "System": "HGX_Baseboard_0",
+        "GPU": "GPU_0",
+        "Id": "AdminOverrideProfile",
+        "Name": "GPU_0 PowerSmoothing AdminOverrideProfile",
+        "RampDownHysteresisSeconds": 4294967295.0,
+        "RampDownWattsPerSecond": 4294967295.0,
+        "RampUpWattsPerSecond": 4294967295.0,
+        "TMPFloorPercent": 4294967295.0,
+        "Uri": (
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+            "Nvidia/PowerSmoothing/AdminOverrideProfile"
+        ),
+    }
+
+    paths = {request.path.lower() for request in requests}
+    assert (
+        "/redfish/v1/systems/hgx_baseboard_0/processors/gpu_0/"
+        "oem/nvidia/powersmoothing"
+        in paths
+    )
+    assert {
+        request.method
+        for request in requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    } == set()


### PR DESCRIPTION
## Summary
- add a read-only `power-smoothing` command that walks Systems -> GPU Processors -> Oem.Nvidia.PowerSmoothing links
- return current GPU PowerSmoothing state, action targets, preset profile collections, preset profiles, and admin override profile setpoints
- document the command in the command reference

## Tests
- `conda run -n idrac_ctl pytest -q tests/test_power_smoothing_dualmode.py`
- `conda run -n idrac_ctl python -m redfish_ctl.redfish_main power-smoothing --help`
- `conda run -n idrac_ctl ruff check redfish_ctl/power/cmd_power_smoothing.py redfish_ctl/idrac_shared.py redfish_ctl/__init__.py tests/test_power_smoothing_dualmode.py`
- `conda run -n idrac_ctl pytest -q`

No live BMC or credentials required.