### PR TITLE
Add guarded NTP configuration command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -120,6 +120,7 @@ Safety labels:
 | `metric-reports` | Read TelemetryService metric reports; `--report` filters by id substring. | Read |
 | `network-adapters` | Read chassis NetworkAdapters such as NICs and DPUs. | Read |
 | `network-ports` | Read NetworkAdapter port link state and speed. | Read |
+| `ntp-set` | Set ManagerNetworkProtocol NTP servers; dry-run by default and `--confirm` applies an NTP-only PATCH. | Guarded |
 | `nvlink-ports` | Read GPU NVLink port resources where the BMC exposes them. | Read |
 | `oem-actions` | Read supported Dell OEM OS deployment actions. | Read |
 | `oem-attach` | Attach a network ISO through a Dell OEM action. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -53,6 +53,7 @@ from .pci.cmd_pci import *
 # manager cmds
 from .manager.cmd_manager import *
 from .manager.cmd_manager_network import *
+from .manager.cmd_ntp_set import *
 from .manager.cmd_manager_reset import *
 
 

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -129,6 +129,7 @@ class ApiRequestType(Enum):
     # idrac manager
     ManagerQuery = auto()
     ManagerNetworkProtocol = auto()
+    NtpSet = auto()
     ManagerReset = auto()
 
     # bios related

--- a/redfish_ctl/manager/cmd_ntp_set.py
+++ b/redfish_ctl/manager/cmd_ntp_set.py
@@ -1,0 +1,177 @@
+"""Set ManagerNetworkProtocol NTP servers with a guarded PATCH."""
+
+import ipaddress
+import re
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+
+_MAX_NTP_SERVERS = 4
+_HOST_LABEL = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+
+
+def _normalize_ntp_servers(servers) -> list[str]:
+    if servers is None:
+        raise InvalidArgument("at least one NTP server is required")
+    if isinstance(servers, str):
+        raw_servers = [servers]
+    else:
+        raw_servers = list(servers)
+
+    normalized = []
+    for raw in raw_servers:
+        for value in str(raw).split(","):
+            server = value.strip()
+            if server:
+                normalized.append(server)
+
+    if not normalized:
+        raise InvalidArgument("at least one NTP server is required")
+    if len(normalized) > _MAX_NTP_SERVERS:
+        raise InvalidArgument("ManagerNetworkProtocol NTP supports at most 4 servers")
+    for server in normalized:
+        if not _is_plausible_ntp_server(server):
+            raise InvalidArgument(f"invalid NTP server: {server!r}")
+    return normalized
+
+
+def _is_plausible_ntp_server(server: str) -> bool:
+    if not server or any(ch.isspace() for ch in server):
+        return False
+    if "://" in server or "/" in server:
+        return False
+    try:
+        ipaddress.ip_address(server)
+        return True
+    except ValueError:
+        pass
+
+    hostname = server[:-1] if server.endswith(".") else server
+    if len(hostname) > 253 or not hostname:
+        return False
+    labels = hostname.split(".")
+    return all(_HOST_LABEL.fullmatch(label) for label in labels)
+
+
+class NtpSet(IDracManager,
+             scm_type=ApiRequestType.NtpSet,
+             name='ntp-set',
+             metaclass=Singleton):
+    """Set ManagerNetworkProtocol NTP servers after dry-run preview."""
+
+    def __init__(self, *args, **kwargs):
+        super(NtpSet, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ntp-set subcommand."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            '--server', action='append', dest='servers', metavar='HOST',
+            required=True, help="NTP hostname or IP; repeat for up to 4 servers")
+        cmd_parser.add_argument(
+            '--manager', type=str, dest='manager_id', default=None, metavar='ID',
+            help="optional Manager id to patch; default patches NTP-capable managers")
+        cmd_parser.add_argument(
+            '--confirm', action='store_true', dest='confirm', default=False,
+            help="apply the PATCH; without it the command only previews")
+        help_text = "set ManagerNetworkProtocol NTP servers"
+        return cmd_parser, "ntp-set", help_text
+
+    @staticmethod
+    def _link(data, key):
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _get(self, uri, do_async):
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def _ntp_plan(self, servers, manager_id, do_async):
+        payload = {"NTP": {"NTPServers": servers, "ProtocolEnabled": True}}
+        plan = []
+        skipped = []
+
+        for manager_uri in self.discover_manager_ids():
+            manager = self._get(manager_uri, do_async)
+            current_manager_id = manager.get("Id") or manager_uri.rsplit("/", 1)[-1]
+            network_uri = self._link(manager, "NetworkProtocol")
+            if manager_id and current_manager_id != manager_id:
+                continue
+            if not network_uri:
+                skipped.append({
+                    "Manager": current_manager_id,
+                    "target": None,
+                    "reason": "NetworkProtocol link is not available",
+                })
+                continue
+            network = self._get(network_uri, do_async)
+            if not isinstance(network.get("NTP"), dict):
+                skipped.append({
+                    "Manager": current_manager_id,
+                    "target": network_uri,
+                    "reason": "NTP block is not available",
+                })
+                continue
+            plan.append({
+                "Manager": current_manager_id,
+                "target": network_uri,
+                "payload": payload,
+            })
+
+        if manager_id and not plan:
+            raise InvalidArgument(f"Manager {manager_id!r} has no NTP-capable NetworkProtocol")
+        if not plan:
+            raise InvalidArgument("no NTP-capable ManagerNetworkProtocol resources found")
+        return plan, skipped
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                servers=None,
+                manager_id: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or apply NTP servers on ManagerNetworkProtocol resources."""
+        normalized_servers = _normalize_ntp_servers(servers)
+        plan, skipped = self._ntp_plan(normalized_servers, manager_id, do_async)
+
+        if not confirm:
+            return CommandResult({
+                "dry_run": True,
+                "note": "preview only; re-run with --confirm to apply",
+                "servers": normalized_servers,
+                "plan": plan,
+                "skipped": skipped,
+            }, None, None, None)
+
+        applied = []
+        for item in plan:
+            result, status = self.base_patch(
+                item["target"],
+                payload=item["payload"],
+                do_async=do_async,
+                expected_status=200,
+            )
+            applied.append({
+                "Manager": item["Manager"],
+                "target": item["target"],
+                "status": str(status),
+                "error": result.error,
+            })
+
+        return CommandResult({
+            "servers": normalized_servers,
+            "applied": applied,
+            "skipped": skipped,
+        }, None, None, None)

--- a/tests/test_ntp_set_dualmode.py
+++ b/tests/test_ntp_set_dualmode.py
@@ -1,0 +1,102 @@
+"""Dual-mode tests for the ntp-set command."""
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+
+def _mutating_requests(service):
+    return [
+        request for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    ]
+
+
+def test_ntp_set_dry_run_builds_gb300_patch_plan_without_writing(
+        redfish_mock_factory):
+    """ntp-set previews NTP-only ManagerNetworkProtocol PATCHes by default."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org", "1.pool.ntp.org"],
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["servers"] == ["0.pool.ntp.org", "1.pool.ntp.org"]
+    assert result.data["skipped"] == [{
+        "Manager": "HGX_BMC_0",
+        "target": "/redfish/v1/Managers/HGX_BMC_0/NetworkProtocol",
+        "reason": "NTP block is not available",
+    }]
+    assert result.data["plan"] == [{
+        "Manager": "BMC_0",
+        "target": "/redfish/v1/Managers/BMC_0/NetworkProtocol",
+        "payload": {
+            "NTP": {
+                "NTPServers": ["0.pool.ntp.org", "1.pool.ntp.org"],
+                "ProtocolEnabled": True,
+            },
+        },
+    }]
+    assert _mutating_requests(service) == []
+
+
+def test_ntp_set_confirm_patches_only_the_ntp_block(redfish_mock_factory):
+    """ntp-set --confirm PATCHes NTP servers without changing other protocols."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org"],
+        confirm=True,
+    )
+
+    patches = [request for request in service.requests if request.method == "PATCH"]
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/bmc_0/networkprotocol"
+    assert patches[0].json() == {
+        "NTP": {
+            "NTPServers": ["0.pool.ntp.org"],
+            "ProtocolEnabled": True,
+        },
+    }
+    assert set(patches[0].json()) == {"NTP"}
+    assert result.data["applied"] == [{
+        "Manager": "BMC_0",
+        "target": "/redfish/v1/Managers/BMC_0/NetworkProtocol",
+        "status": "IdracApiRespond.Ok",
+        "error": None,
+    }]
+
+
+@pytest.mark.parametrize(
+    "servers",
+    [
+        ["https://0.pool.ntp.org"],
+        ["bad host"],
+        ["ntp_underscore.example"],
+        ["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org",
+         "3.pool.ntp.org", "4.pool.ntp.org"],
+    ],
+)
+def test_ntp_set_rejects_invalid_server_lists_before_patch(
+        redfish_mock_factory, servers):
+    """ntp-set validates server names and the Redfish four-server limit first."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument):
+        manager.sync_invoke(
+            ApiRequestType.NtpSet,
+            "ntp-set",
+            servers=servers,
+            confirm=True,
+        )
+
+    assert _mutating_requests(service) == []


### PR DESCRIPTION
## Summary
- add an ntp-set command that discovers ManagerNetworkProtocol resources and previews NTP-only PATCHes by default
- validate hostname/IP server values, limit requests to four servers, and support optional --manager plus --confirm
- add offline Supermicro corpus coverage and document the command in the reference table

## Verification
- pytest -q tests/test_ntp_set_dualmode.py
- pytest -q
- ruff check redfish_ctl/manager/cmd_ntp_set.py redfish_ctl/idrac_shared.py redfish_ctl/__init__.py tests/test_ntp_set_dualmode.py
- python -m redfish_ctl.redfish_main ntp-set --help
- git diff --cached --check