### PR TITLE
Add EnvironmentMetrics exporter rollups

### DIFF
--- a/docs/telemetry-exporter.md
+++ b/docs/telemetry-exporter.md
@@ -8,14 +8,17 @@ in-band host agent misses: chassis power, fans, voltages, GPU power, and NVLink 
 
 ## What It Reads
 
-- Chassis `EnvironmentMetrics`, where many BMCs publish power and energy rollups.
+- Chassis, Processor, and Memory `EnvironmentMetrics` resources, discovered by the
+  `environment-metrics` command, where many BMCs publish power and energy rollups.
 - Chassis `Sensors`, followed through linked Sensor resources.
 - TelemetryService `MetricReports`, where GB300 exposes fabric and GPU metric properties.
 - GPU `nvlink-ports`, `network-adapters`, and `component-integrity` command output.
 
 The exporter emits `hw.power`, `hw.temperature`, `hw.fan_speed`, `hw.voltage`, `hw.energy_kwh`,
-`hw.gpu.power`, and `hw.fabric.*`. Fabric metrics include link state, negotiated speed, RX/TX bytes,
-bandwidth, FEC/CRC-style counters when Redfish exposes them, and other NVLink error counters.
+`hw.gpu.power`, and `hw.fabric.*`. EnvironmentMetrics rollups add `resource_type` and `resource`
+dimensions so chassis, processor, and memory power can be separated. Fabric metrics include link
+state, negotiated speed, RX/TX bytes, bandwidth, FEC/CRC-style counters when Redfish exposes them,
+and other NVLink error counters.
 
 ## Credentials
 
@@ -112,9 +115,10 @@ redfish_ctl exporter --vendor supermicro --output otlp --once             # push
 
 The contract is unchanged: metric names and dimension keys are identical to the Prometheus/SignalFx
 outputs. The identity dimensions (`host.name`, `server.address`, `bmc.ip`, `node`, `vendor`) map to
-OTel **resource** attributes; the per-metric dimensions (`gpu`, `port`, `chassis`, `system`, `index`)
-map to **datapoint** attributes. Monotonic cumulative counters (fabric byte/frame/error/packet/count
-totals and `hw.energy_kwh`) are emitted as OTLP **Sum**; everything instantaneous stays a **Gauge**.
+OTel **resource** attributes; the per-metric dimensions (`gpu`, `port`, `chassis`, `system`, `index`,
+`resource_type`, `resource`) map to **datapoint** attributes. Monotonic cumulative counters (fabric
+byte/frame/error/packet/count totals and `hw.energy_kwh`) are emitted as OTLP **Sum**; everything
+instantaneous stays a **Gauge**.
 
 ## What Good Looks Like
 
@@ -122,6 +126,7 @@ A Prometheus scrape should include at least one chassis power metric and, on GB3
 
 ```text
 hw.power{...} 1349.263802
+hw.power{resource_type="Memory",resource="GPU_0_DRAM_0",...} 34.458
 hw.gpu.power{gpu="GPU_0",...} 231.958
 hw.fabric.link_up{fabric="nvlink",gpu="GPU_0",port="NVLink_0",...} 1
 hw.fabric.rx_bytes{fabric="nvlink",gpu="GPU_0",port="NVLink_0",...} 9460179851686

--- a/redfish_ctl/telemetry/cmd_exporter.py
+++ b/redfish_ctl/telemetry/cmd_exporter.py
@@ -129,6 +129,23 @@ class Exporter(IDracManager,
             rows.append(env_data)
         return rows
 
+    def _environment_command_rows(self, do_async: bool = False) -> list[dict]:
+        """Return normalized rows from the environment-metrics command."""
+        try:
+            result = self.sync_invoke(
+                ApiRequestType.EnvironmentMetrics,
+                "environment-metrics",
+                do_async=do_async,
+            )
+        except Exception:
+            return self._environment_rows(do_async=do_async)
+        data = result.data
+        if isinstance(data, dict) and isinstance(data.get("metrics"), list):
+            return data["metrics"]
+        if isinstance(data, list):
+            return data
+        return self._environment_rows(do_async=do_async)
+
     def _vendor_label(self, vendor: Optional[str]) -> str:
         """Return a stable lower-case vendor label."""
         if vendor:
@@ -149,7 +166,7 @@ class Exporter(IDracManager,
             label_bmc_ip or self.idrac_ip,
             vendor=self._vendor_label(vendor),
         )
-        environment_rows = self._environment_rows(do_async=do_async)
+        environment_rows = self._environment_command_rows(do_async=do_async)
         sensor_rows = self._invoke_rows(ApiRequestType.Sensors, "sensors",
                                         do_async=do_async, do_expanded=do_expanded)
         nvlink_rows = self._invoke_rows(ApiRequestType.NvLinkPorts, "nvlink-ports",

--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -190,15 +190,21 @@ def samples_from_environment_rows(
     """Map Chassis EnvironmentMetrics rows into chassis/GPU power metrics."""
     samples = []
     for row in rows:
-        chassis = str(row.get("Chassis") or row.get("Id") or "unknown")
-        dims = _with_dims(identity, source="environment", chassis=chassis)
+        chassis = _environment_chassis(row)
+        dims = _environment_dims(identity, row, chassis)
+        gpu = _environment_gpu(row, chassis)
         power = _as_float(_reading(row.get("PowerWatts")))
         if power is not None:
-            metric = "hw.gpu.power" if _gpu_from_chassis(chassis) else "hw.power"
-            samples.append(_sample(metric, power, dims | _gpu_dim(chassis), unit="W"))
+            metric = "hw.gpu.power" if gpu and row.get("ParentType") != "Memory" else "hw.power"
+            samples.append(_sample(metric, power, dims | ({"gpu": gpu} if gpu else {}), unit="W"))
         energy = _as_float(_reading(row.get("EnergykWh") or row.get("EnergyKWh")))
         if energy is not None:
-            samples.append(_sample("hw.energy_kwh", energy, dims | _gpu_dim(chassis), unit="kWh"))
+            samples.append(_sample(
+                "hw.energy_kwh",
+                energy,
+                dims | ({"gpu": gpu} if gpu else {}),
+                unit="kWh",
+            ))
         for fan_name, rpm in _fan_readings(row):
             samples.append(_sample("hw.fan_speed", rpm, dims | {"fan": _dim_value(fan_name)}, "RPM"))
     return samples
@@ -504,6 +510,44 @@ def _with_dims(identity: Mapping[str, str], **extra) -> dict[str, str]:
         if value not in (None, ""):
             dims[key] = str(value)
     return dims
+
+
+def _environment_chassis(row: Mapping) -> str:
+    parent_type = row.get("ParentType")
+    parent_id = row.get("ParentId")
+    if parent_type == "Chassis" and parent_id:
+        return str(parent_id)
+    return str(row.get("Chassis") or row.get("Id") or "unknown")
+
+
+def _environment_dims(identity: Mapping[str, str],
+                      row: Mapping,
+                      chassis: str) -> dict[str, str]:
+    dims = _with_dims(identity, source="environment", chassis=chassis)
+    parent_type = row.get("ParentType")
+    parent_id = row.get("ParentId")
+    if parent_type:
+        dims["resource_type"] = str(parent_type)
+    if parent_id:
+        resource = _dim_value(parent_id)
+        dims["resource"] = resource
+        if parent_type == "Processor":
+            dims["processor"] = resource
+        elif parent_type == "Memory":
+            dims["memory"] = resource
+    return dims
+
+
+def _environment_gpu(row: Mapping, chassis: str) -> Optional[str]:
+    parent_type = row.get("ParentType")
+    parent_id = str(row.get("ParentId") or "")
+    if parent_type == "Processor" and parent_id.startswith("GPU_"):
+        return parent_id
+    if parent_type == "Memory":
+        match = re.match(r"(GPU_\d+)", parent_id)
+        if match:
+            return match.group(1)
+    return _gpu_from_chassis(chassis)
 
 
 def _fabric_dims(identity: Mapping[str, str],

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -1,10 +1,13 @@
 """Offline tests for the Redfish telemetry exporter contract."""
 
 import argparse
+import json
+from pathlib import Path
 
 import pytest
 
 import redfish_ctl.telemetry.exporter as exporter_mod
+from redfish_ctl.idrac_manager import IDracManager
 from redfish_ctl.idrac_shared import ApiRequestType
 from redfish_ctl.telemetry.exporter import (
     MetricSample,
@@ -19,6 +22,45 @@ from redfish_ctl.telemetry.exporter import (
 )
 
 REQUIRED_DIMS = {"host.name", "node", "server.address", "bmc.ip", "vendor"}
+GB300_CORPUS = (
+    Path(__file__).parent
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+GB300_INDEX = {path.name.lower(): path for path in GB300_CORPUS.glob("*.json")}
+
+
+def _gb300_fixture_for_path(path):
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def gb300_exporter_manager():
+    """Serve the committed GB300 crawl over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _gb300_fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        manager = IDracManager(
+            idrac_ip="mock-gb300",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
 
 
 def test_identity_dimensions_follow_nv72_slot_contract():
@@ -284,6 +326,52 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
     assert {"hw.power", "hw.gpu.power", "hw.fabric.rx_bytes"} <= metrics
     assert all(REQUIRED_DIMS <= set(point["dimensions"]) for point in gauges)
     assert all(recorded.method != "POST" for recorded in service.requests)
+
+
+def test_exporter_uses_environment_metrics_command_rollups(gb300_exporter_manager):
+    """Exporter output includes EnvironmentMetrics rows for every GB300 resource."""
+    manager, requests = gb300_exporter_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.Exporter,
+        "exporter",
+        once=True,
+        exporter_output="signalfx",
+        label_bmc_ip="172.25.230.37",
+        vendor="supermicro",
+    )
+
+    gauges = result.data["gauge"]
+    processor_power = [
+        point for point in gauges
+        if point["metric"] == "hw.gpu.power"
+        and point["dimensions"].get("source") == "environment"
+        and point["dimensions"].get("resource_type") == "Processor"
+        and point["dimensions"].get("resource") == "GPU_0"
+    ]
+    memory_power = [
+        point for point in gauges
+        if point["metric"] == "hw.power"
+        and point["dimensions"].get("source") == "environment"
+        and point["dimensions"].get("resource_type") == "Memory"
+        and point["dimensions"].get("resource") == "GPU_0_DRAM_0"
+    ]
+    processor_energy = [
+        point for point in gauges
+        if point["metric"] == "hw.energy_kwh"
+        and point["dimensions"].get("source") == "environment"
+        and point["dimensions"].get("resource_type") == "Processor"
+        and point["dimensions"].get("resource") == "GPU_0"
+    ]
+
+    assert processor_power[0]["value"] == pytest.approx(231.939)
+    assert memory_power[0]["value"] == pytest.approx(34.458)
+    assert processor_energy[0]["value"] == pytest.approx(63.95437164505238)
+    assert {
+        request.method
+        for request in requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    } == set()
 
 
 def test_once_push_signalfx_posts_body_exactly_once(redfish_mock_factory, monkeypatch):


### PR DESCRIPTION
## Summary
- source exporter EnvironmentMetrics rows from the environment-metrics command so chassis, processor, and memory rollups are included
- add resource_type and resource dimensions for per-resource power and energy series
- document the exporter resource rollup dimensions

## Tests
- pytest -q
- ruff check redfish_ctl/telemetry/exporter.py redfish_ctl/telemetry/cmd_exporter.py tests/test_telemetry_exporter.py
- python -m redfish_ctl.redfish_main exporter --help
- git diff --check