### PR TITLE
Add read-only mock BMC sandbox container

### DIFF
--- a/docker/Dockerfile.mock-bmc
+++ b/docker/Dockerfile.mock-bmc
@@ -1,0 +1,38 @@
+# Read-only Redfish mock-BMC image for the Kubernetes sandbox.
+#
+# Build:
+#   docker build -f docker/Dockerfile.mock-bmc -t redfish-ctl-mock-bmc:local .
+# Run locally:
+#   docker run --rm -p 8080:8080 redfish-ctl-mock-bmc:local
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    MOCK_BMC_CORPUS_DIR=/corpus/172.25.230.37
+
+RUN groupadd --system mockbmc \
+    && useradd \
+        --system \
+        --gid mockbmc \
+        --home-dir /home/mockbmc \
+        --create-home \
+        mockbmc
+
+WORKDIR /app
+
+COPY --chown=mockbmc:mockbmc k8s/sandbox/mock_bmc_server.py \
+    /app/mock_bmc_server.py
+COPY --chown=mockbmc:mockbmc \
+    tests/supermicro_gb300_corpus/json_responses/172.25.230.37 \
+    /corpus/172.25.230.37
+
+USER mockbmc
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c \
+        "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/redfish/v1/', timeout=2).close()"
+
+ENTRYPOINT ["python", "/app/mock_bmc_server.py"]
+CMD ["--host", "0.0.0.0", "--port", "8080"]

--- a/k8s/sandbox/mock-bmc.yaml
+++ b/k8s/sandbox/mock-bmc.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mock-bmc
+  labels:
+    app.kubernetes.io/name: mock-bmc
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: mock-bmc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: mock-bmc
+        app.kubernetes.io/component: redfish-sandbox
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: mock-bmc
+          image: redfish-ctl-mock-bmc:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: MOCK_BMC_CORPUS_DIR
+              value: /corpus/172.25.230.37
+          readinessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mock-bmc
+  labels:
+    app.kubernetes.io/name: mock-bmc
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: mock-bmc
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Serve a captured Redfish corpus over a small read-only HTTP endpoint."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Iterator
+from urllib.parse import unquote, urlsplit
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8080
+DEFAULT_CORPUS_DIR = Path(
+    os.environ.get("MOCK_BMC_CORPUS_DIR", "/corpus/172.25.230.37")
+)
+
+
+def _build_fixture_index(corpus_dir: Path) -> dict[str, Path]:
+    root = Path(corpus_dir)
+    return {path.name.lower(): path for path in root.glob("*.json")}
+
+
+def fixture_for_redfish_path(corpus_dir: Path, request_path: str) -> Path | None:
+    """Return the flattened corpus file for a Redfish request path."""
+    path = unquote(urlsplit(request_path).path)
+    if path != "/" and path.endswith("/"):
+        path = path.rstrip("/")
+    if not path.startswith("/redfish/v1"):
+        return None
+
+    key = "_" + path.strip("/").replace("/", "_") + ".json"
+    return _build_fixture_index(Path(corpus_dir)).get(key.lower())
+
+
+class CorpusRequestHandler(BaseHTTPRequestHandler):
+    """HTTP handler that serves GET and HEAD from a flattened Redfish corpus."""
+
+    server_version = "redfish-ctl-mock-bmc/1.0"
+
+    def _fixture_for_request(self) -> Path | None:
+        fixture_index = getattr(type(self), "fixture_index")
+        path = unquote(urlsplit(self.path).path)
+        if path != "/" and path.endswith("/"):
+            path = path.rstrip("/")
+        if not path.startswith("/redfish/v1"):
+            return None
+        key = "_" + path.strip("/").replace("/", "_") + ".json"
+        return fixture_index.get(key.lower())
+
+    def _send_json(self, status: int, payload: dict[str, object]) -> None:
+        content = json.dumps(payload, sort_keys=True).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def _serve_fixture(self, send_body: bool) -> None:
+        fixture = self._fixture_for_request()
+        if fixture is None:
+            self._send_json(404, {"error": f"no fixture for {self.path}"})
+            return
+
+        content = fixture.read_bytes()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        if send_body:
+            self.wfile.write(content)
+
+    def do_GET(self) -> None:
+        self._serve_fixture(send_body=True)
+
+    def do_HEAD(self) -> None:
+        self._serve_fixture(send_body=False)
+
+    def do_OPTIONS(self) -> None:
+        self.send_response(204)
+        self.send_header("Allow", "GET, HEAD, OPTIONS")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_POST(self) -> None:
+        self._send_method_not_allowed()
+
+    def do_PATCH(self) -> None:
+        self._send_method_not_allowed()
+
+    def do_PUT(self) -> None:
+        self._send_method_not_allowed()
+
+    def do_DELETE(self) -> None:
+        self._send_method_not_allowed()
+
+    def _send_method_not_allowed(self) -> None:
+        self.send_response(405)
+        self.send_header("Allow", "GET, HEAD, OPTIONS")
+        self.send_header("Content-Type", "application/json")
+        content = b'{"error": "read-only mock BMC"}'
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def log_message(self, format: str, *args: object) -> None:
+        if os.environ.get("MOCK_BMC_VERBOSE") == "1":
+            super().log_message(format, *args)
+
+
+def make_handler(corpus_dir: Path) -> type[CorpusRequestHandler]:
+    root = Path(corpus_dir)
+    if not root.is_dir():
+        raise FileNotFoundError(f"corpus directory not found: {root}")
+
+    class Handler(CorpusRequestHandler):
+        pass
+
+    Handler.fixture_index = _build_fixture_index(root)
+    if not Handler.fixture_index:
+        raise ValueError(f"no JSON fixtures found under {root}")
+    return Handler
+
+
+@contextmanager
+def run_server(
+    host: str,
+    port: int,
+    corpus_dir: Path,
+) -> Iterator[ThreadingHTTPServer]:
+    server = ThreadingHTTPServer((host, port), make_handler(corpus_dir))
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Serve a flattened Redfish JSON corpus over read-only HTTP."
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT)
+    parser.add_argument(
+        "--corpus-dir",
+        type=Path,
+        default=DEFAULT_CORPUS_DIR,
+        help="Directory containing flattened _redfish_v1*.json files.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    server = None
+    try:
+        server = ThreadingHTTPServer(
+            (args.host, args.port),
+            make_handler(args.corpus_dir),
+        )
+        host, port = server.server_address
+        print(f"Serving Redfish corpus from {args.corpus_dir} on {host}:{port}")
+        server.serve_forever()
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"mock-bmc: {exc}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        if server is not None:
+            server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -1,0 +1,109 @@
+"""Contracts for the Kubernetes sandbox mock-BMC container."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.mock-bmc"
+MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "mock-bmc.yaml"
+GB300_CORPUS = (
+    REPO_ROOT
+    / "tests"
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+
+
+def _load_server_module():
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mock_bmc_maps_redfish_paths_to_gb300_corpus() -> None:
+    """Redfish URLs resolve to the flattened files in the GB300 corpus."""
+    module = _load_server_module()
+
+    fixture = module.fixture_for_redfish_path(
+        GB300_CORPUS,
+        "/redfish/v1/Managers/BMC_0/NetworkProtocol?$select=NTP",
+    )
+
+    assert fixture == GB300_CORPUS / "_redfish_v1_Managers_BMC_0_NetworkProtocol.json"
+    assert module.fixture_for_redfish_path(GB300_CORPUS, "/redfish/v1/NoSuchResource") is None
+
+
+def test_mock_bmc_serves_json_read_only_over_http() -> None:
+    """The HTTP server serves corpus JSON and rejects mutating verbs."""
+    module = _load_server_module()
+
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS) as server:
+        host, port = server.server_address
+        url = f"http://{host}:{port}/redfish/v1/Managers/BMC_0/NetworkProtocol"
+
+        with urllib.request.urlopen(url, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        assert payload["@odata.id"] == "/redfish/v1/Managers/BMC_0/NetworkProtocol"
+
+        head_request = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(head_request, timeout=5) as response:
+            assert response.status == 200
+            assert int(response.headers["Content-Length"]) > 0
+
+        post_request = urllib.request.Request(url, data=b"{}", method="POST")
+        try:
+            urllib.request.urlopen(post_request, timeout=5)
+        except urllib.error.HTTPError as exc:
+            assert exc.code == 405
+        else:  # pragma: no cover - the assertion above is the expected path.
+            raise AssertionError("POST unexpectedly succeeded")
+
+
+def test_mock_bmc_container_builds_from_corpus_without_credentials() -> None:
+    """The sandbox image copies only the server and public corpus data."""
+    dockerfile = DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "FROM python:3.12-slim" in dockerfile
+    assert "--chown=mockbmc:mockbmc" in dockerfile
+    assert "k8s/sandbox/mock_bmc_server.py" in dockerfile
+    assert "tests/supermicro_gb300_corpus/json_responses/172.25.230.37" in dockerfile
+    assert "USER mockbmc" in dockerfile
+    assert "EXPOSE 8080" in dockerfile
+    assert "ENTRYPOINT" in dockerfile
+    assert "REDFISH_PASSWORD" not in dockerfile
+    assert "IDRAC_PASSWORD" not in dockerfile
+
+
+def test_mock_bmc_manifest_exposes_read_only_service_without_secrets() -> None:
+    """The sandbox manifest deploys the mock BMC as an in-cluster HTTP service."""
+    docs = [
+        doc
+        for doc in yaml.safe_load_all(MANIFEST.read_text(encoding="utf-8"))
+        if doc
+    ]
+    by_kind = {doc["kind"]: doc for doc in docs}
+
+    deployment = by_kind["Deployment"]
+    service = by_kind["Service"]
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    env_names = {entry["name"] for entry in container.get("env", [])}
+
+    assert deployment["metadata"]["name"] == "mock-bmc"
+    assert service["metadata"]["name"] == "mock-bmc"
+    assert container["image"] == "redfish-ctl-mock-bmc:local"
+    assert container["ports"][0]["containerPort"] == 8080
+    assert container["readinessProbe"]["httpGet"]["path"] == "/redfish/v1/"
+    assert service["spec"]["ports"][0]["targetPort"] == "http"
+    assert not {name for name in env_names if "PASSWORD" in name or "SECRET" in name}


### PR DESCRIPTION
## Summary

- Add a small read-only HTTP server that maps `/redfish/v1/...` requests to the committed GB300 corpus JSON files.
- Add a local mock-BMC Docker image and Kubernetes Deployment/Service manifest for sandbox consumers.
- Add focused tests for path mapping, HTTP read-only behavior, container contents, and manifest shape.

## Validation

- `/Users/spyroot/miniconda3/bin/conda run -n idrac_ctl pytest -q tests/test_k8s_mock_bmc_server.py`
- `/Users/spyroot/miniconda3/bin/conda run -n idrac_ctl pytest -q`
- `/Users/spyroot/miniconda3/bin/conda run -n idrac_ctl ruff check k8s/sandbox/mock_bmc_server.py tests/test_k8s_mock_bmc_server.py`
- `git diff --check`
- `git diff --cached --check`
- `docker build -f docker/Dockerfile.mock-bmc -t redfish-ctl-mock-bmc:ds1 .`
- `curl -fsS http://127.0.0.1:18088/redfish/v1/Managers/BMC_0/NetworkProtocol` against the temporary container

The temporary container and image tag were removed after validation.