### PR TITLE
Add typed read API facade

### DIFF
--- a/redfish_ctl/api.py
+++ b/redfish_ctl/api.py
@@ -1,0 +1,187 @@
+"""Typed read helpers for embedding redfish_ctl in services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Protocol
+
+from .idrac_shared import ApiRequestType
+from .redfish_manager import CommandResult
+
+
+class SyncInvoker(Protocol):
+    """Object that can invoke registered redfish_ctl commands synchronously."""
+
+    def sync_invoke(
+        self, api_call: ApiRequestType, name: str, **kwargs: Any
+    ) -> CommandResult:
+        ...
+
+
+class RedfishApiError(RuntimeError):
+    """Raised when a wrapped command returns a CommandResult error."""
+
+
+@dataclass(frozen=True)
+class SystemStatus:
+    """ComputerSystem status fields most useful to service consumers."""
+
+    id: str | None
+    name: str | None
+    power_state: str | None
+    health: str | None
+    state: str | None
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class SensorReading:
+    """Normalized reading returned by the sensors command."""
+
+    chassis: str | None
+    name: str | None
+    reading: int | float | str | None
+    reading_units: str | None
+    reading_type: str | None
+    health: str | None
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class TemperatureReading:
+    """ThermalSubsystem temperature row."""
+
+    chassis: str | None
+    device_name: str | None
+    physical_context: str | None
+    reading_celsius: int | float | str | None
+    data_source_uri: str | None
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class FanReading:
+    """ThermalSubsystem fan row."""
+
+    chassis: str | None
+    name: str | None
+    state: str | None
+    health: str | None
+    speed_percent: int | float | str | None
+    uri: str | None
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ThermalStatus:
+    """Typed summary of the thermal command payload."""
+
+    summary: Mapping[str, Any]
+    temperatures: tuple[TemperatureReading, ...]
+    fans: tuple[FanReading, ...]
+    raw: Mapping[str, Any]
+
+
+def _invoke(
+    manager: SyncInvoker,
+    api_call: ApiRequestType,
+    name: str,
+    **kwargs: Any,
+) -> Any:
+    result = manager.sync_invoke(api_call, name, **kwargs)
+    if result.error:
+        raise RedfishApiError(str(result.error))
+    return result.data
+
+
+def _mapping(data: Any) -> Mapping[str, Any]:
+    return data if isinstance(data, Mapping) else {}
+
+
+def _rows(data: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(data, list):
+        return ()
+    return tuple(row for row in data if isinstance(row, Mapping))
+
+
+def get_system(manager: SyncInvoker, *, deep: bool = False) -> SystemStatus:
+    """Return typed ComputerSystem status through the existing system command."""
+    data = _mapping(
+        _invoke(
+            manager,
+            ApiRequestType.SystemQuery,
+            "system_query",
+            do_deep=deep,
+        )
+    )
+    status = _mapping(data.get("Status"))
+    return SystemStatus(
+        id=data.get("Id"),
+        name=data.get("Name"),
+        power_state=data.get("PowerState"),
+        health=status.get("Health"),
+        state=status.get("State"),
+        raw=data,
+    )
+
+
+def get_sensors(
+    manager: SyncInvoker, *, expanded: bool = False
+) -> tuple[SensorReading, ...]:
+    """Return typed chassis sensor readings through the sensors command."""
+    rows = _rows(
+        _invoke(
+            manager,
+            ApiRequestType.Sensors,
+            "sensors",
+            do_expanded=expanded,
+        )
+    )
+    return tuple(
+        SensorReading(
+            chassis=row.get("Chassis"),
+            name=row.get("Name"),
+            reading=row.get("Reading"),
+            reading_units=row.get("ReadingUnits"),
+            reading_type=row.get("ReadingType"),
+            health=row.get("Health"),
+            raw=row,
+        )
+        for row in rows
+    )
+
+
+def get_thermal(manager: SyncInvoker) -> ThermalStatus:
+    """Return typed thermal status through the thermal command."""
+    data = _mapping(_invoke(manager, ApiRequestType.Thermal, "thermal"))
+    temperature_rows = _rows(data.get("temperature_readings"))
+    fan_rows = _rows(data.get("fans"))
+    temperatures = tuple(
+        TemperatureReading(
+            chassis=row.get("Chassis"),
+            device_name=row.get("DeviceName"),
+            physical_context=row.get("PhysicalContext"),
+            reading_celsius=row.get("ReadingCelsius"),
+            data_source_uri=row.get("DataSourceUri"),
+            raw=row,
+        )
+        for row in temperature_rows
+    )
+    fans = tuple(
+        FanReading(
+            chassis=row.get("Chassis"),
+            name=row.get("Name"),
+            state=row.get("State"),
+            health=row.get("Health"),
+            speed_percent=row.get("SpeedPercent"),
+            uri=row.get("Uri"),
+            raw=row,
+        )
+        for row in fan_rows
+    )
+    return ThermalStatus(
+        summary=_mapping(data.get("summary")),
+        temperatures=temperatures,
+        fans=fans,
+        raw=data,
+    )

--- a/tests/test_api_facade.py
+++ b/tests/test_api_facade.py
@@ -1,0 +1,241 @@
+"""Tests for the small typed API facade used by controller code."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.api import (
+    FanReading,
+    SensorReading,
+    SystemStatus,
+    TemperatureReading,
+    ThermalStatus,
+    get_sensors,
+    get_system,
+    get_thermal,
+)
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+GB300_CORPUS = (
+    Path(__file__).parent
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+GB300_INDEX = {path.name.lower(): path for path in GB300_CORPUS.glob("*.json")}
+
+
+class RecordingManager:
+    """Record sync_invoke calls and return configured command payloads."""
+
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def sync_invoke(self, api_call, name, **kwargs):
+        self.calls.append((api_call, name, kwargs))
+        return self.results[(api_call, name)]
+
+
+def _fixture_for_path(path):
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def gb300_corpus_manager():
+    """Serve the committed GB300 crawl over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        manager = IDracManager(
+            idrac_ip="mock-gb300",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def test_get_system_returns_typed_status_from_system_query():
+    """get_system delegates to system_query and exposes controller fields."""
+    manager = RecordingManager({
+        (ApiRequestType.SystemQuery, "system_query"): CommandResult(
+            {
+                "Id": "System.Embedded.1",
+                "Name": "Primary system",
+                "PowerState": "On",
+                "Status": {"Health": "OK", "State": "Enabled"},
+            },
+            None,
+            None,
+            None,
+        )
+    })
+
+    status = get_system(manager, deep=True)
+
+    assert status == SystemStatus(
+        id="System.Embedded.1",
+        name="Primary system",
+        power_state="On",
+        health="OK",
+        state="Enabled",
+        raw={
+            "Id": "System.Embedded.1",
+            "Name": "Primary system",
+            "PowerState": "On",
+            "Status": {"Health": "OK", "State": "Enabled"},
+        },
+    )
+    assert manager.calls == [
+        (ApiRequestType.SystemQuery, "system_query", {"do_deep": True})
+    ]
+
+
+def test_get_sensors_returns_typed_readings_from_sensors_command():
+    """get_sensors delegates to sensors and keeps raw sensor rows."""
+    rows = [
+        {
+            "Chassis": "Chassis_0",
+            "Name": "Front IO Temp",
+            "Reading": 24.4,
+            "ReadingUnits": "Cel",
+            "ReadingType": "Temperature",
+            "Health": "OK",
+        }
+    ]
+    manager = RecordingManager({
+        (ApiRequestType.Sensors, "sensors"): CommandResult(rows, None, None, None)
+    })
+
+    readings = get_sensors(manager, expanded=True)
+
+    assert readings == (
+        SensorReading(
+            chassis="Chassis_0",
+            name="Front IO Temp",
+            reading=24.4,
+            reading_units="Cel",
+            reading_type="Temperature",
+            health="OK",
+            raw=rows[0],
+        ),
+    )
+    assert manager.calls == [
+        (ApiRequestType.Sensors, "sensors", {"do_expanded": True})
+    ]
+
+
+def test_get_thermal_returns_typed_summary_temperatures_and_fans():
+    """get_thermal delegates to thermal and shapes controller-facing rows."""
+    payload = {
+        "summary": {
+            "chassis": 1,
+            "thermal_subsystems": 1,
+            "thermal_metrics": 1,
+            "fan_collections": 1,
+            "fans": 1,
+            "temperature_readings": 1,
+        },
+        "temperature_readings": [
+            {
+                "Chassis": "Chassis_0",
+                "DeviceName": "Front IO Temp",
+                "PhysicalContext": "Intake",
+                "ReadingCelsius": 24.4,
+                "DataSourceUri": "/redfish/v1/Chassis/Chassis_0/Sensors/Front",
+            }
+        ],
+        "fans": [
+            {
+                "Chassis": "Chassis_0",
+                "Name": "Fan 1",
+                "State": "Enabled",
+                "Health": "OK",
+                "SpeedPercent": 44,
+                "Uri": "/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/Fans/1",
+            }
+        ],
+    }
+    manager = RecordingManager({
+        (ApiRequestType.Thermal, "thermal"): CommandResult(payload, None, None, None)
+    })
+
+    thermal = get_thermal(manager)
+
+    assert thermal == ThermalStatus(
+        summary=payload["summary"],
+        temperatures=(
+            TemperatureReading(
+                chassis="Chassis_0",
+                device_name="Front IO Temp",
+                physical_context="Intake",
+                reading_celsius=24.4,
+                data_source_uri="/redfish/v1/Chassis/Chassis_0/Sensors/Front",
+                raw=payload["temperature_readings"][0],
+            ),
+        ),
+        fans=(
+            FanReading(
+                chassis="Chassis_0",
+                name="Fan 1",
+                state="Enabled",
+                health="OK",
+                speed_percent=44,
+                uri="/redfish/v1/Chassis/Chassis_0/ThermalSubsystem/Fans/1",
+                raw=payload["fans"][0],
+            ),
+        ),
+        raw=payload,
+    )
+    assert manager.calls == [(ApiRequestType.Thermal, "thermal", {})]
+
+
+def test_facade_wrappers_read_gb300_corpus_through_command_registry(
+    gb300_corpus_manager,
+):
+    """Facade helpers use real read commands against the GB300 fixture tree."""
+    manager, requests = gb300_corpus_manager
+
+    system = get_system(manager)
+    sensors = get_sensors(manager)
+    thermal = get_thermal(manager)
+
+    assert system.id == "System_0"
+    assert system.name == "System_0"
+    assert system.power_state == "On"
+    assert system.health == "OK"
+    assert len(sensors) >= 250
+    assert any(
+        reading.name == "Chassis 0 Front IO Temp 0"
+        and reading.reading_units == "Cel"
+        for reading in sensors
+    )
+    assert thermal.summary["thermal_subsystems"] == 28
+    assert thermal.summary["temperature_readings"] == 72
+    assert any(
+        reading.device_name == "Chassis_0_Front_IO_Temp_0"
+        and reading.reading_celsius == 24.437
+        for reading in thermal.temperatures
+    )
+
+    paths = {request.path.lower() for request in requests}
+    assert "/redfish/v1/systems/system_0" in paths
+    assert "/redfish/v1/chassis/chassis_0/sensors" in paths
+    assert "/redfish/v1/chassis/chassis_0/thermalsubsystem" in paths


### PR DESCRIPTION
## Summary
- Add `redfish_ctl.api` typed read helpers for system, sensors, and thermal data.
- Shape existing command results into immutable dataclasses for service and controller consumers.
- Cover unit-level dispatch plus GB300 corpus-backed registry integration.

## Validation
- `conda run -n idrac_ctl pytest -q`
- `conda run -n idrac_ctl ruff check redfish_ctl/api.py tests/test_api_facade.py`