### PR TITLE
Add BIOS tuning profile catalog with seed profiles

### DIFF
--- a/specs/profiles/README.md
+++ b/specs/profiles/README.md
@@ -1,0 +1,34 @@
+# BIOS tuning profiles
+
+Each `*.json` file in this directory is a named BIOS tuning profile — a small,
+vendor-scoped set of BIOS attribute overrides that a `bios-profile` reader can
+list, show, diff against a live system, and (guarded) stage via the existing
+`bios-change` path.
+
+## Schema
+
+| Field         | Type   | Meaning                                                            |
+| ------------- | ------ | ----------------------------------------------------------------- |
+| `name`        | string | Profile id; must equal the filename stem.                         |
+| `vendor`      | string | Vendor the profile targets (`supermicro`, `dell`, …).            |
+| `model`       | string | Model/family label (e.g. `GB300`, `PowerEdge`).                  |
+| `description` | string | One sentence on what the profile does and why.                   |
+| `risk`        | string | `low` / `medium` / `high` — operator-facing caution level.       |
+| `notes`       | string | Optional: apply semantics, provenance.                           |
+| `attributes`  | object | `{ <BiosAttributeName>: <value> }` overrides to stage.           |
+
+## No invented knobs
+
+Every key in `attributes` must exist in the target vendor's captured BIOS
+attribute registry, and its value must be allowable there. This is enforced by
+`tests/test_bios_profiles_specs.py`, which validates each profile against the
+committed registries:
+
+- `supermicro` → the GB300 corpus registry
+  (`tests/supermicro_gb300_corpus/.../_redfish_v1_Registries_BiosAttributeRegistry_BiosAttributeRegistry.json`).
+- `dell` → `tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Bios_BiosRegistry.json`.
+
+GB300 is a Grace-Blackwell (ARM) platform: its registry exposes knobs such as
+`ServerPowerControl`, `ActiveCores`, and `EGM` — **not** the x86
+`C-states`/`NPS`/`turbo` attributes. Do not add a knob that isn't in the
+registry; add the matching registry capture first.

--- a/specs/profiles/dell-cstates-off.json
+++ b/specs/profiles/dell-cstates-off.json
@@ -1,0 +1,11 @@
+{
+  "name": "dell-cstates-off",
+  "vendor": "dell",
+  "model": "PowerEdge",
+  "description": "Disable processor C-states for latency-sensitive workloads that cannot tolerate deep-sleep wakeup jitter.",
+  "risk": "medium",
+  "notes": "Trades idle power savings for lower and more predictable latency. ProcCStates is an Enumeration (Enabled/Disabled) in the Dell BIOS registry.",
+  "attributes": {
+    "ProcCStates": "Disabled"
+  }
+}

--- a/specs/profiles/gb300-extended-gpu-memory.json
+++ b/specs/profiles/gb300-extended-gpu-memory.json
@@ -1,0 +1,11 @@
+{
+  "name": "gb300-extended-gpu-memory",
+  "vendor": "supermicro",
+  "model": "GB300",
+  "description": "Enable Extended GPU Memory (EGM) so the GPU can coherently address Grace CPU memory on Grace-Blackwell nodes, expanding the usable memory pool for large models.",
+  "risk": "medium",
+  "notes": "Staged as a BIOS change and applied on the next host reset. EGM is a Boolean attribute in the GB300 BiosAttributeRegistry (default false).",
+  "attributes": {
+    "EGM": true
+  }
+}

--- a/specs/profiles/gb300-power-capped.json
+++ b/specs/profiles/gb300-power-capped.json
@@ -1,0 +1,11 @@
+{
+  "name": "gb300-power-capped",
+  "vendor": "supermicro",
+  "model": "GB300",
+  "description": "Enforce BMC input power capping on a 1-second timescale instead of the 50 ms default, smoothing power draw for rack-level power budgeting.",
+  "risk": "medium",
+  "notes": "Staged as a BIOS change and applied on the next host reset. ServerPowerControl and its allowable values are verified against the GB300 BiosAttributeRegistry.",
+  "attributes": {
+    "ServerPowerControl": "InputPowerCappingUsing1sTimescale"
+  }
+}

--- a/tests/test_bios_profiles_specs.py
+++ b/tests/test_bios_profiles_specs.py
@@ -1,0 +1,111 @@
+"""Validate the committed BIOS tuning profiles under specs/profiles/.
+
+Each profile declares BIOS attribute overrides. These tests guard the
+"no invented knobs" rule: every attribute a profile sets must exist in the
+matching vendor's committed BIOS attribute registry, and the value must be
+allowable there. The profiles feed the ``bios-profile`` catalog reader.
+
+The registries are real captures committed to the repo, so this runs fully
+offline with no iDRAC and no network.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+PROFILE_DIR = REPO / "specs" / "profiles"
+
+# vendor -> committed BIOS attribute registry captured from real hardware.
+REGISTRY_BY_VENDOR = {
+    "supermicro": (
+        REPO
+        / "tests"
+        / "supermicro_gb300_corpus"
+        / "json_responses"
+        / "172.25.230.37"
+        / "_redfish_v1_Registries_BiosAttributeRegistry_BiosAttributeRegistry.json"
+    ),
+    "dell": (
+        REPO
+        / "tests"
+        / "idrac_fixtures"
+        / "_redfish_v1_Systems_System.Embedded.1_Bios_BiosRegistry.json"
+    ),
+}
+
+REQUIRED_KEYS = {"name", "vendor", "model", "description", "risk", "attributes"}
+
+
+def _load_registry(path):
+    """Return {AttributeName: attribute-entry} from a BIOS registry capture."""
+    data = json.loads(path.read_text())
+    entries = data.get("RegistryEntries", {}).get("Attributes", [])
+    return {a["AttributeName"]: a for a in entries if "AttributeName" in a}
+
+
+def _profile_files():
+    """All committed profile JSON files (excludes the README)."""
+    return sorted(PROFILE_DIR.glob("*.json"))
+
+
+def test_profiles_present():
+    """specs/profiles/ exists and holds at least one profile (unblocks the reader)."""
+    assert _profile_files(), "no profiles found under specs/profiles/"
+
+
+@pytest.mark.parametrize("path", _profile_files(), ids=lambda p: p.name)
+def test_profile_schema_and_grounded(path):
+    """Each profile parses, carries the required keys, and sets only real knobs.
+
+    Edge cases covered: a value outside a knob's allowable set, a wrong python
+    type for a boolean/integer knob, and an attribute absent from the registry
+    (the classic "invented knob") all fail here rather than at apply time on
+    real hardware.
+    """
+    profile = json.loads(path.read_text())
+
+    missing = REQUIRED_KEYS - profile.keys()
+    assert not missing, f"{path.name} missing keys: {sorted(missing)}"
+    assert path.stem == profile["name"], (
+        f"{path.name}: filename stem must equal profile name {profile['name']!r}"
+    )
+    assert profile["risk"] in {"low", "medium", "high"}, (
+        f"{path.name}: risk must be low/medium/high"
+    )
+
+    vendor = profile["vendor"]
+    assert vendor in REGISTRY_BY_VENDOR, (
+        f"{path.name}: no committed BIOS registry pinned for vendor {vendor!r}"
+    )
+    registry = _load_registry(REGISTRY_BY_VENDOR[vendor])
+
+    attributes = profile["attributes"]
+    assert attributes, f"{path.name}: profile sets no attributes"
+    for attr_name, value in attributes.items():
+        assert attr_name in registry, (
+            f"{path.name}: {attr_name!r} is not in the {vendor} BIOS registry "
+            "(no invented knobs)"
+        )
+        entry = registry[attr_name]
+        atype = entry.get("Type")
+        if atype == "Enumeration":
+            allowed = {v.get("ValueName") for v in entry.get("Value", [])}
+            assert value in allowed, (
+                f"{path.name}: {attr_name}={value!r} not in allowable {sorted(allowed)}"
+            )
+        elif atype == "Boolean":
+            # bool is a subclass of int, so check bool explicitly.
+            assert isinstance(value, bool), (
+                f"{path.name}: {attr_name} must be a boolean"
+            )
+        elif atype == "Integer":
+            assert isinstance(value, int) and not isinstance(value, bool), (
+                f"{path.name}: {attr_name} must be an integer"
+            )
+            lower, upper = entry.get("LowerBound"), entry.get("UpperBound")
+            if lower is not None:
+                assert value >= lower, f"{path.name}: {attr_name}={value} < {lower}"
+            if upper is not None:
+                assert value <= upper, f"{path.name}: {attr_name}={value} > {upper}"


### PR DESCRIPTION
## Summary
- Add `specs/profiles/` with vendor-scoped BIOS tuning profiles: GB300 power-capping and extended GPU memory, and Dell C-states-off.
- Each profile is a small `{name, vendor, model, description, risk, attributes}` document; `specs/profiles/README.md` documents the schema.
- Add `tests/test_bios_profiles_specs.py` validating every profile against the committed BIOS attribute registries, so a profile can only set knobs the hardware actually exposes (with allowable values).

## Notes
- GB300 is Grace-Blackwell (ARM); its registry exposes `ServerPowerControl`/`ActiveCores`/`EGM`, not x86 C-states/NPS. Values verified against the captured registry.
- Read-only data + tests; no engine changes.

## Validation
- `pytest -q tests/test_bios_profiles_specs.py` (offline, no hardware).