### PR TITLE
Add BIOS profile catalog command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,6 +68,7 @@ Safety labels:
 | `bios-change` | Stage BIOS attributes from a spec or attribute pair. | Write |
 | `bios-clear-pending` | Clear pending BIOS values. | Write |
 | `bios-pending` | Read pending BIOS values. | Read |
+| `bios-profile` | List committed BIOS tuning profiles or show one full profile. | Read |
 | `bios-registry` | Read BIOS registry metadata, choices, and writable attributes. | Read |
 | `bios-snapshot` | Capture a BIOS restore point for rollback-able changes. | Read |
 | `bmc-scan` | Scan a network segment for Redfish BMCs. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -25,6 +25,7 @@ from .bios.cmd_bios_clear_pending import *
 from .bios.cmd_bios_pending import *
 from .bios.cmd_change_boot_order import *
 from .bios.bios_registry import *
+from .bios.cmd_bios_profile import *
 from .bios.cmd_change_bios import *
 from .bios.cmd_bios_snapshot import *
 from .bios.cmd_bios_reset_default import *

--- a/redfish_ctl/bios/cmd_bios_profile.py
+++ b/redfish_ctl/bios/cmd_bios_profile.py
@@ -1,0 +1,101 @@
+"""Read the committed BIOS tuning profile catalog."""
+
+import json
+from abc import abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from ..cmd_utils import save_if_needed
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+
+PROFILE_DIR = Path(__file__).resolve().parents[2] / "specs" / "profiles"
+SUMMARY_KEYS = ("name", "vendor", "model", "description", "risk")
+
+
+class BiosProfile(IDracManager,
+                  scm_type=ApiRequestType.BiosProfile,
+                  name="bios-profile",
+                  metaclass=Singleton):
+    """Read local BIOS profile specifications without contacting a BMC."""
+
+    def __init__(self, *args, **kwargs):
+        super(BiosProfile, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only ``bios-profile`` catalog subcommand."""
+        cmd_parser = cls.base_parser(is_async=False, is_expanded=False)
+        cmd_parser.add_argument(
+            "action",
+            nargs="?",
+            choices=("list", "show"),
+            default="list",
+            help="catalog action to run",
+        )
+        cmd_parser.add_argument(
+            "profile_name",
+            nargs="?",
+            help="profile name for the show action",
+        )
+        return (
+            cmd_parser,
+            "bios-profile",
+            "command read committed BIOS profile catalog entries",
+        )
+
+    @staticmethod
+    def _profile_files(profile_dir):
+        path = Path(profile_dir)
+        if not path.exists() or not path.is_dir():
+            return []
+        return sorted(path.glob("*.json"))
+
+    @staticmethod
+    def _load_profile(path):
+        return json.loads(path.read_text())
+
+    @classmethod
+    def _profiles(cls, profile_dir):
+        return [cls._load_profile(path) for path in cls._profile_files(profile_dir)]
+
+    @staticmethod
+    def _summary(profile):
+        return {key: profile.get(key) for key in SUMMARY_KEYS}
+
+    @classmethod
+    def _find_profile(cls, profiles, profile_name):
+        for profile in profiles:
+            if profile.get("name") == profile_name:
+                return profile
+        return None
+
+    def execute(self,
+                action: Optional[str] = "list",
+                profile_name: Optional[str] = None,
+                profile_dir: Optional[str] = PROFILE_DIR,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Return local BIOS profile summaries or one full profile."""
+        profiles = self._profiles(profile_dir)
+        error = None
+
+        if action == "show":
+            if not profile_name:
+                data = {}
+                error = "profile name is required for show"
+            else:
+                data = self._find_profile(profiles, profile_name) or {}
+                if not data:
+                    error = f"profile not found: {profile_name}"
+        else:
+            data = [self._summary(profile) for profile in profiles]
+
+        save_if_needed(filename, data, data_format=data_type)
+        return CommandResult(data, None, None, error)

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -138,6 +138,7 @@ class ApiRequestType(Enum):
 
     # bios related
     BiosRegistry = auto()
+    BiosProfile = auto()
     BiosChangeSettings = auto()
     BiosResetDefault = auto()
     BiosClearPending = auto()

--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -97,6 +97,7 @@ class TermColors:
 
 "note we do sub-string match"
 TermList = ["xterm", "linux", "ansi", "xterm-256color"]
+LOCAL_COMMANDS = {"bios-profile"}
 
 
 def color_printer(msg: str, tcolor: Optional[str] = TermColors.WARNING):
@@ -272,6 +273,11 @@ def is_network_scan(args) -> bool:
     return False
 
 
+def is_local_command(args) -> bool:
+    """True when the command reads only local repository data."""
+    return getattr(args, "subcommand", None) in LOCAL_COMMANDS
+
+
 def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
     """Main entry point
     """
@@ -295,7 +301,9 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
     # A network scan has no single target host, so skip the version handshake
     # (it would try to connect to a host we do not have).
     scan_mode = is_network_scan(cmd_args)
-    if not scan_mode:
+    local_mode = is_local_command(cmd_args)
+    connectionless_mode = scan_mode or local_mode
+    if not connectionless_mode:
         _ = redfish_api.check_api_version()
 
     if cmd_args.verbose:
@@ -314,12 +322,12 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
             json_printer(arg_dict, cmd_args, colorized=cmd_args.nocolor)
 
         # invoke cmd
-        if scan_mode:
-            # Credential-less dispatch: inject empty connection fields (invoke
-            # pops them) without the non-empty IDRAC_IP/credential check that
-            # sync_invoke enforces — a segment scan needs neither.
-            scan_kwargs = dict(arg_dict)
-            scan_kwargs.update({
+        if connectionless_mode:
+            # Connectionless dispatch: inject empty connection fields (invoke
+            # pops them) without the non-empty credential check that sync_invoke
+            # enforces. Segment scans and local catalog reads need no host.
+            invoke_kwargs = dict(arg_dict)
+            invoke_kwargs.update({
                 "idrac_ip": cmd_args.idrac_ip or "",
                 "username": cmd_args.idrac_username or "",
                 "password": cmd_args.idrac_password or "",
@@ -327,13 +335,13 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
                 "insecure": insecure,
                 "is_http": cmd_args.use_http,
             })
-            command_result = redfish_api.invoke(cmd.type, cmd.name, **scan_kwargs)
+            command_result = redfish_api.invoke(cmd.type, cmd.name, **invoke_kwargs)
         else:
             command_result = redfish_api.sync_invoke(
                 cmd.type, cmd.name, **arg_dict
             )
 
-        if not scan_mode and redfish_api.redfish_vendor == "Dell":
+        if not connectionless_mode and redfish_api.redfish_vendor == "Dell":
             if isinstance(command_result.data, dict):
                 command_result.data["idrac_version"] = redfish_api.idrac_manager_version
                 command_result.data["redfish_version"] = redfish_api.redfish_version
@@ -537,7 +545,7 @@ def redfish_main_ctl():
     # A network-segment scan (bmc-scan, or discovery --network) has no single
     # target host and uses no credentials, so it skips the IDRAC_IP/credential
     # gate that every host-targeted command requires.
-    if not is_network_scan(args):
+    if not is_network_scan(args) and not is_local_command(args):
         if args.idrac_ip is None or len(args.idrac_ip) == 0:
             print(
                 "Please indicate the idrac ip. "

--- a/tests/test_bios_profile_catalog.py
+++ b/tests/test_bios_profile_catalog.py
@@ -1,0 +1,116 @@
+"""Tests for the read-only BIOS profile catalog command."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_bios_profile_list_returns_committed_profile_rows(
+        redfish_mock, redfish_service):
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosProfile,
+        "bios-profile",
+        action="list",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.discovered is None
+    assert result.extra is None
+    assert result.error is None
+    json.dumps(result.data, sort_keys=True)
+
+    rows_by_name = {row["name"]: row for row in result.data}
+    assert set(rows_by_name) >= {
+        "dell-cstates-off",
+        "gb300-extended-gpu-memory",
+        "gb300-power-capped",
+    }
+    assert rows_by_name["gb300-power-capped"] == {
+        "name": "gb300-power-capped",
+        "vendor": "supermicro",
+        "model": "GB300",
+        "description": (
+            "Enforce BMC input power capping on a 1-second timescale instead "
+            "of the 50 ms default, smoothing power draw for rack-level power "
+            "budgeting."
+        ),
+        "risk": "medium",
+    }
+    assert redfish_service.requests == []
+
+
+def test_bios_profile_show_returns_full_profile(redfish_mock):
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosProfile,
+        "bios-profile",
+        action="show",
+        profile_name="gb300-extended-gpu-memory",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["name"] == "gb300-extended-gpu-memory"
+    assert result.data["vendor"] == "supermicro"
+    assert result.data["model"] == "GB300"
+    assert result.data["risk"] == "medium"
+    assert result.data["attributes"] == {"EGM": True}
+
+
+def test_bios_profile_missing_directory_lists_empty(redfish_mock, tmp_path):
+    missing_dir = tmp_path / "missing-profiles"
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosProfile,
+        "bios-profile",
+        action="list",
+        profile_dir=missing_dir,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == []
+    assert result.error is None
+
+
+def test_bios_profile_cli_runs_without_bmc_credentials():
+    env = os.environ.copy()
+    for name in (
+            "REDFISH_IP",
+            "REDFISH_USERNAME",
+            "REDFISH_PASSWORD",
+            "IDRAC_IP",
+            "IDRAC_USERNAME",
+            "IDRAC_PASSWORD",
+    ):
+        env.pop(name, None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-m",
+            "redfish_ctl.redfish_main",
+            "--json_only",
+            "--nocolor",
+            "bios-profile",
+            "show",
+            "dell-cstates-off",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["data"]["name"] == "dell-cstates-off"
+    assert payload["data"]["attributes"] == {"ProcCStates": "Disabled"}


### PR DESCRIPTION
## Summary
- add a read-only `bios-profile` catalog command with `list` and `show <name>` actions over `specs/profiles/*.json`
- register the command and let local catalog reads skip BMC credential/version preflight
- add focused tests for catalog list/show behavior, missing profile directories, and CLI use without endpoint credentials
- document the command in `docs/commands.md`

## Verification
- `python -m pytest -q tests/test_bios_profile_catalog.py tests/test_bios_profiles_specs.py` -> `8 passed in 0.24s`
- `python -m pytest -q` -> `790 passed, 57 skipped in 24.01s`
- `ruff check redfish_ctl/bios/cmd_bios_profile.py redfish_ctl/idrac_shared.py redfish_ctl/__init__.py redfish_ctl/redfish_main.py tests/test_bios_profile_catalog.py` -> `All checks passed!`
- `python -B -m redfish_ctl.redfish_main bios-profile --help` rendered help