### PR TITLE
Add BIOS profile diff command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,7 +68,7 @@ Safety labels:
 | `bios-change` | Stage BIOS attributes from a spec or attribute pair. | Write |
 | `bios-clear-pending` | Clear pending BIOS values. | Write |
 | `bios-pending` | Read pending BIOS values. | Read |
-| `bios-profile` | List committed BIOS tuning profiles or show one full profile. | Read |
+| `bios-profile` | List committed BIOS tuning profiles, show one full profile, or diff a profile against current BIOS attributes. | Read |
 | `bios-registry` | Read BIOS registry metadata, choices, and writable attributes. | Read |
 | `bios-snapshot` | Capture a BIOS restore point for rollback-able changes. | Read |
 | `bmc-scan` | Scan a network segment for Redfish BMCs. | Read |

--- a/redfish_ctl/bios/cmd_bios_profile.py
+++ b/redfish_ctl/bios/cmd_bios_profile.py
@@ -12,6 +12,7 @@ from ..redfish_manager import CommandResult
 
 PROFILE_DIR = Path(__file__).resolve().parents[2] / "specs" / "profiles"
 SUMMARY_KEYS = ("name", "vendor", "model", "description", "risk")
+PROFILE_ID_KEYS = ("name", "vendor", "model", "risk")
 
 
 class BiosProfile(IDracManager,
@@ -31,14 +32,14 @@ class BiosProfile(IDracManager,
         cmd_parser.add_argument(
             "action",
             nargs="?",
-            choices=("list", "show"),
+            choices=("list", "show", "diff"),
             default="list",
             help="catalog action to run",
         )
         cmd_parser.add_argument(
             "profile_name",
             nargs="?",
-            help="profile name for the show action",
+            help="profile name for the show or diff action",
         )
         return (
             cmd_parser,
@@ -65,12 +66,73 @@ class BiosProfile(IDracManager,
     def _summary(profile):
         return {key: profile.get(key) for key in SUMMARY_KEYS}
 
+    @staticmethod
+    def _profile_identity(profile):
+        return {key: profile.get(key) for key in PROFILE_ID_KEYS}
+
     @classmethod
     def _find_profile(cls, profiles, profile_name):
         for profile in profiles:
             if profile.get("name") == profile_name:
                 return profile
         return None
+
+    @staticmethod
+    def _attributes_from_bios_result(result):
+        data = result.data if isinstance(result.data, dict) else {}
+        attributes = data.get("Attributes")
+        if isinstance(attributes, dict):
+            return attributes
+        return data
+
+    @classmethod
+    def _diff_profile(cls, profile, current_attributes):
+        rows = []
+        summary = {
+            "total": 0,
+            "matching": 0,
+            "different": 0,
+            "missing": 0,
+        }
+        for attribute, desired in profile.get("attributes", {}).items():
+            missing = attribute not in current_attributes
+            current = current_attributes.get(attribute)
+            if missing:
+                status = "missing"
+            elif current == desired:
+                status = "matching"
+            else:
+                status = "different"
+            summary["total"] += 1
+            summary[status] += 1
+            rows.append({
+                "attribute": attribute,
+                "current": current,
+                "desired": desired,
+                "status": status,
+            })
+
+        return {
+            "profile": cls._profile_identity(profile),
+            "matches": (
+                summary["different"] == 0
+                and summary["missing"] == 0
+            ),
+            "summary": summary,
+            "attributes": rows,
+        }
+
+    def _read_current_attributes(self, profile, verbose, do_async):
+        attribute_names = ",".join(profile.get("attributes", {}).keys())
+        result = self.sync_invoke(
+            ApiRequestType.BiosQuery,
+            "bios_inventory",
+            attr_only=True,
+            attr_filter=attribute_names,
+            verbose=verbose,
+            do_async=do_async,
+        )
+        return self._attributes_from_bios_result(result)
 
     def execute(self,
                 action: Optional[str] = "list",
@@ -86,14 +148,22 @@ class BiosProfile(IDracManager,
         profiles = self._profiles(profile_dir)
         error = None
 
-        if action == "show":
+        if action in {"show", "diff"}:
             if not profile_name:
                 data = {}
-                error = "profile name is required for show"
+                error = f"profile name is required for {action}"
             else:
-                data = self._find_profile(profiles, profile_name) or {}
-                if not data:
+                profile = self._find_profile(profiles, profile_name)
+                if not profile:
+                    data = {}
                     error = f"profile not found: {profile_name}"
+                elif action == "show":
+                    data = profile
+                else:
+                    current_attributes = self._read_current_attributes(
+                        profile, verbose, do_async
+                    )
+                    data = self._diff_profile(profile, current_attributes)
         else:
             data = [self._summary(profile) for profile in profiles]
 

--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -275,7 +275,10 @@ def is_network_scan(args) -> bool:
 
 def is_local_command(args) -> bool:
     """True when the command reads only local repository data."""
-    return getattr(args, "subcommand", None) in LOCAL_COMMANDS
+    subcommand = getattr(args, "subcommand", None)
+    if subcommand == "bios-profile":
+        return getattr(args, "action", "list") in {"list", "show"}
+    return subcommand in LOCAL_COMMANDS
 
 
 def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:

--- a/tests/test_bios_profile_catalog.py
+++ b/tests/test_bios_profile_catalog.py
@@ -63,6 +63,65 @@ def test_bios_profile_show_returns_full_profile(redfish_mock):
     assert result.data["attributes"] == {"EGM": True}
 
 
+def test_bios_profile_diff_compares_profile_to_current_bios(
+        redfish_mock, redfish_service, tmp_path):
+    profile_dir = tmp_path / "profiles"
+    profile_dir.mkdir()
+    (profile_dir / "dell-low-latency.json").write_text(json.dumps({
+        "name": "dell-low-latency",
+        "vendor": "dell",
+        "model": "PowerEdge",
+        "description": "Test profile that changes one current BIOS value.",
+        "risk": "medium",
+        "attributes": {
+            "ProcCStates": "Enabled",
+            "SriovGlobalEnable": "Enabled",
+        },
+    }))
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosProfile,
+        "bios-profile",
+        action="diff",
+        profile_name="dell-low-latency",
+        profile_dir=profile_dir,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "profile": {
+            "name": "dell-low-latency",
+            "vendor": "dell",
+            "model": "PowerEdge",
+            "risk": "medium",
+        },
+        "matches": False,
+        "summary": {
+            "total": 2,
+            "matching": 1,
+            "different": 1,
+            "missing": 0,
+        },
+        "attributes": [
+            {
+                "attribute": "ProcCStates",
+                "current": "Disabled",
+                "desired": "Enabled",
+                "status": "different",
+            },
+            {
+                "attribute": "SriovGlobalEnable",
+                "current": "Enabled",
+                "desired": "Enabled",
+                "status": "matching",
+            },
+        ],
+    }
+    assert redfish_service.requests
+    assert {request.method for request in redfish_service.requests} == {"GET"}
+
+
 def test_bios_profile_missing_directory_lists_empty(redfish_mock, tmp_path):
     missing_dir = tmp_path / "missing-profiles"
 
@@ -114,3 +173,39 @@ def test_bios_profile_cli_runs_without_bmc_credentials():
     payload = json.loads(result.stdout)
     assert payload["data"]["name"] == "dell-cstates-off"
     assert payload["data"]["attributes"] == {"ProcCStates": "Disabled"}
+
+
+def test_bios_profile_diff_cli_requires_bmc_connection():
+    env = os.environ.copy()
+    for name in (
+            "REDFISH_IP",
+            "REDFISH_USERNAME",
+            "REDFISH_PASSWORD",
+            "IDRAC_IP",
+            "IDRAC_USERNAME",
+            "IDRAC_PASSWORD",
+    ):
+        env.pop(name, None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-m",
+            "redfish_ctl.redfish_main",
+            "--json_only",
+            "--nocolor",
+            "bios-profile",
+            "diff",
+            "dell-cstates-off",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Please indicate the idrac ip" in result.stdout


### PR DESCRIPTION
## Summary

- Add `bios-profile diff <name>` to compare a named BIOS profile with current BIOS attributes.
- Keep `bios-profile list` and `show` available without BMC credentials, while `diff` uses the normal BMC connection path.
- Update the command reference and add offline coverage for the diff output and credential gate.

## Verification

- `pytest -q tests/test_bios_profile_catalog.py` -> 6 passed
- `ruff check redfish_ctl/bios/cmd_bios_profile.py redfish_ctl/redfish_main.py tests/test_bios_profile_catalog.py` -> All checks passed
- `pytest -q` -> 792 passed, 57 skipped
