### PR TITLE
Add RedfishEndpoint controller scaffold

### DIFF
--- a/k8s/controller/redfish-endpoint-crd.yaml
+++ b/k8s/controller/redfish-endpoint-crd.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: redfishendpoints.redfish.ctl.dev
+spec:
+  group: redfish.ctl.dev
+  scope: Namespaced
+  names:
+    plural: redfishendpoints
+    singular: redfishendpoint
+    kind: RedfishEndpoint
+    shortNames:
+      - rfe
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - address
+              properties:
+                address:
+                  type: string
+                  minLength: 1
+                  description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                port:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  default: 443
+                  description: TCP port for the Redfish endpoint.
+                insecure:
+                  type: boolean
+                  default: true
+                  description: Skip TLS certificate verification for self-signed BMC certificates.
+                pollInterval:
+                  type: string
+                  default: 30s
+                  pattern: ^[0-9]+(s|m|h)$
+                  description: Desired controller polling interval.
+                secretRef:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                      description: Secret in the same namespace containing BMC login data.
+                    usernameKey:
+                      type: string
+                      default: username
+                      description: Secret data key containing the BMC username.
+                    passwordKey:
+                      type: string
+                      default: password
+                      description: Secret data key containing the BMC password.
+                  additionalProperties: false
+              additionalProperties: false
+            status:
+              type: object
+              properties:
+                powerState:
+                  type: string
+                  nullable: true
+                health:
+                  type: string
+                  nullable: true
+                temperature:
+                  type: object
+                  properties:
+                    count:
+                      type: integer
+                      minimum: 0
+                    maxCelsius:
+                      type: number
+                      nullable: true
+                  additionalProperties: false
+                lastPolled:
+                  type: string
+                  format: date-time
+              additionalProperties: false

--- a/k8s/controller/redfish_endpoint_controller.py
+++ b/k8s/controller/redfish_endpoint_controller.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Read-only status controller for RedfishEndpoint resources."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, MutableMapping
+from urllib.parse import urlsplit
+
+try:  # pragma: no cover - exercised only in a deployed controller image.
+    import kopf
+except ImportError:  # pragma: no cover - unit tests call the handler directly.
+    kopf = None
+
+from redfish_ctl.api import (
+    SensorReading,
+    SystemStatus,
+    ThermalStatus,
+    get_sensors,
+    get_system,
+    get_thermal,
+)
+from redfish_ctl.idrac_manager import IDracManager
+
+REDFISH_GROUP = "redfish.ctl.dev"
+REDFISH_VERSION = "v1alpha1"
+REDFISH_PLURAL = "redfishendpoints"
+DEFAULT_PORT = 443
+DEFAULT_USERNAME = "root"
+
+ManagerFactory = Callable[..., Any]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _rfc3339(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    value = value.astimezone(timezone.utc).replace(microsecond=0)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _number(value: int | float | str | None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def _temperature_summary(thermal: ThermalStatus) -> dict[str, int | float | None]:
+    values = [
+        reading
+        for row in thermal.temperatures
+        if (reading := _number(row.reading_celsius)) is not None
+    ]
+    return {
+        "count": len(values),
+        "maxCelsius": max(values) if values else None,
+    }
+
+
+def _health_from_sensors(sensors: tuple[SensorReading, ...]) -> str | None:
+    rank = {
+        "OK": 0,
+        "Warning": 1,
+        "Critical": 2,
+    }
+    health_values = [sensor.health for sensor in sensors if sensor.health]
+    if not health_values:
+        return None
+    return max(health_values, key=lambda value: rank.get(value, -1))
+
+
+def build_status(
+    system: SystemStatus,
+    sensors: tuple[SensorReading, ...],
+    thermal: ThermalStatus,
+    *,
+    polled_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Return the RedfishEndpoint status object from typed read results."""
+    return {
+        "powerState": system.power_state,
+        "health": system.health or _health_from_sensors(sensors),
+        "temperature": _temperature_summary(thermal),
+        "lastPolled": _rfc3339(polled_at or _utc_now()),
+    }
+
+
+def _manager_address(spec: Mapping[str, Any]) -> tuple[str, bool]:
+    raw_address = str(spec.get("address") or "").strip()
+    if not raw_address:
+        raise ValueError("RedfishEndpoint spec.address is required")
+
+    parsed = urlsplit(raw_address)
+    if parsed.scheme in {"http", "https"}:
+        host = parsed.netloc or parsed.path
+        return host.rstrip("/"), parsed.scheme == "http"
+
+    port = int(spec.get("port") or DEFAULT_PORT)
+    return raw_address, port != DEFAULT_PORT and bool(spec.get("insecure", False))
+
+
+def _make_manager(
+    spec: Mapping[str, Any],
+    credentials: Mapping[str, str],
+    manager_factory: ManagerFactory,
+) -> Any:
+    address, is_http = _manager_address(spec)
+    return manager_factory(
+        idrac_ip=address,
+        idrac_username=credentials.get("username", DEFAULT_USERNAME),
+        idrac_password=credentials.get("password", ""),
+        idrac_port=int(spec.get("port") or DEFAULT_PORT),
+        insecure=bool(spec.get("insecure", True)),
+        is_http=is_http,
+        is_debug=False,
+    )
+
+
+def poll_endpoint(
+    spec: Mapping[str, Any],
+    *,
+    credentials: Mapping[str, str] | None = None,
+    manager_factory: ManagerFactory = IDracManager,
+    polled_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Read a BMC through the facade and return a status patch payload."""
+    manager = _make_manager(spec, credentials or {}, manager_factory)
+    system = get_system(manager)
+    sensors = get_sensors(manager)
+    thermal = get_thermal(manager)
+    return build_status(system, sensors, thermal, polled_at=polled_at)
+
+
+def _decode_secret_value(data: Mapping[str, str], key: str) -> str | None:
+    encoded = data.get(key)
+    if not encoded:
+        return None
+    return base64.b64decode(encoded).decode("utf-8")
+
+
+def load_secret_credentials(
+    namespace: str | None,
+    secret_ref: Mapping[str, Any] | None,
+) -> dict[str, str]:
+    """Read credentials from the Secret named by spec.secretRef when available."""
+    if not namespace or not secret_ref or not secret_ref.get("name"):
+        return {}
+    try:  # pragma: no cover - requires a Kubernetes client in-cluster or locally.
+        from kubernetes import client, config
+    except ImportError:  # pragma: no cover - controller images carry this dependency.
+        return {}
+
+    try:  # pragma: no cover - not exercised by offline tests.
+        config.load_incluster_config()
+    except Exception:
+        try:
+            config.load_kube_config()
+        except Exception:
+            return {}
+
+    api = client.CoreV1Api()
+    secret = api.read_namespaced_secret(str(secret_ref["name"]), namespace)
+    data = secret.data or {}
+    username_key = str(secret_ref.get("usernameKey") or "username")
+    password_key = str(secret_ref.get("passwordKey") or "password")
+    credentials: dict[str, str] = {}
+    username = _decode_secret_value(data, username_key)
+    password = _decode_secret_value(data, password_key)
+    if username is not None:
+        credentials["username"] = username
+    if password is not None:
+        credentials["password"] = password
+    return credentials
+
+
+def poll_redfish_endpoint(
+    spec: Mapping[str, Any],
+    body: Mapping[str, Any] | None = None,
+    namespace: str | None = None,
+    name: str | None = None,
+    logger: Any | None = None,
+    patch: MutableMapping[str, Any] | None = None,
+    **_: Any,
+) -> dict[str, Any]:
+    """Kopf callback that updates only the RedfishEndpoint status subresource."""
+    credentials = load_secret_credentials(namespace, spec.get("secretRef"))
+    status = poll_endpoint(spec, credentials=credentials)
+    if patch is not None:
+        patch.setdefault("status", {}).update(status)
+    if logger is not None:
+        logger.info("polled RedfishEndpoint %s/%s", namespace or "", name or "")
+    return {"status": status}
+
+
+if kopf is not None:  # pragma: no cover - decorator wiring is runtime-only.
+    poll_redfish_endpoint = kopf.on.create(
+        REDFISH_GROUP,
+        REDFISH_VERSION,
+        REDFISH_PLURAL,
+    )(poll_redfish_endpoint)
+    poll_redfish_endpoint = kopf.on.update(
+        REDFISH_GROUP,
+        REDFISH_VERSION,
+        REDFISH_PLURAL,
+    )(poll_redfish_endpoint)
+    poll_redfish_endpoint = kopf.timer(
+        REDFISH_GROUP,
+        REDFISH_VERSION,
+        REDFISH_PLURAL,
+        interval=30,
+        sharp=True,
+    )(poll_redfish_endpoint)

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -1,0 +1,227 @@
+"""Contracts for the read-only Kubernetes RedfishEndpoint controller."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import yaml
+
+from redfish_ctl.api import (
+    FanReading,
+    SensorReading,
+    SystemStatus,
+    TemperatureReading,
+    ThermalStatus,
+)
+from redfish_ctl.idrac_manager import IDracManager
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTROLLER_MODULE = REPO_ROOT / "k8s" / "controller" / "redfish_endpoint_controller.py"
+CRD_MANIFEST = REPO_ROOT / "k8s" / "controller" / "redfish-endpoint-crd.yaml"
+GB300_CORPUS = (
+    REPO_ROOT
+    / "tests"
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+GB300_INDEX = {path.name.lower(): path for path in GB300_CORPUS.glob("*.json")}
+
+
+def _load_controller_module():
+    spec = importlib.util.spec_from_file_location(
+        "redfish_endpoint_controller",
+        CONTROLLER_MODULE,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fixture_for_path(path: str) -> Path | None:
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_INDEX.get(name.lower())
+
+
+def test_crd_schema_pins_read_only_endpoint_spec_and_status_shape() -> None:
+    """The CRD exposes only connection fields and read-only status."""
+    crd = yaml.safe_load(CRD_MANIFEST.read_text(encoding="utf-8"))
+    schema = crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]
+    spec_props = schema["properties"]["spec"]["properties"]
+    status_props = schema["properties"]["status"]["properties"]
+
+    assert crd["kind"] == "CustomResourceDefinition"
+    assert crd["spec"]["names"]["kind"] == "RedfishEndpoint"
+    assert crd["spec"]["scope"] == "Namespaced"
+    assert set(spec_props) == {
+        "address",
+        "port",
+        "insecure",
+        "pollInterval",
+        "secretRef",
+    }
+    secret_ref_props = spec_props["secretRef"]["properties"]
+    assert secret_ref_props["name"]["type"] == "string"
+    assert secret_ref_props["usernameKey"]["default"] == "username"
+    assert secret_ref_props["passwordKey"]["default"] == "password"
+    assert set(status_props) == {
+        "powerState",
+        "health",
+        "temperature",
+        "lastPolled",
+    }
+    assert status_props["temperature"]["properties"]["maxCelsius"]["type"] == "number"
+    assert "valueFrom" not in json.dumps(crd)
+
+
+def test_build_status_tolerates_missing_values_and_summarizes_temperatures() -> None:
+    """Status rendering keeps fields optional and ignores non-numeric temperatures."""
+    module = _load_controller_module()
+    polled_at = datetime(2026, 7, 10, 14, 40, 0, tzinfo=timezone.utc)
+    system = SystemStatus(
+        id="System_0",
+        name="System_0",
+        power_state="On",
+        health="OK",
+        state="Enabled",
+        raw={},
+    )
+    thermal = ThermalStatus(
+        summary={},
+        temperatures=(
+            TemperatureReading("Chassis_0", "Inlet", "Intake", 24.4, "/sensor/1", {}),
+            TemperatureReading("Chassis_0", "Outlet", "Exhaust", "31.2", "/sensor/2", {}),
+            TemperatureReading("Chassis_0", "Bad", "Unknown", None, "/sensor/3", {}),
+        ),
+        fans=(
+            FanReading("Chassis_0", "Fan 1", "Enabled", "OK", 42, "/fan/1", {}),
+        ),
+        raw={},
+    )
+
+    status = module.build_status(system, (), thermal, polled_at=polled_at)
+
+    assert status == {
+        "powerState": "On",
+        "health": "OK",
+        "temperature": {
+            "count": 2,
+            "maxCelsius": 31.2,
+        },
+        "lastPolled": "2026-07-10T14:40:00Z",
+    }
+
+
+def test_poll_endpoint_reads_gb300_corpus_without_mutating_requests() -> None:
+    """The poll path uses read commands through the facade and never writes."""
+    requests_mock = pytest.importorskip("requests_mock")
+    module = _load_controller_module()
+    seen_methods: list[str] = []
+
+    def get_cb(request, context):
+        seen_methods.append(request.method)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text(encoding="utf-8")
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        manager = IDracManager(
+            idrac_ip="mock-gb300",
+            idrac_username="root",
+            idrac_password="mock",
+            idrac_port=8080,
+            insecure=True,
+            is_http=True,
+            is_debug=False,
+        )
+        status = module.poll_endpoint(
+            {
+                "address": "mock-gb300",
+                "port": 8080,
+                "insecure": True,
+                "pollInterval": "30s",
+                "secretRef": {"name": "bmc-login"},
+            },
+            credentials={"username": "root", "password": "mock"},
+            manager_factory=lambda **_: manager,
+            polled_at=datetime(2026, 7, 10, 14, 45, 0, tzinfo=timezone.utc),
+        )
+
+    assert status["powerState"] == "On"
+    assert status["health"] == "OK"
+    assert status["temperature"]["count"] == 56
+    assert status["temperature"]["maxCelsius"] == 54.1875
+    assert status["lastPolled"] == "2026-07-10T14:45:00Z"
+    assert seen_methods
+    assert set(seen_methods) == {"GET"}
+
+
+def test_kopf_handler_patches_status_only(monkeypatch) -> None:
+    """The resource handler returns a status patch and never mutates the BMC."""
+    module = _load_controller_module()
+    calls: list[tuple[dict, dict]] = []
+
+    def fake_poll_endpoint(spec, credentials):
+        calls.append((spec, credentials))
+        return {
+            "powerState": "On",
+            "health": "OK",
+            "temperature": {"count": 1, "maxCelsius": 24.4},
+            "lastPolled": "2026-07-10T14:50:00Z",
+        }
+
+    monkeypatch.setattr(module, "poll_endpoint", fake_poll_endpoint)
+
+    patch = module.poll_redfish_endpoint(
+        spec={"address": "mock-bmc", "secretRef": {"name": "bmc-login"}},
+        body={},
+        namespace="default",
+        name="node-a",
+        logger=None,
+    )
+
+    assert patch == {
+        "status": {
+            "powerState": "On",
+            "health": "OK",
+            "temperature": {"count": 1, "maxCelsius": 24.4},
+            "lastPolled": "2026-07-10T14:50:00Z",
+        }
+    }
+    assert calls == [
+        (
+            {"address": "mock-bmc", "secretRef": {"name": "bmc-login"}},
+            {},
+        )
+    ]
+
+
+def test_sensor_health_falls_back_when_system_health_absent() -> None:
+    """Sensor health gives the status a useful fallback when system health is missing."""
+    module = _load_controller_module()
+    system = SystemStatus(None, None, "Off", None, None, {})
+    sensors = (
+        SensorReading("Chassis_0", "Temp", 20, "Cel", "Temperature", "OK", {}),
+        SensorReading("Chassis_0", "Fan", 40, "%", "Fan", "Warning", {}),
+    )
+    thermal = ThermalStatus({}, (), (), {})
+
+    status = module.build_status(
+        system,
+        sensors,
+        thermal,
+        polled_at=datetime(2026, 7, 10, 14, 55, tzinfo=timezone.utc),
+    )
+
+    assert status["powerState"] == "Off"
+    assert status["health"] == "Warning"
+    assert status["temperature"] == {"count": 0, "maxCelsius": None}


### PR DESCRIPTION
## Summary
- add a read-only `RedfishEndpoint` CRD status schema for BMC power, health, temperature, and poll timestamp
- add a Python controller scaffold that reads through `redfish_ctl.api` and updates status only
- add offline tests for CRD shape, status summarization, corpus-backed polling, and handler status patching

## Verification
- `python -m pytest -q tests/test_k8s_controller.py` -> `5 passed in 1.15s`
- `python -m pytest -q tests/test_api_facade.py tests/test_k8s_mock_bmc_server.py` -> `8 passed in 1.69s`
- `python -m pytest -q` -> `795 passed, 57 skipped in 27.93s`
- `ruff check k8s/controller/redfish_endpoint_controller.py tests/test_k8s_controller.py` -> `All checks passed!`