### PR TITLE
Add guarded BIOS profile apply

### DIFF
--- a/docs/bios-profiles.md
+++ b/docs/bios-profiles.md
@@ -32,7 +32,8 @@ redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset -r
 schema described in [BIOS tuning profiles](../specs/profiles/README.md). Each profile lists the BIOS
 attributes to stage and must match a captured vendor registry before it is accepted by the test suite.
 
-`bios-profile`, the CLI's read-only catalog command, reads that directory without contacting a BMC:
+`bios-profile`, the CLI's named-profile command, reads that directory for `list` and `show` without
+contacting a BMC:
 
 ```bash
 redfish_ctl bios-profile list
@@ -57,11 +58,10 @@ redfish_ctl bios-profile apply gb300-power-capped --dry_run
 redfish_ctl bios-profile apply gb300-power-capped --confirm
 ```
 
-The current catalog command ships the read-only `list` and `show` actions. Until the `diff` and
-guarded `apply` actions are available in your installed version, use `bios-profile show <name>` to
-review the profile and then use the existing `bios-change --from_spec ... --show` path for previews.
-Applying a profile stages BIOS settings and can require a host reset; only run the apply step during
-an approved maintenance window.
+The current catalog command ships `list`, `show`, and guarded `apply`. Until `diff` is available in
+your installed version, use `bios-profile show <name>` plus a read-only `bios --filter ...` check to
+compare current values. Applying a profile stages BIOS settings and can require a host reset; only run
+the apply step during an approved maintenance window.
 
 ## Included Examples
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,7 +84,7 @@ Safety labels:
 | `bios-change` | Stage BIOS attributes from a spec or attribute pair. | Write |
 | `bios-clear-pending` | Clear pending BIOS values. | Write |
 | `bios-pending` | Read pending BIOS values. | Read |
-| `bios-profile` | List committed BIOS tuning profiles, show one full profile, or diff a profile against current BIOS attributes. | Read |
+| `bios-profile` | List/show committed BIOS tuning profiles, diff against current BIOS attributes, or preview/apply a profile with `--confirm`. | Guarded |
 | `bios-registry` | Read BIOS registry metadata, choices, and writable attributes. | Read |
 | `bios-snapshot` | Capture a BIOS restore point for rollback-able changes. | Read |
 | `bmc-scan` | Scan a network segment for Redfish BMCs. | Read |
@@ -237,6 +237,20 @@ for the host reset:
 ```bash
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset -r
 ```
+
+Named profiles under `specs/profiles/` use the same staging path but add an automatic rollback
+snapshot before the profile is previewed or staged:
+
+```bash
+redfish_ctl bios-profile list
+redfish_ctl bios-profile show dell-cstates-off
+redfish_ctl bios-profile apply dell-cstates-off
+redfish_ctl bios-profile apply dell-cstates-off --confirm
+```
+
+`bios-profile apply` is a dry-run by default. It reads the current BIOS values for the named
+attributes, returns a rollback spec, and only stages the profile through `bios-change` when
+`--confirm` is present.
 
 ### Secure Boot
 

--- a/redfish_ctl/bios/cmd_bios_profile.py
+++ b/redfish_ctl/bios/cmd_bios_profile.py
@@ -3,6 +3,7 @@
 import json
 from abc import abstractmethod
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Optional
 
 from ..cmd_utils import save_if_needed
@@ -19,7 +20,7 @@ class BiosProfile(IDracManager,
                   scm_type=ApiRequestType.BiosProfile,
                   name="bios-profile",
                   metaclass=Singleton):
-    """Read local BIOS profile specifications without contacting a BMC."""
+    """Read or stage local BIOS profile specifications."""
 
     def __init__(self, *args, **kwargs):
         super(BiosProfile, self).__init__(*args, **kwargs)
@@ -27,24 +28,36 @@ class BiosProfile(IDracManager,
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the read-only ``bios-profile`` catalog subcommand."""
+        """Register the ``bios-profile`` catalog subcommand."""
         cmd_parser = cls.base_parser(is_async=False, is_expanded=False)
         cmd_parser.add_argument(
             "action",
             nargs="?",
-            choices=("list", "show", "diff"),
+            choices=("list", "show", "diff", "apply"),
             default="list",
             help="catalog action to run",
         )
         cmd_parser.add_argument(
             "profile_name",
             nargs="?",
-            help="profile name for the show or diff action",
+            help="profile name for the show, diff, or apply action",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="stage the selected profile through bios-change",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            default=False,
+            help="preview the staged payload even when --confirm is present",
         )
         return (
             cmd_parser,
             "bios-profile",
-            "command read committed BIOS profile catalog entries",
+            "command read or stage committed BIOS profile catalog entries",
         )
 
     @staticmethod
@@ -134,10 +147,65 @@ class BiosProfile(IDracManager,
         )
         return self._attributes_from_bios_result(result)
 
+    @staticmethod
+    def _profile_change(profile):
+        attributes = profile.get("attributes")
+        return {"Attributes": attributes} if isinstance(attributes, dict) else {}
+
+    def _apply_profile(self, profile, confirm, dry_run, do_async):
+        change = self._profile_change(profile)
+        if not change.get("Attributes"):
+            return CommandResult(
+                {
+                    "profile": profile.get("name"),
+                    "dry_run": True,
+                    "change": change,
+                    "rollback": {"Attributes": {}},
+                    "staged": {},
+                },
+                None,
+                None,
+                "profile has no attributes",
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            spec_path = Path(tmp_dir) / f"{profile.get('name', 'profile')}.json"
+            spec_path.write_text(json.dumps(change))
+
+            rollback = self.sync_invoke(
+                ApiRequestType.BiosSnapshot,
+                "bios_snapshot",
+                from_spec=str(spec_path),
+                do_async=do_async,
+            )
+            preview = bool(dry_run or not confirm)
+            staged = self.sync_invoke(
+                ApiRequestType.BiosChangeSettings,
+                "bios_change_settings",
+                from_spec=str(spec_path),
+                apply="on-reset",
+                do_show=preview,
+                do_async=do_async,
+            )
+
+        data = {
+            "profile": profile.get("name"),
+            "dry_run": preview,
+            "change": change,
+            "rollback": rollback.data if rollback else {"Attributes": {}},
+            "staged": staged.data if staged else {},
+        }
+        error = rollback.error if rollback and rollback.error is not None else None
+        if error is None and staged and staged.error is not None:
+            error = staged.error
+        return CommandResult(data, None, None, error)
+
     def execute(self,
                 action: Optional[str] = "list",
                 profile_name: Optional[str] = None,
                 profile_dir: Optional[str] = PROFILE_DIR,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
                 filename: Optional[str] = None,
                 data_type: Optional[str] = "json",
                 verbose: Optional[bool] = False,
@@ -164,6 +232,21 @@ class BiosProfile(IDracManager,
                         profile, verbose, do_async
                     )
                     data = self._diff_profile(profile, current_attributes)
+        elif action == "apply":
+            if not profile_name:
+                data = {}
+                error = "profile name is required for apply"
+            else:
+                profile = self._find_profile(profiles, profile_name)
+                if not profile:
+                    data = {}
+                    error = f"profile not found: {profile_name}"
+                else:
+                    result = self._apply_profile(
+                        profile, bool(confirm), bool(dry_run), do_async
+                    )
+                    save_if_needed(filename, result.data, data_format=data_type)
+                    return result
         else:
             data = [self._summary(profile) for profile in profiles]
 

--- a/tests/test_bios_profile_catalog.py
+++ b/tests/test_bios_profile_catalog.py
@@ -1,4 +1,4 @@
-"""Tests for the read-only BIOS profile catalog command."""
+"""Tests for the BIOS profile catalog, diff, and guarded apply command."""
 
 import json
 import os
@@ -122,6 +122,68 @@ def test_bios_profile_diff_compares_profile_to_current_bios(
     assert {request.method for request in redfish_service.requests} == {"GET"}
 
 
+def test_bios_profile_apply_defaults_to_dry_run_with_snapshot(
+        redfish_mock, redfish_service):
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosProfile,
+        "bios-profile",
+        action="apply",
+        profile_name="dell-cstates-off",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["profile"] == "dell-cstates-off"
+    assert result.data["change"] == {"Attributes": {"ProcCStates": "Disabled"}}
+    assert result.data["rollback"] == {"Attributes": {"ProcCStates": "Disabled"}}
+    assert result.data["staged"] == {
+        "Attributes": {"ProcCStates": "Disabled"},
+        "@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"},
+    }
+    assert [
+        request
+        for request in redfish_service.requests
+        if request.method in {"PATCH", "POST", "DELETE"}
+    ] == []
+
+
+def test_bios_profile_apply_confirm_stages_bios_settings(
+        redfish_mock, redfish_service):
+    redfish_service._overlay[
+        "/redfish/v1/Systems/System.Embedded.1/Bios/Settings"
+    ] = {"Attributes": {}}
+    redfish_service._overlay[
+        "/redfish/v1/systems/system.embedded.1/bios/settings"
+    ] = {"Attributes": {}}
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosProfile,
+        "bios-profile",
+        action="apply",
+        profile_name="dell-cstates-off",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is False
+    assert result.data["profile"] == "dell-cstates-off"
+    assert result.data["change"] == {"Attributes": {"ProcCStates": "Disabled"}}
+    assert result.data["rollback"] == {"Attributes": {"ProcCStates": "Disabled"}}
+
+    patch_requests = [
+        request for request in redfish_service.requests
+        if request.method == "PATCH"
+    ]
+    assert len(patch_requests) == 1
+    assert patch_requests[0].path.lower().endswith("/bios/settings")
+    assert patch_requests[0].json() == {
+        "Attributes": {"ProcCStates": "Disabled"},
+        "@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"},
+    }
+
+
 def test_bios_profile_missing_directory_lists_empty(redfish_mock, tmp_path):
     missing_dir = tmp_path / "missing-profiles"
 
@@ -208,4 +270,40 @@ def test_bios_profile_diff_cli_requires_bmc_connection():
     )
 
     assert result.returncode == 1
-    assert "Please indicate the idrac ip" in result.stdout
+    assert "Please indicate the idrac ip." in result.stdout
+
+
+def test_bios_profile_apply_cli_requires_bmc_credentials():
+    env = os.environ.copy()
+    for name in (
+            "REDFISH_IP",
+            "REDFISH_USERNAME",
+            "REDFISH_PASSWORD",
+            "IDRAC_IP",
+            "IDRAC_USERNAME",
+            "IDRAC_PASSWORD",
+    ):
+        env.pop(name, None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-m",
+            "redfish_ctl.redfish_main",
+            "--json_only",
+            "--nocolor",
+            "bios-profile",
+            "apply",
+            "dell-cstates-off",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Please indicate the idrac ip." in result.stdout


### PR DESCRIPTION
## Summary
- Add `bios-profile apply <name>` alongside the existing catalog and diff actions.
- Preview by default with rollback snapshot data and staged payload output.
- Require `--confirm` before staging through the existing `bios-change` on-reset path.
- Keep `bios-profile list/show` credentialless while routing `diff/apply` through the normal BMC connection gate.
- Update command and BIOS profile docs for the guarded apply flow.

## Verification
- `pytest -q tests/test_bios_profile_catalog.py` (`9 passed`)
- `pytest -q` (`816 passed, 57 skipped`)
- `ruff check redfish_ctl/bios/cmd_bios_profile.py tests/test_bios_profile_catalog.py`
- `git diff --check`
