### PR TITLE
Add global Redfish query flags

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -24,6 +24,22 @@ TLS verification is off by default because lab BMCs commonly use self-signed cer
 `--verify-ssl`, defined by the root parser in `redfish_main.py`, opts into certificate verification
 when you have a trusted chain.
 
+## Server-Side Query Flags
+
+`redfish_main.py` defines top-level Redfish GET query flags that must appear before the subcommand:
+
+```bash
+redfish_ctl --select Id,Name query --resource /redfish/v1/Managers
+redfish_ctl --top 5 query --resource /redfish/v1/Managers
+redfish_ctl --expand --expand-levels 2 query --resource /redfish/v1/Systems
+```
+
+The supported flags are `--select`, `--filter`, `--expand`, `--expand-levels`, `--top`, and `--only`.
+They are validated against the target vendor capability profile before any command GET is issued.
+For example, Dell iDRAC profiles allow the standard Redfish query parameters but enforce iDRAC's
+one-query-parameter-per-URI rule, while profiles that do not declare support reject the flag early.
+These root flags are separate from command-specific filters such as `bios --filter`.
+
 ## First Reads
 
 ```bash

--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -26,7 +26,6 @@ import asyncio
 import functools
 import json
 import logging
-import os
 import time
 from abc import abstractmethod
 from datetime import datetime
@@ -275,6 +274,10 @@ class IDracManager(RedfishManager):
         _port = kwargs.pop("port")
         _insecure = kwargs.pop("insecure")
         _is_http = kwargs.pop("is_http")
+        _redfish_query = kwargs.pop("redfish_query", None)
+        _redfish_query_one_param_per_uri = kwargs.pop(
+            "redfish_query_one_param_per_uri", False
+        )
 
         inst = disp(
             idrac_ip=_idrac_ip,
@@ -284,6 +287,8 @@ class IDracManager(RedfishManager):
             insecure=_insecure,
             is_http=_is_http
         )
+        inst._redfish_query = _redfish_query
+        inst._redfish_query_one_param_per_uri = _redfish_query_one_param_per_uri
 
         return inst.execute(**kwargs)
 
@@ -305,6 +310,10 @@ class IDracManager(RedfishManager):
         _port = kwargs.pop("port")
         _insecure = kwargs.pop("insecure")
         _is_http = kwargs.pop("is_http")
+        _redfish_query = kwargs.pop("redfish_query", None)
+        _redfish_query_one_param_per_uri = kwargs.pop(
+            "redfish_query_one_param_per_uri", False
+        )
         module_logger.debug(f"dispatching {name} to idrac port {_port}")
 
         inst = disp(
@@ -315,6 +324,8 @@ class IDracManager(RedfishManager):
             insecure=_insecure,
             is_http=_is_http
         )
+        inst._redfish_query = _redfish_query
+        inst._redfish_query_one_param_per_uri = _redfish_query_one_param_per_uri
         return inst.execute(**kwargs)
 
     async def api_async_get_call(self, loop, req, hdr: Dict):

--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -50,7 +50,9 @@ from .cmd_utils import save_if_needed
 from .custom_argparser.customer_argdefault import CustomArgumentDefaultsHelpFormatter
 from .idrac_manager import IDracManager
 from .idrac_shared import RedfishAction, RedfishActionEncoder
+from .redfish_query import RedfishQuery
 from .telemetry.exporter import apply_exporter_env_file, exporter_argv_uses_secret
+from .vendors import VendorCapabilities, get_vendor
 
 
 def _env(*names, default=""):
@@ -98,6 +100,13 @@ class TermColors:
 "note we do sub-string match"
 TermList = ["xterm", "linux", "ansi", "xterm-256color"]
 LOCAL_COMMANDS = {"bios-profile"}
+_QUERY_CAPABILITY_FLAGS = (
+    ("$select", "select", "query_select"),
+    ("$filter", "filter", "query_filter"),
+    ("$expand", "expand", "query_expand"),
+    ("$top", "top", "query_top"),
+    ("only", "only", "query_only"),
+)
 
 
 def color_printer(msg: str, tcolor: Optional[str] = TermColors.WARNING):
@@ -278,6 +287,45 @@ def is_local_command(args) -> bool:
     return getattr(args, "subcommand", None) in LOCAL_COMMANDS
 
 
+def _redfish_query_from_args(args: argparse.Namespace) -> RedfishQuery:
+    """Build the global Redfish query object from top-level CLI flags."""
+    return RedfishQuery(
+        select=getattr(args, "query_select", None),
+        filter=getattr(args, "query_filter", None),
+        expand=getattr(args, "query_expand", None),
+        expand_levels=getattr(args, "query_expand_levels", 1),
+        top=getattr(args, "query_top", None),
+        only=getattr(args, "query_only", False),
+    )
+
+
+def _query_flag_is_active(query: RedfishQuery, attr: str) -> bool:
+    """Return whether a RedfishQuery field should be vendor-gated."""
+    value = getattr(query, attr)
+    if attr == "top":
+        return value is not None
+    return bool(value)
+
+
+def _validate_redfish_query_for_vendor(
+        query: RedfishQuery,
+        caps: VendorCapabilities) -> None:
+    """Raise when the target vendor profile does not support query flags."""
+    unsupported = [
+        name for name, attr, enabled_attr in _QUERY_CAPABILITY_FLAGS
+        if _query_flag_is_active(query, attr) and not getattr(caps, enabled_attr)
+    ]
+    if unsupported:
+        joined = ", ".join(unsupported)
+        raise InvalidArgument(
+            f"{caps.vendor} does not declare support for {joined}"
+        )
+    try:
+        query.to_query_string(caps.one_query_param_per_uri)
+    except ValueError as err:
+        raise InvalidArgument(str(err)) from err
+
+
 def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
     """Main entry point
     """
@@ -317,6 +365,15 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
         cmd = command_name_to_cmd[cmd_args.subcommand]
         arg_dict = dict((k, v) for k, v
                         in vars(cmd_args).items() if k != "message_type")
+
+        redfish_query = _redfish_query_from_args(cmd_args)
+        if not connectionless_mode and not redfish_query.is_empty():
+            query_caps = get_vendor(redfish_api.redfish_vendor)
+            _validate_redfish_query_for_vendor(redfish_query, query_caps)
+            arg_dict["redfish_query"] = redfish_query
+            arg_dict["redfish_query_one_param_per_uri"] = (
+                query_caps.one_query_param_per_uri
+            )
 
         if cmd_args.verbose:
             json_printer(arg_dict, cmd_args, colorized=cmd_args.nocolor)
@@ -477,6 +534,30 @@ def redfish_main_ctl():
     credentials.add_argument(
         '--use_http', action='store_true', required=False, default=False,
         help="use http instead https as transport.")
+
+    redfish_query = parser.add_argument_group(
+        'redfish query', '# server-side Redfish GET query options')
+    redfish_query.add_argument(
+        '--select', dest='query_select', required=False, default=None,
+        help="apply Redfish $select to GET commands, for example Id,Name.")
+    redfish_query.add_argument(
+        '--filter', dest='query_filter', required=False, default=None,
+        help="apply Redfish $filter to GET commands.")
+    redfish_query.add_argument(
+        '--expand', dest='query_expand', nargs='?', const='*',
+        choices=['*', '.', '~'], required=False, default=None,
+        help="apply Redfish $expand to GET commands; mode defaults to '*'.")
+    redfish_query.add_argument(
+        '--expand-levels', dest='query_expand_levels', required=False,
+        type=int, default=1,
+        help="Redfish $expand levels when --expand is used.")
+    redfish_query.add_argument(
+        '--top', dest='query_top', required=False, type=int, default=None,
+        help="apply Redfish $top to GET commands.")
+    redfish_query.add_argument(
+        '--only', dest='query_only', action='store_true',
+        required=False, default=False,
+        help="apply the Redfish only query parameter to GET commands.")
 
     verbose_group = parser.add_argument_group('verbose', '# verbose and debug options')
     verbose_group.add_argument(

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -10,7 +10,6 @@ import asyncio
 import collections
 import functools
 import logging
-import os
 import re
 from abc import abstractmethod
 from functools import cached_property
@@ -419,6 +418,20 @@ class RedfishManager:
         if len(select_target) > 0:
             r = f"{self._default_method}{self.redfish_ip}" \
                 f"{resource}{self.select(select_property=select_target)}"
+
+        request_query = kwargs.get("redfish_query", None)
+        if request_query is None:
+            request_query = getattr(self, "_redfish_query", None)
+        one_param_per_uri = kwargs.get(
+            "redfish_query_one_param_per_uri",
+            getattr(self, "_redfish_query_one_param_per_uri", False),
+        )
+        if (
+            request_query is not None
+            and not request_query.is_empty()
+            and "?" not in r
+        ):
+            r = request_query.apply(r, one_param_per_uri)
 
         logging.debug(f"Sending request to {r}")
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -4,7 +4,25 @@ Author Mus spyroot@gmail.com
 """
 import pytest
 
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_main import (
+    _redfish_query_from_args,
+    _validate_redfish_query_for_vendor,
+)
 from redfish_ctl.redfish_query import RedfishQuery
+from redfish_ctl.vendors import get_vendor
+
+
+class QueryArgs:
+    """Small argparse-like object for global Redfish query flags."""
+
+    query_select = "Id,Name"
+    query_filter = "Id eq 'Manager'"
+    query_expand = "."
+    query_expand_levels = 2
+    query_top = 5
+    query_only = True
 
 
 def test_empty_query_is_blank():
@@ -12,6 +30,40 @@ def test_empty_query_is_blank():
     q = RedfishQuery()
     assert q.is_empty()
     assert q.to_query_string() == ""
+
+
+def test_global_cli_query_flags_build_redfish_query():
+    """Global CLI-style query args become one RedfishQuery object."""
+    query = _redfish_query_from_args(QueryArgs())
+
+    assert query.to_query_string() == (
+        "?$select=Id,Name&$filter=Id%20eq%20'Manager'"
+        "&$expand=.($levels=2)&$top=5&only"
+    )
+
+
+def test_vendor_gate_rejects_unsupported_query_flags():
+    """Vendor profiles block query parameters not declared for that target."""
+    query = RedfishQuery(select="Id")
+
+    with pytest.raises(InvalidArgument, match=r"\$select"):
+        _validate_redfish_query_for_vendor(query, get_vendor("supermicro"))
+
+
+def test_vendor_gate_treats_top_zero_as_active_query():
+    """$top=0 is valid Redfish syntax and still needs vendor support."""
+    query = RedfishQuery(top=0)
+
+    with pytest.raises(InvalidArgument, match=r"\$top"):
+        _validate_redfish_query_for_vendor(query, get_vendor("supermicro"))
+
+
+def test_dell_vendor_gate_rejects_combined_query_flags():
+    """Dell's one-query-parameter rule is enforced before any GET."""
+    query = RedfishQuery(select="Id", top=5)
+
+    with pytest.raises(InvalidArgument, match="only one query parameter"):
+        _validate_redfish_query_for_vendor(query, get_vendor("dell"))
 
 
 def test_select_list_and_string():
@@ -104,3 +156,17 @@ def test_get_with_query_enforces_one_param(redfish_mock):
         redfish_mock.get_with_query(
             "https://mock-idrac/redfish/v1/Managers", q, one_param_per_uri=True
         )
+
+
+def test_invoke_attaches_global_query_to_base_query(redfish_mock, redfish_service):
+    """Dispatch stores global query flags so base_query appends them to GETs."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.QueryIdrac,
+        "query_idrac",
+        resource="/redfish/v1/Managers",
+        redfish_query=RedfishQuery(top=1),
+        redfish_query_one_param_per_uri=False,
+    )
+
+    assert result.data["@odata.id"] == "/redfish/v1/Managers"
+    assert "top=1" in redfish_service.last_request.query


### PR DESCRIPTION
## Summary
- add top-level Redfish GET query flags for select, filter, expand, top, and only
- validate requested query parameters against the target vendor capability profile
- attach the validated query to command dispatch so base_query appends it without changing startup probes or URLs that already include a query string
- document the root-level flag placement in the command reference

## Tests
- pytest -q tests/test_query.py
- pytest -q
- ruff check redfish_ctl/redfish_main.py redfish_ctl/idrac_manager.py redfish_ctl/redfish_manager.py tests/test_query.py
- python -B -m redfish_ctl.redfish_main --help