### PR TITLE
Add fleet inventory command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `firmware` | Read firmware view data. | Read |
 | `firmware-update` | Run UpdateService SimpleUpdate; `--dry_run` previews, `--confirm` writes. | Guarded |
 | `firmware_inventory` | Read firmware inventory. | Read |
+| `fleet` | Read a YAML fleet inventory and summarize per-node health, sensor count, and temperature max. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
 | `insert_vm` | Insert virtual media from a URI. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -155,3 +155,4 @@ from .accounts.cmd_privilage_registry import *
 
 from .discovery.cmd_discovery import *
 from .discovery.cmd_bmc_scan import *
+from .fleet.cmd_fleet import *

--- a/redfish_ctl/fleet/__init__.py
+++ b/redfish_ctl/fleet/__init__.py
@@ -1,0 +1,1 @@
+"""Fleet read helpers and commands."""

--- a/redfish_ctl/fleet/cmd_fleet.py
+++ b/redfish_ctl/fleet/cmd_fleet.py
@@ -1,0 +1,233 @@
+"""Read a small fleet inventory through existing redfish_ctl commands."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from abc import abstractmethod
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+from ..api import RedfishApiError, get_sensors, get_system, get_thermal
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+
+
+@dataclass(frozen=True)
+class FleetNode:
+    """Connection details for one BMC inventory entry."""
+
+    name: str
+    address: str
+    username: str
+    password: str
+    port: int
+    insecure: bool
+    use_http: bool
+
+
+def _env_value(raw: Mapping[str, Any], field: str, env_field: str, default: str) -> str:
+    value = raw.get(field)
+    if value is not None:
+        return str(value)
+    env_name = raw.get(env_field)
+    if env_name:
+        return os.environ.get(str(env_name), default)
+    return default
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "yes", "true", "on"}
+    return bool(value)
+
+
+def _as_int(value: Any, default: int) -> int:
+    if value is None:
+        return default
+    return int(value)
+
+
+def _as_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _inventory_nodes(data: Any) -> list[Mapping[str, Any]]:
+    if isinstance(data, list):
+        rows = data
+    elif isinstance(data, Mapping):
+        rows = data.get("nodes", [])
+    else:
+        rows = []
+    return [row for row in rows if isinstance(row, Mapping)]
+
+
+def load_inventory(path: str | Path) -> tuple[FleetNode, ...]:
+    """Load a YAML fleet inventory into connection entries."""
+    inventory_path = Path(path)
+    with inventory_path.open() as handle:
+        data = yaml.safe_load(handle) or {}
+
+    nodes = []
+    for index, raw in enumerate(_inventory_nodes(data), start=1):
+        address = raw.get("address") or raw.get("host") or raw.get("ip")
+        if not address:
+            raise ValueError(f"fleet node {index} is missing address")
+        address = str(address)
+        nodes.append(
+            FleetNode(
+                name=str(raw.get("name") or address),
+                address=address,
+                username=_env_value(raw, "username", "usernameEnv", "root"),
+                password=_env_value(raw, "password", "passwordEnv", ""),
+                port=_as_int(raw.get("port"), 443),
+                insecure=_as_bool(raw.get("insecure"), True),
+                use_http=_as_bool(raw.get("useHttp", raw.get("use_http")), False),
+            )
+        )
+    return tuple(nodes)
+
+
+def _temperature_summary(readings: tuple[Any, ...]) -> dict[str, int | float | None]:
+    values = [
+        value
+        for value in (_as_float(reading.reading_celsius) for reading in readings)
+        if value is not None
+    ]
+    max_celsius = max(values) if values else None
+    return {
+        "count": len(readings),
+        "max_celsius": max_celsius,
+    }
+
+
+def _node_manager(node: FleetNode) -> IDracManager:
+    return IDracManager(
+        idrac_ip=node.address,
+        idrac_username=node.username,
+        idrac_password=node.password,
+        idrac_port=node.port,
+        insecure=node.insecure,
+        is_http=node.use_http,
+    )
+
+
+def _error_row(node: FleetNode, exc: BaseException) -> dict[str, Any]:
+    return {
+        "name": node.name,
+        "address": node.address,
+        "ok": False,
+        "powerState": None,
+        "health": None,
+        "state": None,
+        "sensors": {"count": 0},
+        "temperature": {"count": 0, "max_celsius": None},
+        "error": str(exc),
+    }
+
+
+def read_node(node: FleetNode) -> dict[str, Any]:
+    """Read one node through the typed facade and return a public summary."""
+    try:
+        manager = _node_manager(node)
+        system = get_system(manager)
+        sensors = get_sensors(manager)
+        thermal = get_thermal(manager)
+        return {
+            "name": node.name,
+            "address": node.address,
+            "ok": True,
+            "powerState": system.power_state,
+            "health": system.health,
+            "state": system.state,
+            "sensors": {"count": len(sensors)},
+            "temperature": _temperature_summary(thermal.temperatures),
+            "error": None,
+        }
+    except (RedfishApiError, OSError, ValueError) as exc:
+        return _error_row(node, exc)
+
+
+def read_fleet(nodes: tuple[FleetNode, ...], concurrency: int) -> dict[str, Any]:
+    """Fan out read-only status calls across inventory nodes."""
+    if not nodes:
+        return {"summary": {"total": 0, "ok": 0, "failed": 0}, "nodes": []}
+
+    max_concurrency = max(1, min(int(concurrency or 1), len(nodes)))
+    rows_by_index: dict[int, dict[str, Any]] = {}
+    with ThreadPoolExecutor(max_workers=max_concurrency) as executor:
+        future_to_index = {
+            executor.submit(read_node, node): index
+            for index, node in enumerate(nodes)
+        }
+        for future in as_completed(future_to_index):
+            index = future_to_index[future]
+            try:
+                rows_by_index[index] = future.result()
+            except Exception as exc:
+                rows_by_index[index] = _error_row(nodes[index], exc)
+
+    rows = [rows_by_index[index] for index in range(len(nodes))]
+    ok_count = sum(1 for row in rows if row["ok"])
+    return {
+        "summary": {
+            "total": len(rows),
+            "ok": ok_count,
+            "failed": len(rows) - ok_count,
+        },
+        "nodes": rows,
+    }
+
+
+class FleetInventory(IDracManager,
+                     scm_type=ApiRequestType.FleetInventory,
+                     name="fleet",
+                     metaclass=Singleton):
+    """Read a YAML fleet inventory and summarize node health."""
+
+    def __init__(self, *args, **kwargs):
+        super(FleetInventory, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only fleet subcommand."""
+        cmd_parser = argparse.ArgumentParser(add_help=False)
+        cmd_parser.add_argument(
+            "--inventory",
+            required=True,
+            help="YAML file with a top-level nodes list.",
+        )
+        cmd_parser.add_argument(
+            "--concurrency",
+            type=int,
+            default=8,
+            help="maximum concurrent BMC reads.",
+        )
+        return cmd_parser, "fleet", "read fleet inventory status from a YAML file"
+
+    def execute(self,
+                inventory: str,
+                concurrency: int = 8,
+                **kwargs) -> CommandResult:
+        """Execute read-only fan-out over the configured inventory."""
+        nodes = load_inventory(inventory)
+        return CommandResult(read_fleet(nodes, concurrency), None, None, None)

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -170,6 +170,7 @@ class ApiRequestType(Enum):
     JobDellServices = auto()
 
     Discovery = auto()
+    FleetInventory = auto()
 
 
 class ScheduleJobType(Enum):

--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -107,6 +107,7 @@ _QUERY_CAPABILITY_FLAGS = (
     ("$top", "top", "query_top"),
     ("only", "only", "query_only"),
 )
+FLEET_COMMANDS = {"fleet"}
 
 
 def color_printer(msg: str, tcolor: Optional[str] = TermColors.WARNING):
@@ -329,6 +330,11 @@ def _validate_redfish_query_for_vendor(
         raise InvalidArgument(str(err)) from err
 
 
+def is_fleet_command(args) -> bool:
+    """True when the command manages its own per-node connections."""
+    return getattr(args, "subcommand", None) in FLEET_COMMANDS
+
+
 def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
     """Main entry point
     """
@@ -353,7 +359,8 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
     # (it would try to connect to a host we do not have).
     scan_mode = is_network_scan(cmd_args)
     local_mode = is_local_command(cmd_args)
-    connectionless_mode = scan_mode or local_mode
+    fleet_mode = is_fleet_command(cmd_args)
+    connectionless_mode = scan_mode or local_mode or fleet_mode
     if not connectionless_mode:
         _ = redfish_api.check_api_version()
 
@@ -629,7 +636,11 @@ def redfish_main_ctl():
     # A network-segment scan (bmc-scan, or discovery --network) has no single
     # target host and uses no credentials, so it skips the IDRAC_IP/credential
     # gate that every host-targeted command requires.
-    if not is_network_scan(args) and not is_local_command(args):
+    if (
+        not is_network_scan(args)
+        and not is_local_command(args)
+        and not is_fleet_command(args)
+    ):
         if args.idrac_ip is None or len(args.idrac_ip) == 0:
             print(
                 "Please indicate the idrac ip. "

--- a/tests/test_fleet_inventory.py
+++ b/tests/test_fleet_inventory.py
@@ -1,0 +1,112 @@
+"""Offline tests for the fleet inventory read command."""
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from redfish_ctl.fleet import cmd_fleet
+from redfish_ctl.fleet.cmd_fleet import FleetInventory, FleetNode, read_fleet
+
+GB300_CORPUS = (
+    Path(__file__).parent
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+GB300_INDEX = {path.name.lower(): path for path in GB300_CORPUS.glob("*.json")}
+
+
+def _fixture_for_path(path):
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_INDEX.get(name.lower())
+
+
+def test_fleet_inventory_reads_gb300_node_from_yaml(tmp_path):
+    """fleet reads a YAML node list and returns corpus-backed status rows."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    inventory = tmp_path / "fleet.yaml"
+    inventory.write_text(
+        yaml.safe_dump({
+            "nodes": [
+                {
+                    "name": "gb300-a",
+                    "address": "mock-gb300",
+                    "username": "root",
+                    "password": "mock",
+                    "insecure": True,
+                }
+            ]
+        })
+    )
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        result = FleetInventory().execute(inventory=str(inventory), concurrency=2)
+
+    assert result.error is None
+    assert result.data["summary"] == {"total": 1, "ok": 1, "failed": 0}
+    assert result.data["nodes"] == [
+        {
+            "name": "gb300-a",
+            "address": "mock-gb300",
+            "ok": True,
+            "powerState": "On",
+            "health": "OK",
+            "state": "Enabled",
+            "sensors": {"count": 266},
+            "temperature": {"count": 72, "max_celsius": 54.1875},
+            "error": None,
+        }
+    ]
+    assert {request.method for request in requests} == {"GET"}
+
+
+def test_fleet_inventory_records_per_node_failures(monkeypatch):
+    """fleet keeps one failed node from aborting the full inventory read."""
+
+    def fail_node(node):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(cmd_fleet, "read_node", fail_node)
+
+    node = FleetNode(
+        name="offline-a",
+        address="offline.example.test",
+        username="root",
+        password="mock",
+        port=443,
+        insecure=True,
+        use_http=False,
+    )
+
+    data = read_fleet((node,), concurrency=1)
+
+    assert data == {
+        "summary": {"total": 1, "ok": 0, "failed": 1},
+        "nodes": [
+            {
+                "name": "offline-a",
+                "address": "offline.example.test",
+                "ok": False,
+                "powerState": None,
+                "health": None,
+                "state": None,
+                "sensors": {"count": 0},
+                "temperature": {"count": 0, "max_celsius": None},
+                "error": "connection refused",
+            }
+        ],
+    }


### PR DESCRIPTION
## Summary
- Add a read-only `fleet` command that loads a YAML nodes inventory and fans out status reads with `--concurrency`.
- Summarize power state, health, sensor count, and max thermal reading per node through the typed read facade.
- Let `fleet` manage per-node connection fields from inventory, so it can run without a single global BMC target.
- Document the command and add GB300 corpus-backed offline coverage, including per-node failure isolation.

## Validation
- `conda run -n idrac_ctl pytest -q tests/test_fleet_inventory.py` -> `2 passed in 1.45s`
- `conda run -n idrac_ctl pytest -q` -> `817 passed, 57 skipped in 27.53s`
- `conda run -n idrac_ctl ruff check redfish_ctl/__init__.py redfish_ctl/fleet/__init__.py redfish_ctl/fleet/cmd_fleet.py redfish_ctl/idrac_shared.py redfish_ctl/redfish_main.py tests/test_fleet_inventory.py` -> `All checks passed!`
- `python -B -m redfish_ctl.redfish_main fleet --help` rendered the `fleet` options.
