### PR TITLE
Pin HPE vendor capability profile

### DIFF
--- a/tests/test_hpe_profile.py
+++ b/tests/test_hpe_profile.py
@@ -1,0 +1,48 @@
+"""Offline tests for the HPE iLO vendor capability profile.
+
+The profile is intentionally conservative while iLO-specific command behavior
+is built out. These tests pin the one known query capability and the disabled
+defaults so unverified features are not silently enabled.
+
+Author Mus spyroot@gmail.com
+"""
+from redfish_ctl.vendors import get_vendor
+from redfish_ctl.vendors.base import VendorCapabilities
+
+
+def test_hpe_oem_prefix_matches_ilo_oem_namespace():
+    """HPE iLO uses the Hpe OEM namespace; the profile mirrors that prefix."""
+    caps = get_vendor("hpe")
+    assert caps.vendor == "hpe"
+    assert caps.oem_prefix == "Hpe"
+
+
+def test_hpe_query_params_keep_only_verified_expand_enabled():
+    """Only server-side expand is pinned; other query parameters stay disabled."""
+    caps = get_vendor("hpe")
+    assert caps.query_expand is True
+    assert caps.query_select is False
+    assert caps.query_filter is False
+    assert caps.query_top is False
+    assert caps.query_only is False
+    assert caps.one_query_param_per_uri is False
+
+
+def test_hpe_job_scheduling_is_conservative():
+    """Recurring JobService scheduling is unverified, so it stays disabled."""
+    caps = get_vendor("hpe")
+    assert caps.job_scheduling is False
+    assert caps.one_recurring_job_per_type is False
+    assert caps.schedulable_uris == ()
+
+
+def test_hpe_profile_is_frozen():
+    """The profile is immutable so a command cannot mutate shared state."""
+    caps = get_vendor("hpe")
+    assert isinstance(caps, VendorCapabilities)
+    try:
+        caps.oem_prefix = "Dell"  # type: ignore[misc]
+    except Exception as exc:
+        assert isinstance(exc, (AttributeError, TypeError))
+    else:
+        raise AssertionError("VendorCapabilities should be immutable")


### PR DESCRIPTION
Summary
- Adds an offline HPE vendor profile test covering the OEM prefix, query capability flags, JobService defaults, and immutability.
- Keeps the profile behavior pinned without requiring HPE fixtures, live hardware, or network access.

Validation
- PYTHONDONTWRITEBYTECODE=1 conda run -n idrac_ctl pytest -q -p no:cacheprovider tests/test_hpe_profile.py tests/test_vendors.py -> 9 passed
- RUFF_CACHE_DIR=/private/tmp/redfish_ctl_ruff_cache PYTHONDONTWRITEBYTECODE=1 conda run -n idrac_ctl ruff check tests/test_hpe_profile.py -> All checks passed
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD -u REDFISH_PORT PYTHONDONTWRITEBYTECODE=1 conda run -n idrac_ctl pytest -q -p no:cacheprovider -> 817 passed, 57 skipped