### PR TITLE
Add desired-state reconcile core

### DIFF
--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -1,0 +1,58 @@
+# Desired-State Reconciler
+
+`redfish_ctl.reconcile`, the library module added for service controllers, turns a desired node state
+into a plan and only applies it when the caller passes `confirm=True`.
+
+The `DesiredState` dataclass, defined in `redfish_ctl/reconcile.py`, currently accepts:
+
+- `bios_profile`: a profile name from `specs/profiles/*.json`.
+- `ntp_servers`: ManagerNetworkProtocol NTP servers for the guarded `ntp-set` command.
+- `ntp_manager_id`: optional Manager id for the NTP change.
+- `boot_device`, `boot_mode`, and `uefi_target`: one-time boot settings for `boot-one-shot`.
+- `reset_type`: host reset type for the guarded reboot facade path.
+
+`DesiredState.from_mapping()` accepts CRD-style keys such as `biosProfile`, `ntp.servers`,
+`boot.device`, and `reboot.resetType`, so Kubernetes and proxy layers can pass structured specs
+without depending on CLI argument names.
+
+## Safety Model
+
+`reconcile(manager, desired)` is a dry-run by default. In dry-run mode it may call read or preview
+commands:
+
+- `bios-profile diff`, from `redfish_ctl/bios/cmd_bios_profile.py`, reads current BIOS attributes.
+- `ntp-set` without `confirm`, from `redfish_ctl/manager/cmd_ntp_set.py`, builds a PATCH plan but does
+  not write it.
+- `reboot` with `dry_run=True`, from `redfish_ctl/compute/cmd_power_state.py`, discovers the reset
+  target and payload without POSTing.
+- `boot-one-shot` is not invoked during dry-run because it has no preview-only command path.
+
+`reconcile(manager, desired, confirm=True)` applies only the required planned changes:
+
+- A BIOS profile is applied only when `bios-profile diff` reports `matches: false`.
+- NTP settings are applied through `ntp-set --confirm`.
+- A one-time boot target is applied through `boot-one-shot`.
+- A reset is executed through the reboot facade path, with `wait_for_reboot=True` available to request
+  the existing wait behavior.
+
+The core does not create credentials, store secrets, or contact a BMC on its own. The caller supplies
+the `SyncInvoker` manager, which is the same interface used by `redfish_ctl.api`.
+
+## Example
+
+```python
+from redfish_ctl.reconcile import DesiredState, reconcile
+
+desired = DesiredState.from_mapping({
+    "biosProfile": "gb300-power-capped",
+    "ntp": {"servers": ["0.pool.ntp.org"]},
+    "boot": {"device": "Pxe", "mode": "UEFI"},
+    "reboot": {"resetType": "GracefulRestart"},
+})
+
+plan = reconcile(manager, desired)
+assert plan.dry_run is True
+
+applied = reconcile(manager, desired, confirm=True, wait_for_reboot=True)
+assert applied.dry_run is False
+```

--- a/redfish_ctl/reconcile.py
+++ b/redfish_ctl/reconcile.py
@@ -1,0 +1,313 @@
+"""Desired-state reconciliation primitives for service controllers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+from .api import RedfishApiError, SyncInvoker
+from .idrac_shared import ApiRequestType
+
+
+@dataclass(frozen=True)
+class DesiredState:
+    """Desired Redfish node state accepted by controller and service layers."""
+
+    bios_profile: str | None = None
+    ntp_servers: tuple[str, ...] = ()
+    ntp_manager_id: str | None = None
+    boot_device: str | None = None
+    boot_mode: str | None = None
+    uefi_target: str | None = None
+    reset_type: str | None = None
+
+    @classmethod
+    def from_mapping(cls, spec: Mapping[str, Any]) -> "DesiredState":
+        """Build desired state from a CRD-style or JSON-style mapping."""
+        ntp = _mapping(spec.get("ntp"))
+        boot = _mapping(spec.get("boot"))
+        reboot_spec = spec.get("reboot")
+        reboot = _mapping(reboot_spec)
+        return cls(
+            bios_profile=_optional_str(
+                _first(spec, "biosProfile", "bios_profile")
+            ),
+            ntp_servers=_str_tuple(
+                _first(ntp, "servers")
+                or _first(spec, "ntpServers", "ntp_servers")
+            ),
+            ntp_manager_id=_optional_str(
+                _first(ntp, "manager", "managerId", "manager_id")
+            ),
+            boot_device=_optional_str(_first(boot, "device")),
+            boot_mode=_optional_str(_first(boot, "mode")),
+            uefi_target=_optional_str(
+                _first(boot, "uefiTarget", "uefi_target")
+            ),
+            reset_type=_reset_type(reboot_spec, reboot),
+        )
+
+
+@dataclass(frozen=True)
+class ReconcileStep:
+    """One planned reconciliation action."""
+
+    kind: str
+    required: bool
+    description: str
+    preview: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class AppliedChange:
+    """One confirmed reconciliation action result."""
+
+    kind: str
+    changed: bool
+    result: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class ReconcileResult:
+    """Plan and optional apply result for one desired state."""
+
+    dry_run: bool
+    steps: tuple[ReconcileStep, ...]
+    applied: tuple[AppliedChange, ...]
+
+
+def reconcile(
+    manager: SyncInvoker,
+    desired: DesiredState | Mapping[str, Any],
+    *,
+    confirm: bool = False,
+    wait_for_reboot: bool = False,
+    async_call: bool = False,
+) -> ReconcileResult:
+    """Plan desired state and apply only when explicitly confirmed."""
+    state = (
+        DesiredState.from_mapping(desired)
+        if isinstance(desired, Mapping)
+        else desired
+    )
+    steps: list[ReconcileStep] = []
+    applied: list[AppliedChange] = []
+
+    if state.bios_profile:
+        _reconcile_bios_profile(manager, state, confirm, steps, applied)
+    if state.ntp_servers:
+        _reconcile_ntp(manager, state, confirm, steps, applied)
+    if state.boot_device:
+        _reconcile_boot(manager, state, confirm, steps, applied)
+    if state.reset_type:
+        _reconcile_reboot(
+            manager,
+            state,
+            confirm,
+            wait_for_reboot,
+            async_call,
+            steps,
+            applied,
+        )
+
+    return ReconcileResult(
+        dry_run=not confirm,
+        steps=tuple(steps),
+        applied=tuple(applied),
+    )
+
+
+def _reconcile_bios_profile(
+    manager: SyncInvoker,
+    state: DesiredState,
+    confirm: bool,
+    steps: list[ReconcileStep],
+    applied: list[AppliedChange],
+) -> None:
+    profile_name = state.bios_profile
+    diff = _invoke_mapping(
+        manager,
+        ApiRequestType.BiosProfile,
+        "bios-profile",
+        action="diff",
+        profile_name=profile_name,
+    )
+    required = not bool(diff.get("matches"))
+    steps.append(
+        ReconcileStep(
+            kind="bios-profile",
+            required=required,
+            description=f"BIOS profile {profile_name}",
+            preview=diff,
+        )
+    )
+    if confirm and required:
+        result = _invoke_mapping(
+            manager,
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            action="apply",
+            profile_name=profile_name,
+            confirm=True,
+            dry_run=False,
+        )
+        applied.append(
+            AppliedChange(
+                kind="bios-profile",
+                changed=True,
+                result=result,
+            )
+        )
+
+
+def _reconcile_ntp(
+    manager: SyncInvoker,
+    state: DesiredState,
+    confirm: bool,
+    steps: list[ReconcileStep],
+    applied: list[AppliedChange],
+) -> None:
+    result = _invoke_mapping(
+        manager,
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=state.ntp_servers,
+        manager_id=state.ntp_manager_id,
+        confirm=confirm,
+    )
+    required = confirm or bool(result.get("plan") or result.get("applied"))
+    steps.append(
+        ReconcileStep(
+            kind="ntp",
+            required=required,
+            description="Manager NTP servers",
+            preview=result,
+        )
+    )
+    if confirm:
+        applied.append(
+            AppliedChange(
+                kind="ntp",
+                changed=bool(result.get("applied")),
+                result=result,
+            )
+        )
+
+
+def _reconcile_boot(
+    manager: SyncInvoker,
+    state: DesiredState,
+    confirm: bool,
+    steps: list[ReconcileStep],
+    applied: list[AppliedChange],
+) -> None:
+    preview = {
+        "device": state.boot_device,
+        "mode": state.boot_mode,
+        "uefiTarget": state.uefi_target,
+    }
+    steps.append(
+        ReconcileStep(
+            kind="boot",
+            required=True,
+            description="One-time boot override",
+            preview=preview,
+        )
+    )
+    if confirm:
+        result = _invoke_mapping(
+            manager,
+            ApiRequestType.BootOneShot,
+            "boot_one_shot",
+            device=state.boot_device,
+            mode=state.boot_mode,
+            uefi_target=state.uefi_target,
+            do_reboot=False,
+        )
+        applied.append(
+            AppliedChange(kind="boot", changed=True, result=result)
+        )
+
+
+def _reconcile_reboot(
+    manager: SyncInvoker,
+    state: DesiredState,
+    confirm: bool,
+    wait_for_reboot: bool,
+    async_call: bool,
+    steps: list[ReconcileStep],
+    applied: list[AppliedChange],
+) -> None:
+    result = _invoke_mapping(
+        manager,
+        ApiRequestType.ComputerSystemReset,
+        "reboot",
+        reset_type=state.reset_type,
+        dry_run=not confirm,
+        do_wait=bool(wait_for_reboot and confirm),
+        do_async=async_call,
+    )
+    steps.append(
+        ReconcileStep(
+            kind="reboot",
+            required=True,
+            description=f"Host reset {state.reset_type}",
+            preview=result,
+        )
+    )
+    if confirm:
+        applied.append(
+            AppliedChange(kind="reboot", changed=True, result=result)
+        )
+
+
+def _invoke_mapping(
+    manager: SyncInvoker,
+    api_call: ApiRequestType,
+    name: str,
+    **kwargs: Any,
+) -> Mapping[str, Any]:
+    result = manager.sync_invoke(api_call, name, **kwargs)
+    if result.error:
+        raise RedfishApiError(str(result.error))
+    return _mapping(result.data)
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _str_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        values: Iterable[Any] = value.split(",")
+    else:
+        values = value
+    return tuple(
+        item
+        for raw in values
+        if (item := str(raw).strip())
+    )
+
+
+def _reset_type(reboot_spec: Any, reboot: Mapping[str, Any]) -> str | None:
+    if isinstance(reboot_spec, str):
+        return _optional_str(reboot_spec)
+    if reboot_spec is True:
+        return "GracefulRestart"
+    return _optional_str(_first(reboot, "resetType", "reset_type"))

--- a/tests/test_reconcile_core.py
+++ b/tests/test_reconcile_core.py
@@ -1,0 +1,370 @@
+"""Tests for desired-state reconciliation planning and guarded apply."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.reconcile import DesiredState, reconcile
+from redfish_ctl.redfish_manager import CommandResult
+
+GB300_CORPUS = (
+    Path(__file__).parent
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+)
+GB300_INDEX = {path.name.lower(): path for path in GB300_CORPUS.glob("*.json")}
+
+
+class RecordingManager:
+    """Return configured command payloads and record every facade call."""
+
+    def __init__(self, results):
+        self.results = results
+        self.calls = []
+
+    def sync_invoke(self, api_call, name, **kwargs):
+        self.calls.append((api_call, name, kwargs))
+        return self.results[(api_call, name, self._call_key(kwargs))]
+
+    @staticmethod
+    def _call_key(kwargs):
+        return tuple(sorted((key, _freeze(value)) for key, value in kwargs.items()))
+
+
+def _freeze(value):
+    if isinstance(value, dict):
+        return tuple(sorted((key, _freeze(item)) for key, item in value.items()))
+    if isinstance(value, list | tuple):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _key(**kwargs):
+    return RecordingManager._call_key(kwargs)
+
+
+def _fixture_for_path(path: str) -> Path | None:
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_INDEX.get(name.lower())
+
+
+def test_reconcile_dry_run_plans_without_mutating_commands():
+    """Dry-run may read and preview, but it must not apply BIOS or boot changes."""
+    diff_payload = {
+        "profile": {"name": "gb300-power-capped"},
+        "matches": False,
+        "summary": {"different": 1, "missing": 0, "matching": 2, "total": 3},
+        "attributes": [
+            {
+                "attribute": "ServerPowerControl",
+                "current": "Balanced",
+                "desired": "PowerSaving",
+                "status": "different",
+            }
+        ],
+    }
+    ntp_preview = {
+        "dry_run": True,
+        "servers": ["0.pool.ntp.org"],
+        "plan": [
+            {
+                "Manager": "BMC_0",
+                "target": "/redfish/v1/Managers/BMC_0/NetworkProtocol",
+                "payload": {
+                    "NTP": {
+                        "NTPServers": ["0.pool.ntp.org"],
+                        "ProtocolEnabled": True,
+                    }
+                },
+            }
+        ],
+        "skipped": [],
+    }
+    reboot_preview = {
+        "dry_run": True,
+        "target": "/redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset",
+        "payload": {"ResetType": "GracefulRestart"},
+    }
+    manager = RecordingManager({
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            _key(action="diff", profile_name="gb300-power-capped"),
+        ): CommandResult(diff_payload, None, None, None),
+        (
+            ApiRequestType.NtpSet,
+            "ntp-set",
+            _key(
+                servers=("0.pool.ntp.org",),
+                manager_id="BMC_0",
+                confirm=False,
+            ),
+        ): CommandResult(ntp_preview, None, None, None),
+        (
+            ApiRequestType.ComputerSystemReset,
+            "reboot",
+            _key(
+                reset_type="GracefulRestart",
+                dry_run=True,
+                do_wait=False,
+                do_async=False,
+            ),
+        ): CommandResult(reboot_preview, None, None, None),
+    })
+    desired = DesiredState.from_mapping({
+        "biosProfile": "gb300-power-capped",
+        "ntp": {"servers": ["0.pool.ntp.org"], "manager": "BMC_0"},
+        "boot": {"device": "Pxe", "mode": "UEFI"},
+        "reboot": {"resetType": "GracefulRestart"},
+    })
+
+    result = reconcile(manager, desired)
+
+    assert result.dry_run is True
+    assert [(step.kind, step.required) for step in result.steps] == [
+        ("bios-profile", True),
+        ("ntp", True),
+        ("boot", True),
+        ("reboot", True),
+    ]
+    assert result.applied == ()
+    assert manager.calls == [
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            {"action": "diff", "profile_name": "gb300-power-capped"},
+        ),
+        (
+            ApiRequestType.NtpSet,
+            "ntp-set",
+            {
+                "servers": ("0.pool.ntp.org",),
+                "manager_id": "BMC_0",
+                "confirm": False,
+            },
+        ),
+        (
+            ApiRequestType.ComputerSystemReset,
+            "reboot",
+            {
+                "reset_type": "GracefulRestart",
+                "dry_run": True,
+                "do_wait": False,
+                "do_async": False,
+            },
+        ),
+    ]
+
+
+def test_reconcile_confirm_applies_only_required_changes():
+    """Confirmed reconciliation applies planned changes through guarded commands."""
+    diff_payload = {
+        "profile": {"name": "gb300-power-capped"},
+        "matches": False,
+        "summary": {"different": 1, "missing": 0, "matching": 2, "total": 3},
+    }
+    apply_payload = {
+        "profile": "gb300-power-capped",
+        "dry_run": False,
+        "staged": {"Attributes": {"ServerPowerControl": "PowerSaving"}},
+    }
+    ntp_apply = {
+        "servers": ["0.pool.ntp.org"],
+        "applied": [
+            {
+                "Manager": "BMC_0",
+                "target": "/redfish/v1/Managers/BMC_0/NetworkProtocol",
+                "status": "IdracApiRespond.Ok",
+                "error": None,
+            }
+        ],
+        "skipped": [],
+    }
+    boot_result = {"task_id": "JID_BOOT", "task_state": "Running"}
+    reboot_result = {"task_id": "JID_RESET", "task_state": "Running"}
+    manager = RecordingManager({
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            _key(action="diff", profile_name="gb300-power-capped"),
+        ): CommandResult(diff_payload, None, None, None),
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            _key(
+                action="apply",
+                profile_name="gb300-power-capped",
+                confirm=True,
+                dry_run=False,
+            ),
+        ): CommandResult(apply_payload, None, None, None),
+        (
+            ApiRequestType.NtpSet,
+            "ntp-set",
+            _key(
+                servers=("0.pool.ntp.org",),
+                manager_id=None,
+                confirm=True,
+            ),
+        ): CommandResult(ntp_apply, None, None, None),
+        (
+            ApiRequestType.BootOneShot,
+            "boot_one_shot",
+            _key(device="Pxe", mode=None, uefi_target=None, do_reboot=False),
+        ): CommandResult(boot_result, None, None, None),
+        (
+            ApiRequestType.ComputerSystemReset,
+            "reboot",
+            _key(
+                reset_type="GracefulRestart",
+                dry_run=False,
+                do_wait=True,
+                do_async=False,
+            ),
+        ): CommandResult(reboot_result, None, None, None),
+    })
+    desired = DesiredState(
+        bios_profile="gb300-power-capped",
+        ntp_servers=("0.pool.ntp.org",),
+        boot_device="Pxe",
+        reset_type="GracefulRestart",
+    )
+
+    result = reconcile(manager, desired, confirm=True, wait_for_reboot=True)
+
+    assert result.dry_run is False
+    assert [(item.kind, item.changed) for item in result.applied] == [
+        ("bios-profile", True),
+        ("ntp", True),
+        ("boot", True),
+        ("reboot", True),
+    ]
+    assert manager.calls == [
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            {"action": "diff", "profile_name": "gb300-power-capped"},
+        ),
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            {
+                "action": "apply",
+                "profile_name": "gb300-power-capped",
+                "confirm": True,
+                "dry_run": False,
+            },
+        ),
+        (
+            ApiRequestType.NtpSet,
+            "ntp-set",
+            {
+                "servers": ("0.pool.ntp.org",),
+                "manager_id": None,
+                "confirm": True,
+            },
+        ),
+        (
+            ApiRequestType.BootOneShot,
+            "boot_one_shot",
+            {
+                "device": "Pxe",
+                "mode": None,
+                "uefi_target": None,
+                "do_reboot": False,
+            },
+        ),
+        (
+            ApiRequestType.ComputerSystemReset,
+            "reboot",
+            {
+                "reset_type": "GracefulRestart",
+                "dry_run": False,
+                "do_wait": True,
+                "do_async": False,
+            },
+        ),
+    ]
+
+
+def test_reconcile_skips_matching_profile():
+    """A matching BIOS profile is reported but not applied."""
+    manager = RecordingManager({
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            _key(action="diff", profile_name="balanced"),
+        ): CommandResult(
+            {
+                "profile": {"name": "balanced"},
+                "matches": True,
+                "summary": {"different": 0, "missing": 0, "matching": 3, "total": 3},
+            },
+            None,
+            None,
+            None,
+        )
+    })
+
+    result = reconcile(manager, DesiredState(bios_profile="balanced"), confirm=True)
+
+    assert [(step.kind, step.required) for step in result.steps] == [
+        ("bios-profile", False),
+    ]
+    assert result.applied == ()
+    assert manager.calls == [
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            {"action": "diff", "profile_name": "balanced"},
+        )
+    ]
+
+
+def test_reconcile_dry_run_uses_gb300_corpus_without_writes():
+    """Dry-run reconciliation uses registered commands without mutating requests."""
+    requests_mock = pytest.importorskip("requests_mock")
+    seen_methods: list[str] = []
+
+    def get_cb(request, context):
+        seen_methods.append(request.method)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text(encoding="utf-8")
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        manager = IDracManager(
+            idrac_ip="mock-gb300",
+            idrac_username="root",
+            idrac_password="mock",
+            idrac_port=8080,
+            insecure=True,
+            is_http=True,
+            is_debug=False,
+        )
+        result = reconcile(
+            manager,
+            DesiredState(
+                ntp_servers=("0.pool.ntp.org",),
+                reset_type="GracefulRestart",
+            ),
+        )
+
+    assert result.dry_run is True
+    assert [(step.kind, step.required) for step in result.steps] == [
+        ("ntp", True),
+        ("reboot", True),
+    ]
+    assert result.applied == ()
+    assert seen_methods
+    assert set(seen_methods) == {"GET"}


### PR DESCRIPTION
## Summary
- Add a dependency-light desired-state reconciler over the existing SyncInvoker interface.
- Support BIOS profile diff/apply, NTP, one-time boot, and reboot with dry-run as the default.
- Document the safety model and CRD-style desired-state mapping.

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q tests/test_reconcile_core.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/reconcile.py tests/test_reconcile_core.py
- /usr/bin/env -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD -u REDFISH_PORT -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q