### PR TITLE
Add Kubernetes sandbox harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,12 +44,7 @@ docker-image: ## Build the production CLI image locally.
 	$(DOCKER) build -f docker/Dockerfile -t $(IMAGE) .
 
 k8s-sandbox: ## Run the local Kubernetes read-path sandbox when present.
-	@test -f k8s/sandbox/kind-config.yaml || { \
-		printf '%s\n' 'k8s/sandbox/kind-config.yaml is not present yet.'; \
-		printf '%s\n' 'Add the sandbox manifests and smoke script before using this target.'; \
-		exit 2; \
-	}
-	@printf '%s\n' 'Run the sandbox smoke harness from k8s/sandbox/.'
+	./k8s/sandbox/run-sandbox.sh
 
 clean: ## Remove local build, test, and type-check artifacts.
 	rm -rf build dist *.egg-info .coverage htmlcov .pytest_cache .ruff_cache .mypy_cache

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -1,0 +1,33 @@
+# Read-only RedfishEndpoint controller image for the local Kubernetes sandbox.
+#
+# Build:
+#   docker build -f docker/Dockerfile.controller -t redfish-ctl-controller:local .
+FROM python:3.12-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN groupadd --system redfish \
+    && useradd \
+        --system \
+        --gid redfish \
+        --home-dir /home/redfish \
+        --create-home \
+        redfish
+
+WORKDIR /app
+
+COPY pyproject.toml setup.py requirements.txt README.md LICENSE ./
+COPY idrac_ctl ./idrac_ctl
+COPY redfish_ctl ./redfish_ctl
+COPY k8s/controller ./k8s/controller
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-cache-dir . "kopf>=1.37" "kubernetes>=29" \
+    && python -m pip check
+
+USER redfish
+
+ENTRYPOINT ["kopf"]
+CMD ["run", "--standalone", "/app/k8s/controller/redfish_endpoint_controller.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,6 +8,8 @@ non-root user. Credentials are supplied at container runtime only; do not add th
 | --- | --- | --- |
 | `docker/Dockerfile` | Production CLI/exporter image with the OTLP extra installed. | `docker build -f docker/Dockerfile -t redfish-ctl .` |
 | `docker/Dockerfile.test` | Linux image for the offline pytest suite. | `./docker/run-tests.sh` |
+| `docker/Dockerfile.mock-bmc` | Read-only mock BMC image for the kind sandbox. | `docker build -f docker/Dockerfile.mock-bmc -t redfish-ctl-mock-bmc:local .` |
+| `docker/Dockerfile.controller` | RedfishEndpoint controller image for the kind sandbox. | `docker build -f docker/Dockerfile.controller -t redfish-ctl-controller:local .` |
 
 ## Runtime Environment
 

--- a/k8s/controller/deployment.yaml
+++ b/k8s/controller/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redfish-endpoint-controller
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-endpoint-controller
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redfish-endpoint-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redfish-endpoint-controller
+        app.kubernetes.io/component: redfish-sandbox
+    spec:
+      serviceAccountName: redfish-endpoint-controller
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: controller
+          image: redfish-ctl-controller:local
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - --standalone
+            - /app/k8s/controller/redfish_endpoint_controller.py
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/k8s/controller/rbac.yaml
+++ b/k8s/controller/rbac.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redfish-endpoint-controller
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-endpoint-controller
+    app.kubernetes.io/component: redfish-sandbox
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: redfish-endpoint-controller
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-endpoint-controller
+    app.kubernetes.io/component: redfish-sandbox
+rules:
+  - apiGroups:
+      - redfish.ctl.dev
+    resources:
+      - redfishendpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - redfish.ctl.dev
+    resources:
+      - redfishendpoints/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: redfish-endpoint-controller
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-endpoint-controller
+    app.kubernetes.io/component: redfish-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: redfish-endpoint-controller
+subjects:
+  - kind: ServiceAccount
+    name: redfish-endpoint-controller
+    namespace: redfish-sandbox

--- a/k8s/sandbox/README.md
+++ b/k8s/sandbox/README.md
@@ -1,0 +1,23 @@
+# Kubernetes Sandbox
+
+The `make k8s-sandbox` target runs an opt-in local read-path check with `kind`.
+It builds the mock BMC image from `docker/Dockerfile.mock-bmc`, builds the
+controller image from `docker/Dockerfile.controller`, loads both images into the
+cluster named by `KIND_CLUSTER_NAME`, then applies the sample
+`RedfishEndpoint` custom resource defined in `k8s/sandbox/redfish-endpoint-sample.yaml`.
+
+Required local tools:
+
+- `docker`
+- `kind`
+- `kubectl`
+
+Run the sandbox from the repository root:
+
+```bash
+make k8s-sandbox
+```
+
+The smoke check waits until `.status.powerState` is populated on the sample
+resource. The mock BMC serves only the committed GB300 corpus and rejects
+mutating HTTP verbs.

--- a/k8s/sandbox/kind-config.yaml
+++ b/k8s/sandbox/kind-config.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane

--- a/k8s/sandbox/namespace.yaml
+++ b/k8s/sandbox/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: redfish-sandbox
+  labels:
+    app.kubernetes.io/component: redfish-sandbox

--- a/k8s/sandbox/redfish-endpoint-sample.yaml
+++ b/k8s/sandbox/redfish-endpoint-sample.yaml
@@ -1,0 +1,12 @@
+apiVersion: redfish.ctl.dev/v1alpha1
+kind: RedfishEndpoint
+metadata:
+  name: gb300-mock
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  address: http://mock-bmc.redfish-sandbox.svc.cluster.local
+  port: 80
+  insecure: true
+  pollInterval: 10s

--- a/k8s/sandbox/run-sandbox.sh
+++ b/k8s/sandbox/run-sandbox.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Build and run the local read-path Kubernetes sandbox.
+set -euo pipefail
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-redfish-sandbox}"
+KIND_CONFIG="${KIND_CONFIG:-k8s/sandbox/kind-config.yaml}"
+NAMESPACE="${NAMESPACE:-redfish-sandbox}"
+STATUS_TIMEOUT_SECONDS="${STATUS_TIMEOUT_SECONDS:-180}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+require_tool() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		printf 'missing required tool: %s\n' "$1" >&2
+		exit 127
+	fi
+}
+
+section() {
+	printf '\n>> %s\n' "$1"
+}
+
+require_tool docker
+require_tool kind
+require_tool kubectl
+
+section "building sandbox images"
+docker build \
+	-f docker/Dockerfile.mock-bmc \
+	-t redfish-ctl-mock-bmc:local \
+	.
+docker build \
+	-f docker/Dockerfile.controller \
+	-t redfish-ctl-controller:local \
+	.
+
+if kind get clusters | grep -Fxq "${KIND_CLUSTER_NAME}"; then
+	section "using existing kind cluster ${KIND_CLUSTER_NAME}"
+else
+	section "creating kind cluster ${KIND_CLUSTER_NAME}"
+	kind create cluster --name "${KIND_CLUSTER_NAME}" --config "${KIND_CONFIG}"
+fi
+
+section "loading images into kind"
+kind load docker-image redfish-ctl-mock-bmc:local --name "${KIND_CLUSTER_NAME}"
+kind load docker-image redfish-ctl-controller:local --name "${KIND_CLUSTER_NAME}"
+
+section "applying sandbox resources"
+kubectl apply -f k8s/sandbox/namespace.yaml
+kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml
+kubectl apply -f k8s/sandbox/mock-bmc.yaml
+kubectl apply -f k8s/controller/rbac.yaml
+kubectl apply -f k8s/controller/deployment.yaml
+kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml
+
+section "waiting for deployments"
+kubectl -n "${NAMESPACE}" rollout status deploy/mock-bmc --timeout=120s
+kubectl -n "${NAMESPACE}" \
+	rollout status deploy/redfish-endpoint-controller \
+	--timeout=120s
+
+section "waiting for RedfishEndpoint status"
+deadline=$((SECONDS + STATUS_TIMEOUT_SECONDS))
+power_state=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+	power_state="$(
+		kubectl -n "${NAMESPACE}" \
+			get redfishendpoint gb300-mock \
+			-o 'jsonpath={.status.powerState}' 2>/dev/null || true
+	)"
+	if [ -n "$power_state" ]; then
+		printf 'RedfishEndpoint gb300-mock powerState=%s\n' "$power_state"
+		exit 0
+	fi
+	sleep 5
+done
+
+printf 'timed out waiting for RedfishEndpoint status.powerState\n' >&2
+kubectl -n "${NAMESPACE}" get redfishendpoint gb300-mock -o yaml || true
+exit 1

--- a/tests/test_k8s_sandbox_harness.py
+++ b/tests/test_k8s_sandbox_harness.py
@@ -1,0 +1,136 @@
+"""Contracts for the local Kubernetes read-path sandbox harness."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+KIND_CONFIG = REPO_ROOT / "k8s" / "sandbox" / "kind-config.yaml"
+SMOKE_SCRIPT = REPO_ROOT / "k8s" / "sandbox" / "run-sandbox.sh"
+SAMPLE_ENDPOINT = REPO_ROOT / "k8s" / "sandbox" / "redfish-endpoint-sample.yaml"
+CONTROLLER_DEPLOYMENT = REPO_ROOT / "k8s" / "controller" / "deployment.yaml"
+CONTROLLER_RBAC = REPO_ROOT / "k8s" / "controller" / "rbac.yaml"
+CONTROLLER_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.controller"
+MAKEFILE = REPO_ROOT / "Makefile"
+
+
+def _yaml_documents(path: Path) -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(path.read_text(encoding="utf-8")) if doc]
+
+
+def test_kind_config_defines_a_local_redfish_sandbox_cluster() -> None:
+    """The kind config keeps the sandbox local and single-node."""
+    config = yaml.safe_load(KIND_CONFIG.read_text(encoding="utf-8"))
+
+    assert config["kind"] == "Cluster"
+    assert config["apiVersion"] == "kind.x-k8s.io/v1alpha4"
+    assert config["nodes"] == [{"role": "control-plane"}]
+
+
+def test_sample_endpoint_points_at_mock_bmc_without_credentials() -> None:
+    """The sample CR reads the in-cluster mock BMC without embedding secrets."""
+    endpoint = yaml.safe_load(SAMPLE_ENDPOINT.read_text(encoding="utf-8"))
+
+    assert endpoint["apiVersion"] == "redfish.ctl.dev/v1alpha1"
+    assert endpoint["kind"] == "RedfishEndpoint"
+    assert endpoint["metadata"]["name"] == "gb300-mock"
+    assert endpoint["metadata"]["namespace"] == "redfish-sandbox"
+    assert endpoint["spec"] == {
+        "address": "http://mock-bmc.redfish-sandbox.svc.cluster.local",
+        "port": 80,
+        "insecure": True,
+        "pollInterval": "10s",
+    }
+    assert "secretRef" not in endpoint["spec"]
+    assert "PASSWORD" not in SAMPLE_ENDPOINT.read_text(encoding="utf-8")
+
+
+def test_controller_deployment_is_read_only_and_uses_local_image() -> None:
+    """The sandbox controller can patch status but has no BMC write path."""
+    docs = _yaml_documents(CONTROLLER_RBAC)
+    deployment = yaml.safe_load(CONTROLLER_DEPLOYMENT.read_text(encoding="utf-8"))
+    role = next(doc for doc in docs if doc["kind"] == "Role")
+    service_account = next(doc for doc in docs if doc["kind"] == "ServiceAccount")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert service_account["metadata"]["name"] == "redfish-endpoint-controller"
+    assert deployment["metadata"]["namespace"] == "redfish-sandbox"
+    assert container["image"] == "redfish-ctl-controller:local"
+    assert container["imagePullPolicy"] == "IfNotPresent"
+    assert container["securityContext"]["allowPrivilegeEscalation"] is False
+    assert deployment["spec"]["template"]["spec"]["securityContext"]["runAsNonRoot"] is True
+    assert container["args"] == [
+        "run",
+        "--standalone",
+        "/app/k8s/controller/redfish_endpoint_controller.py",
+    ]
+
+    redfish_rules = [
+        rule
+        for rule in role["rules"]
+        if "redfish.ctl.dev" in rule.get("apiGroups", [])
+    ]
+    assert redfish_rules
+    allowed_verbs = set().union(*(set(rule["verbs"]) for rule in redfish_rules))
+    assert {"get", "list", "watch", "patch", "update"} <= allowed_verbs
+    assert "delete" not in allowed_verbs
+    assert "create" not in allowed_verbs
+
+    secret_rules = [
+        rule
+        for rule in role["rules"]
+        if "" in rule.get("apiGroups", []) and "secrets" in rule.get("resources", [])
+    ]
+    assert secret_rules == [
+        {
+            "apiGroups": [""],
+            "resources": ["secrets"],
+            "verbs": ["get"],
+        }
+    ]
+
+
+def test_controller_image_runs_kopf_without_credentials() -> None:
+    """The controller image installs runtime deps and starts the Kopf module."""
+    dockerfile = CONTROLLER_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "FROM python:3.12-slim" in dockerfile
+    assert "redfish_ctl" in dockerfile
+    assert "kopf" in dockerfile
+    assert "kubernetes" in dockerfile
+    assert "USER redfish" in dockerfile
+    assert 'ENTRYPOINT ["kopf"]' in dockerfile
+    assert "redfish_endpoint_controller.py" in dockerfile
+    assert "REDFISH_PASSWORD" not in dockerfile
+    assert "IDRAC_PASSWORD" not in dockerfile
+
+
+def test_sandbox_smoke_script_applies_manifests_and_waits_for_status() -> None:
+    """The opt-in smoke harness proves the CR status is populated."""
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+    mode = os.stat(SMOKE_SCRIPT).st_mode
+
+    assert mode & stat.S_IXUSR
+    assert "kind create cluster --name \"${KIND_CLUSTER_NAME}\"" in script
+    assert "kind load docker-image redfish-ctl-mock-bmc:local" in script
+    assert "kind load docker-image redfish-ctl-controller:local" in script
+    assert "kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml" in script
+    assert "kubectl apply -f k8s/sandbox/mock-bmc.yaml" in script
+    assert "kubectl apply -f k8s/controller/rbac.yaml" in script
+    assert "kubectl apply -f k8s/controller/deployment.yaml" in script
+    assert "kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml" in script
+    assert "jsonpath={.status.powerState}" in script
+    assert "kubectl delete" not in script
+    assert "docker push" not in script
+
+
+def test_make_k8s_sandbox_invokes_smoke_harness() -> None:
+    """The Makefile target should run the DS4 harness, not a placeholder."""
+    makefile = MAKEFILE.read_text(encoding="utf-8")
+
+    assert "k8s/sandbox/run-sandbox.sh" in makefile
+    assert "kind-config.yaml is not present yet" not in makefile


### PR DESCRIPTION
## Summary

- Add a local kind sandbox config, namespace, and sample `RedfishEndpoint` that points at the in-cluster mock BMC.
- Add the controller image, deployment, and RBAC needed to run the read-only status controller in the sandbox.
- Wire `make k8s-sandbox` to a smoke harness that builds/loads images, applies manifests, and waits for `.status.powerState`.
- Add offline contract tests and document the sandbox images.

## Validation

- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check tests/test_k8s_sandbox_harness.py`
- `/opt/homebrew/bin/bash -n k8s/sandbox/run-sandbox.sh`
- `/opt/homebrew/bin/shellcheck k8s/sandbox/run-sandbox.sh`
- `/opt/homebrew/bin/shfmt -d k8s/sandbox/run-sandbox.sh`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q tests/test_k8s_sandbox_harness.py tests/test_k8s_controller.py tests/test_k8s_mock_bmc_server.py tests/test_makefile_targets.py` (`17 passed`)
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD -u REDFISH_PORT -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT pytest -q` (`828 passed, 57 skipped`)

The kind smoke target itself is opt-in and was not run locally.