### PR TITLE
Add BIOS profile API facade helpers

### DIFF
--- a/redfish_ctl/api.py
+++ b/redfish_ctl/api.py
@@ -171,6 +171,40 @@ class RebootResult:
     raw: Mapping[str, Any]
 
 
+@dataclass(frozen=True)
+class BiosProfileAttributeDiff:
+    """One BIOS attribute comparison row from bios-profile diff."""
+
+    attribute: str | None
+    current: Any
+    desired: Any
+    status: str | None
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class BiosProfileDiffResult:
+    """Typed result from the bios-profile diff action."""
+
+    profile: Mapping[str, Any]
+    matches: bool
+    summary: Mapping[str, Any]
+    attributes: tuple[BiosProfileAttributeDiff, ...]
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class BiosProfileApplyResult:
+    """Typed result from the guarded bios-profile apply action."""
+
+    profile: str | None
+    dry_run: bool
+    change: Mapping[str, Any]
+    rollback: Mapping[str, Any]
+    staged: Mapping[str, Any]
+    raw: Mapping[str, Any]
+
+
 def _invoke(
     manager: SyncInvoker,
     api_call: ApiRequestType,
@@ -410,5 +444,68 @@ def reboot(
         payload=payload,
         task_id=data.get("task_id"),
         task_state=data.get("task_state"),
+        raw=data,
+    )
+
+
+def bios_profile_diff(
+    manager: SyncInvoker,
+    profile_name: str,
+) -> BiosProfileDiffResult:
+    """Return a typed BIOS profile diff through bios-profile diff."""
+    data = _mapping(
+        _invoke(
+            manager,
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            action="diff",
+            profile_name=profile_name,
+        )
+    )
+    attributes = tuple(
+        BiosProfileAttributeDiff(
+            attribute=row.get("attribute"),
+            current=row.get("current"),
+            desired=row.get("desired"),
+            status=row.get("status"),
+            raw=row,
+        )
+        for row in _rows(data.get("attributes"))
+    )
+    return BiosProfileDiffResult(
+        profile=_mapping(data.get("profile")),
+        matches=bool(data.get("matches", False)),
+        summary=_mapping(data.get("summary")),
+        attributes=attributes,
+        raw=data,
+    )
+
+
+def bios_profile_apply(
+    manager: SyncInvoker,
+    profile_name: str,
+    *,
+    confirm: bool = False,
+    dry_run: bool = False,
+) -> BiosProfileApplyResult:
+    """Preview or stage a BIOS profile through guarded bios-profile apply."""
+    data = _mapping(
+        _invoke(
+            manager,
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            action="apply",
+            profile_name=profile_name,
+            confirm=confirm,
+            dry_run=dry_run,
+        )
+    )
+    profile = data.get("profile")
+    return BiosProfileApplyResult(
+        profile=profile if isinstance(profile, str) else None,
+        dry_run=bool(data.get("dry_run", not confirm)),
+        change=_mapping(data.get("change")),
+        rollback=_mapping(data.get("rollback")),
+        staged=_mapping(data.get("staged")),
         raw=data,
     )

--- a/tests/test_api_facade.py
+++ b/tests/test_api_facade.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import pytest
 
 from redfish_ctl.api import (
+    BiosProfileApplyResult,
+    BiosProfileAttributeDiff,
+    BiosProfileDiffResult,
     FanReading,
     GpuMetricRow,
     GpuMetricsStatus,
@@ -18,6 +21,8 @@ from redfish_ctl.api import (
     SystemStatus,
     TemperatureReading,
     ThermalStatus,
+    bios_profile_apply,
+    bios_profile_diff,
     get_gpu_metrics,
     get_sensors,
     get_system,
@@ -499,6 +504,122 @@ def test_reboot_confirm_invokes_host_reset_and_maps_task_result():
     ]
 
 
+def test_bios_profile_diff_returns_typed_attribute_rows():
+    """bios_profile_diff exposes the guarded diff command result."""
+    payload = {
+        "profile": {
+            "name": "gb300-power-capped",
+            "vendor": "supermicro",
+            "model": "gb300",
+            "risk": "medium",
+        },
+        "matches": False,
+        "summary": {"total": 2, "matching": 1, "different": 1, "missing": 0},
+        "attributes": [
+            {
+                "attribute": "ServerPowerControl",
+                "current": "Performance",
+                "desired": "Efficiency",
+                "status": "different",
+            },
+            {
+                "attribute": "ActiveCores",
+                "current": "All",
+                "desired": "All",
+                "status": "matching",
+            },
+        ],
+    }
+    manager = RecordingManager({
+        (ApiRequestType.BiosProfile, "bios-profile"): CommandResult(
+            payload,
+            None,
+            None,
+            None,
+        )
+    })
+
+    result = bios_profile_diff(manager, "gb300-power-capped")
+
+    assert result == BiosProfileDiffResult(
+        profile=payload["profile"],
+        matches=False,
+        summary=payload["summary"],
+        attributes=(
+            BiosProfileAttributeDiff(
+                attribute="ServerPowerControl",
+                current="Performance",
+                desired="Efficiency",
+                status="different",
+                raw=payload["attributes"][0],
+            ),
+            BiosProfileAttributeDiff(
+                attribute="ActiveCores",
+                current="All",
+                desired="All",
+                status="matching",
+                raw=payload["attributes"][1],
+            ),
+        ),
+        raw=payload,
+    )
+    assert manager.calls == [
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            {
+                "action": "diff",
+                "profile_name": "gb300-power-capped",
+            },
+        )
+    ]
+
+
+def test_bios_profile_apply_previews_by_default():
+    """bios_profile_apply delegates to apply without confirming by default."""
+    payload = {
+        "profile": "gb300-power-capped",
+        "dry_run": True,
+        "change": {"Attributes": {"ServerPowerControl": "Efficiency"}},
+        "rollback": {"Attributes": {"ServerPowerControl": "Performance"}},
+        "staged": {
+            "Attributes": {"ServerPowerControl": "Efficiency"},
+            "preview": True,
+        },
+    }
+    manager = RecordingManager({
+        (ApiRequestType.BiosProfile, "bios-profile"): CommandResult(
+            payload,
+            None,
+            None,
+            None,
+        )
+    })
+
+    result = bios_profile_apply(manager, "gb300-power-capped")
+
+    assert result == BiosProfileApplyResult(
+        profile="gb300-power-capped",
+        dry_run=True,
+        change=payload["change"],
+        rollback=payload["rollback"],
+        staged=payload["staged"],
+        raw=payload,
+    )
+    assert manager.calls == [
+        (
+            ApiRequestType.BiosProfile,
+            "bios-profile",
+            {
+                "action": "apply",
+                "profile_name": "gb300-power-capped",
+                "confirm": False,
+                "dry_run": False,
+            },
+        )
+    ]
+
+
 def test_facade_wrappers_read_gb300_corpus_through_command_registry(
     gb300_corpus_manager,
 ):
@@ -511,6 +632,7 @@ def test_facade_wrappers_read_gb300_corpus_through_command_registry(
     gpu_metrics = get_gpu_metrics(manager)
     ntp = set_ntp(manager, ["0.pool.ntp.org"])
     reset_preview = reboot(manager)
+    profile_diff = bios_profile_diff(manager, "gb300-power-capped")
 
     assert system.id == "System_0"
     assert system.name == "System_0"
@@ -556,6 +678,9 @@ def test_facade_wrappers_read_gb300_corpus_through_command_registry(
         "/redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset"
     )
     assert reset_preview.payload == {"ResetType": "GracefulRestart"}
+    assert profile_diff.profile["name"] == "gb300-power-capped"
+    assert profile_diff.summary["total"] == 1
+    assert profile_diff.attributes
 
     paths = {request.path.lower() for request in requests}
     assert "/redfish/v1/systems/system_0" in paths


### PR DESCRIPTION
## Summary
- Add typed `bios_profile_diff` and `bios_profile_apply` helpers to `redfish_ctl.api`
- Map BIOS profile diff rows and guarded apply previews into frozen dataclasses
- Extend facade tests, including a corpus-backed diff check through the command registry

## Validation
- `conda run -n idrac_ctl pytest -q tests/test_api_facade.py`
- `conda run -n idrac_ctl ruff check redfish_ctl/api.py tests/test_api_facade.py`
- `conda run -n idrac_ctl pytest -q`
