### PR TITLE
Add RedfishNodeProfile controller scaffold

### DIFF
--- a/k8s/controller/redfish-node-profile-crd.yaml
+++ b/k8s/controller/redfish-node-profile-crd.yaml
@@ -1,0 +1,189 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: redfishnodeprofiles.redfish.ctl.dev
+spec:
+  group: redfish.ctl.dev
+  scope: Namespaced
+  names:
+    plural: redfishnodeprofiles
+    singular: redfishnodeprofile
+    kind: RedfishNodeProfile
+    shortNames:
+      - rnp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - endpoint
+                - desiredState
+              properties:
+                endpoint:
+                  type: object
+                  required:
+                    - address
+                  properties:
+                    address:
+                      type: string
+                      minLength: 1
+                      description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                    port:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                      default: 443
+                      description: TCP port for the Redfish endpoint.
+                    insecure:
+                      type: boolean
+                      default: true
+                      description: Skip TLS certificate verification for self-signed BMC certificates.
+                    secretRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          description: Secret in the same namespace containing BMC login data.
+                        usernameKey:
+                          type: string
+                          default: username
+                          description: Secret data key containing the BMC username.
+                        passwordKey:
+                          type: string
+                          default: password
+                          description: Secret data key containing the BMC password.
+                      additionalProperties: false
+                  additionalProperties: false
+                desiredState:
+                  type: object
+                  properties:
+                    biosProfile:
+                      type: string
+                      nullable: true
+                      description: Named BIOS profile to diff or stage through the reconciler.
+                    ntp:
+                      type: object
+                      properties:
+                        servers:
+                          type: array
+                          items:
+                            type: string
+                          maxItems: 4
+                        managerId:
+                          type: string
+                          nullable: true
+                      additionalProperties: false
+                    boot:
+                      type: object
+                      properties:
+                        device:
+                          type: string
+                          nullable: true
+                        mode:
+                          type: string
+                          nullable: true
+                        uefiTarget:
+                          type: string
+                          nullable: true
+                      additionalProperties: false
+                    reboot:
+                      type: object
+                      properties:
+                        resetType:
+                          type: string
+                          nullable: true
+                      additionalProperties: false
+                  additionalProperties: false
+                approve:
+                  type: boolean
+                  default: false
+                  description: Required approval gate before any desired-state changes are applied.
+                waitForReboot:
+                  type: boolean
+                  default: false
+                  description: Wait for the BMC to answer again after an approved reboot step.
+              additionalProperties: false
+            status:
+              type: object
+              properties:
+                dryRun:
+                  type: boolean
+                drift:
+                  type: boolean
+                  nullable: true
+                plannedSteps:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - kind
+                      - required
+                      - description
+                    properties:
+                      kind:
+                        type: string
+                      required:
+                        type: boolean
+                      description:
+                        type: string
+                      preview:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties: false
+                appliedChanges:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - kind
+                      - changed
+                    properties:
+                      kind:
+                        type: string
+                      changed:
+                        type: boolean
+                      result:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties: false
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                      - lastTransitionTime
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                    additionalProperties: false
+                lastReconciled:
+                  type: string
+                  format: date-time
+              additionalProperties: false

--- a/k8s/controller/redfish_node_profile_controller.py
+++ b/k8s/controller/redfish_node_profile_controller.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Desired-state controller for RedfishNodeProfile resources."""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+from typing import Any, Callable, Mapping, MutableMapping
+from urllib.parse import urlsplit
+
+try:  # pragma: no cover - exercised only in a deployed controller image.
+    import kopf
+except ImportError:  # pragma: no cover - unit tests call the handler directly.
+    kopf = None
+
+from redfish_ctl.idrac_manager import IDracManager
+
+REDFISH_GROUP = "redfish.ctl.dev"
+REDFISH_VERSION = "v1alpha1"
+REDFISH_PLURAL = "redfishnodeprofiles"
+DEFAULT_PORT = 443
+DEFAULT_USERNAME = "root"
+
+ManagerFactory = Callable[..., Any]
+ReconcileFunc = Callable[..., Any]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _rfc3339(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    value = value.astimezone(timezone.utc).replace(microsecond=0)
+    return value.isoformat().replace("+00:00", "Z")
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _condition(
+    condition_type: str,
+    status: bool | None,
+    reason: str,
+    *,
+    message: str = "",
+    changed_at: datetime,
+) -> dict[str, str]:
+    if status is True:
+        status_text = "True"
+    elif status is False:
+        status_text = "False"
+    else:
+        status_text = "Unknown"
+    condition = {
+        "type": condition_type,
+        "status": status_text,
+        "reason": reason,
+        "lastTransitionTime": _rfc3339(changed_at),
+    }
+    if message:
+        condition["message"] = message
+    return condition
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _planned_step(step: Any) -> dict[str, Any]:
+    return {
+        "kind": str(getattr(step, "kind", "")),
+        "required": bool(getattr(step, "required", False)),
+        "description": str(getattr(step, "description", "")),
+        "preview": _as_dict(getattr(step, "preview", {})),
+    }
+
+
+def _applied_change(change: Any) -> dict[str, Any]:
+    return {
+        "kind": str(getattr(change, "kind", "")),
+        "changed": bool(getattr(change, "changed", False)),
+        "result": _as_dict(getattr(change, "result", {})),
+    }
+
+
+def build_status(
+    result: Any,
+    *,
+    approved: bool,
+    reconciled_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Return the RedfishNodeProfile status object from a reconcile result."""
+    observed_at = reconciled_at or _utc_now()
+    steps = tuple(getattr(result, "steps", ()))
+    applied = tuple(getattr(result, "applied", ()))
+    planned_steps = [_planned_step(step) for step in steps]
+    applied_changes = [_applied_change(change) for change in applied]
+    drift = any(step["required"] for step in planned_steps)
+    changed = any(change["changed"] for change in applied_changes)
+    if changed:
+        applied_reason = "Applied"
+    elif approved:
+        applied_reason = "NoChanges"
+    else:
+        applied_reason = "DryRun"
+    return {
+        "dryRun": bool(getattr(result, "dry_run", not approved)),
+        "drift": drift,
+        "plannedSteps": planned_steps,
+        "appliedChanges": applied_changes,
+        "conditions": [
+            _condition(
+                "Approved",
+                approved,
+                "Approved" if approved else "ApprovalRequired",
+                changed_at=observed_at,
+            ),
+            _condition(
+                "DriftDetected",
+                drift,
+                "PlanRequiresChanges" if drift else "InSync",
+                changed_at=observed_at,
+            ),
+            _condition(
+                "Applied",
+                bool(changed and approved),
+                applied_reason,
+                changed_at=observed_at,
+            ),
+        ],
+        "lastReconciled": _rfc3339(observed_at),
+    }
+
+
+def build_error_status(
+    message: str,
+    *,
+    reconciled_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Return status for controller failures that occur before reconcile runs."""
+    observed_at = reconciled_at or _utc_now()
+    return {
+        "dryRun": True,
+        "drift": None,
+        "plannedSteps": [],
+        "appliedChanges": [],
+        "conditions": [
+            _condition(
+                "ReconcileAvailable",
+                False,
+                "BackendUnavailable",
+                message=message,
+                changed_at=observed_at,
+            )
+        ],
+        "lastReconciled": _rfc3339(observed_at),
+    }
+
+
+def _endpoint_spec(spec: Mapping[str, Any]) -> Mapping[str, Any]:
+    endpoint = _mapping(spec.get("endpoint"))
+    if not endpoint:
+        raise ValueError("RedfishNodeProfile spec.endpoint is required")
+    return endpoint
+
+
+def _manager_address(endpoint: Mapping[str, Any]) -> tuple[str, int, bool]:
+    raw_address = str(endpoint.get("address") or "").strip()
+    if not raw_address:
+        raise ValueError("RedfishNodeProfile spec.endpoint.address is required")
+
+    parsed = urlsplit(raw_address)
+    if parsed.scheme in {"http", "https"}:
+        host = parsed.hostname or ""
+        if not host:
+            raise ValueError("RedfishNodeProfile endpoint URL requires a host")
+        port = int(parsed.port or endpoint.get("port") or DEFAULT_PORT)
+        return host, port, parsed.scheme == "http"
+
+    return raw_address, int(endpoint.get("port") or DEFAULT_PORT), False
+
+
+def _make_manager(
+    endpoint: Mapping[str, Any],
+    credentials: Mapping[str, str],
+    manager_factory: ManagerFactory,
+) -> Any:
+    address, port, is_http = _manager_address(endpoint)
+    return manager_factory(
+        idrac_ip=address,
+        idrac_username=credentials.get("username", DEFAULT_USERNAME),
+        idrac_password=credentials.get("password", ""),
+        idrac_port=port,
+        insecure=bool(endpoint.get("insecure", True)),
+        is_http=is_http,
+        is_debug=False,
+    )
+
+
+def _load_reconcile_func() -> ReconcileFunc:
+    try:
+        from redfish_ctl.reconcile import reconcile
+    except ImportError as exc:  # pragma: no cover - depends on merge order.
+        raise RuntimeError("redfish_ctl.reconcile is unavailable") from exc
+    return reconcile
+
+
+def reconcile_profile(
+    spec: Mapping[str, Any],
+    *,
+    credentials: Mapping[str, str] | None = None,
+    manager_factory: ManagerFactory = IDracManager,
+    reconcile_func: ReconcileFunc | None = None,
+    reconciled_at: datetime | None = None,
+) -> dict[str, Any]:
+    """Plan or apply the desired state from a RedfishNodeProfile spec."""
+    endpoint = _endpoint_spec(spec)
+    desired_state = _mapping(spec.get("desiredState"))
+    manager = _make_manager(endpoint, credentials or {}, manager_factory)
+    approved = bool(spec.get("approve", False))
+    result = (reconcile_func or _load_reconcile_func())(
+        manager,
+        desired_state,
+        confirm=approved,
+        wait_for_reboot=bool(spec.get("waitForReboot", False)),
+        async_call=False,
+    )
+    return build_status(result, approved=approved, reconciled_at=reconciled_at)
+
+
+def _decode_secret_value(data: Mapping[str, str], key: str) -> str | None:
+    encoded = data.get(key)
+    if not encoded:
+        return None
+    return base64.b64decode(encoded).decode("utf-8")
+
+
+def load_secret_credentials(
+    namespace: str | None,
+    secret_ref: Mapping[str, Any] | None,
+) -> dict[str, str]:
+    """Read credentials from the Secret named by spec.endpoint.secretRef when available."""
+    if not namespace or not secret_ref or not secret_ref.get("name"):
+        return {}
+    try:  # pragma: no cover - requires a Kubernetes client in-cluster or locally.
+        from kubernetes import client, config
+    except ImportError:  # pragma: no cover - controller images carry this dependency.
+        return {}
+
+    try:  # pragma: no cover - not exercised by offline tests.
+        config.load_incluster_config()
+    except Exception:
+        try:
+            config.load_kube_config()
+        except Exception:
+            return {}
+
+    api = client.CoreV1Api()
+    secret = api.read_namespaced_secret(str(secret_ref["name"]), namespace)
+    data = secret.data or {}
+    username_key = str(secret_ref.get("usernameKey") or "username")
+    password_key = str(secret_ref.get("passwordKey") or "password")
+    credentials: dict[str, str] = {}
+    username = _decode_secret_value(data, username_key)
+    password = _decode_secret_value(data, password_key)
+    if username is not None:
+        credentials["username"] = username
+    if password is not None:
+        credentials["password"] = password
+    return credentials
+
+
+def reconcile_redfish_node_profile(
+    spec: Mapping[str, Any],
+    body: Mapping[str, Any] | None = None,
+    namespace: str | None = None,
+    name: str | None = None,
+    logger: Any | None = None,
+    patch: MutableMapping[str, Any] | None = None,
+    **_: Any,
+) -> dict[str, Any]:
+    """Kopf callback that updates only the RedfishNodeProfile status subresource."""
+    endpoint = _mapping(spec.get("endpoint"))
+    credentials = load_secret_credentials(namespace, endpoint.get("secretRef"))
+    try:
+        status = reconcile_profile(spec, credentials=credentials)
+    except Exception as exc:
+        status = build_error_status(str(exc))
+    if patch is not None:
+        patch.setdefault("status", {}).update(status)
+    if logger is not None:
+        logger.info("reconciled RedfishNodeProfile %s/%s", namespace or "", name or "")
+    return {"status": status}
+
+
+if kopf is not None:  # pragma: no cover - decorator wiring is runtime-only.
+    reconcile_redfish_node_profile = kopf.on.create(
+        REDFISH_GROUP,
+        REDFISH_VERSION,
+        REDFISH_PLURAL,
+    )(reconcile_redfish_node_profile)
+    reconcile_redfish_node_profile = kopf.on.update(
+        REDFISH_GROUP,
+        REDFISH_VERSION,
+        REDFISH_PLURAL,
+    )(reconcile_redfish_node_profile)
+    reconcile_redfish_node_profile = kopf.timer(
+        REDFISH_GROUP,
+        REDFISH_VERSION,
+        REDFISH_PLURAL,
+        interval=30,
+        sharp=True,
+    )(reconcile_redfish_node_profile)

--- a/tests/test_k8s_node_profile_controller.py
+++ b/tests/test_k8s_node_profile_controller.py
@@ -1,0 +1,237 @@
+"""Contracts for the Kubernetes RedfishNodeProfile controller."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTROLLER_MODULE = REPO_ROOT / "k8s" / "controller" / "redfish_node_profile_controller.py"
+CRD_MANIFEST = REPO_ROOT / "k8s" / "controller" / "redfish-node-profile-crd.yaml"
+
+
+class FakeStep:
+    """Small reconcile step object matching the public attributes the controller reads."""
+
+    def __init__(self, kind: str, required: bool, description: str) -> None:
+        self.kind = kind
+        self.required = required
+        self.description = description
+        self.preview = {"kind": kind}
+
+
+class FakeAppliedChange:
+    """Small applied-change object matching the reconciler result contract."""
+
+    def __init__(self, kind: str, changed: bool) -> None:
+        self.kind = kind
+        self.changed = changed
+        self.result = {"kind": kind, "changed": changed}
+
+
+class FakeResult:
+    """Small reconcile result object matching the attributes used by status rendering."""
+
+    def __init__(self, *, dry_run: bool, applied: tuple[FakeAppliedChange, ...] = ()) -> None:
+        self.dry_run = dry_run
+        self.steps = (
+            FakeStep("bios-profile", True, "BIOS profile gb300-power-capped"),
+            FakeStep("ntp", False, "Manager NTP servers"),
+        )
+        self.applied = applied
+
+
+def _load_controller_module():
+    spec = importlib.util.spec_from_file_location(
+        "redfish_node_profile_controller",
+        CONTROLLER_MODULE,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_crd_schema_pins_profile_spec_and_status_shape() -> None:
+    """The profile CRD keeps desired state explicit and approval separate."""
+    crd = yaml.safe_load(CRD_MANIFEST.read_text(encoding="utf-8"))
+    schema = crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]
+    spec_props = schema["properties"]["spec"]["properties"]
+    status_props = schema["properties"]["status"]["properties"]
+
+    assert crd["kind"] == "CustomResourceDefinition"
+    assert crd["spec"]["names"]["kind"] == "RedfishNodeProfile"
+    assert crd["spec"]["scope"] == "Namespaced"
+    assert set(spec_props) == {
+        "endpoint",
+        "desiredState",
+        "approve",
+        "waitForReboot",
+    }
+    assert spec_props["approve"]["default"] is False
+    endpoint_props = spec_props["endpoint"]["properties"]
+    assert set(endpoint_props) == {
+        "address",
+        "port",
+        "insecure",
+        "secretRef",
+    }
+    desired_props = spec_props["desiredState"]["properties"]
+    assert set(desired_props) == {
+        "biosProfile",
+        "ntp",
+        "boot",
+        "reboot",
+    }
+    assert set(status_props) == {
+        "dryRun",
+        "drift",
+        "plannedSteps",
+        "appliedChanges",
+        "conditions",
+        "lastReconciled",
+    }
+
+
+def test_build_status_reports_drift_without_apply_when_unapproved() -> None:
+    """Status keeps drift visible while showing that unapproved resources are dry-runs."""
+    module = _load_controller_module()
+    status = module.build_status(
+        FakeResult(dry_run=True),
+        approved=False,
+        reconciled_at=datetime(2026, 7, 10, 22, 40, tzinfo=timezone.utc),
+    )
+
+    assert status["dryRun"] is True
+    assert status["drift"] is True
+    assert status["plannedSteps"][0] == {
+        "kind": "bios-profile",
+        "required": True,
+        "description": "BIOS profile gb300-power-capped",
+        "preview": {"kind": "bios-profile"},
+    }
+    assert status["appliedChanges"] == []
+    conditions = {item["type"]: item for item in status["conditions"]}
+    assert conditions["Approved"]["status"] == "False"
+    assert conditions["Approved"]["reason"] == "ApprovalRequired"
+    assert conditions["DriftDetected"]["status"] == "True"
+    assert conditions["Applied"]["status"] == "False"
+    assert conditions["Applied"]["reason"] == "DryRun"
+    assert status["lastReconciled"] == "2026-07-10T22:40:00Z"
+
+
+def test_reconcile_profile_requires_approval_before_confirming() -> None:
+    """The controller never applies desired state until spec.approve is true."""
+    module = _load_controller_module()
+    calls: list[dict] = []
+
+    def fake_reconcile(manager, desired, **kwargs):
+        calls.append({"manager": manager, "desired": desired, **kwargs})
+        return FakeResult(dry_run=not kwargs["confirm"])
+
+    status = module.reconcile_profile(
+        {
+            "endpoint": {"address": "mock-bmc", "secretRef": {"name": "bmc-login"}},
+            "desiredState": {"biosProfile": "gb300-power-capped"},
+        },
+        credentials={"username": "root", "password": "mock"},
+        manager_factory=lambda **kwargs: kwargs,
+        reconcile_func=fake_reconcile,
+        reconciled_at=datetime(2026, 7, 10, 22, 45, tzinfo=timezone.utc),
+    )
+
+    assert calls == [
+        {
+            "manager": {
+                "idrac_ip": "mock-bmc",
+                "idrac_username": "root",
+                "idrac_password": "mock",
+                "idrac_port": 443,
+                "insecure": True,
+                "is_http": False,
+                "is_debug": False,
+            },
+            "desired": {"biosProfile": "gb300-power-capped"},
+            "confirm": False,
+            "wait_for_reboot": False,
+            "async_call": False,
+        }
+    ]
+    assert status["dryRun"] is True
+    assert {item["type"]: item["status"] for item in status["conditions"]}["Approved"] == "False"
+
+
+def test_reconcile_profile_confirms_only_when_approved() -> None:
+    """An approved profile may call the reconciler with confirm enabled."""
+    module = _load_controller_module()
+    calls: list[dict] = []
+
+    def fake_reconcile(manager, desired, **kwargs):
+        calls.append(kwargs)
+        return FakeResult(
+            dry_run=False,
+            applied=(FakeAppliedChange("bios-profile", True),),
+        )
+
+    status = module.reconcile_profile(
+        {
+            "endpoint": {"address": "https://mock-bmc:8443", "secretRef": {"name": "bmc-login"}},
+            "desiredState": {"biosProfile": "gb300-power-capped"},
+            "approve": True,
+            "waitForReboot": True,
+        },
+        credentials={"username": "root", "password": "mock"},
+        manager_factory=lambda **kwargs: kwargs,
+        reconcile_func=fake_reconcile,
+        reconciled_at=datetime(2026, 7, 10, 22, 50, tzinfo=timezone.utc),
+    )
+
+    assert calls == [
+        {
+            "confirm": True,
+            "wait_for_reboot": True,
+            "async_call": False,
+        }
+    ]
+    assert status["dryRun"] is False
+    assert status["appliedChanges"] == [
+        {
+            "kind": "bios-profile",
+            "changed": True,
+            "result": {"kind": "bios-profile", "changed": True},
+        }
+    ]
+    conditions = {item["type"]: item for item in status["conditions"]}
+    assert conditions["Approved"]["status"] == "True"
+    assert conditions["Applied"]["status"] == "True"
+
+
+def test_kopf_handler_reports_reconciler_load_errors_as_status(monkeypatch) -> None:
+    """A missing reconcile backend becomes a status condition instead of an exception."""
+    module = _load_controller_module()
+
+    def fake_reconcile_profile(*args, **kwargs):
+        raise RuntimeError("redfish_ctl.reconcile is unavailable")
+
+    monkeypatch.setattr(module, "reconcile_profile", fake_reconcile_profile)
+
+    patch = module.reconcile_redfish_node_profile(
+        spec={
+            "endpoint": {"address": "mock-bmc"},
+            "desiredState": {"biosProfile": "gb300-power-capped"},
+        },
+        body={},
+        namespace="default",
+        name="node-a",
+        logger=None,
+    )
+
+    assert patch["status"]["dryRun"] is True
+    assert patch["status"]["drift"] is None
+    conditions = {item["type"]: item for item in patch["status"]["conditions"]}
+    assert conditions["ReconcileAvailable"]["status"] == "False"
+    assert conditions["ReconcileAvailable"]["reason"] == "BackendUnavailable"
+    assert "unavailable" in conditions["ReconcileAvailable"]["message"]


### PR DESCRIPTION
Summary:
- Add a RedfishNodeProfile CRD for endpoint connection data, desired state, approval, and reboot waiting.
- Add a controller handler that reports drift by default and only calls the reconciler with confirm=True when spec.approve is true.
- Add offline tests for the CRD schema, status conditions, approval gate, and unavailable reconciler status.

Tests:
- conda run -n idrac_ctl pytest -q tests/test_k8s_node_profile_controller.py
- conda run -n idrac_ctl pytest -q
- conda run -n idrac_ctl ruff check k8s/controller/redfish_node_profile_controller.py tests/test_k8s_node_profile_controller.py