### PR TITLE
Add proxy telemetry sample endpoint

### DIFF
--- a/docs/redfish-proxy.md
+++ b/docs/redfish-proxy.md
@@ -52,6 +52,10 @@ The optional FastAPI adapter, defined in `redfish_ctl/proxy/fastapi_app.py`, imp
 `create_app()` is called. That keeps the CLI install dependency-light while still providing the route
 binding for deployments that install an ASGI runtime.
 
+The routes below are bound by `create_app()`, the adapter function in
+`redfish_ctl/proxy/fastapi_app.py`, and implemented by `ReadOnlyProxy`, the read facade in
+`redfish_ctl/proxy/core.py`.
+
 | Method | Path | Backing read |
 | --- | --- | --- |
 | `GET` | `/nodes` | Sanitized `NodeRegistry` inventory |
@@ -59,6 +63,7 @@ binding for deployments that install an ASGI runtime.
 | `GET` | `/nodes/{node_id}/sensors` | `sensors` command via `redfish_ctl.api.get_sensors()` |
 | `GET` | `/nodes/{node_id}/gpu-metrics` | `gpu-metrics` command |
 | `GET` | `/nodes/{node_id}/bios?attr_filter=...` | `bios` command |
+| `GET` | `/nodes/{node_id}/metrics` | Exporter `MetricSample` rows built from existing read commands |
 
 These routes are read-only. They do not create desired state, patch BMC resources, or run Redfish
 actions. The manager factory is intentionally supplied by the embedding service so credentials can
@@ -126,7 +131,7 @@ The read-only core now covers:
 - register a server,
 - read observed state,
 - list servers,
-- expose sensor, GPU metric, and BIOS reads through GET endpoints.
+- expose sensor, GPU metric, BIOS, and exporter-sample metric reads through GET endpoints.
 
 The next useful version should add persistent storage, desired power and boot override fields, and a
 reconcile loop that handles one server at a time with SQLite or Postgres.

--- a/redfish_ctl/proxy/core.py
+++ b/redfish_ctl/proxy/core.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
+from urllib.parse import urlparse
 
 from redfish_ctl.api import (
     RedfishApiError,
@@ -16,6 +17,11 @@ from redfish_ctl.api import (
     get_thermal,
 )
 from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.telemetry.exporter import (
+    MetricSample,
+    build_identity_dimensions,
+    build_metric_samples,
+)
 
 
 @dataclass(frozen=True)
@@ -125,6 +131,68 @@ def _sensor_dicts(manager: SyncInvoker) -> list[dict[str, Any]]:
     ]
 
 
+def _address_host(address: str) -> str:
+    text = str(address or "").strip()
+    if "://" in text:
+        parsed = urlparse(text)
+        return parsed.hostname or text
+    hostport = text.split("/", 1)[0].rsplit("@", 1)[-1]
+    if hostport.startswith("[") and "]" in hostport:
+        return hostport.split("]", 1)[0].lstrip("[")
+    return hostport.split(":", 1)[0] or text
+
+
+def _vendor_label(manager: SyncInvoker, vendor: str | None) -> str:
+    if vendor:
+        return vendor
+    try:
+        detected = getattr(manager, "redfish_vendor")
+    except Exception:
+        detected = None
+    return str(detected or "unknown")
+
+
+def _optional_command(
+    manager: SyncInvoker,
+    api_call: ApiRequestType,
+    name: str,
+    **kwargs: Any,
+) -> Any:
+    try:
+        result = manager.sync_invoke(api_call, name, **kwargs)
+    except Exception:
+        return None
+    if result.error:
+        return None
+    return result.data
+
+
+def _list_payload(data: Any) -> list[dict[str, Any]]:
+    if not isinstance(data, list):
+        return []
+    return [row for row in data if isinstance(row, dict)]
+
+
+def _dict_payload(data: Any) -> dict[str, Any]:
+    return dict(data) if isinstance(data, dict) else {}
+
+
+def _dict_rows(data: Any, key: str) -> list[dict[str, Any]]:
+    rows = _dict_payload(data).get(key)
+    return _list_payload(rows)
+
+
+def _sample_dict(sample: MetricSample) -> dict[str, Any]:
+    return {
+        "metric": sample.metric,
+        "value": sample.value,
+        "dimensions": dict(sample.dimensions),
+        "metricType": sample.metric_type,
+        "unit": sample.unit,
+        "timestamp": sample.timestamp,
+    }
+
+
 class ReadOnlyProxy:
     """Read-only facade that shapes Redfish command results for service APIs."""
 
@@ -203,4 +271,111 @@ class ReadOnlyProxy:
                 attr_only=False,
                 do_deep=False,
             ),
+        }
+
+    def node_metric_samples(
+        self,
+        node_id: str,
+        *,
+        label_bmc_ip: str | None = None,
+        vendor: str | None = None,
+        do_expanded: bool = False,
+    ) -> tuple[MetricSample, ...]:
+        """Read one node and return exporter-compatible telemetry samples."""
+        node, manager = self._node_and_manager(node_id)
+        identity = build_identity_dimensions(
+            label_bmc_ip or _address_host(node.address),
+            vendor=_vendor_label(manager, vendor),
+        )
+        environment_rows = _dict_rows(
+            _optional_command(
+                manager,
+                ApiRequestType.EnvironmentMetrics,
+                "environment-metrics",
+            ),
+            "metrics",
+        )
+        thermal_rows = _dict_rows(
+            _optional_command(manager, ApiRequestType.Thermal, "thermal"),
+            "temperature_readings",
+        )
+        sensor_rows = _list_payload(
+            _optional_command(
+                manager,
+                ApiRequestType.Sensors,
+                "sensors",
+                do_expanded=do_expanded,
+            )
+        )
+        nvlink_rows = _list_payload(
+            _optional_command(
+                manager,
+                ApiRequestType.NvLinkPorts,
+                "nvlink-ports",
+                do_expanded=do_expanded,
+            )
+        )
+        metric_report_rows = _list_payload(
+            _optional_command(
+                manager,
+                ApiRequestType.MetricReports,
+                "metric-reports",
+                do_expanded=do_expanded,
+            )
+        )
+        leak_detection_rows = _dict_rows(
+            _optional_command(
+                manager,
+                ApiRequestType.LeakDetectors,
+                "leak-detectors",
+            ),
+            "detectors",
+        )
+        network_rows = _list_payload(
+            _optional_command(
+                manager,
+                ApiRequestType.NetworkAdapters,
+                "network-adapters",
+                do_expanded=do_expanded,
+            )
+        )
+        component_rows = _list_payload(
+            _optional_command(
+                manager,
+                ApiRequestType.ComponentIntegrity,
+                "component-integrity",
+                do_expanded=do_expanded,
+            )
+        )
+        return tuple(build_metric_samples(
+            identity=identity,
+            environment_rows=environment_rows,
+            sensor_rows=sensor_rows,
+            nvlink_rows=nvlink_rows,
+            metric_report_rows=metric_report_rows,
+            thermal_rows=thermal_rows,
+            leak_detection_rows=leak_detection_rows,
+            network_rows=network_rows,
+            component_integrity_rows=component_rows,
+        ))
+
+    def node_metrics(
+        self,
+        node_id: str,
+        *,
+        label_bmc_ip: str | None = None,
+        vendor: str | None = None,
+        do_expanded: bool = False,
+    ) -> dict[str, Any]:
+        """Return JSON-safe exporter samples for one node."""
+        samples = self.node_metric_samples(
+            node_id,
+            label_bmc_ip=label_bmc_ip,
+            vendor=vendor,
+            do_expanded=do_expanded,
+        )
+        return {
+            "id": node_id,
+            "sampleCount": len(samples),
+            "samples": [_sample_dict(sample) for sample in samples],
         }

--- a/redfish_ctl/proxy/fastapi_app.py
+++ b/redfish_ctl/proxy/fastapi_app.py
@@ -49,4 +49,17 @@ def create_app(proxy: ReadOnlyProxy):
     def node_bios(node_id: str, attr_filter: str | None = None):
         return call(proxy.node_bios, node_id, attr_filter=attr_filter)
 
+    @app.get("/nodes/{node_id}/metrics")
+    def node_metrics(
+        node_id: str,
+        label_bmc_ip: str | None = None,
+        vendor: str | None = None,
+    ):
+        return call(
+            proxy.node_metrics,
+            node_id,
+            label_bmc_ip=label_bmc_ip,
+            vendor=vendor,
+        )
+
     return app

--- a/tests/test_proxy_readonly.py
+++ b/tests/test_proxy_readonly.py
@@ -14,6 +14,7 @@ from redfish_ctl.idrac_manager import IDracManager
 from redfish_ctl.idrac_shared import ApiRequestType
 from redfish_ctl.proxy import NodeConfig, NodeRegistry, ReadOnlyProxy, create_app
 from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.telemetry.exporter import MetricSample
 
 GB300_CORPUS = (
     Path(__file__).parent
@@ -219,6 +220,213 @@ def test_proxy_read_endpoints_delegate_to_existing_commands():
     ]
 
 
+def test_proxy_metric_samples_reuse_exporter_contract_per_node():
+    """Node telemetry samples reuse the exporter hw.* metric contract."""
+    manager = RecordingManager({
+        (ApiRequestType.EnvironmentMetrics, "environment-metrics"): CommandResult(
+            {
+                "metrics": [
+                    {
+                        "Chassis": "Chassis_0",
+                        "PowerWatts": {"Reading": 640.5},
+                        "EnergykWh": {"Reading": 2.25},
+                    }
+                ]
+            },
+            None,
+            None,
+            None,
+        ),
+        (ApiRequestType.Thermal, "thermal"): CommandResult(
+            {
+                "temperature_readings": [
+                    {
+                        "Chassis": "Chassis_0",
+                        "DeviceName": "Front IO Temp",
+                        "PhysicalContext": "Intake",
+                        "ReadingCelsius": "24.5",
+                    }
+                ],
+                "fans": [],
+            },
+            None,
+            None,
+            None,
+        ),
+        (ApiRequestType.Sensors, "sensors"): CommandResult(
+            [
+                {
+                    "Chassis": "Chassis_0",
+                    "Name": "Fan Bay 1",
+                    "Reading": 12000,
+                    "ReadingUnits": "RPM",
+                    "ReadingType": "Rotational",
+                    "Health": "OK",
+                }
+            ],
+            None,
+            None,
+            None,
+        ),
+        (ApiRequestType.NvLinkPorts, "nvlink-ports"): CommandResult(
+            [
+                {
+                    "System": "HGX_Baseboard_0",
+                    "GPU": "GPU_0",
+                    "Port": "NVLink_0",
+                    "LinkStatus": "LinkUp",
+                    "CurrentSpeedGbps": 400,
+                }
+            ],
+            None,
+            None,
+            None,
+        ),
+        (ApiRequestType.MetricReports, "metric-reports"): CommandResult(
+            [
+                {
+                    "Report": "HGX_ProcessorMetrics_0",
+                    "MetricProperty": (
+                        "/redfish/v1/Chassis/HGX_GPU_0/Sensors/"
+                        "GPU_0_Temp#/GPU_0_Temperature"
+                    ),
+                    "MetricValue": "34.5",
+                    "Timestamp": "2026-06-29T08:05:20.895+00:00",
+                }
+            ],
+            None,
+            None,
+            None,
+        ),
+        (ApiRequestType.LeakDetectors, "leak-detectors"): CommandResult(
+            {
+                "detectors": [
+                    {
+                        "Chassis": "Chassis_0",
+                        "Id": "LeakDetector0",
+                        "DetectorState": "Normal",
+                        "LeakDetectorType": "Moisture",
+                        "Health": "OK",
+                    }
+                ]
+            },
+            None,
+            None,
+            None,
+        ),
+        (ApiRequestType.NetworkAdapters, "network-adapters"): CommandResult(
+            [{"Id": "NIC0", "DeviceClass": "NIC", "Model": "ConnectX"}],
+            None,
+            None,
+            None,
+        ),
+        (ApiRequestType.ComponentIntegrity, "component-integrity"): CommandResult(
+            [{"Id": "TPM-0", "Enabled": True, "Type": "TPM"}],
+            None,
+            None,
+            None,
+        ),
+    })
+    proxy = ReadOnlyProxy(
+        NodeRegistry([_node()]),
+        manager_factory=lambda node: manager,
+    )
+
+    samples = proxy.node_metric_samples(
+        "gb300-a",
+        label_bmc_ip="192.0.2.29",
+        vendor="supermicro",
+    )
+
+    assert samples
+    assert all(isinstance(sample, MetricSample) for sample in samples)
+    assert {
+        "hw.power",
+        "hw.energy_kwh",
+        "hw.temperature",
+        "hw.fan_speed",
+        "hw.fabric.link_up",
+        "hw.fabric.port_speed",
+        "hw.gpu.temperature",
+        "hw.leak.state",
+        "hw.fabric.adapter_present",
+        "hw.component_integrity.enabled",
+    } <= {sample.metric for sample in samples}
+    assert all(sample.dimensions["bmc.ip"] == "192.0.2.29" for sample in samples)
+    assert all(sample.dimensions["vendor"] == "supermicro" for sample in samples)
+    assert manager.calls == [
+        (ApiRequestType.EnvironmentMetrics, "environment-metrics", {}),
+        (ApiRequestType.Thermal, "thermal", {}),
+        (ApiRequestType.Sensors, "sensors", {"do_expanded": False}),
+        (ApiRequestType.NvLinkPorts, "nvlink-ports", {"do_expanded": False}),
+        (ApiRequestType.MetricReports, "metric-reports", {"do_expanded": False}),
+        (ApiRequestType.LeakDetectors, "leak-detectors", {}),
+        (ApiRequestType.NetworkAdapters, "network-adapters", {"do_expanded": False}),
+        (ApiRequestType.ComponentIntegrity, "component-integrity", {"do_expanded": False}),
+    ]
+
+
+def test_proxy_metrics_response_is_json_safe():
+    """Proxy metric responses serialize exporter samples without credentials."""
+    manager = RecordingManager({
+        (ApiRequestType.EnvironmentMetrics, "environment-metrics"): CommandResult(
+            {"metrics": []}, None, None, None
+        ),
+        (ApiRequestType.Thermal, "thermal"): CommandResult(
+            {"temperature_readings": [], "fans": []}, None, None, None
+        ),
+        (ApiRequestType.Sensors, "sensors"): CommandResult(
+            [
+                {
+                    "Chassis": "Chassis_0",
+                    "Name": "Inlet Temp",
+                    "Reading": 24.0,
+                    "ReadingUnits": "Cel",
+                    "ReadingType": "Temperature",
+                }
+            ],
+            None,
+            None,
+            None,
+        ),
+    })
+    proxy = ReadOnlyProxy(
+        NodeRegistry([_node()]),
+        manager_factory=lambda node: manager,
+    )
+
+    payload = proxy.node_metrics(
+        "gb300-a",
+        label_bmc_ip="192.0.2.29",
+        vendor="supermicro",
+    )
+
+    assert payload["id"] == "gb300-a"
+    assert payload["sampleCount"] == 1
+    assert payload["samples"] == [
+        {
+            "metric": "hw.temperature",
+            "value": 24.0,
+            "dimensions": {
+                "bmc.ip": "192.0.2.29",
+                "chassis": "Chassis_0",
+                "host.name": "gb300-poc1-slot9",
+                "node": "slot9",
+                "sensor": "Inlet_Temp",
+                "server.address": "192.0.2.49",
+                "source": "sensor",
+                "vendor": "supermicro",
+            },
+            "metricType": "gauge",
+            "unit": "Cel",
+            "timestamp": None,
+        }
+    ]
+    encoded = json.dumps(payload)
+    assert "operator" not in encoded
+    assert "do-not-expose" not in encoded
+
+
 def test_create_app_registers_read_only_routes(monkeypatch):
     """The optional FastAPI adapter exposes only GET routes."""
     routes = []
@@ -259,6 +467,7 @@ def test_create_app_registers_read_only_routes(monkeypatch):
         ("GET", "/nodes/{node_id}/sensors"),
         ("GET", "/nodes/{node_id}/gpu-metrics"),
         ("GET", "/nodes/{node_id}/bios"),
+        ("GET", "/nodes/{node_id}/metrics"),
     ]
 
 
@@ -293,4 +502,32 @@ def test_proxy_reads_gb300_corpus_through_registered_commands(
     assert "/redfish/v1/chassis/chassis_0/sensors" in paths
     assert "/redfish/v1/systems/hgx_baseboard_0/processors/gpu_0" in paths
     assert "/redfish/v1/systems/system_0/bios" in paths
+    assert {request.method for request in requests} == {"GET"}
+
+
+def test_proxy_builds_node_metric_samples_from_gb300_corpus(
+    gb300_corpus_manager,
+):
+    """The proxy telemetry pipeline reads the GB300 corpus without writes."""
+    manager, requests = gb300_corpus_manager
+    proxy = ReadOnlyProxy(
+        NodeRegistry([_node()]),
+        manager_factory=lambda node: manager,
+    )
+
+    samples = proxy.node_metric_samples(
+        "gb300-a",
+        label_bmc_ip="192.0.2.29",
+        vendor="supermicro",
+    )
+
+    by_metric = {sample.metric for sample in samples}
+    assert {
+        "hw.power",
+        "hw.temperature",
+        "hw.gpu.temperature",
+        "hw.leak.state",
+    } <= by_metric
+    assert all(sample.dimensions["bmc.ip"] == "192.0.2.29" for sample in samples)
+    assert all(sample.dimensions["vendor"] == "supermicro" for sample in samples)
     assert {request.method for request in requests} == {"GET"}


### PR DESCRIPTION
## Summary
- add per-node proxy telemetry sample collection using the existing exporter MetricSample pipeline
- expose GET /nodes/{node_id}/metrics as a JSON-safe read endpoint
- document the proxy metrics route and cover it with focused plus GB300 corpus tests

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q tests/test_proxy_readonly.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/proxy/core.py redfish_ctl/proxy/fastapi_app.py tests/test_proxy_readonly.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q