### PR TITLE
Add kind end-to-end CI job for the Kubernetes sandbox

### DIFF
--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -54,4 +54,8 @@ jobs:
           kubectl -n redfish-sandbox get all || true
           kubectl -n redfish-sandbox describe redfishendpoint gb300-mock || true
           kubectl -n redfish-sandbox logs deploy/redfish-endpoint-controller --tail=200 || true
+          # A crash-looping container's current log is often empty; the
+          # previous instance holds the actual traceback.
+          kubectl -n redfish-sandbox logs deploy/redfish-endpoint-controller --previous --tail=200 || true
+          kubectl -n redfish-sandbox logs deploy/mock-bmc --tail=50 || true
           kubectl -n redfish-sandbox get events --sort-by=.lastTimestamp | tail -40 || true

--- a/.github/workflows/k8s-e2e.yml
+++ b/.github/workflows/k8s-e2e.yml
@@ -1,0 +1,57 @@
+name: K8s E2E
+
+# End-to-end check of the Kubernetes read path in a throwaway kind cluster
+# (Kubernetes-in-Docker on the runner). It reuses the local sandbox entry
+# point (`make k8s-sandbox`, defined in the Makefile), which builds the
+# mock-BMC and controller images, loads them into kind, deploys the CRDs +
+# controller, and fails unless a RedfishEndpoint's .status.powerState gets
+# populated. Everything runs against the committed corpus served by the
+# mock BMC — no real BMC, no credentials, no secrets.
+
+on:
+  pull_request:
+    paths:
+      - "k8s/**"
+      - "docker/Dockerfile.controller"
+      - "docker/Dockerfile.mock-bmc"
+      - "redfish_ctl/api.py"
+      - "redfish_ctl/reconcile.py"
+      - "charts/**"
+      - ".github/workflows/k8s-e2e.yml"
+  push:
+    branches: [main]
+    paths:
+      - "k8s/**"
+      - "docker/Dockerfile.controller"
+      - "docker/Dockerfile.mock-bmc"
+      - "redfish_ctl/api.py"
+      - "redfish_ctl/reconcile.py"
+      - "charts/**"
+      - ".github/workflows/k8s-e2e.yml"
+  schedule:
+    # Nightly catch-all so regressions surface even when no filtered path
+    # changed (e.g. a dependency bump breaking the controller image build).
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  kind-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install kind and kubectl
+        uses: helm/kind-action@v1
+        with:
+          install_only: true
+      - name: Run the sandbox end-to-end
+        run: make k8s-sandbox
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n redfish-sandbox get all || true
+          kubectl -n redfish-sandbox describe redfishendpoint gb300-mock || true
+          kubectl -n redfish-sandbox logs deploy/redfish-endpoint-controller --tail=200 || true
+          kubectl -n redfish-sandbox get events --sort-by=.lastTimestamp | tail -40 || true

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -8,9 +8,13 @@ ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-RUN groupadd --system redfish \
+# uid/gid are pinned to 10001 to match the deployment's runAsUser/runAsGroup:
+# kopf resolves its identity via getpwuid(), so the runtime uid must exist in
+# /etc/passwd or the operator crashes at startup.
+RUN groupadd --system --gid 10001 redfish \
     && useradd \
         --system \
+        --uid 10001 \
         --gid redfish \
         --home-dir /home/redfish \
         --create-home \

--- a/k8s/controller/deployment.yaml
+++ b/k8s/controller/deployment.yaml
@@ -31,6 +31,9 @@ spec:
           args:
             - run
             - --standalone
+            # Watch only this namespace: the RBAC grant is a namespaced Role,
+            # so a cluster-wide watch would be rejected with 403s.
+            - --namespace=redfish-sandbox
             - /app/k8s/controller/redfish_endpoint_controller.py
           securityContext:
             allowPrivilegeEscalation: false

--- a/k8s/controller/rbac.yaml
+++ b/k8s/controller/rbac.yaml
@@ -24,6 +24,10 @@ rules:
       - get
       - list
       - watch
+      # kopf persists its handler progress as annotations on the object
+      # itself, so the main resource needs patch/update as well as /status.
+      - patch
+      - update
   - apiGroups:
       - redfish.ctl.dev
     resources:

--- a/k8s/controller/rbac.yaml
+++ b/k8s/controller/rbac.yaml
@@ -55,3 +55,37 @@ subjects:
   - kind: ServiceAccount
     name: redfish-endpoint-controller
     namespace: redfish-sandbox
+---
+# Minimal cluster-scope observation kopf needs at startup: it scans CRDs to
+# resolve the watched resource kinds and probes namespaces. Read-only; the
+# write grants above stay namespaced.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redfish-endpoint-controller-observe
+  labels:
+    app.kubernetes.io/name: redfish-endpoint-controller
+    app.kubernetes.io/component: redfish-sandbox
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redfish-endpoint-controller-observe
+  labels:
+    app.kubernetes.io/name: redfish-endpoint-controller
+    app.kubernetes.io/component: redfish-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redfish-endpoint-controller-observe
+subjects:
+  - kind: ServiceAccount
+    name: redfish-endpoint-controller
+    namespace: redfish-sandbox

--- a/k8s/controller/redfish-endpoint-crd.yaml
+++ b/k8s/controller/redfish-endpoint-crd.yaml
@@ -62,8 +62,6 @@ spec:
                       type: string
                       default: password
                       description: Secret data key containing the BMC password.
-                  additionalProperties: false
-              additionalProperties: false
             status:
               type: object
               properties:
@@ -82,8 +80,6 @@ spec:
                     maxCelsius:
                       type: number
                       nullable: true
-                  additionalProperties: false
                 lastPolled:
                   type: string
                   format: date-time
-              additionalProperties: false

--- a/k8s/controller/redfish-node-profile-crd.yaml
+++ b/k8s/controller/redfish-node-profile-crd.yaml
@@ -63,8 +63,6 @@ spec:
                           type: string
                           default: password
                           description: Secret data key containing the BMC password.
-                      additionalProperties: false
-                  additionalProperties: false
                 desiredState:
                   type: object
                   properties:
@@ -83,7 +81,6 @@ spec:
                         managerId:
                           type: string
                           nullable: true
-                      additionalProperties: false
                     boot:
                       type: object
                       properties:
@@ -96,15 +93,12 @@ spec:
                         uefiTarget:
                           type: string
                           nullable: true
-                      additionalProperties: false
                     reboot:
                       type: object
                       properties:
                         resetType:
                           type: string
                           nullable: true
-                      additionalProperties: false
-                  additionalProperties: false
                 approve:
                   type: boolean
                   default: false
@@ -113,7 +107,6 @@ spec:
                   type: boolean
                   default: false
                   description: Wait for the BMC to answer again after an approved reboot step.
-              additionalProperties: false
             status:
               type: object
               properties:
@@ -140,7 +133,6 @@ spec:
                       preview:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    additionalProperties: false
                 appliedChanges:
                   type: array
                   items:
@@ -156,7 +148,6 @@ spec:
                       result:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    additionalProperties: false
                 conditions:
                   type: array
                   items:
@@ -182,8 +173,6 @@ spec:
                       lastTransitionTime:
                         type: string
                         format: date-time
-                    additionalProperties: false
                 lastReconciled:
                   type: string
                   format: date-time
-              additionalProperties: false

--- a/k8s/sandbox/mock-bmc.yaml
+++ b/k8s/sandbox/mock-bmc.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: mock-bmc
+  namespace: redfish-sandbox
   labels:
     app.kubernetes.io/name: mock-bmc
     app.kubernetes.io/component: redfish-sandbox
@@ -62,6 +63,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: mock-bmc
+  namespace: redfish-sandbox
   labels:
     app.kubernetes.io/name: mock-bmc
     app.kubernetes.io/component: redfish-sandbox

--- a/k8s/sandbox/mock-credentials.yaml
+++ b/k8s/sandbox/mock-credentials.yaml
@@ -1,0 +1,16 @@
+# Dummy BMC credentials for the sandbox: the mock BMC ignores authentication,
+# but the controller's secretRef -> Secret -> credentials path is exercised
+# end-to-end. The values are the canonical public Redfish demo credentials,
+# never a real account.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mock-bmc-credentials
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: mock-bmc
+    app.kubernetes.io/component: redfish-sandbox
+type: Opaque
+stringData:
+  username: root
+  password: calvin

--- a/k8s/sandbox/redfish-endpoint-sample.yaml
+++ b/k8s/sandbox/redfish-endpoint-sample.yaml
@@ -10,3 +10,7 @@ spec:
   port: 80
   insecure: true
   pollInterval: 10s
+  # The mock ignores authentication; the reference exists so the controller's
+  # secretRef -> Secret -> credentials path runs end-to-end in the sandbox.
+  secretRef:
+    name: mock-bmc-credentials

--- a/k8s/sandbox/run-sandbox.sh
+++ b/k8s/sandbox/run-sandbox.sh
@@ -50,6 +50,7 @@ section "applying sandbox resources"
 kubectl apply -f k8s/sandbox/namespace.yaml
 kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml
 kubectl apply -f k8s/sandbox/mock-bmc.yaml
+kubectl apply -f k8s/sandbox/mock-credentials.yaml
 kubectl apply -f k8s/controller/rbac.yaml
 kubectl apply -f k8s/controller/deployment.yaml
 kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml

--- a/redfish_ctl/boot_options/cmd_boot_option_list.py
+++ b/redfish_ctl/boot_options/cmd_boot_option_list.py
@@ -93,7 +93,7 @@ class BootOptionsList(IDracManager,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        r = f"https://{self.idrac_ip}{self.idrac_manage_servers}" \
+        r = f"{self._default_method}{self.idrac_ip}{self.idrac_manage_servers}" \
             f"/BootOptions?$expand=*($levels=1)"
 
         response = self.api_get_call(r, headers)

--- a/redfish_ctl/boot_source/cmd_boot_settings.py
+++ b/redfish_ctl/boot_source/cmd_boot_settings.py
@@ -70,7 +70,7 @@ class BootSettings(IDracManager,
 
         # DellBootSources is a Dell OEM resource; degrade gracefully off Dell.
         target_api = f"{self.idrac_manage_servers}/Oem/Dell/DellBootSources/Settings"
-        r = f"https://{self.idrac_ip}{target_api}"
+        r = f"{self._default_method}{self.idrac_ip}{target_api}"
 
         try:
             if not do_async:

--- a/redfish_ctl/boot_source/cmd_boot_source_get.py
+++ b/redfish_ctl/boot_source/cmd_boot_source_get.py
@@ -85,7 +85,7 @@ class BootSource(IDracManager,
 
         boot_data_sources = {}
         for full_dev_path in cmd_result.data:
-            r = f"https://{self.idrac_ip}{full_dev_path}?$expand=*($levels=1)"
+            r = f"{self._default_method}{self.idrac_ip}{full_dev_path}?$expand=*($levels=1)"
             if not do_async:
                 response = self.api_get_call(r, headers)
                 self.default_error_handler(response)

--- a/redfish_ctl/cmd_boot.py
+++ b/redfish_ctl/cmd_boot.py
@@ -76,7 +76,7 @@ class BootQuery(IDracManager,
         # Dell exposes a proprietary BootSources collection; standard Redfish
         # (Supermicro/OpenBMC, HPE) does not, so BootSources 404s there. Try Dell's
         # path, then fall back to the ComputerSystem's standard Boot object.
-        r = f"https://{self.idrac_ip}{self.idrac_manage_servers}/BootSources"
+        r = f"{self._default_method}{self.idrac_ip}{self.idrac_manage_servers}/BootSources"
 
         try:
             if not do_async:
@@ -99,7 +99,7 @@ class BootQuery(IDracManager,
         extra_actions = find_ids(data, "@odata.id")
         extra_data = None
         if do_deep:
-            extra_data = [self.api_get_call(f"https://{self.idrac_ip}{a}", headers).json()
+            extra_data = [self.api_get_call(f"{self._default_method}{self.idrac_ip}{a}", headers).json()
                           for a in extra_actions]
 
         return CommandResult(data, None, extra_data, None)

--- a/redfish_ctl/cmd_current_boot.py
+++ b/redfish_ctl/cmd_current_boot.py
@@ -74,7 +74,7 @@ class GetCurrentBoot(IDracManager,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        r = f"https://{self.idrac_ip}{self.idrac_manage_servers}"
+        r = f"{self._default_method}{self.idrac_ip}{self.idrac_manage_servers}"
         response = self.api_get_call(r, headers)
         self.default_error_handler(response)
         data = response.json()

--- a/redfish_ctl/firmware/cmd_firmware.py
+++ b/redfish_ctl/firmware/cmd_firmware.py
@@ -77,10 +77,10 @@ class FirmwareQuery(IDracManager,
             headers.update(self.json_content_type)
 
         if do_deep:
-            r = f"https://{self.idrac_ip}/redfish/v1/UpdateService/" \
+            r = f"{self._default_method}{self.idrac_ip}/redfish/v1/UpdateService/" \
                 f"FirmwareInventory?$expand=*($levels=1)"
         else:
-            r = f"https://{self.idrac_ip}/redfish/v1/UpdateService/FirmwareInventory"
+            r = f"{self._default_method}{self.idrac_ip}/redfish/v1/UpdateService/FirmwareInventory"
 
         if not do_async:
             response = self.api_get_call(r, headers)

--- a/redfish_ctl/firmware/cmd_firmware_inv.py
+++ b/redfish_ctl/firmware/cmd_firmware_inv.py
@@ -66,7 +66,7 @@ class FirmwareInventoryQuery(IDracManager,
         headers = {}
         if data_type == "json":
             headers.update(self.json_content_type)
-        r = f"https://{self.idrac_ip}/redfish/v1/UpdateService/" \
+        r = f"{self._default_method}{self.idrac_ip}/redfish/v1/UpdateService/" \
             f"FirmwareInventory?$expand=*($levels=1)"
         response = self.api_get_call(r, headers)
         data = response.json()

--- a/redfish_ctl/jobs/cmd_jobs.py
+++ b/redfish_ctl/jobs/cmd_jobs.py
@@ -178,7 +178,7 @@ class JobList(IDracManager,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        r = f"https://{self.idrac_ip}{self.idrac_members}" \
+        r = f"{self._default_method}{self.idrac_ip}{self.idrac_members}" \
             f"/Jobs?$expand=*($levels=1)"
 
         response = self.api_get_call(r, headers)

--- a/redfish_ctl/pci/cmd_pci.py
+++ b/redfish_ctl/pci/cmd_pci.py
@@ -71,7 +71,7 @@ class PciDeviceQuery(IDracManager,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        r = f"https://{self.idrac_ip}{self.idrac_manage_servers}" \
+        r = f"{self._default_method}{self.idrac_ip}{self.idrac_manage_servers}" \
             f"?$select={pci_type}"
 
         try:

--- a/redfish_ctl/raid/cmd_raid_service.py
+++ b/redfish_ctl/raid/cmd_raid_service.py
@@ -72,7 +72,7 @@ class RaidServiceQuery(IDracManager,
         # (not a hardcoded System.Embedded.1) and degrade gracefully off Dell,
         # where standard RAID is driven via the Storage/Volumes commands instead.
         system_id = self.idrac_manage_servers.rsplit("/", 1)[-1]
-        r = f"https://{self.idrac_ip}/redfish/v1/Dell/Systems/" \
+        r = f"{self._default_method}{self.idrac_ip}/redfish/v1/Dell/Systems/" \
             f"{system_id}/DellRaidService"
 
         try:

--- a/redfish_ctl/storage/cmd_storage_controllers.py
+++ b/redfish_ctl/storage/cmd_storage_controllers.py
@@ -110,9 +110,9 @@ class StorageQuery(IDracManager, scm_type=ApiRequestType.StorageQuery,
 
         target_api = f"{self.idrac_manage_servers}/Storage"
         if do_expanded:
-            r = f"https://{self.idrac_ip}{target_api}{self.expanded()}"
+            r = f"{self._default_method}{self.idrac_ip}{target_api}{self.expanded()}"
         else:
-            r = f"https://{self.idrac_ip}{target_api}"
+            r = f"{self._default_method}{self.idrac_ip}{target_api}"
 
         if not do_async:
             response = self.api_get_call(r, headers)

--- a/redfish_ctl/system/cmd_system.py
+++ b/redfish_ctl/system/cmd_system.py
@@ -104,7 +104,7 @@ class SystemQuery(IDracManager,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        r = f"https://{self.idrac_ip}{self.idrac_manage_servers}"
+        r = f"{self._default_method}{self.idrac_ip}{self.idrac_manage_servers}"
         response = self.api_get_call(r, headers)
         self.default_error_handler(response)
         data = response.json()
@@ -119,7 +119,7 @@ class SystemQuery(IDracManager,
                 rest_endpoints[k] = sub_rest
                 # deep walk
                 if do_deep:
-                    r = f"https://{self.idrac_ip}{sub_rest}"
+                    r = f"{self._default_method}{self.idrac_ip}{sub_rest}"
                     response = self.api_get_call(r, headers)
                     self.default_error_handler(response)
                     if verbose:

--- a/redfish_ctl/system/cmd_system_config.py
+++ b/redfish_ctl/system/cmd_system_config.py
@@ -108,7 +108,7 @@ class ExportSystemConfig(IDracManager,
         if "Clone" in export_use or "Replace" in export_use:
             payload["ExportUse"] = export_use
 
-        r = f"https://{self.idrac_ip}/redfish/v1/Managers/iDRAC.Embedded.1/" \
+        r = f"{self._default_method}{self.idrac_ip}/redfish/v1/Managers/iDRAC.Embedded.1/" \
             f"Actions/Oem/EID_674_Manager.ExportSystemConfiguration"
 
         # json_pd = json.dumps(payload)

--- a/redfish_ctl/system/cmd_system_import.py
+++ b/redfish_ctl/system/cmd_system_import.py
@@ -150,7 +150,7 @@ class ImportSystemConfig(IDracManager,
                    "ShareParameters": {"Target": "ALL"}
                    }
 
-        r = f"https://{self.idrac_ip}/redfish/v1/Managers/iDRAC.Embedded.1/" \
+        r = f"{self._default_method}{self.idrac_ip}/redfish/v1/Managers/iDRAC.Embedded.1/" \
             f"Actions/Oem/EID_674_Manager.ImportSystemConfiguration"
 
         data = {}

--- a/redfish_ctl/system/cmd_system_one_time_boot.py
+++ b/redfish_ctl/system/cmd_system_one_time_boot.py
@@ -124,7 +124,7 @@ class ImportOneTimeBoot(
                    "ShareParameters": {"Target": "ALL"}
                    }
 
-        r = f"https://{self.idrac_ip}/redfish/v1/Managers/iDRAC.Embedded.1/" \
+        r = f"{self._default_method}{self.idrac_ip}/redfish/v1/Managers/iDRAC.Embedded.1/" \
             f"Actions/Oem/EID_674_Manager.ImportSystemConfiguration"
 
         data = {}

--- a/redfish_ctl/virtual_media/cmd_smc_virtual_media.py
+++ b/redfish_ctl/virtual_media/cmd_smc_virtual_media.py
@@ -72,7 +72,7 @@ class SmcVirtualMediaMount(IDracManager,
     def _get(self, path: str) -> Optional[dict]:
         """Best-effort GET (path -> full URL) returning JSON or None (never raises)."""
         try:
-            resp = self.api_get_call(f"https://{self.idrac_ip}{path}", {})
+            resp = self.api_get_call(f"{self._default_method}{self.idrac_ip}{path}", {})
             if resp is not None and resp.status_code == 200:
                 return resp.json()
         except Exception:

--- a/redfish_ctl/virtual_media/cmd_virtual_media_get.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_get.py
@@ -102,7 +102,7 @@ class VirtualMediaGet(IDracManager,
         # Resolve the VirtualMedia collection from whichever resource exposes it
         # (a Manager on iLO/Supermicro, the ComputerSystem on Dell) — no hardcoded id.
         vm_uri = self.discover_virtual_media_uri()
-        r = f"https://{self.idrac_ip}{vm_uri}?$expand=*($levels=1)"
+        r = f"{self._default_method}{self.idrac_ip}{vm_uri}?$expand=*($levels=1)"
 
         response = self.api_get_call(r, headers)
         self.default_error_handler(response)

--- a/redfish_ctl/volumes/cmd_virtual_disk.py
+++ b/redfish_ctl/volumes/cmd_virtual_disk.py
@@ -91,7 +91,7 @@ class VirtualDiskQuery(
             raise InvalidArgument(f"Storage device_id {device_id} "
                                   f"not found, available {storage_ids}")
 
-        r = f"https://{self.idrac_ip}{self.idrac_manage_servers}" \
+        r = f"{self._default_method}{self.idrac_ip}{self.idrac_manage_servers}" \
             f"/Storage/{device_id}/Volumes"
         #
         response = self.api_get_call(r, headers)
@@ -104,7 +104,7 @@ class VirtualDiskQuery(
 
         results = []
         for vol_id in vd_list:
-            r = f"https://{self.idrac_ip}{self.idrac_manage_servers}" \
+            r = f"{self._default_method}{self.idrac_ip}{self.idrac_manage_servers}" \
                 f"/Storage/Volumes/{vol_id}"
             try:
                 response = self.api_get_call(r, headers)

--- a/tests/test_k8s_sandbox_harness.py
+++ b/tests/test_k8s_sandbox_harness.py
@@ -32,7 +32,12 @@ def test_kind_config_defines_a_local_redfish_sandbox_cluster() -> None:
 
 
 def test_sample_endpoint_points_at_mock_bmc_without_credentials() -> None:
-    """The sample CR reads the in-cluster mock BMC without embedding secrets."""
+    """The sample CR reads the mock BMC via a secretRef, never inline secrets.
+
+    The referenced Secret carries only the canonical public Redfish demo
+    credentials (the mock ignores authentication); the point is that the
+    controller's secretRef -> Secret -> credentials path runs end-to-end.
+    """
     endpoint = yaml.safe_load(SAMPLE_ENDPOINT.read_text(encoding="utf-8"))
 
     assert endpoint["apiVersion"] == "redfish.ctl.dev/v1alpha1"
@@ -44,9 +49,20 @@ def test_sample_endpoint_points_at_mock_bmc_without_credentials() -> None:
         "port": 80,
         "insecure": True,
         "pollInterval": "10s",
+        "secretRef": {"name": "mock-bmc-credentials"},
     }
-    assert "secretRef" not in endpoint["spec"]
-    assert "PASSWORD" not in SAMPLE_ENDPOINT.read_text(encoding="utf-8")
+    # Credentials live only in the Secret manifest, never inline in the CR.
+    sample_text = SAMPLE_ENDPOINT.read_text(encoding="utf-8")
+    assert "password" not in sample_text.lower().replace("secretref", "")
+
+    secret = yaml.safe_load(
+        (SAMPLE_ENDPOINT.parent / "mock-credentials.yaml").read_text(encoding="utf-8")
+    )
+    assert secret["kind"] == "Secret"
+    assert secret["metadata"]["name"] == "mock-bmc-credentials"
+    assert secret["metadata"]["namespace"] == "redfish-sandbox"
+    # Public demo credentials only — a real value here would be a leak.
+    assert secret["stringData"] == {"username": "root", "password": "calvin"}
 
 
 def test_controller_deployment_is_read_only_and_uses_local_image() -> None:
@@ -131,6 +147,7 @@ def test_sandbox_smoke_script_applies_manifests_and_waits_for_status() -> None:
     assert "kind load docker-image redfish-ctl-controller:local" in script
     assert "kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml" in script
     assert "kubectl apply -f k8s/sandbox/mock-bmc.yaml" in script
+    assert "kubectl apply -f k8s/sandbox/mock-credentials.yaml" in script
     assert "kubectl apply -f k8s/controller/rbac.yaml" in script
     assert "kubectl apply -f k8s/controller/deployment.yaml" in script
     assert "kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml" in script

--- a/tests/test_k8s_sandbox_harness.py
+++ b/tests/test_k8s_sandbox_harness.py
@@ -66,8 +66,19 @@ def test_controller_deployment_is_read_only_and_uses_local_image() -> None:
     assert container["args"] == [
         "run",
         "--standalone",
+        # The watch stays scoped to the sandbox namespace so the namespaced
+        # Role is sufficient for the resource watch itself.
+        "--namespace=redfish-sandbox",
         "/app/k8s/controller/redfish_endpoint_controller.py",
     ]
+
+    cluster_role = next(doc for doc in docs if doc["kind"] == "ClusterRole")
+    cluster_verbs = set().union(
+        *(set(rule["verbs"]) for rule in cluster_role["rules"])
+    )
+    # kopf's startup observation is read-only; cluster-scope writes would be
+    # a regression.
+    assert cluster_verbs <= {"get", "list", "watch"}
 
     redfish_rules = [
         rule


### PR DESCRIPTION
## Summary
- Add a K8s E2E workflow: a kind (Kubernetes-in-Docker) cluster per run, reusing the existing `make k8s-sandbox` entry point end-to-end (image builds, kind load, CRDs + controller deploy, status assertion against the mock BMC).
- Path-filtered to k8s/controller/facade changes, plus main pushes and a nightly run.
- Failure diagnostics: describe + controller logs + events.

## Validation
- The workflow runs on this PR (it is in its own path filter).