### PR TITLE
Add Helm chart for Redfish controllers

### DIFF
--- a/charts/redfish-controller/Chart.yaml
+++ b/charts/redfish-controller/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: redfish-controller
+description: Helm chart for the redfish_ctl Kubernetes controllers.
+type: application
+version: 0.1.0
+appVersion: v1.2.0
+home: https://github.com/spyroot/redfish_ctl
+sources:
+  - https://github.com/spyroot/redfish_ctl
+keywords:
+  - redfish
+  - bmc
+  - bare-metal
+  - kubernetes

--- a/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
+++ b/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
@@ -1,0 +1,89 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: redfishendpoints.redfish.ctl.dev
+spec:
+  group: redfish.ctl.dev
+  scope: Namespaced
+  names:
+    plural: redfishendpoints
+    singular: redfishendpoint
+    kind: RedfishEndpoint
+    shortNames:
+      - rfe
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - address
+              properties:
+                address:
+                  type: string
+                  minLength: 1
+                  description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                port:
+                  type: integer
+                  minimum: 1
+                  maximum: 65535
+                  default: 443
+                  description: TCP port for the Redfish endpoint.
+                insecure:
+                  type: boolean
+                  default: true
+                  description: Skip TLS certificate verification for self-signed BMC certificates.
+                pollInterval:
+                  type: string
+                  default: 30s
+                  pattern: ^[0-9]+(s|m|h)$
+                  description: Desired controller polling interval.
+                secretRef:
+                  type: object
+                  required:
+                    - name
+                  properties:
+                    name:
+                      type: string
+                      minLength: 1
+                      description: Secret in the same namespace containing BMC login data.
+                    usernameKey:
+                      type: string
+                      default: username
+                      description: Secret data key containing the BMC username.
+                    passwordKey:
+                      type: string
+                      default: password
+                      description: Secret data key containing the BMC password.
+                  additionalProperties: false
+              additionalProperties: false
+            status:
+              type: object
+              properties:
+                powerState:
+                  type: string
+                  nullable: true
+                health:
+                  type: string
+                  nullable: true
+                temperature:
+                  type: object
+                  properties:
+                    count:
+                      type: integer
+                      minimum: 0
+                    maxCelsius:
+                      type: number
+                      nullable: true
+                  additionalProperties: false
+                lastPolled:
+                  type: string
+                  format: date-time
+              additionalProperties: false

--- a/charts/redfish-controller/crds/redfish-node-profile-crd.yaml
+++ b/charts/redfish-controller/crds/redfish-node-profile-crd.yaml
@@ -1,0 +1,189 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: redfishnodeprofiles.redfish.ctl.dev
+spec:
+  group: redfish.ctl.dev
+  scope: Namespaced
+  names:
+    plural: redfishnodeprofiles
+    singular: redfishnodeprofile
+    kind: RedfishNodeProfile
+    shortNames:
+      - rnp
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required:
+                - endpoint
+                - desiredState
+              properties:
+                endpoint:
+                  type: object
+                  required:
+                    - address
+                  properties:
+                    address:
+                      type: string
+                      minLength: 1
+                      description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                    port:
+                      type: integer
+                      minimum: 1
+                      maximum: 65535
+                      default: 443
+                      description: TCP port for the Redfish endpoint.
+                    insecure:
+                      type: boolean
+                      default: true
+                      description: Skip TLS certificate verification for self-signed BMC certificates.
+                    secretRef:
+                      type: object
+                      required:
+                        - name
+                      properties:
+                        name:
+                          type: string
+                          minLength: 1
+                          description: Secret in the same namespace containing BMC login data.
+                        usernameKey:
+                          type: string
+                          default: username
+                          description: Secret data key containing the BMC username.
+                        passwordKey:
+                          type: string
+                          default: password
+                          description: Secret data key containing the BMC password.
+                      additionalProperties: false
+                  additionalProperties: false
+                desiredState:
+                  type: object
+                  properties:
+                    biosProfile:
+                      type: string
+                      nullable: true
+                      description: Named BIOS profile to diff or stage through the reconciler.
+                    ntp:
+                      type: object
+                      properties:
+                        servers:
+                          type: array
+                          items:
+                            type: string
+                          maxItems: 4
+                        managerId:
+                          type: string
+                          nullable: true
+                      additionalProperties: false
+                    boot:
+                      type: object
+                      properties:
+                        device:
+                          type: string
+                          nullable: true
+                        mode:
+                          type: string
+                          nullable: true
+                        uefiTarget:
+                          type: string
+                          nullable: true
+                      additionalProperties: false
+                    reboot:
+                      type: object
+                      properties:
+                        resetType:
+                          type: string
+                          nullable: true
+                      additionalProperties: false
+                  additionalProperties: false
+                approve:
+                  type: boolean
+                  default: false
+                  description: Required approval gate before any desired-state changes are applied.
+                waitForReboot:
+                  type: boolean
+                  default: false
+                  description: Wait for the BMC to answer again after an approved reboot step.
+              additionalProperties: false
+            status:
+              type: object
+              properties:
+                dryRun:
+                  type: boolean
+                drift:
+                  type: boolean
+                  nullable: true
+                plannedSteps:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - kind
+                      - required
+                      - description
+                    properties:
+                      kind:
+                        type: string
+                      required:
+                        type: boolean
+                      description:
+                        type: string
+                      preview:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties: false
+                appliedChanges:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - kind
+                      - changed
+                    properties:
+                      kind:
+                        type: string
+                      changed:
+                        type: boolean
+                      result:
+                        type: object
+                        x-kubernetes-preserve-unknown-fields: true
+                    additionalProperties: false
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                      - lastTransitionTime
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                    additionalProperties: false
+                lastReconciled:
+                  type: string
+                  format: date-time
+              additionalProperties: false

--- a/charts/redfish-controller/templates/NOTES.txt
+++ b/charts/redfish-controller/templates/NOTES.txt
@@ -1,0 +1,16 @@
+The Redfish controllers have been installed in namespace {{ .Release.Namespace }}.
+
+For resources that need BMC credentials, create a Secret in the same namespace
+as the custom resource. The default Secret keys are username and password:
+
+  kubectl create secret generic redfish-bmc -n {{ .Release.Namespace }} \
+    --from-literal=username='<user>' \
+    --from-literal=password='<password>'
+
+Reference it from RedfishEndpoint.spec.secretRef or
+RedfishNodeProfile.spec.endpoint.secretRef:
+
+  secretRef:
+    name: redfish-bmc
+
+The chart does not create or store BMC credentials.

--- a/charts/redfish-controller/templates/_helpers.tpl
+++ b/charts/redfish-controller/templates/_helpers.tpl
@@ -1,0 +1,49 @@
+{{- define "redfish-controller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "redfish-controller.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := include "redfish-controller.name" . -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redfish-controller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- include "redfish-controller.fullname" . -}}
+{{- else -}}
+{{- required "serviceAccount.name is required when serviceAccount.create=false" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redfish-controller.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "redfish-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "redfish-controller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "redfish-controller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "redfish-controller.image" -}}
+{{- printf "%s:%s" .Values.image.repository .Values.image.tag -}}
+{{- end -}}
+
+{{- define "redfish-controller.mockBmcName" -}}
+{{- printf "%s-mock-bmc" (include "redfish-controller.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "redfish-controller.mockBmcImage" -}}
+{{- printf "%s:%s" .Values.mockBmc.image.repository .Values.mockBmc.image.tag -}}
+{{- end -}}

--- a/charts/redfish-controller/templates/deployment.yaml
+++ b/charts/redfish-controller/templates/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redfish-controller.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redfish-controller.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "redfish-controller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "redfish-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "redfish-controller.serviceAccountName" . }}
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: controller
+          image: {{ include "redfish-controller.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - run
+            - --standalone
+            - /app/k8s/controller/redfish_endpoint_controller.py
+            - /app/k8s/controller/redfish_node_profile_controller.py
+          env:
+            - name: REDFISH_CONTROLLER_POLL_INTERVAL
+              value: {{ .Values.controller.pollInterval | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}

--- a/charts/redfish-controller/templates/mock-bmc.yaml
+++ b/charts/redfish-controller/templates/mock-bmc.yaml
@@ -1,0 +1,77 @@
+{{- if .Values.mockBmc.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redfish-controller.mockBmcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redfish-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mock-bmc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "redfish-controller.mockBmcName" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "redfish-controller.mockBmcName" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: mock-bmc
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: mock-bmc
+          image: {{ include "redfish-controller.mockBmcImage" . }}
+          imagePullPolicy: {{ .Values.mockBmc.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          env:
+            - name: MOCK_BMC_CORPUS_DIR
+              value: {{ .Values.mockBmc.corpusDir | quote }}
+          readinessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.mockBmc.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redfish-controller.mockBmcName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redfish-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mock-bmc
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: {{ include "redfish-controller.mockBmcName" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+{{- end }}

--- a/charts/redfish-controller/templates/rbac.yaml
+++ b/charts/redfish-controller/templates/rbac.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redfish-controller.fullname" . }}
+  labels:
+    {{- include "redfish-controller.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - redfish.ctl.dev
+    resources:
+      - redfishendpoints
+      - redfishnodeprofiles
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - redfish.ctl.dev
+    resources:
+      - redfishendpoints/status
+      - redfishnodeprofiles/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "redfish-controller.fullname" . }}
+  labels:
+    {{- include "redfish-controller.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "redfish-controller.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "redfish-controller.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/redfish-controller/templates/serviceaccount.yaml
+++ b/charts/redfish-controller/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "redfish-controller.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "redfish-controller.labels" . | nindent 4 }}
+automountServiceAccountToken: true
+{{- end }}

--- a/charts/redfish-controller/values.yaml
+++ b/charts/redfish-controller/values.yaml
@@ -1,0 +1,36 @@
+image:
+  repository: spyroot/redfish-ctl-controller
+  tag: v1.2.0
+  pullPolicy: IfNotPresent
+
+controller:
+  pollInterval: 30s
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+rbac:
+  create: true
+
+serviceAccount:
+  create: true
+  name: ""
+
+mockBmc:
+  enabled: false
+  image:
+    repository: spyroot/redfish-ctl-mock-bmc
+    tag: v1.2.0
+    pullPolicy: IfNotPresent
+  corpusDir: /corpus/172.25.230.37
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 250m
+      memory: 256Mi

--- a/k8s/controller/deploy.sh
+++ b/k8s/controller/deploy.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Apply the controller CRDs and raw Kubernetes manifests from this checkout.
+set -euo pipefail
+
+KUBECTL="${KUBECTL:-kubectl}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+require_tool() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		printf 'missing required tool: %s\n' "$1" >&2
+		exit 127
+	fi
+}
+
+section() {
+	printf '\n>> %s\n' "$1"
+}
+
+require_tool "$KUBECTL"
+
+section "applying Redfish controller CRDs"
+"$KUBECTL" apply -f k8s/controller/redfish-endpoint-crd.yaml
+"$KUBECTL" apply -f k8s/controller/redfish-node-profile-crd.yaml
+
+section "applying Redfish controller RBAC"
+"$KUBECTL" apply -f k8s/controller/rbac.yaml
+
+section "applying Redfish controller deployment"
+"$KUBECTL" apply -f k8s/controller/deployment.yaml
+
+section "waiting for controller rollout"
+"$KUBECTL" -n redfish-sandbox \
+	rollout status deploy/redfish-endpoint-controller \
+	--timeout=120s

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -1,0 +1,177 @@
+"""Contracts for the Redfish controller Helm chart."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHART_DIR = REPO_ROOT / "charts" / "redfish-controller"
+DEPLOY_SCRIPT = REPO_ROOT / "k8s" / "controller" / "deploy.sh"
+
+
+def _chart_file(relative_path: str) -> Path:
+    return CHART_DIR / relative_path
+
+
+def _yaml_documents(path: Path) -> list[dict]:
+    return [doc for doc in yaml.safe_load_all(path.read_text(encoding="utf-8")) if doc]
+
+
+def _template(extra_args: list[str] | None = None) -> list[dict]:
+    helm = shutil.which("helm")
+    if helm is None and Path("/opt/homebrew/bin/helm").exists():
+        helm = "/opt/homebrew/bin/helm"
+    if helm is None:
+        pytest.skip("helm binary is not installed")
+
+    cmd = [
+        helm,
+        "template",
+        "redfish-controller",
+        str(CHART_DIR),
+        "--namespace",
+        "redfish-system",
+    ]
+    if extra_args:
+        cmd.extend(extra_args)
+    result = subprocess.run(cmd, check=True, text=True, capture_output=True)
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def _by_kind_name(docs: list[dict], kind: str, name: str) -> dict:
+    for doc in docs:
+        if doc.get("kind") == kind and doc.get("metadata", {}).get("name") == name:
+            return doc
+    raise AssertionError(f"missing {kind}/{name}")
+
+
+def test_chart_metadata_and_default_values_are_pinned() -> None:
+    chart = yaml.safe_load(_chart_file("Chart.yaml").read_text(encoding="utf-8"))
+    values = yaml.safe_load(_chart_file("values.yaml").read_text(encoding="utf-8"))
+
+    assert chart["apiVersion"] == "v2"
+    assert chart["name"] == "redfish-controller"
+    assert chart["type"] == "application"
+    assert values["image"]["repository"] == "spyroot/redfish-ctl-controller"
+    assert values["mockBmc"]["image"]["repository"] == "spyroot/redfish-ctl-mock-bmc"
+    assert values["mockBmc"]["enabled"] is False
+    assert values["controller"]["pollInterval"] == "30s"
+    assert values["rbac"]["create"] is True
+    assert values["serviceAccount"]["create"] is True
+
+
+def test_crds_are_installed_from_crds_directory() -> None:
+    crds = sorted(path.name for path in (CHART_DIR / "crds").glob("*.yaml"))
+    endpoint_crd = yaml.safe_load(
+        _chart_file("crds/redfish-endpoint-crd.yaml").read_text(encoding="utf-8")
+    )
+    profile_crd = yaml.safe_load(
+        _chart_file("crds/redfish-node-profile-crd.yaml").read_text(encoding="utf-8")
+    )
+
+    assert crds == [
+        "redfish-endpoint-crd.yaml",
+        "redfish-node-profile-crd.yaml",
+    ]
+    assert endpoint_crd["kind"] == "CustomResourceDefinition"
+    assert endpoint_crd["metadata"]["name"] == "redfishendpoints.redfish.ctl.dev"
+    assert profile_crd["kind"] == "CustomResourceDefinition"
+    assert profile_crd["metadata"]["name"] == "redfishnodeprofiles.redfish.ctl.dev"
+
+
+def test_default_template_renders_controller_rbac_and_no_mock_bmc() -> None:
+    docs = _template()
+    deployment = _by_kind_name(docs, "Deployment", "redfish-controller")
+    service_account = _by_kind_name(docs, "ServiceAccount", "redfish-controller")
+    cluster_role = _by_kind_name(docs, "ClusterRole", "redfish-controller")
+    cluster_role_binding = _by_kind_name(docs, "ClusterRoleBinding", "redfish-controller")
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert service_account["metadata"]["namespace"] == "redfish-system"
+    assert cluster_role_binding["subjects"] == [
+        {
+            "kind": "ServiceAccount",
+            "name": "redfish-controller",
+            "namespace": "redfish-system",
+        }
+    ]
+    assert container["image"] == "spyroot/redfish-ctl-controller:v1.2.0"
+    assert container["imagePullPolicy"] == "IfNotPresent"
+    assert container["args"] == [
+        "run",
+        "--standalone",
+        "/app/k8s/controller/redfish_endpoint_controller.py",
+        "/app/k8s/controller/redfish_node_profile_controller.py",
+    ]
+    assert deployment["spec"]["template"]["spec"]["serviceAccountName"] == "redfish-controller"
+    assert deployment["spec"]["template"]["spec"]["securityContext"]["runAsNonRoot"] is True
+    assert container["securityContext"]["allowPrivilegeEscalation"] is False
+    assert container["securityContext"]["readOnlyRootFilesystem"] is True
+    assert cluster_role["rules"]
+    assert all(doc.get("metadata", {}).get("name") != "redfish-controller-mock-bmc" for doc in docs)
+
+
+def test_rbac_can_be_disabled() -> None:
+    docs = _template(["--set", "rbac.create=false"])
+
+    assert not any(doc.get("kind") == "ClusterRole" for doc in docs)
+    assert not any(doc.get("kind") == "ClusterRoleBinding" for doc in docs)
+    _by_kind_name(docs, "Deployment", "redfish-controller")
+    _by_kind_name(docs, "ServiceAccount", "redfish-controller")
+
+
+def test_existing_service_account_name_can_be_used() -> None:
+    docs = _template(
+        [
+            "--set",
+            "serviceAccount.create=false",
+            "--set",
+            "serviceAccount.name=existing-redfish",
+        ]
+    )
+    deployment = _by_kind_name(docs, "Deployment", "redfish-controller")
+
+    assert not any(doc.get("kind") == "ServiceAccount" for doc in docs)
+    assert deployment["spec"]["template"]["spec"]["serviceAccountName"] == "existing-redfish"
+
+
+def test_mock_bmc_can_be_enabled() -> None:
+    docs = _template(["--set", "mockBmc.enabled=true"])
+    mock_deployment = _by_kind_name(docs, "Deployment", "redfish-controller-mock-bmc")
+    mock_service = _by_kind_name(docs, "Service", "redfish-controller-mock-bmc")
+    container = mock_deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert container["image"] == "spyroot/redfish-ctl-mock-bmc:v1.2.0"
+    assert container["env"] == [
+        {
+            "name": "MOCK_BMC_CORPUS_DIR",
+            "value": "/corpus/172.25.230.37",
+        }
+    ]
+    assert mock_service["spec"]["ports"] == [{"name": "http", "port": 80, "targetPort": "http"}]
+
+
+def test_notes_document_secret_ref_convention() -> None:
+    notes = _chart_file("templates/NOTES.txt").read_text(encoding="utf-8")
+
+    assert "same namespace" in notes
+    assert "username" in notes
+    assert "password" in notes
+    assert "kubectl create secret generic" in notes
+
+
+def test_plain_deploy_script_applies_crds_rbac_and_deployment() -> None:
+    script = DEPLOY_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'KUBECTL="${KUBECTL:-kubectl}"' in script
+    assert "apply -f k8s/controller/redfish-endpoint-crd.yaml" in script
+    assert "apply -f k8s/controller/redfish-node-profile-crd.yaml" in script
+    assert "apply -f k8s/controller/rbac.yaml" in script
+    assert "apply -f k8s/controller/deployment.yaml" in script
+    assert "http://" not in script
+    assert "PASSWORD" not in script


### PR DESCRIPTION
## Summary
- add a Helm chart that installs the Redfish controller CRDs, controller deployment, service account, and optional RBAC
- include an optional mock BMC deployment and service behind mockBmc.enabled=false
- add a plain kubectl deploy helper for users who are not using Helm
- add chart contract tests for default rendering, RBAC toggles, mock BMC rendering, CRD placement, and secretRef guidance

## Validation
- pytest -q tests/test_helm_chart.py
- pytest -q tests/test_helm_chart.py tests/test_k8s_controller.py tests/test_k8s_node_profile_controller.py tests/test_k8s_sandbox_harness.py tests/test_k8s_mock_bmc_server.py tests/test_makefile_targets.py
- pytest -q
- ruff check tests/test_helm_chart.py
- helm lint charts/redfish-controller
- helm template redfish-controller charts/redfish-controller --namespace redfish-system
- helm template redfish-controller charts/redfish-controller --namespace redfish-system --set mockBmc.enabled=true
- bash -n k8s/controller/deploy.sh
- shellcheck k8s/controller/deploy.sh
- shfmt -d k8s/controller/deploy.sh
- git diff --cached --check