### PR TITLE
Enforce neutral voice in public docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TWINE ?= twine
 DOCKER ?= docker
 IMAGE ?= redfish-ctl
 
-.PHONY: help test lint typecheck build docker-test docker-image k8s-sandbox clean
+.PHONY: help test lint typecheck build docker-test docker-image docs-voice-check k8s-sandbox clean
 
 help: ## Show available developer targets.
 	@awk 'BEGIN { \
@@ -42,6 +42,9 @@ docker-image: ## Build the production CLI image locally.
 		exit 2; \
 	}
 	$(DOCKER) build -f docker/Dockerfile -t $(IMAGE) .
+
+docs-voice-check: ## Reject first-person wording in public docs.
+	! grep -rnE '\b(I|me|my|mine|myself)\b' README.md docs/
 
 k8s-sandbox: ## Run the local Kubernetes read-path sandbox when present.
 	./k8s/sandbox/run-sandbox.sh

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ mkdir -p .internal
 cat > .internal/redfish.env <<'EOF'
 REDFISH_IP=192.0.2.10
 REDFISH_USERNAME=root
-REDFISH_PASSWORD=replace-me
+REDFISH_PASSWORD=change-this-password
 REDFISH_PORT=443
 EOF
 ```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 Author: Mus <spyroot@gmail.com>
 
-I use `redfish_ctl system` as the first sanity check: it starts at the CLI, runs a self-registering
+Use `redfish_ctl system` as the first sanity check: it starts at the CLI, runs a self-registering
 command module, uses `IDracManager`, and ends in the generic Redfish HTTP client. The important rule
 is that Redfish stays product-neutral; Dell behavior sits above it.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2,8 +2,8 @@
 
 Author: Mus <spyroot@gmail.com>
 
-When I connect to a new BMC, I run `redfish_ctl system` first. It proves the endpoint, credentials, and
-basic Redfish path before I ask for deeper inventory or stage any change.
+When connecting to a new BMC, run `redfish_ctl system` first. It proves the endpoint, credentials, and
+basic Redfish path before deeper inventory or any staged change.
 
 The table below follows the 105 command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
@@ -67,7 +67,7 @@ Safety labels:
 - **Guarded**: does not mutate by default; requires `--confirm` or an equivalent apply flag.
 - **Write**: may mutate when invoked, even if an optional preview flag exists.
 
-| Command | What I use it for | Safety |
+| Command | Purpose | Safety |
 |---|---|---|
 | `account` | Read one account resource. | Read |
 | `account-create` | Create a Redfish account (ManagerAccount); requires `--confirm` to write. | Guarded |
@@ -221,11 +221,11 @@ Commands labeled **Guarded** block or preview writes by default and require an e
 usually `--confirm`. Commands labeled **Write** can mutate as soon as they are invoked; some still
 offer `--show` or `--dry_run`, but those previews are optional.
 
-Before I run either kind of write, I use the same four phases:
+Before running either kind of write, use the same four phases:
 
 1. Read the current state.
 2. Preview the change when the command supports `--show` or `--dry_run`.
-3. Execute only on an approved target with the exact flags I intend to use.
+3. Execute only on an approved target with the exact intended flags.
 4. Verify with a read-only command or a job/task watch.
 
 ### BIOS Change From A Spec

--- a/docs/redfish-proxy.md
+++ b/docs/redfish-proxy.md
@@ -4,13 +4,13 @@ Author: Mus <spyroot@gmail.com>
 
 > Status: read-only core exists. The CLI works without this service.
 
-For one server, I use `redfish_ctl` directly. For a fleet, I want one service that can reach the BMC
+For one server, run `redfish_ctl` directly. For a fleet, use one service that can reach the BMC
 network, keep desired state, read observed state, and reconcile the two. Clients should not all need
 direct routes to BMCs.
 
 ## What Exists
 
-The CLI already has the pieces I would reuse:
+The CLI already has the pieces a service would reuse:
 
 - `RedfishManager`, defined in `redfish_ctl/redfish_manager.py`, for product-neutral HTTP.
 - `IDracManager`, defined in `redfish_ctl/idrac_manager.py`, for Dell/iDRAC behavior and host-system

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -50,7 +50,7 @@ to publish the one-off `idrac_ctl` deprecation shim under `packaging/idrac_ctl_d
 
 ## Release Checklist
 
-I use this order so a broken package does not reach PyPI:
+Use this order so a broken package does not reach PyPI:
 
 1. Verify the tree.
 2. Build source and wheel distributions.
@@ -98,7 +98,7 @@ redfish_ctl --help
 ```
 
 The current `local_install.sh` helper creates a `test1` conda environment, builds `sdist` and wheel,
-then runs `python setup.py install`. It does not install the wheel with `pip`, so I treat it as a
+then runs `python setup.py install`. It does not install the wheel with `pip`, so treat it as a
 developer shortcut, not the full release gate above.
 
 ## Upload

--- a/docs/scaling-and-benchmarks.md
+++ b/docs/scaling-and-benchmarks.md
@@ -2,8 +2,8 @@
 
 Author: Mus <spyroot@gmail.com>
 
-I want `redfish_ctl` to grow past one server and drive roughly 1,000 BMCs to a desired state with
-numbers that show it is fast, correct, and stable. This page is the design target for that fleet
+The design target is for `redfish_ctl` to grow past one server and drive roughly 1,000 BMCs to a
+desired state with numbers that show it is fast, correct, and stable. This page defines the fleet
 engine, simulator, and benchmark gate. Those runnable artifacts are not in the repository yet.
 
 ## What Exists Today
@@ -21,7 +21,7 @@ seed material for a simulator because it exercises Redfish reads without live ha
 A future operation such as "apply profile `rt-low-latency` to these 1,000 servers" would run as
 bounded per-server pipelines:
 
-- async Redfish I/O through the existing `api_async_*` helpers,
+- async Redfish input/output through the existing `api_async_*` helpers,
 - a cap on simultaneous servers and in-flight requests,
 - ordered per-server steps for changes that create jobs or require reboot,
 - subnet-wide pacing plus capped transient-error backoff,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 Author: Mus <spyroot@gmail.com>
 
-Before I trust a change, I clear any live iDRAC environment and run the offline suite:
+Before trusting a change, clear any live iDRAC environment and run the offline suite:
 
 ```bash
 env -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD pytest -q

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -2,7 +2,7 @@
 
 Author: Mus <spyroot@gmail.com>
 
-I keep vendor facts in capability profiles so the Redfish core can stay product-neutral. Dell,
+Vendor facts live in capability profiles so the Redfish core can stay product-neutral. Dell,
 Supermicro, HPE, and generic Redfish now all have fixture-backed coverage, but they do not have the
 same control surface.
 

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -15,6 +15,7 @@ REQUIRED_TARGETS = {
     "build",
     "docker-test",
     "docker-image",
+    "docs-voice-check",
     "k8s-sandbox",
     "clean",
 }
@@ -39,7 +40,15 @@ def test_make_help_lists_required_developer_targets() -> None:
 def test_make_dry_run_uses_expected_safe_local_commands() -> None:
     """Dry-run recipes should route to local checks and never publish artifacts."""
     result = subprocess.run(
-        ["make", "-n", "build", "docker-test", "docker-image", "k8s-sandbox"],
+        [
+            "make",
+            "-n",
+            "build",
+            "docker-test",
+            "docker-image",
+            "docs-voice-check",
+            "k8s-sandbox",
+        ],
         cwd=REPO_ROOT,
         check=False,
         text=True,
@@ -52,6 +61,8 @@ def test_make_dry_run_uses_expected_safe_local_commands() -> None:
     assert "twine check" in result.stdout
     assert "docker/run-tests.sh" in result.stdout
     assert "docker build" in result.stdout
+    assert "\\b(I|me|my|mine|myself)\\b" in result.stdout
+    assert "README.md docs/" in result.stdout
     assert "k8s/sandbox" in result.stdout
 
     makefile_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- Add a `docs-voice-check` Makefile target for public docs.
- Reword remaining first-person phrasing in README/docs.
- Pin the target in the Makefile contract tests.

## Validation

- `make docs-voice-check`
- `conda run -n idrac_ctl pytest -q tests/test_makefile_targets.py`
- `conda run -n idrac_ctl ruff check tests/test_makefile_targets.py`
- `git diff --check && git diff --cached --check`
- `env -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD -u REDFISH_PORT -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT conda run -n idrac_ctl pytest -q` (`971 passed, 58 skipped`)
