### PR TITLE
Add iLO simulator backend to sandbox

### DIFF
--- a/docker/Dockerfile.ilo-sim
+++ b/docker/Dockerfile.ilo-sim
@@ -1,0 +1,66 @@
+# HPE iLO Redfish emulator image for the Kubernetes sandbox.
+#
+# Build:
+#   docker build -f docker/Dockerfile.ilo-sim -t redfish-ctl-ilo-sim:local .
+FROM alpine:3.21 AS source
+
+ARG ILO_EMULATOR_REF=v1.1.0
+
+# hadolint ignore=DL3018
+RUN apk add --no-cache ca-certificates git \
+    && git clone \
+    --depth 1 \
+    --branch "${ILO_EMULATOR_REF}" \
+    https://github.com/HewlettPackard/ilo-redfish-emulator.git \
+    /src
+
+FROM python:3.12-alpine
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:${PATH}" \
+    MOCKUP_FOLDER=DL380a \
+    ASYNC_SLEEP=0 \
+    PORT=8443
+
+RUN addgroup -S -g 10001 ilosim \
+    && adduser \
+        -S \
+        -D \
+        -u 10001 \
+        -G ilosim \
+        -h /home/ilosim \
+        ilosim
+
+WORKDIR /app
+
+COPY --from=source /src/src/requirements.txt /tmp/requirements.txt
+# hadolint ignore=DL3018
+RUN apk add --no-cache curl libffi openssl \
+    && apk add --no-cache --virtual .build-deps \
+        build-base \
+        cargo \
+        gcc \
+        libffi-dev \
+        musl-dev \
+        openssl-dev \
+        python3-dev \
+    && python -m venv /opt/venv \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && pip check \
+    && apk del .build-deps \
+    && rm -rf /root/.cache/pip /tmp/requirements.txt
+
+COPY --from=source --chown=ilosim:ilosim /src/src /app
+COPY --from=source --chown=ilosim:ilosim \
+    /src/mockups \
+    /app/api_emulator/redfish/static
+
+USER ilosim
+
+EXPOSE 8443
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+    CMD curl -fk https://127.0.0.1:8443/redfish/v1/ >/dev/null
+
+ENTRYPOINT ["python3", "emulator.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,6 +9,7 @@ non-root user. Credentials are supplied at container runtime only; do not add th
 | `docker/Dockerfile` | Production CLI/exporter image with the OTLP extra installed. | `docker build -f docker/Dockerfile -t redfish-ctl .` |
 | `docker/Dockerfile.test` | Linux image for the offline pytest suite. | `./docker/run-tests.sh` |
 | `docker/Dockerfile.mock-bmc` | Read-only mock BMC image for the kind sandbox. | `docker build -f docker/Dockerfile.mock-bmc -t redfish-ctl-mock-bmc:local .` |
+| `docker/Dockerfile.ilo-sim` | HPE iLO Redfish emulator image for the simulator sandbox backend. | `docker build -f docker/Dockerfile.ilo-sim -t redfish-ctl-ilo-sim:local .` |
 | `docker/Dockerfile.controller` | RedfishEndpoint controller image for the kind sandbox. | `docker build -f docker/Dockerfile.controller -t redfish-ctl-controller:local .` |
 
 ## Runtime Environment

--- a/k8s/sandbox/README.md
+++ b/k8s/sandbox/README.md
@@ -1,9 +1,9 @@
 # Kubernetes Sandbox
 
 The `make k8s-sandbox` target runs an opt-in local read-path check with `kind`.
-It builds the mock BMC image from `docker/Dockerfile.mock-bmc`, builds the
-controller image from `docker/Dockerfile.controller`, loads both images into the
-cluster named by `KIND_CLUSTER_NAME`, then applies the sample
+By default it builds the corpus mock BMC image from `docker/Dockerfile.mock-bmc`,
+builds the controller image from `docker/Dockerfile.controller`, loads both
+images into the cluster named by `KIND_CLUSTER_NAME`, then applies the sample
 `RedfishEndpoint` custom resource defined in `k8s/sandbox/redfish-endpoint-sample.yaml`.
 
 Required local tools:
@@ -18,6 +18,16 @@ Run the sandbox from the repository root:
 make k8s-sandbox
 ```
 
+To run the same controller path against the HPE iLO Redfish emulator, add the
+`ilo-sim` backend. The image is built locally from the public BSD-3 source at
+<https://github.com/HewlettPackard/ilo-redfish-emulator> and uses its DL380a
+mockup. The first build needs network access to fetch the pinned emulator tag:
+
+```bash
+SANDBOX_BACKENDS=corpus-mock,ilo-sim make k8s-sandbox
+```
+
 The smoke check waits until `.status.powerState` is populated on the sample
-resource. The mock BMC serves only the committed GB300 corpus and rejects
-mutating HTTP verbs.
+resources. The corpus mock BMC serves only the committed GB300 corpus and
+rejects mutating HTTP verbs; the iLO backend is an emulator service, not a live
+BMC.

--- a/k8s/sandbox/ilo-credentials.yaml
+++ b/k8s/sandbox/ilo-credentials.yaml
@@ -1,0 +1,15 @@
+# Public credentials for the HPE iLO Redfish emulator. These are not real BMC
+# credentials; they exercise the controller secretRef path in the sandbox.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ilo-sim-credentials
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: ilo-sim
+    app.kubernetes.io/component: redfish-sandbox
+type: Opaque
+stringData:
+  username: root
+  password: root_password

--- a/k8s/sandbox/ilo-sim.yaml
+++ b/k8s/sandbox/ilo-sim.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ilo-sim
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: ilo-sim
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: ilo-sim
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: ilo-sim
+        app.kubernetes.io/component: redfish-sandbox
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: ilo-sim
+          image: redfish-ctl-ilo-sim:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: https
+              containerPort: 8443
+          env:
+            - name: MOCKUP_FOLDER
+              value: DL380a
+            - name: ASYNC_SLEEP
+              value: "0"
+            - name: PORT
+              value: "8443"
+          readinessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: https
+              scheme: HTTPS
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ilo-sim
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: ilo-sim
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: ilo-sim
+  ports:
+    - name: https
+      port: 443
+      targetPort: https

--- a/k8s/sandbox/redfish-endpoint-ilo-sim.yaml
+++ b/k8s/sandbox/redfish-endpoint-ilo-sim.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: redfish.ctl.dev/v1alpha1
+kind: RedfishEndpoint
+metadata:
+  name: ilo-sim
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  address: https://ilo-sim.redfish-sandbox.svc.cluster.local
+  port: 443
+  insecure: true
+  pollInterval: 10s
+  secretRef:
+    name: ilo-sim-credentials

--- a/k8s/sandbox/run-sandbox.sh
+++ b/k8s/sandbox/run-sandbox.sh
@@ -5,10 +5,13 @@ set -euo pipefail
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-redfish-sandbox}"
 KIND_CONFIG="${KIND_CONFIG:-k8s/sandbox/kind-config.yaml}"
 NAMESPACE="${NAMESPACE:-redfish-sandbox}"
+SANDBOX_BACKENDS="${SANDBOX_BACKENDS:-corpus-mock}"
 STATUS_TIMEOUT_SECONDS="${STATUS_TIMEOUT_SECONDS:-180}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 cd "$REPO_ROOT"
+
+IFS=',' read -r -a BACKENDS <<<"$SANDBOX_BACKENDS"
 
 require_tool() {
 	if ! command -v "$1" >/dev/null 2>&1; then
@@ -17,19 +20,87 @@ require_tool() {
 	fi
 }
 
+has_backend() {
+	local selected
+
+	for selected in "${BACKENDS[@]}"; do
+		case "$selected" in
+		"$1" | all)
+			return 0
+			;;
+		esac
+	done
+	return 1
+}
+
+validate_backends() {
+	local selected
+
+	for selected in "${BACKENDS[@]}"; do
+		case "$selected" in
+		corpus-mock | ilo-sim | all)
+			;;
+		"")
+			printf 'SANDBOX_BACKENDS contains an empty backend\n' >&2
+			exit 2
+			;;
+		*)
+			printf 'unknown SANDBOX_BACKENDS entry: %s\n' "$selected" >&2
+			printf 'valid entries: corpus-mock, ilo-sim, all\n' >&2
+			exit 2
+			;;
+		esac
+	done
+}
+
 section() {
 	printf '\n>> %s\n' "$1"
 }
 
+wait_for_endpoint() {
+	local endpoint_name="$1"
+	local deadline
+	local power_state
+
+	deadline=$((SECONDS + STATUS_TIMEOUT_SECONDS))
+	power_state=""
+	while [ "$SECONDS" -lt "$deadline" ]; do
+		power_state="$(
+			kubectl -n "${NAMESPACE}" \
+				get redfishendpoint "$endpoint_name" \
+				-o 'jsonpath={.status.powerState}' 2>/dev/null || true
+		)"
+		if [ -n "$power_state" ]; then
+			printf 'RedfishEndpoint %s powerState=%s\n' "$endpoint_name" "$power_state"
+			return 0
+		fi
+		sleep 5
+	done
+
+	printf 'timed out waiting for RedfishEndpoint %s status.powerState\n' \
+		"$endpoint_name" >&2
+	kubectl -n "${NAMESPACE}" get redfishendpoint "$endpoint_name" -o yaml || true
+	return 1
+}
+
+validate_backends
 require_tool docker
 require_tool kind
 require_tool kubectl
 
 section "building sandbox images"
-docker build \
-	-f docker/Dockerfile.mock-bmc \
-	-t redfish-ctl-mock-bmc:local \
-	.
+if has_backend "corpus-mock"; then
+	docker build \
+		-f docker/Dockerfile.mock-bmc \
+		-t redfish-ctl-mock-bmc:local \
+		.
+fi
+if has_backend "ilo-sim"; then
+	docker build \
+		-f docker/Dockerfile.ilo-sim \
+		-t redfish-ctl-ilo-sim:local \
+		.
+fi
 docker build \
 	-f docker/Dockerfile.controller \
 	-t redfish-ctl-controller:local \
@@ -43,40 +114,49 @@ else
 fi
 
 section "loading images into kind"
-kind load docker-image redfish-ctl-mock-bmc:local --name "${KIND_CLUSTER_NAME}"
+if has_backend "corpus-mock"; then
+	kind load docker-image redfish-ctl-mock-bmc:local --name "${KIND_CLUSTER_NAME}"
+fi
+if has_backend "ilo-sim"; then
+	kind load docker-image redfish-ctl-ilo-sim:local --name "${KIND_CLUSTER_NAME}"
+fi
 kind load docker-image redfish-ctl-controller:local --name "${KIND_CLUSTER_NAME}"
 
 section "applying sandbox resources"
 kubectl apply -f k8s/sandbox/namespace.yaml
 kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml
-kubectl apply -f k8s/sandbox/mock-bmc.yaml
-kubectl apply -f k8s/sandbox/mock-credentials.yaml
+if has_backend "corpus-mock"; then
+	kubectl apply -f k8s/sandbox/mock-bmc.yaml
+	kubectl apply -f k8s/sandbox/mock-credentials.yaml
+fi
+if has_backend "ilo-sim"; then
+	kubectl apply -f k8s/sandbox/ilo-sim.yaml
+	kubectl apply -f k8s/sandbox/ilo-credentials.yaml
+fi
 kubectl apply -f k8s/controller/rbac.yaml
 kubectl apply -f k8s/controller/deployment.yaml
-kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml
+if has_backend "corpus-mock"; then
+	kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml
+fi
+if has_backend "ilo-sim"; then
+	kubectl apply -f k8s/sandbox/redfish-endpoint-ilo-sim.yaml
+fi
 
 section "waiting for deployments"
-kubectl -n "${NAMESPACE}" rollout status deploy/mock-bmc --timeout=120s
+if has_backend "corpus-mock"; then
+	kubectl -n "${NAMESPACE}" rollout status deploy/mock-bmc --timeout=120s
+fi
+if has_backend "ilo-sim"; then
+	kubectl -n "${NAMESPACE}" rollout status deploy/ilo-sim --timeout=120s
+fi
 kubectl -n "${NAMESPACE}" \
 	rollout status deploy/redfish-endpoint-controller \
 	--timeout=120s
 
 section "waiting for RedfishEndpoint status"
-deadline=$((SECONDS + STATUS_TIMEOUT_SECONDS))
-power_state=""
-while [ "$SECONDS" -lt "$deadline" ]; do
-	power_state="$(
-		kubectl -n "${NAMESPACE}" \
-			get redfishendpoint gb300-mock \
-			-o 'jsonpath={.status.powerState}' 2>/dev/null || true
-	)"
-	if [ -n "$power_state" ]; then
-		printf 'RedfishEndpoint gb300-mock powerState=%s\n' "$power_state"
-		exit 0
-	fi
-	sleep 5
-done
-
-printf 'timed out waiting for RedfishEndpoint status.powerState\n' >&2
-kubectl -n "${NAMESPACE}" get redfishendpoint gb300-mock -o yaml || true
-exit 1
+if has_backend "corpus-mock"; then
+	wait_for_endpoint gb300-mock
+fi
+if has_backend "ilo-sim"; then
+	wait_for_endpoint ilo-sim
+fi

--- a/tests/test_k8s_sandbox_harness.py
+++ b/tests/test_k8s_sandbox_harness.py
@@ -12,10 +12,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 KIND_CONFIG = REPO_ROOT / "k8s" / "sandbox" / "kind-config.yaml"
 SMOKE_SCRIPT = REPO_ROOT / "k8s" / "sandbox" / "run-sandbox.sh"
 SAMPLE_ENDPOINT = REPO_ROOT / "k8s" / "sandbox" / "redfish-endpoint-sample.yaml"
+ILO_SAMPLE_ENDPOINT = REPO_ROOT / "k8s" / "sandbox" / "redfish-endpoint-ilo-sim.yaml"
+ILO_SIM_MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "ilo-sim.yaml"
 CONTROLLER_DEPLOYMENT = REPO_ROOT / "k8s" / "controller" / "deployment.yaml"
 CONTROLLER_RBAC = REPO_ROOT / "k8s" / "controller" / "rbac.yaml"
 CONTROLLER_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.controller"
+ILO_SIM_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.ilo-sim"
 MAKEFILE = REPO_ROOT / "Makefile"
+SANDBOX_README = REPO_ROOT / "k8s" / "sandbox" / "README.md"
 
 
 def _yaml_documents(path: Path) -> list[dict]:
@@ -63,6 +67,63 @@ def test_sample_endpoint_points_at_mock_bmc_without_credentials() -> None:
     assert secret["metadata"]["namespace"] == "redfish-sandbox"
     # Public demo credentials only — a real value here would be a leak.
     assert secret["stringData"] == {"username": "root", "password": "calvin"}
+
+
+def test_ilo_sim_endpoint_points_at_hpe_emulator_secret_ref() -> None:
+    """The alternate sample CR drives the controller against the iLO emulator."""
+    endpoint = yaml.safe_load(ILO_SAMPLE_ENDPOINT.read_text(encoding="utf-8"))
+
+    assert endpoint["apiVersion"] == "redfish.ctl.dev/v1alpha1"
+    assert endpoint["kind"] == "RedfishEndpoint"
+    assert endpoint["metadata"]["name"] == "ilo-sim"
+    assert endpoint["metadata"]["namespace"] == "redfish-sandbox"
+    assert endpoint["spec"] == {
+        "address": "https://ilo-sim.redfish-sandbox.svc.cluster.local",
+        "port": 443,
+        "insecure": True,
+        "pollInterval": "10s",
+        "secretRef": {"name": "ilo-sim-credentials"},
+    }
+    sample_text = ILO_SAMPLE_ENDPOINT.read_text(encoding="utf-8")
+    assert "root_password" not in sample_text
+
+    secret = yaml.safe_load(
+        (ILO_SAMPLE_ENDPOINT.parent / "ilo-credentials.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert secret["kind"] == "Secret"
+    assert secret["metadata"]["name"] == "ilo-sim-credentials"
+    assert secret["metadata"]["namespace"] == "redfish-sandbox"
+    assert secret["stringData"] == {"username": "root", "password": "root_password"}
+
+
+def test_ilo_sim_manifest_deploys_hpe_emulator_service() -> None:
+    """The sandbox can run a real HPE iLO Redfish emulator backend."""
+    docs = _yaml_documents(ILO_SIM_MANIFEST)
+    by_kind = {doc["kind"]: doc for doc in docs}
+
+    deployment = by_kind["Deployment"]
+    service = by_kind["Service"]
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+
+    assert deployment["metadata"]["name"] == "ilo-sim"
+    assert service["metadata"]["name"] == "ilo-sim"
+    assert container["image"] == "redfish-ctl-ilo-sim:local"
+    assert container["env"] == [
+        {"name": "MOCKUP_FOLDER", "value": "DL380a"},
+        {"name": "ASYNC_SLEEP", "value": "0"},
+        {"name": "PORT", "value": "8443"},
+    ]
+    assert container["ports"][0]["containerPort"] == 8443
+    assert container["readinessProbe"]["httpGet"] == {
+        "path": "/redfish/v1/",
+        "port": "https",
+        "scheme": "HTTPS",
+    }
+    assert service["spec"]["ports"][0]["port"] == 443
+    assert service["spec"]["ports"][0]["targetPort"] == "https"
+    assert container["securityContext"]["allowPrivilegeEscalation"] is False
 
 
 def test_controller_deployment_is_read_only_and_uses_local_image() -> None:
@@ -136,24 +197,57 @@ def test_controller_image_runs_kopf_without_credentials() -> None:
     assert "IDRAC_PASSWORD" not in dockerfile
 
 
+def test_ilo_sim_image_builds_public_hpe_emulator_without_credentials() -> None:
+    """The iLO simulator image is built from the public emulator source."""
+    dockerfile = ILO_SIM_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert "https://github.com/HewlettPackard/ilo-redfish-emulator.git" in dockerfile
+    assert "ARG ILO_EMULATOR_REF=v1.1.0" in dockerfile
+    assert "MOCKUP_FOLDER=DL380a" in dockerfile
+    assert "PORT=8443" in dockerfile
+    assert "EXPOSE 8443" in dockerfile
+    assert "USER ilosim" in dockerfile
+    assert "ENTRYPOINT" in dockerfile
+    assert "REDFISH_PASSWORD" not in dockerfile
+    assert "IDRAC_PASSWORD" not in dockerfile
+
+
 def test_sandbox_smoke_script_applies_manifests_and_waits_for_status() -> None:
     """The opt-in smoke harness proves the CR status is populated."""
     script = SMOKE_SCRIPT.read_text(encoding="utf-8")
     mode = os.stat(SMOKE_SCRIPT).st_mode
 
     assert mode & stat.S_IXUSR
+    assert "SANDBOX_BACKENDS=\"${SANDBOX_BACKENDS:-corpus-mock}\"" in script
+    assert "has_backend \"corpus-mock\"" in script
+    assert "has_backend \"ilo-sim\"" in script
     assert "kind create cluster --name \"${KIND_CLUSTER_NAME}\"" in script
     assert "kind load docker-image redfish-ctl-mock-bmc:local" in script
+    assert "kind load docker-image redfish-ctl-ilo-sim:local" in script
     assert "kind load docker-image redfish-ctl-controller:local" in script
     assert "kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml" in script
     assert "kubectl apply -f k8s/sandbox/mock-bmc.yaml" in script
     assert "kubectl apply -f k8s/sandbox/mock-credentials.yaml" in script
+    assert "kubectl apply -f k8s/sandbox/ilo-sim.yaml" in script
+    assert "kubectl apply -f k8s/sandbox/ilo-credentials.yaml" in script
     assert "kubectl apply -f k8s/controller/rbac.yaml" in script
     assert "kubectl apply -f k8s/controller/deployment.yaml" in script
     assert "kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml" in script
+    assert "kubectl apply -f k8s/sandbox/redfish-endpoint-ilo-sim.yaml" in script
     assert "jsonpath={.status.powerState}" in script
+    assert "wait_for_endpoint gb300-mock" in script
+    assert "wait_for_endpoint ilo-sim" in script
     assert "kubectl delete" not in script
     assert "docker push" not in script
+
+
+def test_sandbox_readme_documents_ilo_backend_selection() -> None:
+    """Operators can opt into the simulator matrix from the sandbox docs."""
+    readme = SANDBOX_README.read_text(encoding="utf-8")
+
+    assert "SANDBOX_BACKENDS=corpus-mock,ilo-sim make k8s-sandbox" in readme
+    assert "HPE iLO Redfish emulator" in readme
+    assert "https://github.com/HewlettPackard/ilo-redfish-emulator" in readme
 
 
 def test_make_k8s_sandbox_invokes_smoke_harness() -> None:


### PR DESCRIPTION
## Summary
- add a local Dockerfile for the HPE iLO Redfish emulator pinned to v1.1.0
- add optional ilo-sim Deployment, Service, Secret, and RedfishEndpoint manifests
- parameterize the sandbox harness with SANDBOX_BACKENDS so corpus-mock remains the default and ilo-sim can be added
- extend sandbox docs and contract tests for the simulator backend

## Verification
- pytest -q tests/test_k8s_sandbox_harness.py
- pytest -q tests/test_k8s_sandbox_harness.py tests/test_k8s_mock_bmc_server.py tests/test_k8s_controller.py
- pytest -q
- ruff check tests/test_k8s_sandbox_harness.py
- bash -n k8s/sandbox/run-sandbox.sh
- shellcheck k8s/sandbox/run-sandbox.sh
- shfmt -d k8s/sandbox/run-sandbox.sh
- hadolint docker/Dockerfile.ilo-sim
- yamllint k8s/sandbox/ilo-sim.yaml k8s/sandbox/ilo-credentials.yaml k8s/sandbox/redfish-endpoint-ilo-sim.yaml
- docker build -f docker/Dockerfile.ilo-sim -t redfish-ctl-ilo-sim:sim1-verify .

The temporary verification image was removed after the build.