### PR TITLE
Fix write-status checks that treated failed writes as success

### DIFF
--- a/redfish_ctl/bios/cmd_change_bios.py
+++ b/redfish_ctl/bios/cmd_change_bios.py
@@ -363,7 +363,7 @@ class BiosChangeSettings(IDracManager,
             task_state = self.fetch_task(task_id)
             cmd_result.data['task_state'] = task_state
             cmd_result.data['task_id'] = task_id
-        elif api_resp.Success or api_resp.Ok:
+        elif api_resp in (IdracApiRespond.Success, IdracApiRespond.Ok):
             if do_commit:
                 self.logger.info("Commit changes and rebooting.")
                 # we commit with a reboot

--- a/redfish_ctl/bios/cmd_change_boot_order.py
+++ b/redfish_ctl/bios/cmd_change_boot_order.py
@@ -11,8 +11,7 @@ from typing import Optional
 from ..cmd_exceptions import InvalidJsonSpec
 from ..cmd_utils import from_json_spec
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond
-from ..idrac_shared import Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, IdracApiRespond, Singleton
 from ..redfish_manager import CommandResult
 from ..redfish_shared import RedfishJson
 
@@ -185,9 +184,9 @@ class ChangeBootOrder(
             task_state = self.fetch_task(task_id)
             cmd_result.data['task_state'] = task_state
             cmd_result.data['task_id'] = task_id
-        elif api_resp.Success or api_resp.Ok:
+        elif api_resp in (IdracApiRespond.Success, IdracApiRespond.Ok):
             if do_commit:
-                self.logger.info(f"Commit changes and rebooting.")
+                self.logger.info("Commit changes and rebooting.")
                 # we commit with a reboot
                 cmd_apply = self.sync_invoke(
                     ApiRequestType.JobApply,

--- a/redfish_ctl/boot_source/cmd_update.py
+++ b/redfish_ctl/boot_source/cmd_update.py
@@ -11,17 +11,9 @@ from typing import Optional
 
 from ..cmd_exceptions import InvalidJsonSpec
 from ..cmd_utils import from_json_spec
-from ..idrac_shared import IdracApiRespond
-from ..redfish_shared import RedfishJson
-from ..cmd_utils import str2bool
-from ..idrac_shared import IdracApiRespond, ResetType
-from ..cmd_utils import save_if_needed
-from ..cmd_exceptions import InvalidArgument
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond, Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, IdracApiRespond, Singleton
 from ..redfish_manager import CommandResult
-from ..idrac_shared import IDRAC_API
-from ..idrac_shared import IdracApiRespond
 
 
 class BootSourceUpdate(IDracManager,
@@ -162,8 +154,8 @@ class BootSourceUpdate(IDracManager,
                     )
         except json.decoder.JSONDecodeError as jde:
             raise InvalidJsonSpec(
-                "It looks like your JSON spec is invalid. "
-                "JSONlint the file and check..".format(str(jde)))
+                f"It looks like your JSON spec is invalid. "
+                f"JSONlint the file and check: {jde}")
 
         job_req_payload = self.create_apply_time_req(
             apply, start_time, start_date, default_duration
@@ -187,9 +179,9 @@ class BootSourceUpdate(IDracManager,
             task_state = self.fetch_task(task_id)
             cmd_result.data['task_state'] = task_state
             cmd_result.data['task_id'] = task_id
-        elif api_resp.Success or api_resp.Ok:
+        elif api_resp in (IdracApiRespond.Success, IdracApiRespond.Ok):
             if do_commit:
-                self.logger.info(f"Commit changes and rebooting.")
+                self.logger.info("Commit changes and rebooting.")
                 # we commit with a reboot
                 cmd_apply = self.sync_invoke(
                     ApiRequestType.JobApply,

--- a/redfish_ctl/chassis/cmd_update_chassis.py
+++ b/redfish_ctl/chassis/cmd_update_chassis.py
@@ -12,17 +12,13 @@ accessible to software that runs on the system.
 
 Author Mus spyroot@gmail.com
 """
-import json
 from abc import abstractmethod
 from typing import Optional
 
-from ..cmd_exceptions import InvalidArgument
-from ..cmd_exceptions import InvalidArgumentFormat
-from ..cmd_exceptions import InvalidJsonSpec
+from ..cmd_exceptions import InvalidArgument, InvalidArgumentFormat
 from ..cmd_utils import from_json_spec
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IDRAC_API
-from ..idrac_shared import Singleton, ApiRequestType
+from ..idrac_shared import IDRAC_API, ApiRequestType, IdracApiRespond, Singleton
 from ..redfish_manager import CommandResult
 
 
@@ -101,16 +97,12 @@ class ChassisUpdate(IDracManager,
 
         if chassis_id is None or len(chassis_id) == 0:
             raise InvalidArgumentFormat(
-                f"chassis_id is empty string"
+                "chassis_id is empty string"
             )
 
-        try:
-            if from_spec is None or len(from_spec) > 0:
-                raise InvalidArgument("Invalid from_spec")
-        except json.decoder.JSONDecodeError as jde:
-            raise InvalidJsonSpec(
-                "It looks like your JSON spec is invalid. "
-                "JSONlint the file and check..".format(str(jde)))
+        # A missing spec is the invalid case; a provided path is parsed below.
+        if from_spec is None or len(from_spec) == 0:
+            raise InvalidArgument("Invalid from_spec")
 
         payload = from_json_spec(from_spec)
         if len(payload) == 0:
@@ -125,7 +117,7 @@ class ChassisUpdate(IDracManager,
             data_type=data_type
         )
 
-        if api_resp.AcceptedTaskGenerated:
+        if api_resp == IdracApiRespond.AcceptedTaskGenerated:
             task_id = cmd_result.data['task_id']
             task_state = self.fetch_task(cmd_result.data['task_id'])
             cmd_result.data['task_state'] = task_state

--- a/redfish_ctl/system/cmd_system_import.py
+++ b/redfish_ctl/system/cmd_system_import.py
@@ -7,21 +7,14 @@ python redfish_ctl.py system-import --config system.json
 
 Author Mus spyroot@gmail.com
 """
-import json
 from abc import abstractmethod
 from pathlib import Path
 from typing import Optional
 
-from ..redfish_manager import CommandResult
 from ..cmd_exceptions import InvalidArgument
-from ..idrac_manager import PostRequestFailed, IDracManager
-from ..redfish_manager import CommandResult
-from ..cmd_exceptions import FailedDiscoverAction
-from ..cmd_exceptions import InvalidArgument
-from ..cmd_exceptions import UnsupportedAction
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond, Singleton, ApiRequestType
-from ..idrac_shared import IDRAC_JSON
+from ..idrac_shared import ApiRequestType, IdracApiRespond, Singleton
+from ..redfish_manager import CommandResult
 
 
 class ImportSystemConfig(IDracManager,
@@ -137,7 +130,7 @@ class ImportSystemConfig(IDracManager,
 
         path_config = Path(config).expanduser().resolve()
         if not path_config.is_file():
-            raise InvalidArgument(f"Invalid path to a config file.")
+            raise InvalidArgument("Invalid path to a config file.")
 
         with open(str(path_config), "r") as f:
             buf = f.read()
@@ -156,11 +149,11 @@ class ImportSystemConfig(IDracManager,
         data = {}
 
         cmd_result, api_resp = self.base_post(r, payload)
-        if api_resp.AcceptedTaskGenerated:
-            job_id = cmd_result.data['job_id']
-            task_state = self.fetch_task(cmd_result.data['job_id'])
+        if api_resp == IdracApiRespond.AcceptedTaskGenerated:
+            task_id = cmd_result.data['task_id']
+            task_state = self.fetch_task(task_id)
             cmd_result.data['task_state'] = task_state
-            cmd_result.data['task_id'] = job_id
+            cmd_result.data['task_id'] = task_id
 
         if do_reboot:
             reboot_result = self.reboot()

--- a/tests/test_write_status_enum_checks.py
+++ b/tests/test_write_status_enum_checks.py
@@ -1,0 +1,170 @@
+"""Regression tests: failed writes must never be treated as success.
+
+``base_post``/``base_patch`` return ``(CommandResult, IdracApiRespond)``.
+``IdracApiRespond`` is an Enum, so ``api_resp.Success`` is attribute access
+returning the class member — always truthy — NOT a comparison. Five commands
+used that pattern, so an Error response satisfied the success branch; three
+of them then escalated a failed PATCH into JobApply with a reboot. These
+tests pin the correct behavior: an Error result returns the error to the
+caller and never schedules a commit, while a real success still commits.
+
+Each test monkeypatches the command's own write seam (``base_patch`` /
+``base_post``) — no network, no live BMC.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+
+from redfish_ctl.bios.cmd_change_bios import BiosChangeSettings
+from redfish_ctl.bios.cmd_change_boot_order import ChangeBootOrder
+from redfish_ctl.boot_source.cmd_update import BootSourceUpdate
+from redfish_ctl.chassis.cmd_update_chassis import ChassisUpdate
+from redfish_ctl.idrac_shared import IdracApiRespond
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.system.cmd_system_import import ImportSystemConfig
+
+MOCK_SERVERS = "/redfish/v1/Systems/System.Embedded.1"
+
+
+def _cmd(cls):
+    """A command instance with mock credentials (offline; nothing contacted)."""
+    return cls(
+        idrac_ip="mock-idrac", idrac_username="root",
+        idrac_password="mock", insecure=True, is_debug=False,
+    )
+
+
+def _error_write(*_args, **_kwargs):
+    """A failed write: the base layer returns Error instead of raising."""
+    return (
+        CommandResult({"Status": "Failed"}, None, None, "mock redfish error"),
+        IdracApiRespond.Error,
+    )
+
+
+def _ok_write(*_args, **_kwargs):
+    """A plain successful write with no task attached (HTTP 200/204)."""
+    return CommandResult({}, None, None, None), IdracApiRespond.Ok
+
+
+def _spy_sync_invoke(record):
+    """Record nested command invocations; serve empty results."""
+    def spy(api_call, name, **kwargs):
+        record.append(name)
+        return CommandResult({}, None, None, None)
+    return spy
+
+
+def _write_spec(tmp_path, payload):
+    spec = tmp_path / "spec.json"
+    spec.write_text(json.dumps(payload))
+    return str(spec)
+
+
+def test_bios_change_failed_patch_does_not_commit(tmp_path, monkeypatch):
+    """bios-change: a failed Settings PATCH with do_commit must not JobApply.
+
+    This was live: IdracApiRespond.Error satisfied ``api_resp.Success or
+    api_resp.Ok`` (enum-member attribute access is always truthy), so a
+    failed BIOS write logged "Commit changes and rebooting" and rebooted.
+    """
+    cmd = _cmd(BiosChangeSettings)
+    invoked = []
+    monkeypatch.setattr(cmd, "sync_invoke", _spy_sync_invoke(invoked))
+    monkeypatch.setattr(
+        cmd, "_resolve_bios_settings_uri", lambda *a, **k: f"{MOCK_SERVERS}/Bios/Settings"
+    )
+    monkeypatch.setattr(cmd, "base_patch", _error_write)
+
+    spec = _write_spec(tmp_path, {"Attributes": {"ProcCStates": "Disabled"}})
+    result = cmd.execute(from_spec=spec, do_commit=True)
+
+    assert "job_apply" not in invoked
+    assert result.error is not None
+
+
+def test_bios_change_ok_patch_still_commits(tmp_path, monkeypatch):
+    """bios-change: a real success with do_commit still schedules JobApply."""
+    cmd = _cmd(BiosChangeSettings)
+    invoked = []
+    monkeypatch.setattr(cmd, "sync_invoke", _spy_sync_invoke(invoked))
+    monkeypatch.setattr(
+        cmd, "_resolve_bios_settings_uri", lambda *a, **k: f"{MOCK_SERVERS}/Bios/Settings"
+    )
+    monkeypatch.setattr(cmd, "base_patch", _ok_write)
+
+    spec = _write_spec(tmp_path, {"Attributes": {"ProcCStates": "Disabled"}})
+    cmd.execute(from_spec=spec, do_commit=True)
+
+    assert "job_apply" in invoked
+
+
+def test_boot_order_failed_patch_does_not_commit(tmp_path, monkeypatch):
+    """boot-order change: a failed PATCH with do_commit must not JobApply."""
+    cmd = _cmd(ChangeBootOrder)
+    invoked = []
+    cmd.__dict__["idrac_manage_servers"] = MOCK_SERVERS
+    monkeypatch.setattr(cmd, "sync_invoke", _spy_sync_invoke(invoked))
+    monkeypatch.setattr(cmd, "base_patch", _error_write)
+
+    spec = _write_spec(tmp_path, {"Boot": {"BootOrder": ["HardDisk.List.1-1"]}})
+    result = cmd.execute(boot_order="", from_spec=spec, do_commit=True)
+
+    assert "job_apply" not in invoked
+    assert result.error is not None
+
+
+def test_boot_source_failed_patch_does_not_commit(tmp_path, monkeypatch):
+    """boot-source update: a failed PATCH with do_commit must not JobApply."""
+    cmd = _cmd(BootSourceUpdate)
+    invoked = []
+    cmd.__dict__["idrac_manage_servers"] = MOCK_SERVERS
+    monkeypatch.setattr(cmd, "sync_invoke", _spy_sync_invoke(invoked))
+    monkeypatch.setattr(cmd, "base_patch", _error_write)
+
+    spec = _write_spec(tmp_path, {"BootSourceOverrideEnabled": "Once"})
+    result = cmd.execute(from_spec=spec, do_commit=True)
+
+    assert "job_apply" not in invoked
+    assert result.error is not None
+
+
+def test_chassis_update_plain_success_has_no_task(tmp_path, monkeypatch):
+    """chassis update: a 200/204 with no task must not KeyError on task_id.
+
+    ``api_resp.AcceptedTaskGenerated`` was always truthy, so every non-task
+    response crashed reading ``data['task_id']`` from an empty dict.
+    """
+    cmd = _cmd(ChassisUpdate)
+    monkeypatch.setattr(cmd, "base_patch", _ok_write)
+
+    spec = _write_spec(tmp_path, {"AssetTag": "lab"})
+    result = cmd.execute(chassis_id="System.Embedded.1", from_spec=spec)
+
+    assert result.error is None
+    assert "task_id" not in result.data
+
+
+def test_system_import_task_reads_task_id_key(tmp_path, monkeypatch):
+    """system-import: an accepted task exposes task_id (job_id never existed).
+
+    The base layer stores the id under 'task_id'; this command read
+    'job_id', so even the legitimate task path raised KeyError.
+    """
+    cmd = _cmd(ImportSystemConfig)
+
+    def accepted_post(*_args, **_kwargs):
+        return (
+            CommandResult({"task_id": "JID_123"}, None, None, None),
+            IdracApiRespond.AcceptedTaskGenerated,
+        )
+
+    monkeypatch.setattr(cmd, "base_post", accepted_post)
+    monkeypatch.setattr(cmd, "fetch_task", lambda *_a, **_k: "scheduled")
+
+    config = tmp_path / "config.json"
+    config.write_text("{}")
+    result = cmd.execute(config=str(config))
+
+    assert result.data["task_id"] == "JID_123"
+    assert result.data["task_state"] == "scheduled"


### PR DESCRIPTION
## Summary
- `IdracApiRespond` members were checked with attribute access (`api_resp.Success or api_resp.Ok`) — always truthy, so an Error response satisfied the success branch. In `bios-change`, `boot-order` change, and `boot-source` update with `--commit`, a FAILED PATCH proceeded to JobApply with a reboot.
- `chassis-update` treated every response as task-generating (KeyError on plain 200/204) and its `from_spec` validation was inverted, rejecting every provided spec.
- `system-import` read the task id under `job_id`; the base layer only ever stores `task_id`.

## Fixes
Proper enum comparisons at all five sites, the real task-id key, the corrected spec check, plus lint cleanup in touched files.

## Tests
- New `tests/test_write_status_enum_checks.py`: each bug reproduced red first (5 failed / 1 passed pre-fix), green post-fix, including a success-path test pinning that a real success still commits.
- Full offline suite: 853 passed, ruff clean on changed files.