### PR TITLE
Guard boot-one-shot dry-run previews

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -89,7 +89,7 @@ Safety labels:
 | `bios-snapshot` | Capture a BIOS restore point for rollback-able changes. | Read |
 | `bmc-scan` | Scan a network segment for Redfish BMCs. | Read |
 | `boot` | Read boot source data (vendor-neutral: falls back to the ComputerSystem `Boot` object). | Read |
-| `boot-one-shot` | Set a one-time boot target and optionally reboot or power on. | Write |
+| `boot-one-shot` | Set a one-time boot target; `--dry_run` previews the Boot PATCH payload. | Write |
 | `boot-options` | Read boot option members. | Read |
 | `boot-options-clear` | Clear pending boot option values. | Write |
 | `boot-pending` | Read pending boot source values. | Read |
@@ -270,6 +270,7 @@ redfish_ctl get_vm
 redfish_ctl eject_vm --device_id 1
 redfish_ctl insert_vm --uri_path http://10.0.0.10/ubuntu.iso --device_id 1
 redfish_ctl get_vm
+redfish_ctl boot-one-shot --device Cd --dry_run
 redfish_ctl boot-one-shot --device Cd -r
 redfish_ctl current_boot
 ```

--- a/docs/reconciler.md
+++ b/docs/reconciler.md
@@ -23,9 +23,10 @@ commands:
 - `bios-profile diff`, from `redfish_ctl/bios/cmd_bios_profile.py`, reads current BIOS attributes.
 - `ntp-set` without `confirm`, from `redfish_ctl/manager/cmd_ntp_set.py`, builds a PATCH plan but does
   not write it.
+- `boot-one-shot` with `dry_run=True`, from `redfish_ctl/boot_source/cmd_boot_one_shot.py`, builds
+  the Boot PATCH payload without PATCHing the ComputerSystem.
 - `reboot` with `dry_run=True`, from `redfish_ctl/compute/cmd_power_state.py`, discovers the reset
   target and payload without POSTing.
-- `boot-one-shot` is not invoked during dry-run because it has no preview-only command path.
 
 `reconcile(manager, desired, confirm=True)` applies only the required planned changes:
 

--- a/redfish_ctl/boot_source/cmd_boot_one_shot.py
+++ b/redfish_ctl/boot_source/cmd_boot_one_shot.py
@@ -64,6 +64,12 @@ class BootOneShot(IDracManager,
                  "entry, e.g. a UEFI virtual CD/DVD on boards where the Legacy "
                  "path is unusable.")
 
+        cmd_parser.add_argument(
+            '--dry_run', action='store_true',
+            required=False, dest="dry_run",
+            default=False,
+            help="preview the one-time boot PATCH payload; write nothing.")
+
         help_text = "command change one shoot boot"
         return cmd_parser, "boot-one-shot", help_text
 
@@ -78,6 +84,8 @@ class BootOneShot(IDracManager,
                 do_async: Optional[bool] = False,
                 do_reboot: Optional[bool] = False,
                 do_power_on: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                confirm: Optional[bool] = True,
                 **kwargs) -> CommandResult:
         """Query information for particular boot source device from idrac.
         Example python redfish_ctl.py get_boot_source --dev "HardDisk.List.1-1"
@@ -86,6 +94,9 @@ class BootOneShot(IDracManager,
 
         :param do_reboot:  will reboot host
         :param do_power_on: will power on server if server in power down state.
+        :param dry_run: preview the PATCH payload without mutating Boot settings.
+        :param confirm: allow the PATCH to fire. Defaults True for backward
+                        compatibility; internal dry-run callers pass False.
         :param mode: boot source override mode, "UEFI" or "Legacy"
                      (Redfish BootSourceOverrideMode). None leaves it unchanged.
         :param uefi_target:
@@ -106,13 +117,6 @@ class BootOneShot(IDracManager,
         headers = {}
         if data_type == "json":
             headers.update(self.json_content_type)
-
-        # power on first if a client requested.
-        if do_power_on:
-            current_boot = self.sync_invoke(
-                ApiRequestType.ChassisReset, "reboot",
-                reset_type="On"
-            )
 
         # query for a power state
         current_boot = self.sync_invoke(
@@ -173,6 +177,26 @@ class BootOneShot(IDracManager,
         for key, value in dict(payload['Boot']).items():
             if value is None:
                 del payload['Boot'][key]
+
+        if dry_run or not confirm:
+            return CommandResult(
+                {
+                    "dry_run": True,
+                    "target": self.idrac_manage_servers,
+                    "payload": payload,
+                    "blocked": None if dry_run else "one-time boot requires confirm",
+                },
+                None,
+                None,
+                None,
+            )
+
+        # power on first if a client requested and this is a confirmed write.
+        if do_power_on:
+            self.sync_invoke(
+                ApiRequestType.ChassisReset, "reboot",
+                reset_type="On"
+            )
 
         cmd_result, api_resp = self.base_patch(
             self.idrac_manage_servers, payload=payload,

--- a/redfish_ctl/reconcile.py
+++ b/redfish_ctl/reconcile.py
@@ -201,29 +201,26 @@ def _reconcile_boot(
     steps: list[ReconcileStep],
     applied: list[AppliedChange],
 ) -> None:
-    preview = {
-        "device": state.boot_device,
-        "mode": state.boot_mode,
-        "uefiTarget": state.uefi_target,
-    }
+    result = _invoke_mapping(
+        manager,
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device=state.boot_device,
+        mode=state.boot_mode,
+        uefi_target=state.uefi_target,
+        do_reboot=False,
+        dry_run=not confirm,
+        confirm=confirm,
+    )
     steps.append(
         ReconcileStep(
             kind="boot",
             required=True,
             description="One-time boot override",
-            preview=preview,
+            preview=result,
         )
     )
     if confirm:
-        result = _invoke_mapping(
-            manager,
-            ApiRequestType.BootOneShot,
-            "boot_one_shot",
-            device=state.boot_device,
-            mode=state.boot_mode,
-            uefi_target=state.uefi_target,
-            do_reboot=False,
-        )
         applied.append(
             AppliedChange(kind="boot", changed=True, result=result)
         )

--- a/tests/test_ast_conventions.py
+++ b/tests/test_ast_conventions.py
@@ -21,6 +21,47 @@ from pathlib import Path
 PACKAGE_ROOT = Path(__file__).resolve().parents[1] / "redfish_ctl"
 
 RESPOND_MEMBERS = {"Success", "Ok", "AcceptedTaskGenerated", "Error"}
+MUTATING_HELPERS = {"base_post", "base_patch", "base_delete"}
+MUTATION_GUARD_ARGS = {"dry_run", "confirm", "confirm_irreversible", "acct_confirm"}
+
+# Existing direct write sites that predate the guarded-command convention.
+# New command code should expose one of MUTATION_GUARD_ARGS or route through
+# invoke_action instead of extending this list.
+LEGACY_UNGUARDED_MUTATION_CALLS = {
+    "redfish_ctl/attribute/cmd_attribute_clear_pending.py:84 execute base_post",
+    "redfish_ctl/attribute/cmd_attribute_update.py:88 execute base_patch",
+    "redfish_ctl/bios/cmd_bios_clear_pending.py:78 execute base_post",
+    "redfish_ctl/bios/cmd_change_bios.py:356 execute base_patch",
+    "redfish_ctl/bios/cmd_change_boot_order.py:176 execute base_patch",
+    "redfish_ctl/boot_source/cmd_clear_pending.py:70 execute base_post",
+    "redfish_ctl/boot_source/cmd_enable.py:120 execute base_patch",
+    "redfish_ctl/boot_source/cmd_update.py:171 execute base_patch",
+    "redfish_ctl/chassis/cmd_chasis_reset.py:114 execute base_post",
+    "redfish_ctl/chassis/cmd_update_chassis.py:115 execute base_patch",
+    "redfish_ctl/dell_lc/cmd_dell_lc_api.py:52 execute base_post",
+    "redfish_ctl/dell_lc/cmd_dell_lc_rs.py:51 execute base_post",
+    "redfish_ctl/delloem/delloem_attach.py:90 execute base_post",
+    "redfish_ctl/delloem/delloem_attach_status.py:66 execute base_post",
+    "redfish_ctl/delloem/delloem_boot_netios.py:97 execute base_post",
+    "redfish_ctl/delloem/delloem_detach.py:56 execute base_post",
+    "redfish_ctl/delloem/delloem_disconnect.py:55 execute base_post",
+    "redfish_ctl/delloem/delloem_get_networkios.py:65 execute base_post",
+    "redfish_ctl/jobs/cmd_job_apply.py:143 execute base_post",
+    "redfish_ctl/jobs/cmd_job_del.py:61 execute base_delete",
+    "redfish_ctl/jobs/cmd_job_delete_all.py:78 execute base_post",
+    "redfish_ctl/manager/cmd_manager_reset.py:92 execute base_post",
+    "redfish_ctl/manager/cmd_manager_time.py:108 execute base_patch",
+    "redfish_ctl/storage/cmd_convert_none_raid.py:114 execute base_post",
+    "redfish_ctl/storage/cmd_convert_to_raid.py:117 execute base_post",
+    "redfish_ctl/system/cmd_system_config.py:116 execute base_post",
+    "redfish_ctl/system/cmd_system_import.py:151 execute base_post",
+    "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:122 execute base_post",
+    "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:135 execute base_patch",
+    "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:142 execute base_post",
+    "redfish_ctl/virtual_media/cmd_virtual_media_eject.py:110 execute base_post",
+    "redfish_ctl/virtual_media/cmd_virtual_media_insert.py:224 execute base_post",
+    "redfish_ctl/volumes/cmd_initilize.py:78 execute base_post",
+}
 
 
 def _accessed_on(node: ast.Attribute) -> str | None:
@@ -56,6 +97,59 @@ def _enum_member_truthiness_findings() -> list:
     return findings
 
 
+def _parent_map(tree):
+    """Map each AST child to its direct parent."""
+    parents = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parents[child] = parent
+    return parents
+
+
+def _enclosing_function(node, parents):
+    """Return the function containing node, if any."""
+    cursor = node
+    while cursor is not None:
+        if isinstance(cursor, ast.FunctionDef | ast.AsyncFunctionDef):
+            return cursor
+        cursor = parents.get(cursor)
+    return None
+
+
+def _function_arg_names(function):
+    """Return all positional and keyword-only argument names for a function."""
+    if function is None:
+        return set()
+    return {
+        arg.arg
+        for arg in function.args.args + function.args.kwonlyargs
+    }
+
+
+def _unguarded_direct_mutation_findings() -> list[str]:
+    """Direct write helpers in command modules without an explicit guard arg."""
+    findings = []
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        if path.name == "idrac_manager.py":
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        parents = _parent_map(tree)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            if node.func.attr not in MUTATING_HELPERS:
+                continue
+            function = _enclosing_function(node, parents)
+            if _function_arg_names(function) & MUTATION_GUARD_ARGS:
+                continue
+            rel = path.relative_to(PACKAGE_ROOT.parent)
+            name = function.name if function is not None else "<module>"
+            findings.append(f"{rel}:{node.lineno} {name} {node.func.attr}")
+    return findings
+
+
 def test_no_enum_member_truthiness_on_respond_values():
     """No module may test an API respond value via member attribute access.
 
@@ -74,3 +168,26 @@ def test_the_guard_actually_detects_the_bad_shape():
         if isinstance(node, ast.Attribute) and node.attr in RESPOND_MEMBERS
     ]
     assert len(hits) == 2
+
+
+def test_new_direct_mutation_calls_are_guarded_or_baselined():
+    """New direct write helpers must expose a dry-run/confirm style guard.
+
+    The legacy baseline keeps this from rewriting older commands as part of an
+    unrelated feature, while still making new unguarded direct writes fail CI.
+    """
+    assert set(_unguarded_direct_mutation_findings()) == LEGACY_UNGUARDED_MUTATION_CALLS
+
+
+def test_mutation_guard_detector_recognizes_unguarded_write():
+    """The mutation helper checker detects a direct unguarded PATCH call."""
+    tree = ast.parse("""
+def execute(self):
+    return self.base_patch("/redfish/v1/Systems/1", payload={})
+""")
+    parents = _parent_map(tree)
+    call = next(node for node in ast.walk(tree) if isinstance(node, ast.Call))
+    function = _enclosing_function(call, parents)
+
+    assert function.name == "execute"
+    assert not (_function_arg_names(function) & MUTATION_GUARD_ARGS)

--- a/tests/test_cmd_boot_dualmode.py
+++ b/tests/test_cmd_boot_dualmode.py
@@ -187,6 +187,72 @@ def test_boot_one_shot_patches_requested_target_in_mock_mode(
     assert current.data["BootSourceOverrideTarget"] == "Pxe"
 
 
+def test_boot_one_shot_dry_run_previews_payload_without_patch(
+    redfish_mock, redfish_service
+):
+    """boot_one_shot dry_run reports the Boot payload without mutating settings."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="Pxe",
+        mode="UEFI",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "target": "/redfish/v1/Systems/System.Embedded.1",
+        "payload": {
+            "Boot": {
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideTarget": "Pxe",
+                "BootSourceOverrideMode": "UEFI",
+            }
+        },
+        "blocked": None,
+    }
+    assert redfish_service.requests
+    assert all(request.method != "PATCH" for request in redfish_service.requests)
+
+
+def test_boot_one_shot_dry_run_suppresses_power_on_and_reboot(
+    redfish_mock, redfish_service
+):
+    """boot_one_shot dry_run does not fire nested power-on or reboot requests."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="Pxe",
+        dry_run=True,
+        do_power_on=True,
+        do_reboot=True,
+    )
+
+    assert result.data["dry_run"] is True
+    assert all(
+        request.method not in {"PATCH", "POST"}
+        for request in redfish_service.requests
+    )
+
+
+def test_boot_one_shot_confirm_false_previews_without_patch(
+    redfish_mock, redfish_service
+):
+    """Internal callers can require explicit confirm before boot-one-shot writes."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="Pxe",
+        confirm=False,
+    )
+
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "one-time boot requires confirm"
+    assert all(request.method != "PATCH" for request in redfish_service.requests)
+
+
 def test_boot_one_shot_rejects_invalid_target_before_patch_in_mock_mode(
     redfish_mock, redfish_service
 ):

--- a/tests/test_reconcile_core.py
+++ b/tests/test_reconcile_core.py
@@ -91,6 +91,17 @@ def test_reconcile_dry_run_plans_without_mutating_commands():
         "target": "/redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset",
         "payload": {"ResetType": "GracefulRestart"},
     }
+    boot_preview = {
+        "dry_run": True,
+        "target": "/redfish/v1/Systems/System_0",
+        "payload": {
+            "Boot": {
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideTarget": "Pxe",
+                "BootSourceOverrideMode": "UEFI",
+            }
+        },
+    }
     manager = RecordingManager({
         (
             ApiRequestType.BiosProfile,
@@ -106,6 +117,18 @@ def test_reconcile_dry_run_plans_without_mutating_commands():
                 confirm=False,
             ),
         ): CommandResult(ntp_preview, None, None, None),
+        (
+            ApiRequestType.BootOneShot,
+            "boot_one_shot",
+            _key(
+                device="Pxe",
+                mode="UEFI",
+                uefi_target=None,
+                do_reboot=False,
+                dry_run=True,
+                confirm=False,
+            ),
+        ): CommandResult(boot_preview, None, None, None),
         (
             ApiRequestType.ComputerSystemReset,
             "reboot",
@@ -146,6 +169,18 @@ def test_reconcile_dry_run_plans_without_mutating_commands():
             {
                 "servers": ("0.pool.ntp.org",),
                 "manager_id": "BMC_0",
+                "confirm": False,
+            },
+        ),
+        (
+            ApiRequestType.BootOneShot,
+            "boot_one_shot",
+            {
+                "device": "Pxe",
+                "mode": "UEFI",
+                "uefi_target": None,
+                "do_reboot": False,
+                "dry_run": True,
                 "confirm": False,
             },
         ),
@@ -216,7 +251,14 @@ def test_reconcile_confirm_applies_only_required_changes():
         (
             ApiRequestType.BootOneShot,
             "boot_one_shot",
-            _key(device="Pxe", mode=None, uefi_target=None, do_reboot=False),
+            _key(
+                device="Pxe",
+                mode=None,
+                uefi_target=None,
+                do_reboot=False,
+                dry_run=False,
+                confirm=True,
+            ),
         ): CommandResult(boot_result, None, None, None),
         (
             ApiRequestType.ComputerSystemReset,
@@ -278,6 +320,8 @@ def test_reconcile_confirm_applies_only_required_changes():
                 "mode": None,
                 "uefi_target": None,
                 "do_reboot": False,
+                "dry_run": False,
+                "confirm": True,
             },
         ),
         (


### PR DESCRIPTION
Summary:
- Add a `boot-one-shot --dry_run` preview that returns the Boot PATCH payload without PATCHing or firing nested power/reset actions.
- Route desired-state dry-run boot planning through the same preview path and pass explicit guard kwargs on confirmed apply.
- Add a structural test so new direct write-helper calls must expose a dry-run/confirm style guard or be in the pinned legacy baseline.

Validation:
- `pytest -q tests/test_cmd_boot_dualmode.py tests/test_reconcile_core.py tests/test_ast_conventions.py`
- `pytest -q`
- `ruff check redfish_ctl/boot_source/cmd_boot_one_shot.py redfish_ctl/reconcile.py tests/test_ast_conventions.py tests/test_cmd_boot_dualmode.py tests/test_reconcile_core.py`
- `git diff --check`
- `python -m redfish_ctl boot-one-shot --help`

No live BMC access was used.