### PR TITLE
Add one-shot RedfishNodeProfile approvals

### DIFF
--- a/k8s/controller/redfish-node-profile-crd.yaml
+++ b/k8s/controller/redfish-node-profile-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -35,7 +36,9 @@ spec:
                     address:
                       type: string
                       minLength: 1
-                      description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                      description: >-
+                        BMC hostname, IP address, or URL for the Redfish
+                        ServiceRoot.
                     port:
                       type: integer
                       minimum: 1
@@ -45,7 +48,9 @@ spec:
                     insecure:
                       type: boolean
                       default: true
-                      description: Skip TLS certificate verification for self-signed BMC certificates.
+                      description: >-
+                        Skip TLS certificate verification for self-signed BMC
+                        certificates.
                     secretRef:
                       type: object
                       required:
@@ -54,22 +59,28 @@ spec:
                         name:
                           type: string
                           minLength: 1
-                          description: Secret in the same namespace containing BMC login data.
+                          description: >-
+                            Secret in the same namespace containing BMC login
+                            data.
                         usernameKey:
                           type: string
                           default: username
-                          description: Secret data key containing the BMC username.
+                          description: >-
+                            Secret data key containing the BMC username.
                         passwordKey:
                           type: string
                           default: password
-                          description: Secret data key containing the BMC password.
+                          description: >-
+                            Secret data key containing the BMC password.
                 desiredState:
                   type: object
                   properties:
                     biosProfile:
                       type: string
                       nullable: true
-                      description: Named BIOS profile to diff or stage through the reconciler.
+                      description: >-
+                        Named BIOS profile to diff or stage through the
+                        reconciler.
                     ntp:
                       type: object
                       properties:
@@ -102,11 +113,21 @@ spec:
                 approve:
                   type: boolean
                   default: false
-                  description: Required approval gate before any desired-state changes are applied.
+                  description: >-
+                    Deprecated standing approval flag; use approvedPlanHash
+                    for one-shot applies.
+                approvedPlanHash:
+                  type: string
+                  nullable: true
+                  description: >-
+                    Current status.planHash value approved for exactly one
+                    apply attempt.
                 waitForReboot:
                   type: boolean
                   default: false
-                  description: Wait for the BMC to answer again after an approved reboot step.
+                  description: >-
+                    Wait for the BMC to answer again after an approved reboot
+                    step.
             status:
               type: object
               properties:
@@ -114,6 +135,12 @@ spec:
                   type: boolean
                 drift:
                   type: boolean
+                  nullable: true
+                planHash:
+                  type: string
+                  nullable: true
+                consumedPlanHash:
+                  type: string
                   nullable: true
                 plannedSteps:
                   type: array

--- a/k8s/controller/redfish_node_profile_controller.py
+++ b/k8s/controller/redfish_node_profile_controller.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import base64
+import hashlib
+import json
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, MutableMapping
 from urllib.parse import urlsplit
@@ -88,10 +90,41 @@ def _applied_change(change: Any) -> dict[str, Any]:
     }
 
 
+def plan_hash(planned_steps: list[dict[str, Any]]) -> str | None:
+    required_steps = [step for step in planned_steps if step.get("required")]
+    if not required_steps:
+        return None
+    encoded = json.dumps(
+        required_steps,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _approval_reason(
+    *,
+    approved: bool,
+    current_plan_hash: str | None,
+    approved_plan_hash: str | None,
+    consumed_plan_hash: str | None,
+) -> str:
+    if approved:
+        return "Approved"
+    if current_plan_hash and consumed_plan_hash == current_plan_hash:
+        return "ApprovalConsumed"
+    if approved_plan_hash and approved_plan_hash != current_plan_hash:
+        return "ApprovalHashMismatch"
+    return "ApprovalRequired"
+
+
 def build_status(
     result: Any,
     *,
     approved: bool,
+    approved_plan_hash: str | None = None,
+    plan_hash_value: str | None = None,
+    consumed_plan_hash: str | None = None,
     reconciled_at: datetime | None = None,
 ) -> dict[str, Any]:
     """Return the RedfishNodeProfile status object from a reconcile result."""
@@ -100,6 +133,10 @@ def build_status(
     applied = tuple(getattr(result, "applied", ()))
     planned_steps = [_planned_step(step) for step in steps]
     applied_changes = [_applied_change(change) for change in applied]
+    current_plan_hash = plan_hash_value or plan_hash(planned_steps)
+    current_consumed_hash = consumed_plan_hash
+    if approved and current_plan_hash:
+        current_consumed_hash = current_plan_hash
     drift = any(step["required"] for step in planned_steps)
     changed = any(change["changed"] for change in applied_changes)
     if changed:
@@ -108,7 +145,7 @@ def build_status(
         applied_reason = "NoChanges"
     else:
         applied_reason = "DryRun"
-    return {
+    status = {
         "dryRun": bool(getattr(result, "dry_run", not approved)),
         "drift": drift,
         "plannedSteps": planned_steps,
@@ -117,7 +154,12 @@ def build_status(
             _condition(
                 "Approved",
                 approved,
-                "Approved" if approved else "ApprovalRequired",
+                _approval_reason(
+                    approved=approved,
+                    current_plan_hash=current_plan_hash,
+                    approved_plan_hash=approved_plan_hash,
+                    consumed_plan_hash=consumed_plan_hash,
+                ),
                 changed_at=observed_at,
             ),
             _condition(
@@ -135,6 +177,11 @@ def build_status(
         ],
         "lastReconciled": _rfc3339(observed_at),
     }
+    if current_plan_hash:
+        status["planHash"] = current_plan_hash
+    if current_consumed_hash:
+        status["consumedPlanHash"] = current_consumed_hash
+    return status
 
 
 def build_error_status(
@@ -214,6 +261,7 @@ def reconcile_profile(
     spec: Mapping[str, Any],
     *,
     credentials: Mapping[str, str] | None = None,
+    current_status: Mapping[str, Any] | None = None,
     manager_factory: ManagerFactory = IDracManager,
     reconcile_func: ReconcileFunc | None = None,
     reconciled_at: datetime | None = None,
@@ -222,15 +270,49 @@ def reconcile_profile(
     endpoint = _endpoint_spec(spec)
     desired_state = _mapping(spec.get("desiredState"))
     manager = _make_manager(endpoint, credentials or {}, manager_factory)
-    approved = bool(spec.get("approve", False))
-    result = (reconcile_func or _load_reconcile_func())(
+    reconcile_action = reconcile_func or _load_reconcile_func()
+    dry_run_result = reconcile_action(
         manager,
         desired_state,
-        confirm=approved,
+        confirm=False,
+        wait_for_reboot=False,
+        async_call=False,
+    )
+    dry_status = build_status(
+        dry_run_result,
+        approved=False,
+        approved_plan_hash=str(spec.get("approvedPlanHash") or "") or None,
+        consumed_plan_hash=str(_mapping(current_status).get("consumedPlanHash") or "") or None,
+        reconciled_at=reconciled_at,
+    )
+    current_plan_hash = dry_status.get("planHash")
+    approved_plan_hash = str(spec.get("approvedPlanHash") or "") or None
+    consumed_plan_hash = str(
+        _mapping(current_status).get("consumedPlanHash") or ""
+    ) or None
+    approved = bool(
+        current_plan_hash
+        and approved_plan_hash == current_plan_hash
+        and consumed_plan_hash != current_plan_hash
+    )
+    if not approved:
+        return dry_status
+
+    result = reconcile_action(
+        manager,
+        desired_state,
+        confirm=True,
         wait_for_reboot=bool(spec.get("waitForReboot", False)),
         async_call=False,
     )
-    return build_status(result, approved=approved, reconciled_at=reconciled_at)
+    return build_status(
+        result,
+        approved=approved,
+        approved_plan_hash=approved_plan_hash,
+        plan_hash_value=current_plan_hash,
+        consumed_plan_hash=current_plan_hash,
+        reconciled_at=reconciled_at,
+    )
 
 
 def _decode_secret_value(data: Mapping[str, str], key: str) -> str | None:
@@ -288,7 +370,11 @@ def reconcile_redfish_node_profile(
     endpoint = _mapping(spec.get("endpoint"))
     credentials = load_secret_credentials(namespace, endpoint.get("secretRef"))
     try:
-        status = reconcile_profile(spec, credentials=credentials)
+        status = reconcile_profile(
+            spec,
+            credentials=credentials,
+            current_status=_mapping(_mapping(body).get("status")),
+        )
     except Exception as exc:
         status = build_error_status(str(exc))
     if patch is not None:

--- a/tests/test_k8s_node_profile_controller.py
+++ b/tests/test_k8s_node_profile_controller.py
@@ -69,9 +69,11 @@ def test_crd_schema_pins_profile_spec_and_status_shape() -> None:
         "endpoint",
         "desiredState",
         "approve",
+        "approvedPlanHash",
         "waitForReboot",
     }
     assert spec_props["approve"]["default"] is False
+    assert spec_props["approvedPlanHash"]["type"] == "string"
     endpoint_props = spec_props["endpoint"]["properties"]
     assert set(endpoint_props) == {
         "address",
@@ -89,6 +91,8 @@ def test_crd_schema_pins_profile_spec_and_status_shape() -> None:
     assert set(status_props) == {
         "dryRun",
         "drift",
+        "planHash",
+        "consumedPlanHash",
         "plannedSteps",
         "appliedChanges",
         "conditions",
@@ -107,6 +111,8 @@ def test_build_status_reports_drift_without_apply_when_unapproved() -> None:
 
     assert status["dryRun"] is True
     assert status["drift"] is True
+    assert status["planHash"] == module.plan_hash(status["plannedSteps"])
+    assert "consumedPlanHash" not in status
     assert status["plannedSteps"][0] == {
         "kind": "bios-profile",
         "required": True,
@@ -164,23 +170,30 @@ def test_reconcile_profile_requires_approval_before_confirming() -> None:
     assert {item["type"]: item["status"] for item in status["conditions"]}["Approved"] == "False"
 
 
-def test_reconcile_profile_confirms_only_when_approved() -> None:
-    """An approved profile may call the reconciler with confirm enabled."""
+def test_reconcile_profile_confirms_only_for_matching_plan_hash() -> None:
+    """A matching approvedPlanHash applies the current drift plan once."""
     module = _load_controller_module()
     calls: list[dict] = []
 
     def fake_reconcile(manager, desired, **kwargs):
         calls.append(kwargs)
-        return FakeResult(
-            dry_run=False,
-            applied=(FakeAppliedChange("bios-profile", True),),
-        )
+        if kwargs["confirm"]:
+            return FakeResult(
+                dry_run=False,
+                applied=(FakeAppliedChange("bios-profile", True),),
+            )
+        return FakeResult(dry_run=True)
+
+    dry_run = FakeResult(dry_run=True)
+    approved_hash = module.plan_hash([
+        module._planned_step(step) for step in dry_run.steps
+    ])
 
     status = module.reconcile_profile(
         {
             "endpoint": {"address": "https://mock-bmc:8443", "secretRef": {"name": "bmc-login"}},
             "desiredState": {"biosProfile": "gb300-power-capped"},
-            "approve": True,
+            "approvedPlanHash": approved_hash,
             "waitForReboot": True,
         },
         credentials={"username": "root", "password": "mock"},
@@ -191,12 +204,19 @@ def test_reconcile_profile_confirms_only_when_approved() -> None:
 
     assert calls == [
         {
+            "confirm": False,
+            "wait_for_reboot": False,
+            "async_call": False,
+        },
+        {
             "confirm": True,
             "wait_for_reboot": True,
             "async_call": False,
         }
     ]
     assert status["dryRun"] is False
+    assert status["planHash"] == approved_hash
+    assert status["consumedPlanHash"] == approved_hash
     assert status["appliedChanges"] == [
         {
             "kind": "bios-profile",
@@ -207,6 +227,48 @@ def test_reconcile_profile_confirms_only_when_approved() -> None:
     conditions = {item["type"]: item for item in status["conditions"]}
     assert conditions["Approved"]["status"] == "True"
     assert conditions["Applied"]["status"] == "True"
+
+
+def test_reconcile_profile_does_not_reapply_consumed_plan_hash() -> None:
+    """A consumed approvedPlanHash cannot reapply on the next timer tick."""
+    module = _load_controller_module()
+    calls: list[dict] = []
+
+    def fake_reconcile(manager, desired, **kwargs):
+        calls.append(kwargs)
+        return FakeResult(dry_run=not kwargs["confirm"])
+
+    dry_run = FakeResult(dry_run=True)
+    consumed_hash = module.plan_hash([
+        module._planned_step(step) for step in dry_run.steps
+    ])
+
+    status = module.reconcile_profile(
+        {
+            "endpoint": {"address": "mock-bmc"},
+            "desiredState": {"biosProfile": "gb300-power-capped"},
+            "approvedPlanHash": consumed_hash,
+        },
+        current_status={"consumedPlanHash": consumed_hash},
+        manager_factory=lambda **kwargs: kwargs,
+        reconcile_func=fake_reconcile,
+        reconciled_at=datetime(2026, 7, 10, 22, 55, tzinfo=timezone.utc),
+    )
+
+    assert calls == [
+        {
+            "confirm": False,
+            "wait_for_reboot": False,
+            "async_call": False,
+        }
+    ]
+    assert status["dryRun"] is True
+    assert status["planHash"] == consumed_hash
+    assert status["consumedPlanHash"] == consumed_hash
+    assert status["appliedChanges"] == []
+    conditions = {item["type"]: item for item in status["conditions"]}
+    assert conditions["Approved"]["status"] == "False"
+    assert conditions["Approved"]["reason"] == "ApprovalConsumed"
 
 
 def test_kopf_handler_reports_reconciler_load_errors_as_status(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- add approvedPlanHash-based one-shot apply gating for RedfishNodeProfile reconciliation
- publish planHash and consumedPlanHash in status so timer reconciles do not repeat an already consumed approval
- update CRD schema and controller contract tests for the new approval flow

## Tests
- pytest -q tests/test_k8s_node_profile_controller.py
- pytest -q tests/test_k8s_node_profile_controller.py tests/test_k8s_controller.py tests/test_reconcile_core.py
- pytest -q
- ruff check k8s/controller/redfish_node_profile_controller.py tests/test_k8s_node_profile_controller.py
- yamllint k8s/controller/redfish-node-profile-crd.yaml
- yq '.' k8s/controller/redfish-node-profile-crd.yaml
- git diff --check