### PR TITLE
Polish Kubernetes sandbox workflow

### DIFF
--- a/k8s/README.md
+++ b/k8s/README.md
@@ -41,8 +41,7 @@ spec:
 ```
 
 ```console
-$ kubectl get redfishendpoints -o custom-columns=\
-NAME:.metadata.name,POWER:.status.powerState,HEALTH:.status.health,POLLED:.status.lastPolled
+$ kubectl get redfishendpoints
 NAME          POWER   HEALTH   POLLED
 rack7-node3   On      OK       2026-07-11T02:10:41Z
 ```

--- a/k8s/controller/redfish-endpoint-crd.yaml
+++ b/k8s/controller/redfish-endpoint-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -17,6 +18,16 @@ spec:
       storage: true
       subresources:
         status: {}
+      additionalPrinterColumns:
+        - name: POWER
+          type: string
+          jsonPath: .status.powerState
+        - name: HEALTH
+          type: string
+          jsonPath: .status.health
+        - name: POLLED
+          type: date
+          jsonPath: .status.lastPolled
       schema:
         openAPIV3Schema:
           type: object
@@ -29,7 +40,9 @@ spec:
                 address:
                   type: string
                   minLength: 1
-                  description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                  description: >-
+                    BMC hostname, IP address, or URL for the Redfish
+                    ServiceRoot.
                 port:
                   type: integer
                   minimum: 1
@@ -39,7 +52,9 @@ spec:
                 insecure:
                   type: boolean
                   default: true
-                  description: Skip TLS certificate verification for self-signed BMC certificates.
+                  description: >-
+                    Skip TLS certificate verification for self-signed BMC
+                    certificates.
                 pollInterval:
                   type: string
                   default: 30s
@@ -53,7 +68,9 @@ spec:
                     name:
                       type: string
                       minLength: 1
-                      description: Secret in the same namespace containing BMC login data.
+                      description: >-
+                        Secret in the same namespace containing BMC login
+                        data.
                     usernameKey:
                       type: string
                       default: username

--- a/k8s/sandbox/README.md
+++ b/k8s/sandbox/README.md
@@ -31,3 +31,9 @@ The smoke check waits until `.status.powerState` is populated on the sample
 resources. The corpus mock BMC serves only the committed GB300 corpus and
 rejects mutating HTTP verbs; the iLO backend is an emulator service, not a live
 BMC.
+
+Remove the default sandbox cluster when finished:
+
+```bash
+kind delete cluster --name redfish-sandbox
+```

--- a/k8s/sandbox/run-sandbox.sh
+++ b/k8s/sandbox/run-sandbox.sh
@@ -7,6 +7,7 @@ KIND_CONFIG="${KIND_CONFIG:-k8s/sandbox/kind-config.yaml}"
 NAMESPACE="${NAMESPACE:-redfish-sandbox}"
 SANDBOX_BACKENDS="${SANDBOX_BACKENDS:-corpus-mock}"
 STATUS_TIMEOUT_SECONDS="${STATUS_TIMEOUT_SECONDS:-180}"
+KUBECTL_CONTEXT="kind-${KIND_CLUSTER_NAME}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 cd "$REPO_ROOT"
@@ -57,6 +58,10 @@ section() {
 	printf '\n>> %s\n' "$1"
 }
 
+kubectl_sandbox() {
+	kubectl --context "${KUBECTL_CONTEXT}" "$@"
+}
+
 wait_for_endpoint() {
 	local endpoint_name="$1"
 	local deadline
@@ -66,7 +71,7 @@ wait_for_endpoint() {
 	power_state=""
 	while [ "$SECONDS" -lt "$deadline" ]; do
 		power_state="$(
-			kubectl -n "${NAMESPACE}" \
+			kubectl_sandbox -n "${NAMESPACE}" \
 				get redfishendpoint "$endpoint_name" \
 				-o 'jsonpath={.status.powerState}' 2>/dev/null || true
 		)"
@@ -79,7 +84,8 @@ wait_for_endpoint() {
 
 	printf 'timed out waiting for RedfishEndpoint %s status.powerState\n' \
 		"$endpoint_name" >&2
-	kubectl -n "${NAMESPACE}" get redfishendpoint "$endpoint_name" -o yaml || true
+	kubectl_sandbox -n "${NAMESPACE}" get redfishendpoint "$endpoint_name" \
+		-o yaml || true
 	return 1
 }
 
@@ -123,33 +129,37 @@ fi
 kind load docker-image redfish-ctl-controller:local --name "${KIND_CLUSTER_NAME}"
 
 section "applying sandbox resources"
-kubectl apply -f k8s/sandbox/namespace.yaml
-kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml
+kubectl_sandbox apply -f k8s/sandbox/namespace.yaml
+kubectl_sandbox apply -f k8s/controller/redfish-endpoint-crd.yaml
 if has_backend "corpus-mock"; then
-	kubectl apply -f k8s/sandbox/mock-bmc.yaml
-	kubectl apply -f k8s/sandbox/mock-credentials.yaml
+	kubectl_sandbox apply -f k8s/sandbox/mock-bmc.yaml
+	kubectl_sandbox apply -f k8s/sandbox/mock-credentials.yaml
 fi
 if has_backend "ilo-sim"; then
-	kubectl apply -f k8s/sandbox/ilo-sim.yaml
-	kubectl apply -f k8s/sandbox/ilo-credentials.yaml
+	kubectl_sandbox apply -f k8s/sandbox/ilo-sim.yaml
+	kubectl_sandbox apply -f k8s/sandbox/ilo-credentials.yaml
 fi
-kubectl apply -f k8s/controller/rbac.yaml
-kubectl apply -f k8s/controller/deployment.yaml
+kubectl_sandbox apply -f k8s/controller/rbac.yaml
+kubectl_sandbox apply -f k8s/controller/deployment.yaml
 if has_backend "corpus-mock"; then
-	kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml
+	kubectl_sandbox apply -f k8s/sandbox/redfish-endpoint-sample.yaml
 fi
 if has_backend "ilo-sim"; then
-	kubectl apply -f k8s/sandbox/redfish-endpoint-ilo-sim.yaml
+	kubectl_sandbox apply -f k8s/sandbox/redfish-endpoint-ilo-sim.yaml
 fi
 
 section "waiting for deployments"
 if has_backend "corpus-mock"; then
-	kubectl -n "${NAMESPACE}" rollout status deploy/mock-bmc --timeout=120s
+	kubectl_sandbox -n "${NAMESPACE}" \
+		rollout status deploy/mock-bmc \
+		--timeout=120s
 fi
 if has_backend "ilo-sim"; then
-	kubectl -n "${NAMESPACE}" rollout status deploy/ilo-sim --timeout=120s
+	kubectl_sandbox -n "${NAMESPACE}" \
+		rollout status deploy/ilo-sim \
+		--timeout=120s
 fi
-kubectl -n "${NAMESPACE}" \
+kubectl_sandbox -n "${NAMESPACE}" \
 	rollout status deploy/redfish-endpoint-controller \
 	--timeout=120s
 

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -51,7 +51,8 @@ def _fixture_for_path(path: str) -> Path | None:
 def test_crd_schema_pins_read_only_endpoint_spec_and_status_shape() -> None:
     """The CRD exposes only connection fields and read-only status."""
     crd = yaml.safe_load(CRD_MANIFEST.read_text(encoding="utf-8"))
-    schema = crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]
+    version = crd["spec"]["versions"][0]
+    schema = version["schema"]["openAPIV3Schema"]
     spec_props = schema["properties"]["spec"]["properties"]
     status_props = schema["properties"]["status"]["properties"]
 
@@ -77,6 +78,23 @@ def test_crd_schema_pins_read_only_endpoint_spec_and_status_shape() -> None:
     }
     assert status_props["temperature"]["properties"]["maxCelsius"]["type"] == "number"
     assert "valueFrom" not in json.dumps(crd)
+    assert version["additionalPrinterColumns"] == [
+        {
+            "name": "POWER",
+            "type": "string",
+            "jsonPath": ".status.powerState",
+        },
+        {
+            "name": "HEALTH",
+            "type": "string",
+            "jsonPath": ".status.health",
+        },
+        {
+            "name": "POLLED",
+            "type": "date",
+            "jsonPath": ".status.lastPolled",
+        },
+    ]
 
 
 def test_build_status_tolerates_missing_values_and_summarizes_temperatures() -> None:

--- a/tests/test_k8s_sandbox_harness.py
+++ b/tests/test_k8s_sandbox_harness.py
@@ -20,6 +20,7 @@ CONTROLLER_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.controller"
 ILO_SIM_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.ilo-sim"
 MAKEFILE = REPO_ROOT / "Makefile"
 SANDBOX_README = REPO_ROOT / "k8s" / "sandbox" / "README.md"
+K8S_README = REPO_ROOT / "k8s" / "README.md"
 
 
 def _yaml_documents(path: Path) -> list[dict]:
@@ -216,24 +217,31 @@ def test_sandbox_smoke_script_applies_manifests_and_waits_for_status() -> None:
     """The opt-in smoke harness proves the CR status is populated."""
     script = SMOKE_SCRIPT.read_text(encoding="utf-8")
     mode = os.stat(SMOKE_SCRIPT).st_mode
+    kubectl_lines = [
+        line.strip()
+        for line in script.splitlines()
+        if line.strip().startswith("kubectl ")
+    ]
 
     assert mode & stat.S_IXUSR
     assert "SANDBOX_BACKENDS=\"${SANDBOX_BACKENDS:-corpus-mock}\"" in script
+    assert "KUBECTL_CONTEXT=\"kind-${KIND_CLUSTER_NAME}\"" in script
+    assert kubectl_lines == ['kubectl --context "${KUBECTL_CONTEXT}" "$@"']
     assert "has_backend \"corpus-mock\"" in script
     assert "has_backend \"ilo-sim\"" in script
     assert "kind create cluster --name \"${KIND_CLUSTER_NAME}\"" in script
     assert "kind load docker-image redfish-ctl-mock-bmc:local" in script
     assert "kind load docker-image redfish-ctl-ilo-sim:local" in script
     assert "kind load docker-image redfish-ctl-controller:local" in script
-    assert "kubectl apply -f k8s/controller/redfish-endpoint-crd.yaml" in script
-    assert "kubectl apply -f k8s/sandbox/mock-bmc.yaml" in script
-    assert "kubectl apply -f k8s/sandbox/mock-credentials.yaml" in script
-    assert "kubectl apply -f k8s/sandbox/ilo-sim.yaml" in script
-    assert "kubectl apply -f k8s/sandbox/ilo-credentials.yaml" in script
-    assert "kubectl apply -f k8s/controller/rbac.yaml" in script
-    assert "kubectl apply -f k8s/controller/deployment.yaml" in script
-    assert "kubectl apply -f k8s/sandbox/redfish-endpoint-sample.yaml" in script
-    assert "kubectl apply -f k8s/sandbox/redfish-endpoint-ilo-sim.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/controller/redfish-endpoint-crd.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/sandbox/mock-bmc.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/sandbox/mock-credentials.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/sandbox/ilo-sim.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/sandbox/ilo-credentials.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/controller/rbac.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/controller/deployment.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/sandbox/redfish-endpoint-sample.yaml" in script
+    assert "kubectl_sandbox apply -f k8s/sandbox/redfish-endpoint-ilo-sim.yaml" in script
     assert "jsonpath={.status.powerState}" in script
     assert "wait_for_endpoint gb300-mock" in script
     assert "wait_for_endpoint ilo-sim" in script
@@ -248,6 +256,16 @@ def test_sandbox_readme_documents_ilo_backend_selection() -> None:
     assert "SANDBOX_BACKENDS=corpus-mock,ilo-sim make k8s-sandbox" in readme
     assert "HPE iLO Redfish emulator" in readme
     assert "https://github.com/HewlettPackard/ilo-redfish-emulator" in readme
+
+
+def test_sandbox_docs_show_teardown_and_plain_endpoint_listing() -> None:
+    """Sandbox docs include cleanup and rely on CRD default columns."""
+    sandbox_readme = SANDBOX_README.read_text(encoding="utf-8")
+    k8s_readme = K8S_README.read_text(encoding="utf-8")
+
+    assert "kind delete cluster --name redfish-sandbox" in sandbox_readme
+    assert "$ kubectl get redfishendpoints\n" in k8s_readme
+    assert "custom-columns" not in k8s_readme
 
 
 def test_make_k8s_sandbox_invokes_smoke_harness() -> None:


### PR DESCRIPTION
## Summary
- add default `kubectl get redfishendpoints` columns for power, health, and poll time
- keep the sandbox smoke harness pinned to the intended kind context while preserving corpus and iLO simulator backends
- document sandbox cleanup and use the default CRD columns in the Kubernetes guide

## Validation
- `conda run -n idrac_ctl pytest -q tests/test_k8s_controller.py tests/test_k8s_sandbox_harness.py`
- `conda run -n idrac_ctl ruff check tests/test_k8s_controller.py tests/test_k8s_sandbox_harness.py`
- `/opt/homebrew/bin/bash -n k8s/sandbox/run-sandbox.sh`
- `/opt/homebrew/bin/shellcheck k8s/sandbox/run-sandbox.sh`
- `/opt/homebrew/bin/shfmt -d k8s/sandbox/run-sandbox.sh`
- `git diff --check`
- `conda run -n idrac_ctl pytest -q`