### PR TITLE
Add reconcile convergence guards

### DIFF
--- a/redfish_ctl/reconcile.py
+++ b/redfish_ctl/reconcile.py
@@ -167,6 +167,26 @@ def _reconcile_ntp(
     steps: list[ReconcileStep],
     applied: list[AppliedChange],
 ) -> None:
+    current = _invoke_rows(
+        manager,
+        ApiRequestType.ManagerNetworkProtocol,
+        "manager-network",
+    )
+    if _ntp_already_matches(current, state):
+        steps.append(
+            ReconcileStep(
+                kind="ntp",
+                required=False,
+                description="Manager NTP servers",
+                preview={
+                    "servers": list(state.ntp_servers),
+                    "manager": state.ntp_manager_id,
+                    "current": list(current),
+                },
+            )
+        )
+        return
+
     result = _invoke_mapping(
         manager,
         ApiRequestType.NtpSet,
@@ -175,7 +195,7 @@ def _reconcile_ntp(
         manager_id=state.ntp_manager_id,
         confirm=confirm,
     )
-    required = confirm or bool(result.get("plan") or result.get("applied"))
+    required = bool(result.get("plan") or result.get("applied"))
     steps.append(
         ReconcileStep(
             kind="ntp",
@@ -201,26 +221,36 @@ def _reconcile_boot(
     steps: list[ReconcileStep],
     applied: list[AppliedChange],
 ) -> None:
-    result = _invoke_mapping(
+    current = _invoke_mapping(
         manager,
-        ApiRequestType.BootOneShot,
-        "boot_one_shot",
-        device=state.boot_device,
-        mode=state.boot_mode,
-        uefi_target=state.uefi_target,
-        do_reboot=False,
-        dry_run=not confirm,
-        confirm=confirm,
+        ApiRequestType.CurrentBoot,
+        "current_boot_query",
     )
+    preview = {
+        "device": state.boot_device,
+        "mode": state.boot_mode,
+        "uefiTarget": state.uefi_target,
+        "current": current,
+    }
+    required = not _boot_already_matches(current, state)
     steps.append(
         ReconcileStep(
             kind="boot",
-            required=True,
+            required=required,
             description="One-time boot override",
-            preview=result,
+            preview=preview,
         )
     )
-    if confirm:
+    if confirm and required:
+        result = _invoke_mapping(
+            manager,
+            ApiRequestType.BootOneShot,
+            "boot_one_shot",
+            device=state.boot_device,
+            mode=state.boot_mode,
+            uefi_target=state.uefi_target,
+            do_reboot=False,
+        )
         applied.append(
             AppliedChange(kind="boot", changed=True, result=result)
         )
@@ -264,14 +294,38 @@ def _invoke_mapping(
     name: str,
     **kwargs: Any,
 ) -> Mapping[str, Any]:
+    return _mapping(_invoke_data(manager, api_call, name, **kwargs))
+
+
+def _invoke_rows(
+    manager: SyncInvoker,
+    api_call: ApiRequestType,
+    name: str,
+    **kwargs: Any,
+) -> tuple[Mapping[str, Any], ...]:
+    return _mapping_rows(_invoke_data(manager, api_call, name, **kwargs))
+
+
+def _invoke_data(
+    manager: SyncInvoker,
+    api_call: ApiRequestType,
+    name: str,
+    **kwargs: Any,
+) -> Any:
     result = manager.sync_invoke(api_call, name, **kwargs)
     if result.error:
         raise RedfishApiError(str(result.error))
-    return _mapping(result.data)
+    return result.data
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
     return value if isinstance(value, Mapping) else {}
+
+
+def _mapping_rows(value: Any) -> tuple[Mapping[str, Any], ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(row for row in value if isinstance(row, Mapping))
 
 
 def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
@@ -302,9 +356,66 @@ def _str_tuple(value: Any) -> tuple[str, ...]:
     )
 
 
+def _ntp_already_matches(
+    rows: tuple[Mapping[str, Any], ...],
+    state: DesiredState,
+) -> bool:
+    desired_servers = tuple(state.ntp_servers)
+    comparable_rows = []
+    for row in rows:
+        manager_id = _optional_str(row.get("Manager"))
+        if state.ntp_manager_id and manager_id != state.ntp_manager_id:
+            continue
+        ntp = _mapping(row.get("NTP"))
+        if not _ntp_row_is_capable(ntp):
+            if state.ntp_manager_id:
+                return False
+            continue
+        comparable_rows.append(row)
+        if ntp.get("ProtocolEnabled") is not True:
+            return False
+        if _str_tuple(ntp.get("NTPServers")) != desired_servers:
+            return False
+    return bool(comparable_rows)
+
+
+def _ntp_row_is_capable(ntp: Mapping[str, Any]) -> bool:
+    return ntp.get("ProtocolEnabled") is not None or bool(ntp.get("NTPServers"))
+
+
+def _boot_already_matches(
+    current: Mapping[str, Any],
+    state: DesiredState,
+) -> bool:
+    desired_device = state.boot_device
+    desired_enabled = "Disabled" if desired_device == "None" else "Once"
+    if current.get("BootSourceOverrideEnabled") != desired_enabled:
+        return False
+    if current.get("BootSourceOverrideTarget") != desired_device:
+        return False
+    if (
+        state.boot_mode is not None
+        and current.get("BootSourceOverrideMode") != state.boot_mode
+    ):
+        return False
+    if (
+        state.uefi_target is not None
+        and current.get("UefiTargetBootSourceOverride") != state.uefi_target
+    ):
+        return False
+    return True
+
+
 def _reset_type(reboot_spec: Any, reboot: Mapping[str, Any]) -> str | None:
     if isinstance(reboot_spec, str):
         return _optional_str(reboot_spec)
-    if reboot_spec is True:
-        return "GracefulRestart"
-    return _optional_str(_first(reboot, "resetType", "reset_type"))
+    if isinstance(reboot_spec, bool):
+        if reboot_spec:
+            raise ValueError("reboot.resetType must be an explicit string")
+        return None
+    reset_type = _first(reboot, "resetType", "reset_type")
+    if reset_type is None:
+        return None
+    if not isinstance(reset_type, str):
+        raise ValueError("reboot.resetType must be an explicit string")
+    return _optional_str(reset_type)

--- a/tests/test_reconcile_core.py
+++ b/tests/test_reconcile_core.py
@@ -49,6 +49,87 @@ def _key(**kwargs):
     return RecordingManager._call_key(kwargs)
 
 
+def test_desired_state_rejects_boolean_reboot_shortcut():
+    """A reboot request must name the reset type instead of using truthy shorthand."""
+    with pytest.raises(ValueError, match="reboot.resetType"):
+        DesiredState.from_mapping({"reboot": True})
+
+
+def test_reconcile_skips_ntp_when_manager_already_matches():
+    """Converged ManagerNetworkProtocol NTP state must not issue an apply call."""
+    manager = RecordingManager({
+        (
+            ApiRequestType.ManagerNetworkProtocol,
+            "manager-network",
+            _key(),
+        ): CommandResult(
+            [
+                {
+                    "Manager": "BMC_0",
+                    "NTP": {
+                        "ProtocolEnabled": True,
+                        "NTPServers": ["0.pool.ntp.org"],
+                    },
+                }
+            ],
+            None,
+            None,
+            None,
+        )
+    })
+
+    result = reconcile(
+        manager,
+        DesiredState(
+            ntp_servers=("0.pool.ntp.org",),
+            ntp_manager_id="BMC_0",
+        ),
+        confirm=True,
+    )
+
+    assert [(step.kind, step.required) for step in result.steps] == [
+        ("ntp", False),
+    ]
+    assert result.applied == ()
+    assert manager.calls == [
+        (ApiRequestType.ManagerNetworkProtocol, "manager-network", {}),
+    ]
+
+
+def test_reconcile_skips_boot_when_one_time_override_already_matches():
+    """Converged one-time boot state must not call the mutating boot command."""
+    manager = RecordingManager({
+        (
+            ApiRequestType.CurrentBoot,
+            "current_boot_query",
+            _key(),
+        ): CommandResult(
+            {
+                "BootSourceOverrideEnabled": "Once",
+                "BootSourceOverrideTarget": "Pxe",
+                "BootSourceOverrideMode": "UEFI",
+            },
+            None,
+            None,
+            None,
+        )
+    })
+
+    result = reconcile(
+        manager,
+        DesiredState(boot_device="Pxe", boot_mode="UEFI"),
+        confirm=True,
+    )
+
+    assert [(step.kind, step.required) for step in result.steps] == [
+        ("boot", False),
+    ]
+    assert result.applied == ()
+    assert manager.calls == [
+        (ApiRequestType.CurrentBoot, "current_boot_query", {}),
+    ]
+
+
 def _fixture_for_path(path: str) -> Path | None:
     name = "_" + path.strip("/").replace("/", "_") + ".json"
     return GB300_INDEX.get(name.lower())
@@ -91,17 +172,6 @@ def test_reconcile_dry_run_plans_without_mutating_commands():
         "target": "/redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset",
         "payload": {"ResetType": "GracefulRestart"},
     }
-    boot_preview = {
-        "dry_run": True,
-        "target": "/redfish/v1/Systems/System_0",
-        "payload": {
-            "Boot": {
-                "BootSourceOverrideEnabled": "Once",
-                "BootSourceOverrideTarget": "Pxe",
-                "BootSourceOverrideMode": "UEFI",
-            }
-        },
-    }
     manager = RecordingManager({
         (
             ApiRequestType.BiosProfile,
@@ -118,17 +188,37 @@ def test_reconcile_dry_run_plans_without_mutating_commands():
             ),
         ): CommandResult(ntp_preview, None, None, None),
         (
-            ApiRequestType.BootOneShot,
-            "boot_one_shot",
-            _key(
-                device="Pxe",
-                mode="UEFI",
-                uefi_target=None,
-                do_reboot=False,
-                dry_run=True,
-                confirm=False,
-            ),
-        ): CommandResult(boot_preview, None, None, None),
+            ApiRequestType.ManagerNetworkProtocol,
+            "manager-network",
+            _key(),
+        ): CommandResult(
+            [
+                {
+                    "Manager": "BMC_0",
+                    "NTP": {
+                        "ProtocolEnabled": True,
+                        "NTPServers": [],
+                    },
+                }
+            ],
+            None,
+            None,
+            None,
+        ),
+        (
+            ApiRequestType.CurrentBoot,
+            "current_boot_query",
+            _key(),
+        ): CommandResult(
+            {
+                "BootSourceOverrideEnabled": "Disabled",
+                "BootSourceOverrideTarget": "None",
+                "BootSourceOverrideMode": "UEFI",
+            },
+            None,
+            None,
+            None,
+        ),
         (
             ApiRequestType.ComputerSystemReset,
             "reboot",
@@ -164,6 +254,11 @@ def test_reconcile_dry_run_plans_without_mutating_commands():
             {"action": "diff", "profile_name": "gb300-power-capped"},
         ),
         (
+            ApiRequestType.ManagerNetworkProtocol,
+            "manager-network",
+            {},
+        ),
+        (
             ApiRequestType.NtpSet,
             "ntp-set",
             {
@@ -173,16 +268,9 @@ def test_reconcile_dry_run_plans_without_mutating_commands():
             },
         ),
         (
-            ApiRequestType.BootOneShot,
-            "boot_one_shot",
-            {
-                "device": "Pxe",
-                "mode": "UEFI",
-                "uefi_target": None,
-                "do_reboot": False,
-                "dry_run": True,
-                "confirm": False,
-            },
+            ApiRequestType.CurrentBoot,
+            "current_boot_query",
+            {},
         ),
         (
             ApiRequestType.ComputerSystemReset,
@@ -249,16 +337,40 @@ def test_reconcile_confirm_applies_only_required_changes():
             ),
         ): CommandResult(ntp_apply, None, None, None),
         (
+            ApiRequestType.ManagerNetworkProtocol,
+            "manager-network",
+            _key(),
+        ): CommandResult(
+            [
+                {
+                    "Manager": "BMC_0",
+                    "NTP": {
+                        "ProtocolEnabled": True,
+                        "NTPServers": [],
+                    },
+                }
+            ],
+            None,
+            None,
+            None,
+        ),
+        (
+            ApiRequestType.CurrentBoot,
+            "current_boot_query",
+            _key(),
+        ): CommandResult(
+            {
+                "BootSourceOverrideEnabled": "Disabled",
+                "BootSourceOverrideTarget": "None",
+            },
+            None,
+            None,
+            None,
+        ),
+        (
             ApiRequestType.BootOneShot,
             "boot_one_shot",
-            _key(
-                device="Pxe",
-                mode=None,
-                uefi_target=None,
-                do_reboot=False,
-                dry_run=False,
-                confirm=True,
-            ),
+            _key(device="Pxe", mode=None, uefi_target=None, do_reboot=False),
         ): CommandResult(boot_result, None, None, None),
         (
             ApiRequestType.ComputerSystemReset,
@@ -304,6 +416,11 @@ def test_reconcile_confirm_applies_only_required_changes():
             },
         ),
         (
+            ApiRequestType.ManagerNetworkProtocol,
+            "manager-network",
+            {},
+        ),
+        (
             ApiRequestType.NtpSet,
             "ntp-set",
             {
@@ -313,6 +430,11 @@ def test_reconcile_confirm_applies_only_required_changes():
             },
         ),
         (
+            ApiRequestType.CurrentBoot,
+            "current_boot_query",
+            {},
+        ),
+        (
             ApiRequestType.BootOneShot,
             "boot_one_shot",
             {
@@ -320,8 +442,6 @@ def test_reconcile_confirm_applies_only_required_changes():
                 "mode": None,
                 "uefi_target": None,
                 "do_reboot": False,
-                "dry_run": False,
-                "confirm": True,
             },
         ),
         (


### PR DESCRIPTION
## Summary

- Require reboot intent to name an explicit `resetType` string instead of accepting boolean shorthand.
- Read current ManagerNetworkProtocol state before NTP apply and skip the apply path when it already matches.
- Read current one-time boot state before boot apply and skip the apply path when target and mode already match.

## Tests

- `pytest -q tests/test_reconcile_core.py`
- `pytest -q tests/test_k8s_node_profile_controller.py tests/test_k8s_controller.py`
- `ruff check redfish_ctl/reconcile.py tests/test_reconcile_core.py`
- `pytest -q`
