### PR TITLE
Add firmware update push upload fallback

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -115,7 +115,7 @@ Safety labels:
 | `event-submit-test` | Submit a Redfish test event; `--dry_run` previews the payload. | Write |
 | `exporter` | Expose BMC telemetry as Prometheus text or SignalFx datapoints. | Read |
 | `firmware` | Read firmware view data. | Read |
-| `firmware-update` | Run UpdateService SimpleUpdate; `--dry_run` previews, `--confirm` writes. | Guarded |
+| `firmware-update` | Run UpdateService SimpleUpdate or a discovered push upload URI; `--dry_run` previews, `--confirm` writes. | Guarded |
 | `firmware_inventory` | Read firmware inventory. | Read |
 | `fleet` | Read a YAML fleet inventory and summarize per-node health, sensor count, and temperature max. | Read |
 | `get_vm` | Read virtual media. | Read |
@@ -293,12 +293,15 @@ unless `--dry_run` is supplied; `--wait` only waits after a real reset.
 redfish_ctl firmware_inventory
 redfish_ctl firmware-update --image_uri https://example.invalid/firmware.exe --dry_run
 redfish_ctl firmware-update --image_uri https://example.invalid/firmware.exe --confirm
+redfish_ctl firmware-update --image_file ./firmware.bin --dry_run
+redfish_ctl firmware-update --image_file ./firmware.bin --confirm
 redfish_ctl tasks
 ```
 
 `firmware-update`, defined in `redfish_ctl/firmware/cmd_firmware_update.py`, is destructive when
-confirmed. Use only approved images and approved non-production targets until you have your own
-firmware rollout process.
+confirmed. It prefers the standard `SimpleUpdate` action when the BMC advertises it; otherwise it
+uses `MultipartHttpPushUri`, then `HttpPushUri`, for local image uploads. Use only approved images
+and approved non-production targets until you have your own firmware rollout process.
 
 ### HPE iLO Canary
 

--- a/redfish_ctl/firmware/cmd_firmware_update.py
+++ b/redfish_ctl/firmware/cmd_firmware_update.py
@@ -1,12 +1,13 @@
-"""Flash firmware via Redfish UpdateService.SimpleUpdate (guarded).
+"""Flash firmware via Redfish UpdateService update mechanisms (guarded).
 
     redfish_ctl firmware-update --image_uri http://host/fw.bin              # dry-run
     redfish_ctl firmware-update --image_uri http://host/fw.bin --confirm    # flash
+    redfish_ctl firmware-update --image_file fw.bin --confirm               # push upload
 
 Resolves ``#UpdateService.SimpleUpdate`` from the UpdateService's own Actions
 block (no hardcoded id) and POSTs {ImageURI, TransferProtocol?} through the
-shared ``invoke_action`` guard. SimpleUpdate is standard DMTF and works on any
-host that advertises it (Dell, HPE iLO, ...).
+same guarded path. If SimpleUpdate is absent, prefers ``MultipartHttpPushUri``
+and then ``HttpPushUri`` for BMCs that accept a local image upload.
 
 DESTRUCTIVE: flashing disrupts/risks the target, so this defaults to a DRY-RUN
 (prints the resolved target + payload, POSTs nothing) until ``--confirm``.
@@ -14,10 +15,13 @@ DESTRUCTIVE: flashing disrupts/risks the target, so this defaults to a DRY-RUN
 Author Mus spyroot@gmail.com
 """
 from abc import abstractmethod
+from pathlib import Path
 from typing import Optional
 
+import requests
+
 from ..idrac_manager import IDracManager
-from ..idrac_shared import ApiRequestType, Singleton
+from ..idrac_shared import ApiRequestType, IdracApiRespond, Singleton
 from ..redfish_manager import CommandResult
 from ..redfish_shared import RedfishApi
 
@@ -26,7 +30,7 @@ class FirmwareUpdate(IDracManager,
                      scm_type=ApiRequestType.FirmwareUpdate,
                      name='firmware-update',
                      metaclass=Singleton):
-    """Flash firmware via a discovered UpdateService.SimpleUpdate action."""
+    """Flash firmware via a discovered UpdateService update endpoint."""
 
     def __init__(self, *args, **kwargs):
         super(FirmwareUpdate, self).__init__(*args, **kwargs)
@@ -40,6 +44,9 @@ class FirmwareUpdate(IDracManager,
             '--image_uri', required=False, dest='image_uri', type=str, default=None,
             help="firmware image URI to flash (ImageURI in the payload)")
         cmd_parser.add_argument(
+            '--image_file', required=False, dest='image_file', type=str, default=None,
+            help="local firmware image file to upload when UpdateService exposes a push URI")
+        cmd_parser.add_argument(
             '--transfer_protocol', required=False, dest='transfer_protocol',
             type=str, default=None, help="optional TransferProtocol (HTTP, HTTPS, ...)")
         cmd_parser.add_argument(
@@ -48,7 +55,7 @@ class FirmwareUpdate(IDracManager,
         cmd_parser.add_argument(
             '--dry_run', action='store_true', dest='dry_run',
             help="force a dry-run preview even if --confirm is given")
-        return cmd_parser, "firmware-update", "command flash firmware via SimpleUpdate (guarded)"
+        return cmd_parser, "firmware-update", "command flash firmware via UpdateService (guarded)"
 
     def _update_service_uri(self, do_async):
         """Resolve the UpdateService URI from the service root, with a fallback."""
@@ -61,8 +68,131 @@ class FirmwareUpdate(IDracManager,
             return link["@odata.id"]
         return f"{RedfishApi.Version}/UpdateService"
 
+    def _read_update_service(self, do_async):
+        """Return ``(uri, resource, error)`` for UpdateService discovery."""
+        uri = self._update_service_uri(do_async)
+        try:
+            resource = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return uri, {}, f"failed to read {uri}: {exc}"
+        return uri, resource, None
+
+    def _action_result(self, target, payload, actions, do_async, dry_run, confirm):
+        """Post the SimpleUpdate action with the same fail-safe response shape."""
+        from ..actions.action_policy import Destructiveness, classify
+
+        full = "#UpdateService.SimpleUpdate"
+        level = classify(full)
+        blocked_reason = None
+        effective_dry = bool(dry_run)
+        if level == Destructiveness.DESTRUCTIVE and not confirm:
+            effective_dry = True
+            blocked_reason = "destructive action requires --confirm"
+
+        if effective_dry:
+            return CommandResult({
+                "dry_run": True,
+                "action": full,
+                "target": target,
+                "payload": payload,
+                "level": level.value,
+                "blocked": blocked_reason,
+            }, actions, None, None)
+
+        result, _ = self.base_post(target, payload=payload, do_async=do_async,
+                                   expected_status=202)
+        data = result.data if isinstance(result.data, dict) else {"result": result.data}
+        data.setdefault("executed", True)
+        data.setdefault("action", full)
+        data.setdefault("target", target)
+        data.setdefault("level", level.value)
+        return CommandResult(data, actions, None, result.error)
+
+    @staticmethod
+    def _push_target(update_service):
+        """Prefer MultipartHttpPushUri, then HttpPushUri, when present."""
+        for method in ("MultipartHttpPushUri", "HttpPushUri"):
+            target = (update_service or {}).get(method)
+            if isinstance(target, str) and target:
+                return method, target
+        return None, None
+
+    def _post_image_file(self, target, method, image_path):
+        """Upload a local image file to the discovered push URI."""
+        headers = {}
+        auth = None
+        if self.x_auth is not None:
+            headers["X-Auth-Token"] = self.x_auth
+        else:
+            auth = (self._username, self._password)
+
+        url = f"{self._default_method}{self.redfish_ip}{target}"
+        with image_path.open("rb") as image:
+            if method == "MultipartHttpPushUri":
+                files = {
+                    "UpdateFile": (
+                        image_path.name,
+                        image,
+                        "application/octet-stream",
+                    )
+                }
+                return requests.post(
+                    url,
+                    files=files,
+                    verify=self._is_verify_cert,
+                    headers=headers,
+                    auth=auth,
+                )
+            headers["Content-Type"] = "application/octet-stream"
+            return requests.post(
+                url,
+                data=image,
+                verify=self._is_verify_cert,
+                headers=headers,
+                auth=auth,
+            )
+
+    def _push_result(self, target, method, image_file, dry_run, confirm):
+        """Preview or execute a push-URI firmware upload."""
+        data = {
+            "method": method,
+            "target": target,
+            "image_file": image_file,
+            "level": "destructive",
+        }
+        effective_dry = bool(dry_run) or not confirm
+        if effective_dry:
+            data.update({
+                "dry_run": True,
+                "blocked": None if confirm else "destructive update requires --confirm",
+            })
+            return CommandResult(data, None, None, None)
+
+        image_path = Path(image_file).expanduser()
+        if not image_path.is_file():
+            return CommandResult(
+                data,
+                None,
+                None,
+                f"image_file not found: {image_file}",
+            )
+
+        try:
+            response = self._post_image_file(target, method, image_path)
+            api_resp = self.read_api_respond(response, expected=202)
+        except Exception as exc:
+            return CommandResult(data, None, None, exc)
+
+        if api_resp == IdracApiRespond.AcceptedTaskGenerated:
+            data["task_id"] = self.job_id_from_header(response)
+        else:
+            data.update(self.api_success_msg(api_resp))
+        data["executed"] = True
+        return CommandResult(data, None, None, None)
+
     def execute(self,
                 image_uri: Optional[str] = None,
+                image_file: Optional[str] = None,
                 transfer_protocol: Optional[str] = None,
                 confirm: Optional[bool] = False,
                 dry_run: Optional[bool] = False,
@@ -71,22 +201,59 @@ class FirmwareUpdate(IDracManager,
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Resolve SimpleUpdate and POST the image payload (guarded).
+        """Resolve UpdateService and POST the image payload (guarded).
 
         Returns a dry-run preview unless ``--confirm``; the destructiveness guard
-        lives in ``invoke_action``. ``image_uri`` is required to actually flash.
+        keeps firmware writes as previews by default.
         """
         payload = {}
         if image_uri:
             payload["ImageURI"] = image_uri
         if transfer_protocol:
             payload["TransferProtocol"] = transfer_protocol
-        return self.invoke_action(
-            self._update_service_uri(do_async),
-            "SimpleUpdate",
-            payload=payload,
-            full_action_type="#UpdateService.SimpleUpdate",
-            do_async=do_async,
-            dry_run=bool(dry_run),
-            confirm=bool(confirm),
+
+        uri, update_service, error = self._read_update_service(do_async)
+        if error:
+            return CommandResult(None, None, None, error)
+
+        actions = self.discover_redfish_actions(self, update_service)
+        simple_target = self._flatten_action_targets(update_service).get(
+            "#UpdateService.SimpleUpdate"
         )
+        if simple_target:
+            return self._action_result(
+                simple_target,
+                payload,
+                actions,
+                do_async,
+                bool(dry_run),
+                bool(confirm),
+            )
+
+        method, target = self._push_target(update_service)
+        available = sorted(set(list(actions.keys()) + list(
+            self._flatten_action_targets(update_service).keys()
+        )))
+        if not target:
+            return CommandResult(
+                {
+                    "action": "firmware-update",
+                    "available": available,
+                    "update_service": uri,
+                },
+                actions,
+                None,
+                "UpdateService exposes no SimpleUpdate, MultipartHttpPushUri, or HttpPushUri",
+            )
+        if not image_file:
+            return CommandResult(
+                {
+                    "action": "firmware-update",
+                    "method": method,
+                    "target": target,
+                },
+                actions,
+                None,
+                f"{method} requires --image_file",
+            )
+        return self._push_result(target, method, image_file, bool(dry_run), bool(confirm))

--- a/tests/test_firmware_update_dualmode.py
+++ b/tests/test_firmware_update_dualmode.py
@@ -1,10 +1,21 @@
 """Dual-mode tests for the guarded firmware-update command."""
 
+import json
+from pathlib import Path
+
 from redfish_ctl.idrac_shared import ApiRequestType
 from redfish_ctl.redfish_manager import CommandResult
 
 SIMPLE_UPDATE_TARGET = (
     "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate"
+)
+MULTIPART_PUSH_TARGET = "/redfish/v1/UpdateService/update-multipart"
+GB300_UPDATE_SERVICE = (
+    Path(__file__).parent
+    / "supermicro_gb300_corpus"
+    / "json_responses"
+    / "172.25.230.37"
+    / "_redfish_v1_UpdateService.json"
 )
 
 
@@ -15,6 +26,17 @@ def _post_requests(redfish_service):
         for request in redfish_service.requests
         if request.method == "POST"
     ]
+
+
+def _gb300_update_service():
+    """Load the GB300 UpdateService fixture used for push-URI fallback tests."""
+    return json.loads(GB300_UPDATE_SERVICE.read_text())
+
+
+def _set_update_service(redfish_service, body):
+    """Overlay UpdateService under both path casings used by requests-mock."""
+    redfish_service._overlay["/redfish/v1/UpdateService"] = body
+    redfish_service._overlay["/redfish/v1/updateservice"] = body
 
 
 def test_firmware_update_defaults_to_dry_run_in_dual_mode(redfish_api):
@@ -87,3 +109,77 @@ def test_firmware_update_confirm_posts_payload_in_mock_mode(
         "ImageURI": "https://example.invalid/firmware.exe",
         "TransferProtocol": "HTTPS",
     }
+
+
+def test_firmware_update_previews_multipart_push_uri_on_gb300(
+    redfish_service, redfish_mock
+):
+    """firmware-update uses GB300 MultipartHttpPushUri when SimpleUpdate is absent."""
+    _set_update_service(redfish_service, _gb300_update_service())
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.FirmwareUpdate,
+        "firmware-update",
+        image_file="firmware.bin",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["method"] == "MultipartHttpPushUri"
+    assert result.data["target"] == MULTIPART_PUSH_TARGET
+    assert result.data["image_file"] == "firmware.bin"
+    assert result.data["blocked"] == "destructive update requires --confirm"
+    assert _post_requests(redfish_service) == []
+
+
+def test_firmware_update_confirm_posts_to_multipart_push_uri_on_gb300(
+    tmp_path, redfish_service, redfish_mock
+):
+    """firmware-update --confirm POSTs only to the discovered push URI."""
+    _set_update_service(redfish_service, _gb300_update_service())
+    image = tmp_path / "firmware.bin"
+    image.write_bytes(b"fw-bytes")
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.FirmwareUpdate,
+        "firmware-update",
+        image_file=str(image),
+        confirm=True,
+    )
+
+    posts = _post_requests(redfish_service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["method"] == "MultipartHttpPushUri"
+    assert result.data["target"] == MULTIPART_PUSH_TARGET
+    assert len(posts) == 1
+    assert posts[0].path.lower() == MULTIPART_PUSH_TARGET.lower()
+    assert b"fw-bytes" in posts[0].body
+    assert b'name="UpdateFile"; filename="firmware.bin"' in posts[0].body
+
+
+def test_firmware_update_refuses_when_no_update_path_exists(redfish_service, redfish_mock):
+    """firmware-update reports a clean error when no update mechanism is exposed."""
+    _set_update_service(redfish_service, {
+        "@odata.id": "/redfish/v1/UpdateService",
+        "Id": "UpdateService",
+        "Actions": {},
+    })
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.FirmwareUpdate,
+        "firmware-update",
+        image_file="firmware.bin",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {
+        "action": "firmware-update",
+        "available": [],
+        "update_service": "/redfish/v1/UpdateService",
+    }
+    assert "SimpleUpdate, MultipartHttpPushUri, or HttpPushUri" in result.error
+    assert _post_requests(redfish_service) == []


### PR DESCRIPTION
Summary:
- Add local-image firmware uploads through discovered MultipartHttpPushUri or HttpPushUri when SimpleUpdate is unavailable.
- Keep firmware writes preview-only by default and require --confirm before posting an image file.
- Document the push-upload examples in the command reference.

Tests:
- pytest -q tests/test_firmware_update_dualmode.py tests/test_ilo_gap_batch2.py
- ruff check redfish_ctl/firmware/cmd_firmware_update.py tests/test_firmware_update_dualmode.py
- git diff --check
- pytest -q