### PR TITLE
Add guarded volume create and delete

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -180,6 +180,8 @@ Safety labels:
 | `telemetry-triggers` | Read TelemetryService triggers and thresholds. | Read |
 | `thermal` | Read Chassis `ThermalSubsystem` links, ThermalMetrics temperature readings, and fan collection counts from `redfish_ctl/thermal/cmd_thermal.py`. | Read |
 | `vm-mount` | Mount/unmount an ISO via Supermicro OEM virtual media (CfgCD). | Write |
+| `volume-create` | Create a Redfish volume; previews unless `--confirm` is given. | Guarded |
+| `volume-delete` | Delete a Redfish volume; requires `--confirm` and `--confirm_volume_id`. | Guarded |
 | `volume-get` | Read one volume from a storage device. | Read |
 | `volume-init` | Initialize a volume. | Write |
 | `volumes` | Read virtual disk data. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -128,6 +128,7 @@ from .tasks.cmd_task_watch import *
 from .volumes.cmd_initilize import *
 from .volumes.cmd_volumes import *
 from .volumes.cmd_virtual_disk import *
+from .volumes.cmd_volume_manage import *
 
 # boot options
 from .boot_options.cmd_boot_option_list import *

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -29,6 +29,8 @@ class ApiRequestType(Enum):
     Drives = auto()
     VolumeInit = auto()
     VolumeQuery = auto()
+    VolumeCreate = auto()
+    VolumeDelete = auto()
     ImportOneTimeBoot = auto()
 
     # dell oem

--- a/redfish_ctl/volumes/cmd_volume_manage.py
+++ b/redfish_ctl/volumes/cmd_volume_manage.py
@@ -1,0 +1,293 @@
+"""Create and delete Redfish Volume resources through the Storage collection."""
+from abc import abstractmethod
+from typing import Iterable, Optional
+
+from ..cmd_exceptions import InvalidArgument, UnsupportedAction
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+
+
+def _last_segment(uri: str) -> str:
+    """Return the last Redfish URI segment."""
+    return str(uri).rstrip("/").split("/")[-1]
+
+
+def _as_list(values: Optional[Iterable[str]]) -> list[str]:
+    """Normalize argparse and direct-call values into a string list."""
+    if values is None:
+        return []
+    if isinstance(values, str):
+        return [values]
+    return [str(value) for value in values]
+
+
+def _collect_supported_raid_types(payload: object) -> list[str]:
+    """Find advertised RAID type values in a Redfish payload."""
+    supported: list[str] = []
+    stack = [payload]
+    while stack:
+        item = stack.pop()
+        if isinstance(item, dict):
+            for key, value in item.items():
+                if key in {
+                    "SupportedRAIDTypes",
+                    "RAIDType@Redfish.AllowableValues",
+                } and isinstance(value, list):
+                    supported.extend(str(entry) for entry in value)
+                elif isinstance(value, (dict, list)):
+                    stack.append(value)
+        elif isinstance(item, list):
+            stack.extend(item)
+    return sorted(set(supported))
+
+
+def build_volume_payload(name: str, raid_type: str, drive_uris: list[str]) -> dict:
+    """Build the standard DMTF Volume create payload."""
+    return {
+        "Name": name,
+        "RAIDType": raid_type,
+        "Links": {"Drives": [{"@odata.id": uri} for uri in drive_uris]},
+    }
+
+
+class _VolumeMutationBase(IDracManager):
+    """Shared Storage/Volume collection helpers for guarded mutations."""
+
+    def _storage(self, controller: str, do_async: bool = False) -> dict:
+        if not controller:
+            raise InvalidArgument("provide --controller")
+        result = self.sync_invoke(
+            ApiRequestType.StorageViewQuery,
+            "storage_get",
+            controller=controller,
+            do_async=do_async,
+        )
+        return result.data or {}
+
+    def _volumes_uri(self, storage: dict, controller: str) -> str:
+        volumes = storage.get("Volumes")
+        if not isinstance(volumes, dict) or not volumes.get("@odata.id"):
+            raise UnsupportedAction(
+                f"Storage controller {controller} does not advertise a Volumes link"
+            )
+        return str(volumes["@odata.id"])
+
+    def _resolve_drive_uris(self, storage: dict, drives: list[str]) -> list[str]:
+        if not drives:
+            raise InvalidArgument("provide at least one --drive")
+        drive_map = {
+            _last_segment(member["@odata.id"]): member["@odata.id"]
+            for member in storage.get("Drives", [])
+            if isinstance(member, dict) and member.get("@odata.id")
+        }
+        resolved = []
+        for drive in drives:
+            if drive.startswith("/redfish/"):
+                resolved.append(drive)
+                continue
+            if drive not in drive_map:
+                available = sorted(drive_map)
+                raise InvalidArgument(
+                    f"Drive {drive} not found, available {available}"
+                )
+            resolved.append(drive_map[drive])
+        return resolved
+
+    def _volume_collection(self, controller: str, do_async: bool = False) -> dict:
+        result = self.sync_invoke(
+            ApiRequestType.VolumeQuery,
+            "vol_query",
+            dev_id=controller,
+            do_async=do_async,
+        )
+        return result.data or {}
+
+    def _resolve_volume_uri(
+            self,
+            controller: str,
+            volume_id: str,
+            do_async: bool = False) -> tuple[str, str, list[str]]:
+        if not volume_id:
+            raise InvalidArgument("provide --volume_id")
+        collection = self._volume_collection(controller, do_async=do_async)
+        members = collection.get("Members", [])
+        available: dict[str, str] = {}
+        for member in members:
+            if not isinstance(member, dict) or not member.get("@odata.id"):
+                continue
+            uri = str(member["@odata.id"])
+            member_id = str(member.get("Id") or _last_segment(uri))
+            available[member_id] = uri
+            available[uri] = uri
+        if volume_id in available:
+            uri = available[volume_id]
+            return uri, _last_segment(uri), sorted(
+                key for key in available if not key.startswith("/redfish/")
+            )
+        ids = sorted(key for key in available if not key.startswith("/redfish/"))
+        raise InvalidArgument(f"Volume {volume_id} not found, available {ids}")
+
+
+class VolumeCreate(
+    _VolumeMutationBase,
+    scm_type=ApiRequestType.VolumeCreate,
+    name="volume-create",
+    metaclass=Singleton,
+):
+    """Create a Redfish Volume through a Storage resource's Volumes collection."""
+
+    def __init__(self, *args, **kwargs):
+        super(VolumeCreate, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--controller", required=True, type=str,
+            help="Storage controller id, for example RAID.Integrated.1-1")
+        cmd_parser.add_argument(
+            "--name", required=True, type=str,
+            dest="volume_name",
+            help="Volume Name to send in the create payload")
+        cmd_parser.add_argument(
+            "--raid_type", required=True, type=str,
+            help="Redfish RAIDType, for example RAID1")
+        cmd_parser.add_argument(
+            "--drive", required=True, action="append", dest="drives",
+            help="Drive id or Redfish drive URI; repeat for multiple drives")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="actually create the volume; otherwise preview only")
+        cmd_parser.add_argument(
+            "--dry_run", action="store_true", dest="dry_run", default=False,
+            help="force a preview even when --confirm is present")
+        return cmd_parser, "volume-create", "create a Redfish volume (guarded)"
+
+    def execute(self,
+                controller: str,
+                volume_name: str,
+                raid_type: str,
+                drives: Optional[Iterable[str]] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        storage = self._storage(controller, do_async=bool(do_async))
+        target = self._volumes_uri(storage, controller)
+        allowed = _collect_supported_raid_types(storage)
+        if allowed and raid_type not in allowed:
+            raise InvalidArgument(
+                f"RAIDType {raid_type} not supported, available {allowed}"
+            )
+        payload = build_volume_payload(
+            volume_name,
+            raid_type,
+            self._resolve_drive_uris(storage, _as_list(drives)),
+        )
+        if dry_run or not confirm:
+            return CommandResult(
+                {
+                    "dry_run": True,
+                    "action": "create",
+                    "target": target,
+                    "payload": payload,
+                    "hint": "re-run with --confirm to create the volume",
+                },
+                None,
+                None,
+                None,
+            )
+        result, status = self.base_post(target, payload=payload, do_async=do_async)
+        return CommandResult(
+            {
+                "action": "create",
+                "target": target,
+                "status": str(status),
+                "error": result.error,
+            },
+            None,
+            None,
+            result.error,
+        )
+
+
+class VolumeDelete(
+    _VolumeMutationBase,
+    scm_type=ApiRequestType.VolumeDelete,
+    name="volume-delete",
+    metaclass=Singleton,
+):
+    """Delete a Redfish Volume member after explicit confirmation."""
+
+    def __init__(self, *args, **kwargs):
+        super(VolumeDelete, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--controller", required=True, type=str,
+            help="Storage controller id, for example RAID.Integrated.1-1")
+        cmd_parser.add_argument(
+            "--volume_id", required=True, type=str,
+            help="Volume id or Redfish Volume URI")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="actually delete the volume; otherwise preview only")
+        cmd_parser.add_argument(
+            "--confirm_volume_id", required=False, type=str, default=None,
+            help="repeat the volume id to authorize deletion")
+        cmd_parser.add_argument(
+            "--dry_run", action="store_true", dest="dry_run", default=False,
+            help="force a preview even when --confirm is present")
+        return cmd_parser, "volume-delete", "delete a Redfish volume (guarded)"
+
+    def execute(self,
+                controller: str,
+                volume_id: str,
+                confirm: Optional[bool] = False,
+                confirm_volume_id: Optional[str] = None,
+                dry_run: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        uri, resolved_id, _ = self._resolve_volume_uri(
+            controller,
+            volume_id,
+            do_async=bool(do_async),
+        )
+        if dry_run or not confirm:
+            return CommandResult(
+                {
+                    "dry_run": True,
+                    "action": "delete",
+                    "target": volume_id,
+                    "uri": uri,
+                    "hint": "re-run with --confirm and --confirm_volume_id to delete",
+                },
+                None,
+                None,
+                None,
+            )
+        if confirm_volume_id != resolved_id:
+            return CommandResult(
+                None,
+                None,
+                None,
+                f"confirm_volume_id must match {resolved_id}",
+            )
+        result, status = self.base_delete(uri, do_async=do_async)
+        return CommandResult(
+            {
+                "action": "delete",
+                "target": resolved_id,
+                "uri": uri,
+                "status": str(status),
+                "error": result.error,
+            },
+            None,
+            None,
+            result.error,
+        )

--- a/tests/test_volume_manage_dualmode.py
+++ b/tests/test_volume_manage_dualmode.py
@@ -1,0 +1,203 @@
+"""Dual-mode tests for guarded Redfish volume create and delete commands."""
+import json
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument, UnsupportedAction
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+_CONTROLLER = "RAID.Integrated.1-1"
+_STORAGE_PATH = f"/redfish/v1/Systems/System.Embedded.1/Storage/{_CONTROLLER}"
+_VOLUMES_PATH = f"{_STORAGE_PATH}/Volumes"
+_DRIVE_PATH = f"{_STORAGE_PATH}/Drives/Disk.Bay.0"
+_VOLUME_ID = f"Disk.Virtual.0:{_CONTROLLER}"
+_VOLUME_PATH = f"{_VOLUMES_PATH}/{_VOLUME_ID}"
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _delete_requests(service):
+    """Return DELETE requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "DELETE"]
+
+
+def _seed_raid_capabilities(service, values=("RAID0", "RAID1")):
+    """Seed advertised RAID types so create validates controller metadata."""
+    storage = dict(service._state(_STORAGE_PATH.lower()))
+    storage["SupportedRAIDTypes"] = list(values)
+    service._overlay[_STORAGE_PATH.lower()] = storage
+
+
+def _invoke_create(redfish_mock, **kwargs):
+    """Invoke volume-create with defaults used across guarded-create tests."""
+    params = {
+        "controller": _CONTROLLER,
+        "volume_name": "os-mirror",
+        "raid_type": "RAID1",
+        "drives": ["Disk.Bay.0"],
+    }
+    params.update(kwargs)
+    return redfish_mock.sync_invoke(
+        ApiRequestType.VolumeCreate,
+        "volume-create",
+        **params,
+    )
+
+
+def _invoke_delete(redfish_mock, **kwargs):
+    """Invoke volume-delete with defaults used across guarded-delete tests."""
+    params = {
+        "controller": _CONTROLLER,
+        "volume_id": _VOLUME_ID,
+    }
+    params.update(kwargs)
+    return redfish_mock.sync_invoke(
+        ApiRequestType.VolumeDelete,
+        "volume-delete",
+        **params,
+    )
+
+
+def test_volume_create_dry_run_resolves_payload_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """volume-create previews the standard Volumes POST without mutating."""
+    _seed_raid_capabilities(redfish_service)
+
+    result = _invoke_create(redfish_mock)
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "create",
+        "target": _VOLUMES_PATH,
+        "payload": {
+            "Name": "os-mirror",
+            "RAIDType": "RAID1",
+            "Links": {"Drives": [{"@odata.id": _DRIVE_PATH}]},
+        },
+        "hint": "re-run with --confirm to create the volume",
+    }
+    assert _post_requests(redfish_service) == []
+
+
+def test_volume_create_confirm_posts_standard_payload(redfish_mock, redfish_service):
+    """volume-create --confirm POSTs a vendor-neutral Volume payload."""
+    _seed_raid_capabilities(redfish_service)
+
+    result = _invoke_create(redfish_mock, confirm=True)
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["status"]
+    posts = _post_requests(redfish_service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == _VOLUMES_PATH.lower()
+    assert posts[0].json() == {
+        "Name": "os-mirror",
+        "RAIDType": "RAID1",
+        "Links": {"Drives": [{"@odata.id": _DRIVE_PATH}]},
+    }
+
+
+def test_volume_create_rejects_unsupported_raid_type_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """volume-create validates RAIDType when the controller advertises a set."""
+    _seed_raid_capabilities(redfish_service, values=("RAID0",))
+
+    with pytest.raises(InvalidArgument, match="RAID1"):
+        _invoke_create(redfish_mock)
+
+    assert _post_requests(redfish_service) == []
+
+
+def test_volume_create_refuses_controller_without_volumes_link(
+    redfish_mock,
+    redfish_service,
+):
+    """volume-create fails closed when a Storage resource has no Volumes link."""
+    storage = dict(redfish_service._state(_STORAGE_PATH.lower()))
+    storage.pop("Volumes")
+    redfish_service._overlay[_STORAGE_PATH.lower()] = storage
+
+    with pytest.raises(UnsupportedAction, match="Volumes"):
+        _invoke_create(redfish_mock)
+
+    assert _post_requests(redfish_service) == []
+
+
+def test_volume_delete_dry_run_requires_no_delete(redfish_mock, redfish_service):
+    """volume-delete previews the member URI and writes nothing by default."""
+    result = _invoke_delete(redfish_mock)
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "delete",
+        "target": _VOLUME_ID,
+        "uri": _VOLUME_PATH,
+        "hint": "re-run with --confirm and --confirm_volume_id to delete",
+    }
+    assert _delete_requests(redfish_service) == []
+
+
+def test_volume_delete_confirm_requires_matching_volume_id(
+    redfish_mock,
+    redfish_service,
+):
+    """volume-delete --confirm requires the volume id to be typed again."""
+    result = _invoke_delete(
+        redfish_mock,
+        confirm=True,
+        confirm_volume_id="wrong-volume",
+    )
+
+    assert result.error == f"confirm_volume_id must match {_VOLUME_ID}"
+    assert _delete_requests(redfish_service) == []
+
+
+def test_volume_delete_confirm_deletes_member(redfish_mock, redfish_service):
+    """volume-delete --confirm deletes the resolved Volume member URI."""
+    result = _invoke_delete(
+        redfish_mock,
+        confirm=True,
+        confirm_volume_id=_VOLUME_ID,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["action"] == "delete"
+    deletes = _delete_requests(redfish_service)
+    assert len(deletes) == 1
+    assert deletes[0].path.lower() == _VOLUME_PATH.lower()
+
+
+def test_volume_delete_unknown_volume_lists_available_ids(redfish_mock):
+    """volume-delete rejects unknown ids and reports the available Volumes."""
+    with pytest.raises(InvalidArgument, match=_VOLUME_ID):
+        _invoke_delete(redfish_mock, volume_id="missing-volume")
+
+
+@pytest.mark.live
+def test_volume_create_live_preview_only(redfish_api):
+    """Live mode keeps volume-create read-only unless an operator confirms."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.VolumeCreate,
+        "volume-create",
+        controller=_CONTROLLER,
+        volume_name="preview-only",
+        raid_type="RAID1",
+        drives=["Disk.Bay.0"],
+    )
+    assert isinstance(result, CommandResult)
+    json.dumps(result.data)
+    assert result.data["dry_run"] is True


### PR DESCRIPTION
## Summary
- Add guarded volume-create and volume-delete commands for standard Redfish Volume resources.
- Resolve Storage/Volumes and drive/member URIs from the service tree instead of hardcoding ids.
- Document the new commands in the command reference.

## Test Plan
- pytest -q tests/test_volume_manage_dualmode.py
- pytest -q tests/test_storage_volume_dualmode.py tests/test_storage_drives_dualmode.py tests/test_storage_get_dualmode.py tests/test_storage_vendor.py tests/test_volume_manage_dualmode.py
- pytest -q
- ruff check redfish_ctl/idrac_shared.py redfish_ctl/volumes/cmd_volume_manage.py tests/test_volume_manage_dualmode.py
- python -m redfish_ctl volume-create --help
- python -m redfish_ctl volume-delete --help