### PR TITLE
Add CSDL action parameter validation

### DIFF
--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -1596,6 +1596,50 @@ class IDracManager(RedfishManager):
                 out[key] = val["target"]
         return out
 
+    @staticmethod
+    def _validate_action_payload(full_action_type: str,
+                                 action: Optional[RedfishAction],
+                                 payload: dict) -> list[dict]:
+        """Validate action payload keys/enum values when action metadata is available."""
+        inline_args = getattr(action, "args", None) or {}
+        if inline_args:
+            strict_names = False
+            parameters = {
+                name: {"allowed": tuple(values or ())}
+                for name, values in inline_args.items()
+            }
+        else:
+            from .redfish_csdl import action_parameters_for
+            strict_names = True
+            parameters = {
+                name: {"allowed": param.allowable_values}
+                for name, param in action_parameters_for(full_action_type).items()
+            }
+        if not parameters:
+            return []
+
+        errors = []
+        for name, value in payload.items():
+            if name not in parameters:
+                if strict_names:
+                    errors.append({
+                        "parameter": name,
+                        "value": value,
+                        "allowed": [],
+                    })
+                continue
+            allowed = tuple(parameters[name].get("allowed") or ())
+            if allowed:
+                values = value if isinstance(value, list) else [value]
+                invalid = [item for item in values if item not in allowed]
+                if invalid:
+                    errors.append({
+                        "parameter": name,
+                        "value": invalid[0] if len(invalid) == 1 else invalid,
+                        "allowed": sorted(allowed),
+                    })
+        return errors
+
     def invoke_action(self,
                       resource_uri: str,
                       action_name: str,
@@ -1675,6 +1719,25 @@ class IDracManager(RedfishManager):
 
         level = classify(full)
         body = payload or {}
+        action = actions.get(action_name)
+        validation_errors = self._validate_action_payload(full, action, body)
+        if validation_errors:
+            first = validation_errors[0]
+            action_label = full.lstrip("#")
+            if first["allowed"]:
+                error = (
+                    f"invalid value for {action_label} {first['parameter']}: "
+                    f"{first['value']}; allowed: {', '.join(first['allowed'])}"
+                )
+            else:
+                error = f"unknown parameter for {action_label}: {first['parameter']}"
+            return CommandResult({
+                "action": full,
+                "target": target,
+                "payload": body,
+                "level": level.value,
+                "validation_errors": validation_errors,
+            }, actions, None, error)
 
         # Fail-safe gate: decide whether this POST is actually allowed to fire.
         blocked_reason = None

--- a/redfish_ctl/redfish_csdl.py
+++ b/redfish_ctl/redfish_csdl.py
@@ -1,0 +1,144 @@
+"""Helpers for reading Redfish CSDL action metadata from a local cache."""
+
+from __future__ import annotations
+
+import os
+import re
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Mapping
+
+_VERSION_SUFFIX = re.compile(r"\.v\d+_\d+_\d+$")
+
+
+@dataclass(frozen=True)
+class CsdlActionParameter:
+    """One CSDL Action parameter from the published Redfish schema bundle."""
+
+    name: str
+    type_name: str
+    allowable_values: tuple[str, ...] = ()
+    nullable: bool = True
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def _namespace_family(namespace: str) -> str:
+    return _VERSION_SUFFIX.sub("", namespace or "")
+
+
+def _type_key(type_name: str) -> str:
+    cleaned = (type_name or "").strip()
+    if cleaned.startswith("Collection(") and cleaned.endswith(")"):
+        cleaned = cleaned[len("Collection("):-1]
+    parts = cleaned.split(".")
+    if len(parts) >= 2:
+        family = _namespace_family(".".join(parts[:-1]))
+        return f"{family}.{parts[-1]}"
+    return cleaned
+
+
+def _default_schema_dir() -> Path:
+    configured = os.environ.get("REDFISH_CSDL_DIR")
+    if configured:
+        return Path(configured)
+    return Path(__file__).resolve().parents[1] / "tools" / "redfish-schemas"
+
+
+def _iter_schema_files(schema_dir: Path) -> tuple[Path, ...]:
+    if not schema_dir.exists():
+        return ()
+    return tuple(sorted(schema_dir.rglob("*.xml")))
+
+
+def _parse_schema_file(
+    path: Path,
+) -> tuple[
+    dict[str, tuple[str, ...]],
+    dict[tuple[str, str], list[CsdlActionParameter]],
+]:
+    root = ET.parse(path).getroot()
+    enums: dict[str, tuple[str, ...]] = {}
+    raw_actions: dict[tuple[str, str], list[CsdlActionParameter]] = {}
+
+    for schema in root.iter():
+        if _local_name(schema.tag) != "Schema":
+            continue
+        namespace = schema.attrib.get("Namespace", "")
+        family = _namespace_family(namespace)
+        for child in list(schema):
+            name = child.attrib.get("Name", "")
+            if not name:
+                continue
+            if _local_name(child.tag) == "EnumType":
+                values = tuple(
+                    member.attrib["Name"]
+                    for member in list(child)
+                    if _local_name(member.tag) == "Member" and member.attrib.get("Name")
+                )
+                enums[f"{namespace}.{name}"] = values
+                enums[f"{family}.{name}"] = values
+            elif _local_name(child.tag) == "Action":
+                params = []
+                parameters = [
+                    param
+                    for param in list(child)
+                    if _local_name(param.tag) == "Parameter" and param.attrib.get("Name")
+                ]
+                if child.attrib.get("IsBound", "").lower() == "true" and parameters:
+                    parameters = parameters[1:]
+                for param in parameters:
+                    params.append(
+                        CsdlActionParameter(
+                            name=param.attrib["Name"],
+                            type_name=param.attrib.get("Type", ""),
+                            nullable=param.attrib.get("Nullable", "true").lower() != "false",
+                        )
+                    )
+                raw_actions[(namespace, name)] = params
+                raw_actions[(family, name)] = params
+
+    return enums, raw_actions
+
+
+@lru_cache(maxsize=8)
+def _load_action_parameters(
+    schema_dir: str,
+) -> dict[tuple[str, str], tuple[CsdlActionParameter, ...]]:
+    enums: dict[str, tuple[str, ...]] = {}
+    actions: dict[tuple[str, str], list[CsdlActionParameter]] = {}
+    for path in _iter_schema_files(Path(schema_dir)):
+        file_enums, file_actions = _parse_schema_file(path)
+        enums.update(file_enums)
+        actions.update(file_actions)
+
+    resolved: dict[tuple[str, str], tuple[CsdlActionParameter, ...]] = {}
+    for key, params in actions.items():
+        resolved[key] = tuple(
+            CsdlActionParameter(
+                name=param.name,
+                type_name=param.type_name,
+                allowable_values=enums.get(_type_key(param.type_name), ()),
+                nullable=param.nullable,
+            )
+            for param in params
+        )
+    return resolved
+
+
+def action_parameters_for(
+    full_action_type: str,
+    schema_dir: str | os.PathLike | None = None,
+) -> Mapping[str, CsdlActionParameter]:
+    """Return CSDL parameters for a full Redfish action type, if cached locally."""
+    parts = (full_action_type or "").lstrip("#").split(".")
+    if len(parts) < 2:
+        return {}
+    namespace, action_name = _namespace_family(".".join(parts[:-1])), parts[-1]
+    root = Path(schema_dir) if schema_dir is not None else _default_schema_dir()
+    params = _load_action_parameters(str(root)).get((namespace, action_name), ())
+    return {param.name: param for param in params}

--- a/tests/test_invoke_action_csdl.py
+++ b/tests/test_invoke_action_csdl.py
@@ -1,0 +1,77 @@
+"""Offline tests for CSDL-backed Redfish action validation."""
+
+import copy
+
+
+def _write_reset_csdl(schema_dir):
+    """Create a minimal ComputerSystem.Reset CSDL cache for tests."""
+    (schema_dir / "ComputerSystem_v1.xml").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="ComputerSystem.v1_0_0" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Action Name="Reset" IsBound="true">
+        <Parameter Name="ComputerSystem" Type="ComputerSystem.v1_0_0.ComputerSystem" Nullable="false"/>
+        <Parameter Name="ResetType" Type="Resource.ResetType"/>
+      </Action>
+    </Schema>
+    <Schema Namespace="Resource" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="ResetType">
+        <Member Name="GracefulRestart"/>
+        <Member Name="ForceRestart"/>
+      </EnumType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>
+""",
+        encoding="utf-8",
+    )
+
+
+def _system_without_inline_allowable_values(redfish_service):
+    """Return the Dell ComputerSystem fixture with inline reset choices removed."""
+    system = copy.deepcopy(
+        redfish_service._state("/redfish/v1/Systems/System.Embedded.1")
+    )
+    reset = system["Actions"]["#ComputerSystem.Reset"]
+    reset.pop("ResetType@Redfish.AllowableValues", None)
+    return system
+
+
+def test_invoke_action_rejects_invalid_csdl_enum_without_post(
+    redfish_mock,
+    redfish_service,
+    tmp_path,
+    monkeypatch,
+):
+    """A CSDL enum fallback blocks invalid action payload values before POST."""
+    _write_reset_csdl(tmp_path)
+    monkeypatch.setenv("REDFISH_CSDL_DIR", str(tmp_path))
+    system = _system_without_inline_allowable_values(redfish_service)
+    redfish_service._overlay["/redfish/v1/Systems/System.Embedded.1"] = system
+    redfish_service._overlay["/redfish/v1/systems/system.embedded.1"] = system
+
+    result = redfish_mock.invoke_action(
+        "/redfish/v1/Systems/System.Embedded.1",
+        "Reset",
+        payload={"ResetType": "BadReset"},
+        full_action_type="#ComputerSystem.Reset",
+        confirm=True,
+    )
+
+    assert result.error == (
+        "invalid value for ComputerSystem.Reset ResetType: BadReset; "
+        "allowed: ForceRestart, GracefulRestart"
+    )
+    assert result.data["payload"] == {"ResetType": "BadReset"}
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "ResetType",
+            "value": "BadReset",
+            "allowed": ["ForceRestart", "GracefulRestart"],
+        }
+    ]
+    assert [
+        request for request in redfish_service.requests
+        if request.method == "POST"
+    ] == []

--- a/tests/test_redfish_csdl.py
+++ b/tests/test_redfish_csdl.py
@@ -1,0 +1,37 @@
+"""Offline tests for Redfish CSDL action metadata helpers."""
+
+from redfish_ctl.redfish_csdl import action_parameters_for
+
+
+def test_csdl_action_parameters_resolve_enum_values(tmp_path):
+    """CSDL action parsing exposes enum choices when inline action info is absent."""
+    (tmp_path / "ComputerSystem_v1.xml").write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="ComputerSystem.v1_0_0" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <Action Name="Reset" IsBound="true">
+        <Parameter Name="ComputerSystem" Type="ComputerSystem.v1_0_0.ComputerSystem" Nullable="false"/>
+        <Parameter Name="ResetType" Type="Resource.ResetType"/>
+      </Action>
+    </Schema>
+    <Schema Namespace="Resource" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="ResetType">
+        <Member Name="GracefulRestart"/>
+        <Member Name="ForceRestart"/>
+      </EnumType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>
+""",
+        encoding="utf-8",
+    )
+
+    params = action_parameters_for("#ComputerSystem.Reset", tmp_path)
+
+    assert tuple(params) == ("ResetType",)
+    assert params["ResetType"].type_name == "Resource.ResetType"
+    assert params["ResetType"].allowable_values == (
+        "GracefulRestart",
+        "ForceRestart",
+    )


### PR DESCRIPTION
## Summary
- Add a Redfish CSDL helper that reads locally cached XML schema files and resolves action parameters plus enum values.
- Use that metadata in `invoke_action` when a resource omits inline action `AllowableValues`, so invalid payload enum values are blocked before any POST.
- Add offline coverage for parser behavior and the no-POST invalid reset path.

## Tests
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python -B -m pytest -q tests/test_redfish_csdl.py tests/test_invoke_action_csdl.py -o cache_dir=/private/tmp/idrac-schema1-pytest-cache`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python -B -m pytest -q tests/test_redfish_csdl.py tests/test_invoke_action_csdl.py tests/test_system_reset_dualmode.py tests/test_manager_reset_dualmode.py tests/test_firmware_update_dualmode.py tests/test_ilo_gap_batch2.py -o cache_dir=/private/tmp/idrac-schema1-pytest-cache-focused`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/redfish_csdl.py redfish_ctl/idrac_manager.py tests/test_redfish_csdl.py tests/test_invoke_action_csdl.py`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python -B -m pytest -q -o cache_dir=/private/tmp/idrac-schema1-pytest-cache-full`
- `git diff --check`