### PR TITLE
Add exporter scrape health metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python versions](https://img.shields.io/pypi/pyversions/redfish-ctl.svg)](https://pypi.org/project/redfish-ctl/)
 [![License: MIT](https://img.shields.io/pypi/l/redfish-ctl.svg)](https://github.com/spyroot/redfish_ctl/blob/main/LICENSE)
 
-`redfish_ctl` is a standalone command-line tool I built to drive server BMCs entirely through the
+`redfish_ctl` is a standalone command-line tool for driving server BMCs entirely through the
 Redfish REST API — no web UI, no vendor GUI. It wraps 100+ subcommands behind one consistent CLI
 with JSON or YAML output (`--yaml`, and save-to-file), both synchronous and asynchronous calls,
 optional server-side `$expand` on large collection reads, and a read-first, guarded-write model
@@ -31,7 +31,9 @@ What it does across the whole server lifecycle:
   Serial-over-LAN service, in one step, vendor-neutrally.
 - **Sensors & telemetry** — read every chassis sensor and TelemetryService report/definition, plus
   an out-of-band exporter that streams BMC metrics — including GB300 GPU, NVLink, thermal, and power
-  — to Prometheus, SignalFx, and Splunk Observability.
+  — to Prometheus, SignalFx, and Splunk Observability. The
+  [telemetry exporter guide](docs/telemetry-exporter.md) covers the one-exporter-per-BMC deployment
+  model and the supported consumer modes.
 - **Firmware** — inventory and guarded `UpdateService` SimpleUpdate.
 - **Accounts & security** — create/update/delete accounts, SSH-key import, the account and privilege
   services, Secure Boot, and SPDM component-integrity attestation.

--- a/docs/telemetry-exporter.md
+++ b/docs/telemetry-exporter.md
@@ -70,6 +70,27 @@ This model is sized for tens up to a couple hundred BMCs per site. Far beyond th
 exporters across several hosts; do not look for a mode where one process owns the whole fleet —
 that mode deliberately does not exist.
 
+## Consumption Models
+
+Different consumers use the same Redfish read paths under different latency and liveness
+assumptions. Treat each mode separately when tuning or debugging.
+
+| Consumer | Where it runs | Latency envelope | Concurrency and caching | Optimize |
+|---|---|---|---|---|
+| Interactive CLI | Operator laptop or jump host | Often WAN/VPN, about 100-800 ms RTT | One BMC, one-shot command, per-connection caching and keep-alive | Clear errors, bounded request count, no hidden writes |
+| Exporter daemon | One process or pod per BMC | Usually in-rack or same-site | No cross-BMC fan-out; one stream per process, supervised by systemd or Kubernetes | Per-BMC scrape cost, health metrics, bounded sampler work |
+| Kubernetes controller/operator | In-cluster controller polling `RedfishEndpoint` resources | Cluster-to-BMC network path | One reconcile loop per endpoint; Kubernetes stores observed status | Status freshness, safe retry/backoff, no automatic mutation without approval |
+| Fleet CLI/proxy | Jump host or in-DC service | Mixed; usually closer to the BMC network than an operator laptop | Bounded read-only fan-out across BMCs; not a telemetry streamer | Per-node isolation, partial-failure reporting, request budgets |
+
+The exporter daemon deliberately keeps many shallow liveness domains: one child process or pod can
+fail, restart, or rotate credentials without disrupting the rest of the fleet. Aggregation belongs
+in the OpenTelemetry Collector or Prometheus, not inside `redfish_ctl`.
+
+Every completed scrape adds `hw.scrape.ok` and `hw.scrape.duration_seconds` so downstream alerts can
+distinguish an alive exporter with a bad scrape from a missing process or route. Long-running
+SignalFx push mode also offsets each sleep interval by plus or minus ten percent to avoid many BMCs
+being polled at the same instant.
+
 ## What It Reads
 
 - Chassis, Processor, and Memory `EnvironmentMetrics` resources, discovered by the

--- a/redfish_ctl/telemetry/cmd_exporter.py
+++ b/redfish_ctl/telemetry/cmd_exporter.py
@@ -194,6 +194,7 @@ class Exporter(IDracManager,
                         do_async: bool = False,
                         do_expanded: bool = False) -> list:
         """Scrape all supported read-only telemetry paths and build samples."""
+        started_at = exporter.time.monotonic()
         identity = build_identity_dimensions(
             label_bmc_ip or self.idrac_ip,
             vendor=self._vendor_label(vendor),
@@ -211,7 +212,7 @@ class Exporter(IDracManager,
                                          do_async=do_async, do_expanded=do_expanded)
         component_rows = self._invoke_rows(ApiRequestType.ComponentIntegrity, "component-integrity",
                                            do_async=do_async, do_expanded=do_expanded)
-        return build_metric_samples(
+        samples = build_metric_samples(
             identity=identity,
             environment_rows=environment_rows,
             sensor_rows=sensor_rows,
@@ -222,6 +223,12 @@ class Exporter(IDracManager,
             network_rows=network_rows,
             component_integrity_rows=component_rows,
         )
+        samples.extend(exporter.scrape_health_samples(
+            identity,
+            ok=bool(samples),
+            duration_seconds=exporter.time.monotonic() - started_at,
+        ))
+        return samples
 
     def execute(self,
                 filename: Optional[str] = None,

--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import math
 import os
+import random
 import re
 import time
 import urllib.request
@@ -110,6 +111,7 @@ DIM_VALUE_OK = re.compile(r"[^A-Za-z0-9_.\-/]")
 # push_signalfx POSTs the ingest URL as-is, so it must be the full SignalFx
 # datapoint endpoint (…/v2/datapoint), never a bare host.
 SIGNALFX_DATAPOINT_PATH = "/v2/datapoint"
+POLL_JITTER_FRACTION = 0.10
 
 
 @dataclass(frozen=True)
@@ -238,6 +240,43 @@ def build_metric_samples(
     samples.extend(samples_from_network_rows(network_rows, identity))
     samples.extend(samples_from_component_integrity_rows(component_integrity_rows, identity))
     return samples
+
+
+def scrape_health_samples(
+        identity: Mapping[str, str],
+        ok: bool,
+        duration_seconds: float) -> list[MetricSample]:
+    """Return per-scrape liveness and duration samples."""
+    dims = _with_dims(identity, source="exporter")
+    duration = _as_float(duration_seconds)
+    return [
+        _sample("hw.scrape.ok", 1.0 if ok else 0.0, dims, None),
+        _sample(
+            "hw.scrape.duration_seconds",
+            max(0.0, duration if duration is not None else 0.0),
+            dims,
+            "s",
+        ),
+    ]
+
+
+def jittered_interval(
+        interval: float,
+        jitter_fraction: float = POLL_JITTER_FRACTION,
+        random_value: Optional[float] = None) -> float:
+    """Return ``interval`` offset by a bounded symmetric jitter fraction."""
+    base = _as_float(interval)
+    if base is None or base <= 0:
+        base = 1.0
+    fraction = _as_float(jitter_fraction)
+    if fraction is None or fraction < 0:
+        fraction = 0.0
+    draw = random.random() if random_value is None else random_value
+    try:
+        bounded = min(1.0, max(0.0, float(draw)))
+    except (TypeError, ValueError):
+        bounded = 0.5
+    return base * (1.0 - fraction + (2.0 * fraction * bounded))
 
 
 def samples_from_environment_rows(
@@ -677,7 +716,7 @@ def run_signalfx_loop(
         start = time.monotonic()
         push_signalfx(to_signalfx_body(scrape_samples()), token, ingest_url, timeout=timeout)
         elapsed = time.monotonic() - start
-        time.sleep(max(1.0, interval - elapsed))
+        time.sleep(max(1.0, jittered_interval(interval) - elapsed))
 
 
 def _reading(field):

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -360,6 +360,24 @@ def test_leak_detection_mapper_emits_state_gauges_with_detector_dimensions():
     assert REQUIRED_DIMS <= set(ok_sample.dimensions)
 
 
+def test_scrape_health_samples_report_success_and_duration():
+    """Each exporter scrape reports a health gauge and duration sample."""
+    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
+
+    samples = exporter_mod.scrape_health_samples(
+        dims,
+        ok=True,
+        duration_seconds=1.25,
+    )
+
+    by_metric = {sample.metric: sample for sample in samples}
+    assert by_metric["hw.scrape.ok"].value == 1
+    assert by_metric["hw.scrape.ok"].dimensions["source"] == "exporter"
+    assert by_metric["hw.scrape.duration_seconds"].value == pytest.approx(1.25)
+    assert by_metric["hw.scrape.duration_seconds"].unit == "s"
+    assert REQUIRED_DIMS <= set(by_metric["hw.scrape.ok"].dimensions)
+
+
 def test_prometheus_text_preserves_contract_names_and_dimensions():
     """Prometheus text output carries hw.* names and dotted OTel dimensions."""
     sample = MetricSample(
@@ -481,6 +499,16 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
     gauges = result.data["gauge"]
     metrics = {point["metric"] for point in gauges}
     assert {"hw.power", "hw.gpu.power", "hw.fabric.rx_bytes", "hw.leak.state"} <= metrics
+    assert {"hw.scrape.ok", "hw.scrape.duration_seconds"} <= metrics
+    scrape_ok = next(point for point in gauges if point["metric"] == "hw.scrape.ok")
+    scrape_duration = next(
+        point for point in gauges
+        if point["metric"] == "hw.scrape.duration_seconds"
+    )
+    assert scrape_ok["value"] == 1
+    assert scrape_ok["dimensions"]["source"] == "exporter"
+    assert scrape_duration["value"] >= 0
+    assert scrape_duration["dimensions"]["source"] == "exporter"
     assert {
         "hw.gpu.clock_mhz",
         "hw.gpu.compute.utilization",
@@ -510,6 +538,47 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
     assert thermal_points
     assert {"chassis", "sensor", "zone"} <= set(thermal_points[0]["dimensions"])
     assert all(recorded.method != "POST" for recorded in service.requests)
+
+
+def test_signalfx_push_loop_jitters_sleep(monkeypatch):
+    """Long-running push mode offsets the poll interval to avoid scrape bursts."""
+    samples = [
+        MetricSample(
+            metric="hw.scrape.ok",
+            value=1,
+            dimensions=build_identity_dimensions("172.25.230.29", vendor="supermicro")
+            | {"source": "exporter"},
+        )
+    ]
+    pushes = []
+
+    def fake_push(body, token, ingest_url, timeout=20.0):
+        pushes.append((body, token, ingest_url, timeout))
+        return 200
+
+    sleep_calls = []
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        raise RuntimeError("stop loop")
+
+    monotonic_values = iter([100.0, 105.0])
+    monkeypatch.setattr(exporter_mod, "push_signalfx", fake_push)
+    monkeypatch.setattr(exporter_mod.random, "random", lambda: 1.0)
+    monkeypatch.setattr(exporter_mod.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(exporter_mod.time, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError, match="stop loop"):
+        exporter_mod.run_signalfx_loop(
+            lambda: samples,
+            "token",
+            "https://ingest.us1.signalfx.com/v2/datapoint",
+            interval=30.0,
+            timeout=1.0,
+        )
+
+    assert len(pushes) == 1
+    assert sleep_calls == [pytest.approx(28.0)]
 
 
 def test_exporter_uses_environment_metrics_command_rollups(gb300_exporter_manager):

--- a/tests/test_telemetry_exporter_dualmode.py
+++ b/tests/test_telemetry_exporter_dualmode.py
@@ -19,9 +19,11 @@ def test_exporter_once_returns_prometheus_metrics_from_mock_reads(
 
     assert isinstance(result, CommandResult)
     assert result.error is None
-    assert result.extra == {"sample_count": 3}
+    assert result.extra == {"sample_count": 5}
     assert isinstance(result.data, str)
     assert "hw.temperature" in result.data
+    assert "hw.scrape.ok" in result.data
+    assert "hw.scrape.duration_seconds" in result.data
     assert 'vendor="dell"' in result.data
     assert redfish_service.requests
     assert {request.method for request in redfish_service.requests} == {"GET"}


### PR DESCRIPTION
## Summary
- Add `hw.scrape.ok` and `hw.scrape.duration_seconds` samples to each exporter scrape.
- Add ten-percent jitter to the long-running SignalFx push loop to reduce synchronized BMC polling.
- Document the exporter consumption models and link the README to the telemetry exporter guide.

## Tests
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT pytest -q tests/test_telemetry_exporter.py tests/test_telemetry_exporter_dualmode.py` -> `20 passed`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/telemetry/exporter.py redfish_ctl/telemetry/cmd_exporter.py tests/test_telemetry_exporter.py tests/test_telemetry_exporter_dualmode.py` -> `All checks passed!`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT pytest -q` -> `865 passed, 57 skipped`