### PR TITLE
Add EventService read command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Author: Mus <spyroot@gmail.com>
 When I connect to a new BMC, I run `redfish_ctl system` first. It proves the endpoint, credentials, and
 basic Redfish path before I ask for deeper inventory or stage any change.
 
-The table below follows the 105 command names imported by `redfish_ctl/__init__.py`. Run
+The table below follows the 116 command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
 backward-compatible alias for the `redfish_ctl` command, and `IDRAC_*` env vars are still read.)
 
@@ -113,6 +113,7 @@ Safety labels:
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |
 | `ethernet-interfaces` | Read host and manager EthernetInterfaces. | Read |
+| `event-service` | Read EventService, SSE filter support, and subscription collection summary. | Read |
 | `event-submit-test` | Submit a Redfish test event; `--dry_run` previews the payload. | Write |
 | `exporter` | Expose BMC telemetry as Prometheus text or SignalFx datapoints. | Read |
 | `firmware` | Read firmware view data. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -97,6 +97,7 @@ from .component_integrity.cmd_component_integrity import *
 from .network.cmd_network_adapters import *
 from .ports.cmd_nvlink_ports import *
 from .actions.cmd_action_list import *
+from .events.cmd_event_service import *
 from .events.cmd_event_submit_test import *
 from .compute.cmd_system_reset import *
 from .logs.cmd_logs import *

--- a/redfish_ctl/events/cmd_event_service.py
+++ b/redfish_ctl/events/cmd_event_service.py
@@ -1,0 +1,94 @@
+"""Read EventService and subscription summary."""
+from abc import abstractmethod
+from typing import Optional
+
+from ..idrac_manager import IDracManager
+from ..idrac_shared import IDRAC_API, ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+
+
+class EventServiceQuery(IDracManager,
+                        scm_type=ApiRequestType.EventServiceQuery,
+                        name='event-service',
+                        metaclass=Singleton):
+    """Read Redfish EventService, SSE, and subscription metadata."""
+
+    def __init__(self, *args, **kwargs):
+        super(EventServiceQuery, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only event-service subcommand."""
+        cmd_parser = cls.base_parser()
+        help_text = "command read EventService and subscription state"
+        return cmd_parser, "event-service", help_text
+
+    @staticmethod
+    def _link(data, key):
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _status_value(data, key):
+        status = (data or {}).get("Status")
+        return status.get(key) if isinstance(status, dict) else None
+
+    def _get(self, uri, do_async):
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def _subscriptions(self, uri, do_async):
+        if not uri:
+            return {"uri": None, "count": None, "members": []}
+
+        data = self._get(uri, do_async)
+        members = data.get("Members") if isinstance(data, dict) else None
+        if not isinstance(members, list):
+            members = []
+        return {
+            "uri": uri,
+            "count": data.get("Members@odata.count") if isinstance(data, dict) else None,
+            "members": [
+                member.get("@odata.id")
+                for member in members
+                if isinstance(member, dict) and member.get("@odata.id")
+            ],
+        }
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Read EventService state without opening or creating subscriptions."""
+        service = self.base_query(
+            IDRAC_API.EventServiceQuery,
+            filename=filename,
+            do_async=do_async,
+            do_expanded=do_expanded,
+        ).data or {}
+        subscriptions_uri = self._link(service, "Subscriptions")
+        data = {
+            "Id": service.get("Id"),
+            "Name": service.get("Name"),
+            "ServiceEnabled": service.get("ServiceEnabled"),
+            "Health": self._status_value(service, "Health"),
+            "State": self._status_value(service, "State"),
+            "ServerSentEventUri": service.get("ServerSentEventUri"),
+            "SSEFilterPropertiesSupported": (
+                service.get("SSEFilterPropertiesSupported") or {}
+            ),
+            "EventFormatTypes": service.get("EventFormatTypes") or [],
+            "EventTypesForSubscription": (
+                service.get("EventTypesForSubscription") or []
+            ),
+            "RegistryPrefixes": service.get("RegistryPrefixes") or [],
+            "ResourceTypes": service.get("ResourceTypes") or [],
+            "Subscriptions": self._subscriptions(subscriptions_uri, do_async),
+        }
+        return CommandResult(data, None, None, None)

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -103,6 +103,7 @@ class ApiRequestType(Enum):
     Exporter = auto()
     ActionList = auto()
     EventSubmitTest = auto()
+    EventServiceQuery = auto()
     SystemReset = auto()
     Logs = auto()
     EthernetInterfaces = auto()

--- a/tests/test_event_service_dualmode.py
+++ b/tests/test_event_service_dualmode.py
@@ -1,0 +1,150 @@
+"""Dual-mode tests for the event-service read command."""
+import json
+
+from redfish_ctl.events.cmd_event_service import EventServiceQuery
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+
+def _mutation_methods(redfish_service):
+    """Return mutating requests recorded by the mock Redfish service."""
+    return {
+        request.method
+        for request in redfish_service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    }
+
+
+def test_event_service_reads_gb300_sse_and_subscription_summary(
+    redfish_mock_factory,
+):
+    """event-service reports SSE support and follows the subscriptions link."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.EventServiceQuery,
+        "event-service",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.discovered is None
+    assert result.extra is None
+    assert result.error is None
+    json.dumps(result.data, sort_keys=True)
+
+    assert result.data == {
+        "Id": "EventService",
+        "Name": "Event Service",
+        "ServiceEnabled": True,
+        "Health": None,
+        "State": "Enabled",
+        "ServerSentEventUri": "/redfish/v1/EventService/SSE",
+        "SSEFilterPropertiesSupported": {
+            "EventFormatType": True,
+            "MessageId": True,
+            "MetricReportDefinition": True,
+            "OriginResource": False,
+            "RegistryPrefix": True,
+            "ResourceType": False,
+        },
+        "EventFormatTypes": ["Event", "MetricReport"],
+        "EventTypesForSubscription": [],
+        "RegistryPrefixes": [
+            "Base",
+            "BiosAttributeRegistry",
+            "OpenBMC",
+            "Platform",
+            "ResourceEvent",
+            "SensorEvent",
+            "TaskEvent",
+            "Telemetry",
+            "Update",
+        ],
+        "ResourceTypes": [
+            "Task",
+            "AccountService",
+            "ManagerAccount",
+            "SessionService",
+            "EventService",
+            "UpdateService",
+            "Chassis",
+            "Systems",
+            "Managers",
+            "CertificateService",
+            "VirtualMedia",
+        ],
+        "Subscriptions": {
+            "uri": "/redfish/v1/EventService/Subscriptions",
+            "count": 0,
+            "members": [],
+        },
+    }
+    assert _mutation_methods(service) == set()
+
+
+def test_event_service_uses_event_types_when_event_formats_are_absent(
+    redfish_mock_factory,
+):
+    """event-service keeps older EventService payloads useful without SSE fields."""
+    manager, _service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.EventServiceQuery,
+        "event-service",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["ServiceEnabled"] is True
+    assert result.data["ServerSentEventUri"] is None
+    assert result.data["SSEFilterPropertiesSupported"] == {}
+    assert result.data["EventFormatTypes"] == []
+    assert result.data["EventTypesForSubscription"] == [
+        "StatusChange",
+        "ResourceUpdated",
+        "ResourceAdded",
+        "ResourceRemoved",
+        "Alert",
+    ]
+    assert result.data["Subscriptions"] == {
+        "uri": "/redfish/v1/EventService/Subscriptions",
+        "count": None,
+        "members": [],
+    }
+
+
+def test_event_service_tolerates_missing_subscriptions_link(redfish_mock_factory):
+    """event-service returns a stable shape when Subscriptions is not advertised."""
+    manager, service = redfish_mock_factory("generic")
+    event_service = dict(service._state("/redfish/v1/EventService"))
+    event_service.pop("Subscriptions", None)
+    service._overlay["/redfish/v1/EventService"] = event_service
+    service._overlay["/redfish/v1/eventservice"] = event_service
+
+    result = manager.sync_invoke(
+        ApiRequestType.EventServiceQuery,
+        "event-service",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["Subscriptions"] == {
+        "uri": None,
+        "count": None,
+        "members": [],
+    }
+
+
+def test_event_service_exposes_cli_entrypoint():
+    """The event-service command is wired into the package registry."""
+    registry = IDracManager().get_registry()
+    assert registry[ApiRequestType.EventServiceQuery]["event-service"] is EventServiceQuery
+
+    cmd_parser, cmd_name, cmd_help = EventServiceQuery.register_subcommand(
+        EventServiceQuery
+    )
+
+    assert cmd_parser.format_help()
+    assert cmd_name == "event-service"
+    assert "EventService" in cmd_help


### PR DESCRIPTION
## Summary
- add a read-only event-service command for EventService, SSE filter support, and subscription summaries
- register the command in the request enum and package import surface
- document the command in the command reference and keep the CLI registration test independent of global parser state

## Tests
- conda run -n idrac_ctl pytest -q tests/test_event_service_dualmode.py tests/test_cli_subcommand_uniqueness.py
- conda run -n idrac_ctl ruff check redfish_ctl/events/cmd_event_service.py tests/test_event_service_dualmode.py redfish_ctl/__init__.py redfish_ctl/idrac_shared.py
- conda run -n idrac_ctl pytest -q
- git diff --check
- git diff --cached --check