### PR TITLE
Add UpdateService read command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -179,6 +179,7 @@ Safety labels:
 | `tasks` | Read the task collection. | Read |
 | `telemetry-triggers` | Read TelemetryService triggers and thresholds. | Read |
 | `thermal` | Read Chassis `ThermalSubsystem` links, ThermalMetrics temperature readings, and fan collection counts from `redfish_ctl/thermal/cmd_thermal.py`. | Read |
+| `update_service` | Read UpdateService inventory links, push URIs, and advertised actions. | Read |
 | `vm-mount` | Mount/unmount an ISO via Supermicro OEM virtual media (CfgCD). | Write |
 | `volume-get` | Read one volume from a storage device. | Read |
 | `volume-init` | Initialize a volume. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -48,6 +48,7 @@ from .jobs.cmd_job_apply import *
 # # firmwares cmds
 from .firmware.cmd_firmware import *
 from .firmware.cmd_firmware_inv import *
+from .firmware.cmd_update_service import *
 
 from .pci.cmd_pci import *
 

--- a/redfish_ctl/firmware/cmd_update_service.py
+++ b/redfish_ctl/firmware/cmd_update_service.py
@@ -1,0 +1,108 @@
+"""Read Redfish UpdateService capabilities and advertised actions."""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_utils import save_if_needed
+from ..idrac_manager import IDracManager
+from ..idrac_shared import IDRAC_API, ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+from ..redfish_shared import RedfishApi
+
+
+class UpdateServiceQuery(IDracManager,
+                         scm_type=ApiRequestType.UpdateServiceQuery,
+                         name='update_service',
+                         metaclass=Singleton):
+    """Read the service, inventory links, push URIs, and action targets."""
+
+    def __init__(self, *args, **kwargs):
+        super(UpdateServiceQuery, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only update_service subcommand."""
+        cmd_parser = cls.base_parser()
+        help_text = "command read UpdateService capabilities and actions"
+        return cmd_parser, "update_service", help_text
+
+    @staticmethod
+    def _link(data, key):
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _action_name(full_name):
+        return full_name.lstrip("#").split(".")[-1]
+
+    @classmethod
+    def _collect_actions(cls, node):
+        rows = []
+        if not isinstance(node, dict):
+            return rows
+        for key, value in node.items():
+            if key.startswith("#") and isinstance(value, dict):
+                target = value.get("target")
+                if not target:
+                    continue
+                parameters = {
+                    param_key.split("@", 1)[0]: param_value
+                    for param_key, param_value in value.items()
+                    if param_key.endswith("@Redfish.AllowableValues")
+                }
+                rows.append({
+                    "Name": cls._action_name(key),
+                    "FullName": key,
+                    "Target": target,
+                    "ActionInfo": value.get("@Redfish.ActionInfo"),
+                    "Parameters": parameters,
+                })
+            elif isinstance(value, dict):
+                rows.extend(cls._collect_actions(value))
+        return rows
+
+    def _update_service_uri(self, do_async):
+        try:
+            root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
+        except Exception:
+            root = {}
+        update_service = root.get("UpdateService")
+        if isinstance(update_service, dict) and update_service.get("@odata.id"):
+            return update_service["@odata.id"]
+        return IDRAC_API.UpdateServiceQuery
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Read UpdateService without invoking any update action."""
+        service_uri = self._update_service_uri(do_async)
+        result = self.base_query(service_uri, do_async=do_async, data_type=data_type)
+        service = result.data or {}
+        data = {
+            "@odata.id": service.get("@odata.id", service_uri),
+            "@odata.type": service.get("@odata.type"),
+            "Id": service.get("Id"),
+            "Name": service.get("Name"),
+            "Description": service.get("Description"),
+            "ServiceEnabled": service.get("ServiceEnabled"),
+            "Status": service.get("Status"),
+            "FirmwareInventory": self._link(service, "FirmwareInventory"),
+            "SoftwareInventory": self._link(service, "SoftwareInventory"),
+            "HttpPushUri": service.get("HttpPushUri"),
+            "HttpPushUriOptions": service.get("HttpPushUriOptions"),
+            "MultipartHttpPushUri": service.get("MultipartHttpPushUri"),
+            "MultipartHttpPushUriOptions": (
+                (service.get("Oem") or {})
+                .get("Nvidia", {})
+                .get("MultipartHttpPushUriOptions")
+            ),
+            "Actions": sorted(
+                self._collect_actions(service.get("Actions")),
+                key=lambda action: action["FullName"],
+            ),
+        }
+        save_if_needed(filename, data)
+        return CommandResult(data, None, None, None)

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -53,6 +53,7 @@ class ApiRequestType(Enum):
     # firmware
     FirmwareQuery = auto()
     FirmwareInventoryQuery = auto()
+    UpdateServiceQuery = auto()
     PciDeviceQuery = auto()
     SystemQuery = auto()
     VirtualDiskQuery = auto()

--- a/tests/test_update_service_dualmode.py
+++ b/tests/test_update_service_dualmode.py
@@ -1,0 +1,93 @@
+"""Dual-mode tests for the read-only UpdateService command."""
+import json
+import subprocess
+import sys
+
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+UPDATE_SERVICE_PATH = "/redfish/v1/UpdateService"
+
+
+def _assert_read_only(service):
+    assert {
+        request.method
+        for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    } == set()
+
+
+def test_update_service_query_reports_standard_simple_update(redfish_api):
+    """update_service reports standard SimpleUpdate action metadata."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.UpdateServiceQuery,
+        "update_service",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert isinstance(result.data, dict)
+    json.dumps(result.data, sort_keys=True)
+    assert result.data["@odata.id"] == UPDATE_SERVICE_PATH
+    assert result.data["Id"] == "UpdateService"
+    assert result.data["ServiceEnabled"] is True
+    assert result.data["FirmwareInventory"] == (
+        "/redfish/v1/UpdateService/FirmwareInventory"
+    )
+
+    simple_update = {
+        action["FullName"]: action for action in result.data["Actions"]
+    }["#UpdateService.SimpleUpdate"]
+    assert simple_update["Name"] == "SimpleUpdate"
+    assert simple_update["Target"].endswith(
+        "/UpdateService/Actions/UpdateService.SimpleUpdate"
+    )
+    assert simple_update["Parameters"]["TransferProtocol"] == ["HTTP", "HTTPS"]
+
+
+def test_update_service_query_reports_oem_push_paths_without_writes(
+    redfish_mock_factory,
+):
+    """update_service reports GB300 push URIs and nested OEM actions read-only."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.UpdateServiceQuery,
+        "update_service",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["@odata.id"] == UPDATE_SERVICE_PATH
+    assert result.data["HttpPushUri"] == "/redfish/v1/UpdateService/update"
+    assert result.data["MultipartHttpPushUri"] == (
+        "/redfish/v1/UpdateService/update-multipart"
+    )
+    assert result.data["SoftwareInventory"] == (
+        "/redfish/v1/UpdateService/SoftwareInventory"
+    )
+
+    actions = {action["FullName"]: action for action in result.data["Actions"]}
+    assert "#UpdateService.SimpleUpdate" not in actions
+    assert actions["#NvidiaUpdateService.CommitImage"]["Target"].endswith(
+        "/Actions/Oem/NvidiaUpdateService.CommitImage"
+    )
+    assert actions["#NvidiaUpdateService.PublicKeyExchange"]["Name"] == (
+        "PublicKeyExchange"
+    )
+    assert all(action["Target"] for action in actions.values())
+    assert service.last_request.method == "GET"
+    assert service.last_request.path.lower() == UPDATE_SERVICE_PATH.lower()
+    _assert_read_only(service)
+
+
+def test_update_service_help_is_registered():
+    """update_service --help builds the CLI parser without option conflicts."""
+    result = subprocess.run(
+        [sys.executable, "-m", "redfish_ctl", "update_service", "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "update_service" in result.stdout
+    assert "--filename" in result.stdout


### PR DESCRIPTION
## Summary
- add a read-only update_service command for UpdateService service state, inventory links, push URIs, and advertised action targets
- register the command and request type, and document it in the command table
- cover standard SimpleUpdate, GB300 OEM/push URI shapes, and CLI help registration

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/idrac_shared.py redfish_ctl/firmware/cmd_update_service.py redfish_ctl/__init__.py tests/test_update_service_dualmode.py
- git diff --check