### PR TITLE
Harden Redfish error parsing

### DIFF
--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -468,6 +468,28 @@ class RedfishManager:
         return CommandResult(data, None, allow_header, None)
 
     @staticmethod
+    def _redfish_error_from_payload(status_code: int, payload) -> RedfishError:
+        if not isinstance(payload, dict):
+            message = "" if payload is None else str(payload)
+            return RedfishError(status_code, message=message)
+
+        code = payload.get("code", "")
+        message = payload.get("message", payload.get(RedfishJsonMessage.Message, ""))
+        redfish_error = RedfishError(
+            status_code,
+            code=str(code or ""),
+            message=str(message or ""),
+        )
+
+        message_extended = payload.get(RedfishJsonMessage.MessageExtendedInfo)
+        if isinstance(message_extended, list):
+            redfish_error.message_extended = [
+                m for m in message_extended if isinstance(m, dict)
+            ]
+
+        return redfish_error
+
+    @staticmethod
     def parse_error(error_response: requests.models.Response) -> RedfishError:
         """Default Parser for error msg from a JSON error.
         Note that respond can be same as success msg.
@@ -479,23 +501,24 @@ class RedfishManager:
 
         try:
             err_resp = error_response.json()
-            if 'error' not in err_resp:
-                return err_resp
+            if not isinstance(err_resp, dict):
+                return RedfishManager._redfish_error_from_payload(
+                    error_response.status_code, err_resp
+                )
 
-            err_data = err_resp['error']
-            # on top of redfish error we copy status code and header
-            # if we need analyze verbose error
-            redfish_error = RedfishError(error_response.status_code)
+            err_data = err_resp.get('error')
+            if not isinstance(err_data, dict):
+                if err_data is not None:
+                    return RedfishManager._redfish_error_from_payload(
+                        error_response.status_code, {"message": err_data}
+                    )
+                return RedfishManager._redfish_error_from_payload(
+                    error_response.status_code, err_resp
+                )
 
-            if 'message' in err_data:
-                redfish_error.message = err_data['message']
-
-            if RedfishJsonMessage.MessageExtendedInfo in err_data:
-                message_extended = err_data[RedfishJsonMessage.MessageExtendedInfo]
-                if isinstance(message_extended, list):
-                    redfish_error.message_extended = [
-                        m for m in message_extended if isinstance(m, dict)
-                    ]
+            redfish_error = RedfishManager._redfish_error_from_payload(
+                error_response.status_code, err_data
+            )
         except requests.exceptions.JSONDecodeError as json_err:
             redfish_error.exception_msg = str(json_err)
             return redfish_error

--- a/tests/test_redfish_parse.py
+++ b/tests/test_redfish_parse.py
@@ -11,6 +11,7 @@ from requests.models import Response
 
 from redfish_ctl.redfish_manager import RedfishManager
 from redfish_ctl.redfish_respond import RedfishRespondMessage
+from redfish_ctl.redfish_respond_error import RedfishError
 from tests.test_utils import create_json_resp
 
 
@@ -62,3 +63,61 @@ def test_json_without_extended_info_is_empty():
     resp = create_json_resp({"SomeOtherKey": "value"})
     parsed = RedfishManager.parse_json_respond_msg(resp)
     assert parsed.message_extended == []
+
+
+def test_parse_error_without_error_envelope_returns_redfish_error():
+    """Non-standard JSON error payloads still honor the RedfishError contract."""
+    resp = create_json_resp({"message": "plain upstream failure"}, status_code=502)
+
+    parsed = RedfishManager.parse_error(resp)
+
+    assert isinstance(parsed, RedfishError)
+    assert parsed.status_code == 502
+    assert parsed.message == "plain upstream failure"
+
+
+def test_parse_error_scalar_json_returns_redfish_error():
+    """Scalar JSON bodies do not escape parse_error as TypeError."""
+    resp = _raw_response(b'"maintenance mode"', status_code=503)
+
+    parsed = RedfishManager.parse_error(resp)
+
+    assert isinstance(parsed, RedfishError)
+    assert parsed.status_code == 503
+    assert parsed.message == "maintenance mode"
+
+
+def test_parse_error_preserves_code_message_and_extended_info():
+    """A standard Redfish error envelope keeps code, message, and ExtendedInfo."""
+    resp = create_json_resp(
+        {
+            "error": {
+                "code": "Base.1.12.PropertyValueNotInList",
+                "message": "The requested value is not in the allowable list.",
+                "@Message.ExtendedInfo": [
+                    {
+                        "MessageId": "Base.1.12.PropertyValueNotInList",
+                        "MessageArgs": ["BootSourceOverrideTarget"],
+                        "Severity": "Warning",
+                        "Resolution": "Choose a value from AllowableValues.",
+                    }
+                ],
+            }
+        },
+        status_code=400,
+    )
+
+    parsed = RedfishManager.parse_error(resp)
+
+    assert isinstance(parsed, RedfishError)
+    assert parsed.status_code == 400
+    assert parsed.code == "Base.1.12.PropertyValueNotInList"
+    assert parsed.message == "The requested value is not in the allowable list."
+    assert parsed.message_extended == [
+        {
+            "MessageId": "Base.1.12.PropertyValueNotInList",
+            "MessageArgs": ["BootSourceOverrideTarget"],
+            "Severity": "Warning",
+            "Resolution": "Choose a value from AllowableValues.",
+        }
+    ]


### PR DESCRIPTION
## Summary
- Normalize non-standard Redfish error payloads into RedfishError instead of returning raw JSON.
- Preserve standard error code, message, and ExtendedInfo fields from Redfish error envelopes.
- Add parser regressions for non-envelope JSON, scalar JSON, and standard Redfish error envelopes.

## Tests
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD conda run -n idrac_ctl pytest -q tests/test_redfish_parse.py tests/test_redfish_models.py
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD conda run -n idrac_ctl ruff check redfish_ctl/redfish_manager.py tests/test_redfish_parse.py
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD conda run -n idrac_ctl pytest -q