### PR TITLE
Add request-count benchmark harness

### DIFF
--- a/tests/request_benchmark.py
+++ b/tests/request_benchmark.py
@@ -1,0 +1,73 @@
+"""Helpers for request-count benchmarks over mocked Redfish services."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from redfish_ctl.idrac_shared import ApiRequestType
+
+RTT_PROFILES = {
+    "rack-local": 0.002,
+    "office-vpn": 0.080,
+    "india-vpn-to-us": 0.300,
+    "congested-vpn": 0.800,
+}
+WRITE_METHODS = {"DELETE", "PATCH", "POST"}
+
+
+def recorded_requests(
+    service: Any,
+    *,
+    method: str | None = None,
+    path: str | None = None,
+    start: int = 0,
+) -> list[Any]:
+    """Return recorded requests, optionally filtered by method and path."""
+    method_name = method.upper() if method else None
+    expected_path = path.rstrip("/").lower() if path else None
+    rows = []
+    for request in service.requests[start:]:
+        if method_name and request.method != method_name:
+            continue
+        if expected_path and request.path.rstrip("/").lower() != expected_path:
+            continue
+        rows.append(request)
+    return rows
+
+
+def projected_walltime(request_count: int, profile: str) -> float:
+    """Serial wall-time projection for a request count and latency profile."""
+    return request_count * RTT_PROFILES[profile]
+
+
+def assert_read_budget(
+    manager: Any,
+    service: Any,
+    *,
+    api_call: ApiRequestType,
+    name: str,
+    max_requests: int,
+    max_india_vpn_seconds: float,
+    **kwargs: Any,
+) -> Any:
+    """Run one command and assert its request count stays under budget."""
+    start = len(service.requests)
+    result = manager.sync_invoke(api_call, name, **kwargs)
+    requests = service.requests[start:]
+    writes = [request for request in requests if request.method in WRITE_METHODS]
+    assert not writes, (
+        f"{name} benchmark expected a read-only path, "
+        f"but saw write methods {[request.method for request in writes]}"
+    )
+
+    request_count = len(requests)
+    assert request_count <= max_requests, (
+        f"{name} used {request_count} BMC round trips; budget is {max_requests}. "
+        f"At 300ms RTT that projects to "
+        f"{projected_walltime(request_count, 'india-vpn-to-us'):.1f}s."
+    )
+    assert (
+        projected_walltime(request_count, "india-vpn-to-us")
+        <= max_india_vpn_seconds
+    )
+    return result

--- a/tests/test_benchmark_reads.py
+++ b/tests/test_benchmark_reads.py
@@ -1,0 +1,28 @@
+"""Request-count benchmark harness for hot read paths."""
+
+from redfish_ctl.idrac_shared import ApiRequestType
+from tests.request_benchmark import assert_read_budget, recorded_requests
+
+FIRMWARE_INVENTORY_PATH = "/redfish/v1/UpdateService/FirmwareInventory"
+
+
+def test_firmware_inventory_read_budget(redfish_mock, redfish_service):
+    """Firmware inventory should remain a single expanded GET."""
+    result = assert_read_budget(
+        redfish_mock,
+        redfish_service,
+        api_call=ApiRequestType.FirmwareInventoryQuery,
+        name="firmware_inv_query",
+        max_requests=1,
+        max_india_vpn_seconds=0.301,
+    )
+
+    firmware_gets = recorded_requests(
+        redfish_service,
+        method="GET",
+        path=FIRMWARE_INVENTORY_PATH,
+    )
+
+    assert result.data["@odata.id"] == FIRMWARE_INVENTORY_PATH
+    assert len(firmware_gets) == 1
+    assert len(redfish_service.requests) == 1


### PR DESCRIPTION
## Summary
- add a reusable test helper for request-count budgets over mocked Redfish services
- pin firmware inventory to one expanded GET with no write methods
- include 300ms RTT projection in budget failure messages

## Tests
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD PYTHONDONTWRITEBYTECODE=1 /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q -p no:cacheprovider tests/test_benchmark_reads.py tests/test_roundtrip_budget.py
- PYTHONDONTWRITEBYTECODE=1 /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check --no-cache tests/test_benchmark_reads.py tests/request_benchmark.py
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD PYTHONDONTWRITEBYTECODE=1 /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q -p no:cacheprovider