### PR TITLE
Add Lenovo XCC vendor profile

### DIFF
--- a/redfish_ctl/vendors/README.md
+++ b/redfish_ctl/vendors/README.md
@@ -10,6 +10,7 @@ vendors/
   base.py            # VendorCapabilities model + registry
   dell/              # Dell iDRAC
   hpe/               # HPE iLO (placeholder)
+  lenovo/            # Lenovo XClarity Controller
   supermicro/        # Supermicro (placeholder)
 ```
 

--- a/redfish_ctl/vendors/__init__.py
+++ b/redfish_ctl/vendors/__init__.py
@@ -16,6 +16,7 @@ from .base import VendorCapabilities, all_vendors
 from .base import get as get_vendor
 from .dell import capabilities as _dell  # noqa: F401
 from .hpe import capabilities as _hpe  # noqa: F401
+from .lenovo import capabilities as _lenovo  # noqa: F401
 from .supermicro import capabilities as _supermicro  # noqa: F401
 
 __all__ = ["VendorCapabilities", "get_vendor", "all_vendors"]

--- a/redfish_ctl/vendors/lenovo/__init__.py
+++ b/redfish_ctl/vendors/lenovo/__init__.py
@@ -1,0 +1,1 @@
+"""Lenovo XClarity Controller vendor package."""

--- a/redfish_ctl/vendors/lenovo/capabilities.py
+++ b/redfish_ctl/vendors/lenovo/capabilities.py
@@ -1,0 +1,25 @@
+"""Lenovo XClarity Controller capability profile.
+
+Lenovo XCC documents query support through ServiceRoot.ProtocolFeaturesSupported.
+Job scheduling and lifecycle event streaming stay conservative until pinned by a
+captured fixture or emulator-backed test.
+
+Author Mus spyroot@gmail.com
+"""
+from ..base import VendorCapabilities, register
+
+LENOVO = register(
+    VendorCapabilities(
+        vendor="lenovo",
+        oem_prefix="Lenovo",
+        query_select=True,
+        query_filter=True,
+        query_expand=True,
+        query_only=True,
+        query_top=False,
+        one_query_param_per_uri=False,
+        job_scheduling=False,
+        one_recurring_job_per_type=False,
+        lifecycle_events_sse=False,
+    )
+)

--- a/tests/lenovo_fixtures/README.md
+++ b/tests/lenovo_fixtures/README.md
@@ -1,0 +1,22 @@
+# Lenovo XCC test fixtures
+
+A small synthetic Lenovo XClarity Controller (XCC) Redfish slice used to prove
+that discovery and profile logic handle Lenovo's documented shape. It is not a
+redistributed vendor mockup; values are reduced, documentation-seeded examples
+based on the public Lenovo XCC REST API reference.
+
+## Provenance
+
+Facts pinned by this slice:
+
+- `ServiceRoot.Vendor` is `Lenovo`, and `ServiceRoot.ProtocolFeaturesSupported`
+  advertises `$select`, `$filter`, `only`, and `$expand` support.
+- The primary ComputerSystem and Manager ids are `/redfish/v1/Systems/1` and
+  `/redfish/v1/Managers/1`.
+- BIOS pending settings are served at `/redfish/v1/Systems/1/Bios/Pending`.
+- Lenovo BIOS attributes can be category-prefixed, such as `Memory_MemorySpeed`
+  and `Processors_CStates`.
+- UpdateService exposes `#UpdateService.SimpleUpdate` plus HTTP push URI
+  fallbacks `/fwupdate` and `/mfwupdate`.
+
+Reference: <https://pubs.lenovo.com/xcc-restapi/>

--- a/tests/lenovo_fixtures/_redfish_v1.json
+++ b/tests/lenovo_fixtures/_redfish_v1.json
@@ -1,0 +1,43 @@
+{
+  "@odata.type": "#ServiceRoot.v1_7_0.ServiceRoot",
+  "@odata.id": "/redfish/v1/",
+  "Id": "RootService",
+  "Name": "Root Service",
+  "Description": "Lenovo XCC Redfish service root fixture.",
+  "Vendor": "Lenovo",
+  "RedfishVersion": "1.10.0",
+  "UUID": "00000000-0000-0000-0000-000000000001",
+  "ProtocolFeaturesSupported": {
+    "ExpandQuery": {
+      "ExpandAll": true,
+      "Levels": true,
+      "Links": true,
+      "NoLinks": true,
+      "MaxLevels": 2
+    },
+    "OnlyMemberQuery": true,
+    "FilterQuery": true,
+    "ExcerptQuery": true,
+    "SelectQuery": true,
+    "DeepOperations": {
+      "DeepPOST": false,
+      "DeepPATCH": false,
+      "MaxLevels": 2
+    }
+  },
+  "Systems": {
+    "@odata.id": "/redfish/v1/Systems"
+  },
+  "Managers": {
+    "@odata.id": "/redfish/v1/Managers"
+  },
+  "Chassis": {
+    "@odata.id": "/redfish/v1/Chassis"
+  },
+  "UpdateService": {
+    "@odata.id": "/redfish/v1/UpdateService"
+  },
+  "Tasks": {
+    "@odata.id": "/redfish/v1/TaskService"
+  }
+}

--- a/tests/lenovo_fixtures/_redfish_v1_Managers.json
+++ b/tests/lenovo_fixtures/_redfish_v1_Managers.json
@@ -1,0 +1,11 @@
+{
+  "@odata.type": "#ManagerCollection.ManagerCollection",
+  "@odata.id": "/redfish/v1/Managers",
+  "Name": "Manager Collection",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Managers/1"
+    }
+  ]
+}

--- a/tests/lenovo_fixtures/_redfish_v1_Managers_1.json
+++ b/tests/lenovo_fixtures/_redfish_v1_Managers_1.json
@@ -1,0 +1,24 @@
+{
+  "@odata.type": "#Manager.v1_10_0.Manager",
+  "@odata.id": "/redfish/v1/Managers/1",
+  "Id": "1",
+  "Name": "XClarity Controller",
+  "ManagerType": "BMC",
+  "FirmwareVersion": "1.00",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK"
+  },
+  "Links": {
+    "ManagerForServers": [
+      {
+        "@odata.id": "/redfish/v1/Systems/1"
+      }
+    ],
+    "ManagerForChassis": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/1"
+      }
+    ]
+  }
+}

--- a/tests/lenovo_fixtures/_redfish_v1_Systems.json
+++ b/tests/lenovo_fixtures/_redfish_v1_Systems.json
@@ -1,0 +1,12 @@
+{
+  "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+  "@odata.id": "/redfish/v1/Systems",
+  "Name": "ComputerSystemCollection",
+  "Description": "A collection of ComputerSystem resource instances.",
+  "Members@odata.count": 1,
+  "Members": [
+    {
+      "@odata.id": "/redfish/v1/Systems/1"
+    }
+  ]
+}

--- a/tests/lenovo_fixtures/_redfish_v1_Systems_1.json
+++ b/tests/lenovo_fixtures/_redfish_v1_Systems_1.json
@@ -1,0 +1,67 @@
+{
+  "@odata.type": "#ComputerSystem.v1_9_0.ComputerSystem",
+  "@odata.id": "/redfish/v1/Systems/1",
+  "Id": "1",
+  "Name": "ComputerSystem",
+  "Description": "Lenovo XCC ComputerSystem fixture.",
+  "SystemType": "Physical",
+  "Manufacturer": "Lenovo",
+  "Model": "ThinkSystem",
+  "SerialNumber": "REDACTED",
+  "PowerState": "On",
+  "BiosVersion": "M5E101Q",
+  "Status": {
+    "State": "Enabled",
+    "Health": "OK",
+    "HealthRollup": "OK"
+  },
+  "Bios": {
+    "@odata.id": "/redfish/v1/Systems/1/Bios"
+  },
+  "Boot": {
+    "BootSourceOverrideEnabled": "Disabled",
+    "BootSourceOverrideTarget": "None",
+    "BootSourceOverrideMode": "UEFI",
+    "BootSourceOverrideEnabled@Redfish.AllowableValues": [
+      "Once",
+      "Disabled"
+    ],
+    "BootSourceOverrideTarget@Redfish.AllowableValues": [
+      "None",
+      "Pxe",
+      "Cd",
+      "Usb",
+      "Hdd",
+      "BiosSetup",
+      "Diags",
+      "UefiTarget"
+    ]
+  },
+  "Links": {
+    "ManagedBy": [
+      {
+        "@odata.id": "/redfish/v1/Managers/1"
+      }
+    ],
+    "Chassis": [
+      {
+        "@odata.id": "/redfish/v1/Chassis/1"
+      }
+    ]
+  },
+  "Actions": {
+    "#ComputerSystem.Reset": {
+      "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+      "title": "Reset",
+      "ResetType@Redfish.AllowableValues": [
+        "On",
+        "Nmi",
+        "GracefulShutdown",
+        "GracefulRestart",
+        "ForceOn",
+        "ForceOff",
+        "ForceRestart"
+      ]
+    }
+  }
+}

--- a/tests/lenovo_fixtures/_redfish_v1_Systems_1_Bios.json
+++ b/tests/lenovo_fixtures/_redfish_v1_Systems_1_Bios.json
@@ -1,0 +1,37 @@
+{
+  "@odata.type": "#Bios.v1_0_6.Bios",
+  "@odata.id": "/redfish/v1/Systems/1/Bios",
+  "Id": "Bios",
+  "Name": "Bios",
+  "Description": "System Bios",
+  "AttributeRegistry": "BiosAttributeRegistry.1.0.0",
+  "Attributes": {
+    "Memory_MemorySpeed": "MaxPerformance",
+    "Processors_CStates": "Disable",
+    "Processors_CPUPstateControl": "Autonomous"
+  },
+  "@Redfish.Settings": {
+    "@odata.type": "#Settings.v1_2_1.Settings",
+    "SettingsObject": {
+      "@odata.id": "/redfish/v1/Systems/1/Bios/Pending"
+    },
+    "Messages": [],
+    "SupportedApplyTimes": [
+      "OnReset"
+    ]
+  },
+  "Actions": {
+    "#Bios.ResetBios": {
+      "target": "/redfish/v1/Systems/1/Bios/Actions/Bios.ResetBios",
+      "title": "ResetBios"
+    },
+    "#Bios.ChangePassword": {
+      "target": "/redfish/v1/Systems/1/Bios/Actions/Bios.ChangePassword",
+      "title": "ChangePassword",
+      "PasswordName@Redfish.AllowableValues": [
+        "UefiAdminPassword",
+        "UefiPowerOnPassword"
+      ]
+    }
+  }
+}

--- a/tests/lenovo_fixtures/_redfish_v1_Systems_1_Bios_Pending.json
+++ b/tests/lenovo_fixtures/_redfish_v1_Systems_1_Bios_Pending.json
@@ -1,0 +1,14 @@
+{
+  "@odata.type": "#Bios.v1_0_6.Bios",
+  "@odata.id": "/redfish/v1/Systems/1/Bios/Pending",
+  "Id": "Pending",
+  "Name": "Pending",
+  "Description": "Bios Pending Setting",
+  "AttributeRegistry": "BiosAttributeRegistry.1.0.0",
+  "Attributes": {
+    "DevicesandIOPorts_Device_Slot6": "Enable",
+    "Memory_MemorySpeed": "MaxPerformance",
+    "Processors_CPUPstateControl": "Autonomous",
+    "Processors_CStates": "Disable"
+  }
+}

--- a/tests/lenovo_fixtures/_redfish_v1_UpdateService.json
+++ b/tests/lenovo_fixtures/_redfish_v1_UpdateService.json
@@ -1,0 +1,48 @@
+{
+  "@odata.type": "#UpdateService.v1_6_0.UpdateService",
+  "@odata.id": "/redfish/v1/UpdateService",
+  "Id": "UpdateService",
+  "Name": "Update Service",
+  "Description": "Lenovo firmware update service.",
+  "ServiceEnabled": true,
+  "Status": {
+    "HealthRollup": "OK",
+    "Health": "OK",
+    "State": "Enabled"
+  },
+  "FirmwareInventory": {
+    "@odata.id": "/redfish/v1/UpdateService/FirmwareInventory"
+  },
+  "HttpPushUri": "/fwupdate",
+  "HttpPushUriTargets": [],
+  "HttpPushUriTargetsBusy": false,
+  "HttpPushUriOptions": {
+    "HttpPushUriApplyTime": {
+      "ApplyTime": "Immediate"
+    }
+  },
+  "MultipartHttpPushUri": "/mfwupdate",
+  "MaxImageSizeBytes": 250000000,
+  "Actions": {
+    "#UpdateService.SimpleUpdate": {
+      "target": "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate",
+      "title": "SimpleUpdate",
+      "TransferProtocol@Redfish.AllowableValues": [
+        "TFTP",
+        "SFTP"
+      ],
+      "Targets@Redfish.AllowableValues": [
+        "/redfish/v1/UpdateService/FirmwareInventory/BMC-Backup"
+      ],
+      "@Redfish.ActionInfo": "/redfish/v1/UpdateService/SimpleUpdateActionInfo"
+    }
+  },
+  "Oem": {
+    "Lenovo": {
+      "@odata.type": "#LenovoUpdateService.v1_0_0.LenovoUpdateService",
+      "FirmwareServices": {
+        "@odata.id": "/redfish/v1/UpdateService/Oem/Lenovo/FirmwareServices"
+      }
+    }
+  }
+}

--- a/tests/test_lenovo_profile.py
+++ b/tests/test_lenovo_profile.py
@@ -1,0 +1,51 @@
+"""Offline tests for the Lenovo XCC vendor capability profile.
+
+Lenovo XCC documents query support in ServiceRoot.ProtocolFeaturesSupported,
+but job scheduling and event streaming are not pinned by the docs fixture slice.
+These tests keep the profile explicit and conservative where behavior is not
+verified.
+
+Author Mus spyroot@gmail.com
+"""
+from redfish_ctl.vendors import all_vendors, get_vendor
+from redfish_ctl.vendors.base import VendorCapabilities
+
+
+def test_lenovo_profile_registered_with_xcc_oem_prefix():
+    """Lenovo XCC uses the Lenovo OEM namespace; the profile mirrors that prefix."""
+    caps = get_vendor("lenovo")
+    assert caps.vendor == "lenovo"
+    assert caps.oem_prefix == "Lenovo"
+    assert "lenovo" in all_vendors()
+
+
+def test_lenovo_query_capabilities_match_xcc_service_root():
+    """XCC advertises select/filter/expand/only support; top stays unverified."""
+    caps = get_vendor("lenovo")
+    assert caps.query_select is True
+    assert caps.query_filter is True
+    assert caps.query_expand is True
+    assert caps.query_only is True
+    assert caps.query_top is False
+    assert caps.one_query_param_per_uri is False
+
+
+def test_lenovo_job_scheduling_is_conservative():
+    """Recurring JobService scheduling is unverified, so it stays disabled."""
+    caps = get_vendor("lenovo")
+    assert caps.job_scheduling is False
+    assert caps.one_recurring_job_per_type is False
+    assert caps.schedulable_uris == ()
+    assert caps.lifecycle_events_sse is False
+
+
+def test_lenovo_profile_is_frozen():
+    """The profile is immutable so a command cannot mutate shared state."""
+    caps = get_vendor("lenovo")
+    assert isinstance(caps, VendorCapabilities)
+    try:
+        caps.oem_prefix = "Dell"  # type: ignore[misc]
+    except Exception as exc:
+        assert isinstance(exc, (AttributeError, TypeError))
+    else:
+        raise AssertionError("VendorCapabilities should be immutable")

--- a/tests/test_lenovo_vendor.py
+++ b/tests/test_lenovo_vendor.py
@@ -1,0 +1,38 @@
+"""Offline proof that core discovery handles Lenovo XCC Redfish shapes.
+
+The fixture slice is seeded from Lenovo XCC public REST API examples. XCC uses
+``Systems/1`` and ``Managers/1`` ids, exposes BIOS pending settings at
+``Systems/1/Bios/Pending``, and documents category-prefixed BIOS attributes such
+as ``Memory_MemorySpeed``.
+
+Author Mus spyroot@gmail.com
+"""
+
+
+def test_lenovo_discovery_resolves_xcc_ids(redfish_mock_factory):
+    """Discovery finds Lenovo's documented ids instead of Dell/Supermicro ids."""
+    mgr, _ = redfish_mock_factory("lenovo")
+    assert mgr.redfish_vendor == "Lenovo"
+    assert mgr.discover_computer_system_ids() == ["/redfish/v1/Systems/1"]
+    assert mgr.discover_manager_ids() == ["/redfish/v1/Managers/1"]
+    assert mgr.idrac_manage_servers == "/redfish/v1/Systems/1"
+
+
+def test_lenovo_bios_pending_uses_category_prefixed_attributes(redfish_mock_factory):
+    """Lenovo pending BIOS attributes retain their category-prefixed names."""
+    mgr, _ = redfish_mock_factory("lenovo")
+    pending = mgr.base_query("/redfish/v1/Systems/1/Bios/Pending").data
+    assert pending["AttributeRegistry"] == "BiosAttributeRegistry.1.0.0"
+    assert pending["Attributes"]["Memory_MemorySpeed"] == "MaxPerformance"
+    assert pending["Attributes"]["Processors_CStates"] == "Disable"
+
+
+def test_lenovo_updateservice_exposes_simple_and_push_update_paths(redfish_mock_factory):
+    """The XCC UpdateService fixture pins SimpleUpdate plus push URI fallbacks."""
+    mgr, _ = redfish_mock_factory("lenovo")
+    update_service = mgr.base_query("/redfish/v1/UpdateService").data
+    assert update_service["Actions"]["#UpdateService.SimpleUpdate"]["target"] == (
+        "/redfish/v1/UpdateService/Actions/UpdateService.SimpleUpdate"
+    )
+    assert update_service["HttpPushUri"] == "/fwupdate"
+    assert update_service["MultipartHttpPushUri"] == "/mfwupdate"


### PR DESCRIPTION
## Summary
- add a Lenovo XCC vendor capability profile and registry import
- add a small synthetic XCC fixture slice for ServiceRoot, Systems, Managers, BIOS Pending, and UpdateService
- add offline tests for Lenovo profile registration and documented XCC resource shapes

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD pytest -q tests/test_lenovo_profile.py tests/test_lenovo_vendor.py -> 7 passed in 0.06s
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD pytest -q tests/test_lenovo_profile.py tests/test_lenovo_vendor.py tests/test_vendors.py tests/test_hpe_profile.py tests/test_supermicro_profile.py tests/test_generic_vendor.py tests/test_hpe_vendor.py tests/test_vendor_portability.py -> 31 passed in 0.99s
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/vendors/__init__.py redfish_ctl/vendors/lenovo/__init__.py redfish_ctl/vendors/lenovo/capabilities.py tests/test_lenovo_profile.py tests/test_lenovo_vendor.py -> All checks passed!
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD pytest -q -> 872 passed, 57 skipped in 32.69s