### PR TITLE
Add Redfish schema tree validator

### DIFF
--- a/docs/fixture-capture.md
+++ b/docs/fixture-capture.md
@@ -194,31 +194,15 @@ Then validate standard Redfish resources with `tools/redfish_validate.py`.
 network fetches and requires schemas already cached under `tools/redfish-schemas/`.
 
 ```bash
-REDFISH_SCHEMA_OFFLINE=1 python - <<'PY'
-import json
-from pathlib import Path
-
-from tools.redfish_validate import SchemaUnavailable, validate_payload
-
-for path in sorted(Path("tests/idrac_fixtures").glob("*.json")):
-    payload = json.loads(path.read_text())
-    try:
-        errors = validate_payload(payload)
-    except (SchemaUnavailable, ValueError) as err:
-        print(f"SKIP {path}: {err}")
-        continue
-    if errors:
-        print(f"FAIL {path}")
-        for err in errors:
-            print(f"  {'/'.join(map(str, err.absolute_path))}: {err.message}")
-        raise SystemExit(1)
-    print(f"OK {path}")
-PY
+REDFISH_SCHEMA_OFFLINE=1 \
+  python tools/redfish_validate.py tests/idrac_fixtures
 ```
 
-OEM resources often skip validation because no standard DMTF schema exists for
-their private type. That is acceptable when the test asserts the exact command
-behavior that depends on the OEM fields.
+The validator classifies each JSON file as valid, error, or skipped. Use
+`--json` when a script needs the same result as machine-readable output. OEM
+resources often skip validation because no standard DMTF schema exists for their
+private type. That is acceptable when the test asserts the exact command behavior
+that depends on the OEM fields.
 
 ### Import
 

--- a/tests/test_redfish_validate_cli.py
+++ b/tests/test_redfish_validate_cli.py
@@ -1,0 +1,69 @@
+"""Tests for the directory-walking Redfish schema validator helper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools import redfish_validate
+
+
+class _FakeValidationError:
+    def __init__(self, path: tuple[str, ...], message: str) -> None:
+        self.absolute_path = path
+        self.message = message
+
+
+def test_validate_tree_classifies_valid_invalid_and_skipped_files(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The tree helper reports every JSON file as valid, error, or skipped."""
+    (tmp_path / "valid.json").write_text(json.dumps({"@odata.type": "#Valid.v1_0_0.Valid"}))
+    (tmp_path / "invalid.json").write_text(
+        json.dumps({"@odata.type": "#Invalid.v1_0_0.Invalid"})
+    )
+    (tmp_path / "missing-type.json").write_text(json.dumps({"Name": "metadata"}))
+    (tmp_path / "broken.json").write_text("{")
+
+    seen_strip_flags: list[bool] = []
+
+    def fake_validate_payload(payload: dict, strip_oem: bool = True) -> list:
+        seen_strip_flags.append(strip_oem)
+        odata_type = payload.get("@odata.type")
+        if not odata_type:
+            raise ValueError("payload has no @odata.type")
+        if "Invalid" in odata_type:
+            return [_FakeValidationError(("Status", "State"), "is not valid")]
+        return []
+
+    monkeypatch.setattr(redfish_validate, "validate_payload", fake_validate_payload)
+
+    summary = redfish_validate.validate_tree(tmp_path, strip_oem=False)
+
+    assert summary["counts"] == {"files": 4, "valid": 1, "error": 2, "skipped": 1}
+    assert summary["valid"] == ["valid.json"]
+    assert summary["skipped"] == [
+        {"path": "missing-type.json", "reason": "payload has no @odata.type"}
+    ]
+    assert {entry["path"] for entry in summary["error"]} == {"broken.json", "invalid.json"}
+    assert seen_strip_flags == [False, False, False]
+
+
+def test_main_returns_nonzero_and_prints_json_when_errors_exist(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """The CLI returns failure for validation errors and can emit JSON output."""
+    summary = {
+        "root": str(tmp_path),
+        "counts": {"files": 1, "valid": 0, "error": 1, "skipped": 0},
+        "valid": [],
+        "error": [{"path": "bad.json", "errors": ["Name: is required"]}],
+        "skipped": [],
+    }
+
+    monkeypatch.setattr(redfish_validate, "validate_tree", lambda *_, **__: summary)
+
+    exit_code = redfish_validate.main([str(tmp_path), "--json"])
+
+    assert exit_code == 1
+    assert json.loads(capsys.readouterr().out) == summary

--- a/tools/redfish_validate.py
+++ b/tools/redfish_validate.py
@@ -13,20 +13,18 @@ private extensions. Resources whose ``@odata.type`` is itself an OEM type (e.g.
 
 Author Mus spyroot@gmail.com
 """
+import argparse
 import json
 import os
+import sys
 import urllib.error
 import urllib.request
 from copy import deepcopy
 from pathlib import Path
 
-from jsonschema import Draft7Validator
-from referencing import Registry, Resource
-from referencing.exceptions import Unresolvable
-from referencing.jsonschema import DRAFT7
-
 SCHEMA_DIR = Path(__file__).resolve().parent / "redfish-schemas"
 PREFIX = "http://redfish.dmtf.org/schemas/v1/"
+_REGISTRY = None
 
 
 class SchemaUnavailable(RuntimeError):
@@ -54,11 +52,29 @@ def _load_schema_doc(uri: str) -> dict:
     return json.loads(data)
 
 
-def _retrieve(uri: str) -> Resource:
-    return Resource.from_contents(_load_schema_doc(uri), default_specification=DRAFT7)
+def _schema_runtime():
+    from jsonschema import Draft7Validator
+    from referencing import Registry, Resource
+    from referencing.exceptions import Unresolvable
+    from referencing.jsonschema import DRAFT7
+
+    return Draft7Validator, Registry, Resource, Unresolvable, DRAFT7
 
 
-_REGISTRY = Registry(retrieve=_retrieve)
+def _retrieve(uri: str):
+    _, _, resource_cls, _, draft7 = _schema_runtime()
+    return resource_cls.from_contents(
+        _load_schema_doc(uri),
+        default_specification=draft7,
+    )
+
+
+def _registry():
+    global _REGISTRY
+    if _REGISTRY is None:
+        _, registry_cls, _, _, _ = _schema_runtime()
+        _REGISTRY = registry_cls(retrieve=_retrieve)
+    return _REGISTRY
 
 
 def schema_ref_for(odata_type: str) -> str:
@@ -116,10 +132,137 @@ def validate_payload(payload: dict, strip_oem: bool = True) -> list:
     if strip_oem:
         _strip_oem(body)
     _reduce_collection_members(body)
-    validator = Draft7Validator({"$ref": schema_ref_for(odata_type)}, registry=_REGISTRY)
+    draft7_validator, _, _, unresolvable, _ = _schema_runtime()
+    validator = draft7_validator(
+        {"$ref": schema_ref_for(odata_type)},
+        registry=_registry(),
+    )
     try:
         errors = list(validator.iter_errors(body))
-    except Unresolvable as err:
+    except unresolvable as err:
         # a referenced schema (often an OEM type) has no standard definition
         raise SchemaUnavailable(str(err)) from err
     return sorted(errors, key=lambda e: list(e.absolute_path))
+
+
+def _entry_path(path: Path, root: Path) -> str:
+    if root.is_file():
+        return path.name
+    return str(path.relative_to(root))
+
+
+def _format_validation_error(error) -> str:
+    location = ".".join(str(part) for part in error.absolute_path)
+    if not location:
+        location = "<root>"
+    return f"{location}: {error.message}"
+
+
+def validate_tree(root: Path, strip_oem: bool = True) -> dict:
+    """Validate every JSON file under ``root`` and classify each result."""
+    root = Path(root)
+    if not root.exists():
+        raise FileNotFoundError(root)
+    if root.is_file():
+        files = [root] if root.suffix == ".json" else []
+    else:
+        files = sorted(root.rglob("*.json"))
+    summary = {
+        "root": str(root),
+        "counts": {"files": len(files), "valid": 0, "error": 0, "skipped": 0},
+        "valid": [],
+        "error": [],
+        "skipped": [],
+    }
+    for path in files:
+        entry = _entry_path(path, root)
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            summary["error"].append(
+                {"path": entry, "errors": [f"invalid JSON: {exc.msg}"]}
+            )
+            continue
+        if not isinstance(payload, dict):
+            summary["skipped"].append(
+                {"path": entry, "reason": "payload is not a JSON object"}
+            )
+            continue
+        try:
+            errors = validate_payload(payload, strip_oem=strip_oem)
+        except (SchemaUnavailable, ValueError) as exc:
+            summary["skipped"].append({"path": entry, "reason": str(exc)})
+            continue
+        except Exception as exc:
+            summary["error"].append(
+                {"path": entry, "errors": [f"validation failed: {exc}"]}
+            )
+            continue
+        if errors:
+            summary["error"].append(
+                {
+                    "path": entry,
+                    "errors": [_format_validation_error(err) for err in errors],
+                }
+            )
+        else:
+            summary["valid"].append(entry)
+    summary["counts"]["valid"] = len(summary["valid"])
+    summary["counts"]["error"] = len(summary["error"])
+    summary["counts"]["skipped"] = len(summary["skipped"])
+    return summary
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate Redfish JSON files against cached DMTF schemas.",
+    )
+    parser.add_argument("root", type=Path, help="JSON file or directory tree to validate")
+    parser.add_argument(
+        "--no-strip-oem",
+        action="store_false",
+        dest="strip_oem",
+        help="validate OEM blocks instead of stripping them first",
+    )
+    parser.add_argument("--json", action="store_true", help="print a machine-readable summary")
+    return parser
+
+
+def _print_summary(summary: dict) -> None:
+    counts = summary["counts"]
+    print(f"root: {summary['root']}")
+    print(
+        "files: {files} valid: {valid} error: {error} skipped: {skipped}".format(
+            **counts,
+        )
+    )
+    if summary["error"]:
+        print("errors:")
+        for entry in summary["error"]:
+            print(f"  {entry['path']}")
+            for error in entry["errors"]:
+                print(f"    - {error}")
+    if summary["skipped"]:
+        print("skipped:")
+        for entry in summary["skipped"]:
+            print(f"  {entry['path']}: {entry['reason']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the directory validator CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        summary = validate_tree(args.root, strip_oem=args.strip_oem)
+    except FileNotFoundError as exc:
+        print(f"redfish_validate: not found: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        _print_summary(summary)
+    return 1 if summary["counts"]["error"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a reusable directory validator for Redfish JSON trees
- add a small CLI wrapper with text and JSON output
- document the validator command in the fixture-capture workflow

## Tests
- `pytest -q tests/test_redfish_validate_cli.py` -> 2 passed
- `pytest -q tests/test_redfish_schema.py tests/test_redfish_validate_cli.py` -> 2 passed, 1 skipped
- `pytest -q` -> 865 passed, 57 skipped
- `ruff check tools/redfish_validate.py tests/test_redfish_validate_cli.py` -> All checks passed
- `git diff --check` -> clean