### PR TITLE
Add vendor capability evidence notes

### DIFF
--- a/redfish_ctl/vendors/base.py
+++ b/redfish_ctl/vendors/base.py
@@ -10,7 +10,8 @@ packages register a profile here.
 Author Mus spyroot@gmail.com
 """
 from dataclasses import dataclass, field
-from typing import Dict, Optional, Tuple
+from types import MappingProxyType
+from typing import Dict, Mapping, Optional, Tuple
 
 
 @dataclass(frozen=True)
@@ -36,6 +37,12 @@ class VendorCapabilities:
 
     # Redfish Lifecycle Events over Server-Sent Events.
     lifecycle_events_sse: bool = False
+
+    # Capability-field name -> short local fixture/source provenance note.
+    evidence: Mapping[str, str] = field(default_factory=dict, compare=False, hash=False)
+
+    def __post_init__(self):
+        object.__setattr__(self, "evidence", MappingProxyType(dict(self.evidence)))
 
 
 _REGISTRY: Dict[str, VendorCapabilities] = {}

--- a/redfish_ctl/vendors/dell/capabilities.py
+++ b/redfish_ctl/vendors/dell/capabilities.py
@@ -20,6 +20,33 @@ DELL_SCHEDULABLE_URIS = (
     "/redfish/v1/Systems/System.Embedded.1/Bios/Actions/Oem/DellBios.RunBIOSLiveScanning",
 )
 
+DELL_SERVICE_ROOT_EVIDENCE = (
+    "tests/idrac_fixtures/_redfish_v1.json: "
+    "Dell ServiceRoot fixture for query-gated reads"
+)
+DELL_JOB_SERVICE_EVIDENCE = (
+    "tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_"
+    "Oem_Dell_DellJobService.json: Dell OEM job service fixture"
+)
+DELL_EVENT_SERVICE_EVIDENCE = (
+    "tests/idrac_fixtures/_redfish_v1_EventService.json: "
+    "Dell EventService fixture"
+)
+DELL_EVIDENCE = {
+    "query_select": DELL_SERVICE_ROOT_EVIDENCE,
+    "query_filter": DELL_SERVICE_ROOT_EVIDENCE,
+    "query_expand": DELL_SERVICE_ROOT_EVIDENCE,
+    "query_top": DELL_SERVICE_ROOT_EVIDENCE,
+    "query_only": DELL_SERVICE_ROOT_EVIDENCE,
+    "one_query_param_per_uri": (
+        "tests/test_query.py: Dell one-query-parameter gate coverage"
+    ),
+    "job_scheduling": DELL_JOB_SERVICE_EVIDENCE,
+    "one_recurring_job_per_type": DELL_JOB_SERVICE_EVIDENCE,
+    "schedulable_uris": DELL_JOB_SERVICE_EVIDENCE,
+    "lifecycle_events_sse": DELL_EVENT_SERVICE_EVIDENCE,
+}
+
 DELL = register(
     VendorCapabilities(
         vendor="dell",
@@ -36,5 +63,6 @@ DELL = register(
         one_recurring_job_per_type=True,
         schedulable_uris=DELL_SCHEDULABLE_URIS,
         lifecycle_events_sse=True,
+        evidence=DELL_EVIDENCE,
     )
 )

--- a/tests/test_vendor_evidence.py
+++ b/tests/test_vendor_evidence.py
@@ -1,0 +1,50 @@
+"""Offline tests for vendor capability evidence notes.
+
+Author Mus spyroot@gmail.com
+"""
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.vendors import get_vendor
+from redfish_ctl.vendors.base import VendorCapabilities
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _evidence_path(note: str) -> Path:
+    """Return the first path token from a capability evidence note."""
+    first_token = note.split()[0]
+    return REPO_ROOT / first_token.rstrip(":")
+
+
+def test_capabilities_evidence_defaults_to_empty_mapping():
+    """Generic profiles can omit evidence until a capability is verified."""
+    caps = VendorCapabilities(vendor="test")
+    assert caps.evidence == {}
+
+
+def test_dell_profile_records_evidence_for_non_default_claims():
+    """Dell-only capability claims carry local fixture or source provenance."""
+    evidence = get_vendor("dell").evidence
+    assert evidence["query_select"].startswith("tests/idrac_fixtures/")
+    assert evidence["query_filter"].startswith("tests/idrac_fixtures/")
+    assert evidence["query_expand"].startswith("tests/idrac_fixtures/")
+    assert evidence["query_top"].startswith("tests/idrac_fixtures/")
+    assert evidence["query_only"].startswith("tests/idrac_fixtures/")
+    assert evidence["one_query_param_per_uri"].startswith("tests/test_query.py")
+    assert evidence["job_scheduling"].startswith("tests/idrac_fixtures/")
+    assert evidence["lifecycle_events_sse"].startswith("tests/idrac_fixtures/")
+
+
+def test_dell_evidence_paths_exist():
+    """Every Dell evidence note starts with a committed file path."""
+    for note in get_vendor("dell").evidence.values():
+        assert _evidence_path(note).exists(), note
+
+
+def test_evidence_mapping_is_immutable():
+    """Evidence notes cannot be mutated through a shared vendor profile."""
+    evidence = get_vendor("dell").evidence
+    with pytest.raises(TypeError):
+        evidence["query_select"] = "tests/test_vendors.py"  # type: ignore[index]


### PR DESCRIPTION
## Summary
- add immutable evidence notes to vendor capability profiles
- record local provenance for Dell non-default capability claims
- add offline tests for evidence defaults, path validity, and immutability

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q tests/test_vendor_evidence.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q tests/test_vendor_evidence.py tests/test_vendors.py tests/test_supermicro_profile.py tests/test_hpe_profile.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/vendors/base.py redfish_ctl/vendors/dell/capabilities.py tests/test_vendor_evidence.py
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q