### PR TITLE
Add vendor conformance claims

### DIFF
--- a/redfish_ctl/vendors/base.py
+++ b/redfish_ctl/vendors/base.py
@@ -38,6 +38,11 @@ class VendorCapabilities:
     # Redfish Lifecycle Events over Server-Sent Events.
     lifecycle_events_sse: bool = False
 
+    # Fixture-backed conformance claims. Keep these empty until a committed
+    # vendor tree proves the resource root or action exists for that vendor.
+    supported_resources: Tuple[str, ...] = field(default_factory=tuple)
+    supported_actions: Tuple[str, ...] = field(default_factory=tuple)
+
     # Capability-field name -> short local fixture/source provenance note.
     evidence: Mapping[str, str] = field(default_factory=dict, compare=False, hash=False)
 

--- a/redfish_ctl/vendors/dell/capabilities.py
+++ b/redfish_ctl/vendors/dell/capabilities.py
@@ -47,6 +47,26 @@ DELL_EVIDENCE = {
     "lifecycle_events_sse": DELL_EVENT_SERVICE_EVIDENCE,
 }
 
+DELL_SUPPORTED_RESOURCES = (
+    "/redfish/v1",
+    "/redfish/v1/Systems",
+    "/redfish/v1/Chassis",
+    "/redfish/v1/Managers",
+    "/redfish/v1/UpdateService",
+    "/redfish/v1/EventService",
+    "/redfish/v1/JobService",
+    "/redfish/v1/AccountService",
+)
+
+DELL_SUPPORTED_ACTIONS = (
+    "#ComputerSystem.Reset",
+    "#Chassis.Reset",
+    "#Manager.Reset",
+    "#UpdateService.SimpleUpdate",
+    "#DellJobService.CreateRebootJob",
+    "#EventService.SubmitTestEvent",
+)
+
 DELL = register(
     VendorCapabilities(
         vendor="dell",
@@ -64,5 +84,7 @@ DELL = register(
         schedulable_uris=DELL_SCHEDULABLE_URIS,
         lifecycle_events_sse=True,
         evidence=DELL_EVIDENCE,
+        supported_resources=DELL_SUPPORTED_RESOURCES,
+        supported_actions=DELL_SUPPORTED_ACTIONS,
     )
 )

--- a/redfish_ctl/vendors/hpe/capabilities.py
+++ b/redfish_ctl/vendors/hpe/capabilities.py
@@ -8,11 +8,31 @@ Author Mus spyroot@gmail.com
 """
 from ..base import VendorCapabilities, register
 
+HPE_SUPPORTED_RESOURCES = (
+    "/redfish/v1",
+    "/redfish/v1/Systems",
+    "/redfish/v1/Chassis",
+    "/redfish/v1/Managers",
+    "/redfish/v1/UpdateService",
+    "/redfish/v1/EventService",
+    "/redfish/v1/TelemetryService",
+)
+
+HPE_SUPPORTED_ACTIONS = (
+    "#ComputerSystem.Reset",
+    "#Manager.Reset",
+    "#UpdateService.SimpleUpdate",
+    "#LogService.ClearLog",
+    "#EventService.SubmitTestEvent",
+)
+
 HPE = register(
     VendorCapabilities(
         vendor="hpe",
         oem_prefix="Hpe",
         # Unverified — keep generic defaults until tested against iLO.
         query_expand=True,
+        supported_resources=HPE_SUPPORTED_RESOURCES,
+        supported_actions=HPE_SUPPORTED_ACTIONS,
     )
 )

--- a/redfish_ctl/vendors/supermicro/capabilities.py
+++ b/redfish_ctl/vendors/supermicro/capabilities.py
@@ -12,6 +12,26 @@ Author Mus spyroot@gmail.com
 """
 from ..base import VendorCapabilities, register
 
+SUPERMICRO_SUPPORTED_RESOURCES = (
+    "/redfish/v1",
+    "/redfish/v1/Systems",
+    "/redfish/v1/Chassis",
+    "/redfish/v1/Managers",
+    "/redfish/v1/UpdateService",
+    "/redfish/v1/EventService",
+    "/redfish/v1/TelemetryService",
+    "/redfish/v1/AccountService",
+)
+
+SUPERMICRO_SUPPORTED_ACTIONS = (
+    "#ComputerSystem.Reset",
+    "#Chassis.Reset",
+    "#Manager.Reset",
+    "#NetworkAdapter.Reset",
+    "#NvidiaWorkloadPower.EnableProfiles",
+    "#Control.ResetToDefaults",
+)
+
 SUPERMICRO = register(
     VendorCapabilities(
         vendor="supermicro",
@@ -26,5 +46,7 @@ SUPERMICRO = register(
         query_only=False,
         job_scheduling=False,
         one_recurring_job_per_type=False,
+        supported_resources=SUPERMICRO_SUPPORTED_RESOURCES,
+        supported_actions=SUPERMICRO_SUPPORTED_ACTIONS,
     )
 )

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,76 @@
+"""Offline conformance checks for declared vendor fixture claims."""
+import json
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.vendors import get_vendor
+
+TESTS_ROOT = Path(__file__).resolve().parent
+FIXTURE_ROOTS = {
+    "dell": TESTS_ROOT / "idrac_fixtures",
+    "hpe": TESTS_ROOT / "hpe_fixtures",
+    "supermicro": TESTS_ROOT / "supermicro_fixtures",
+}
+
+
+def _path_to_fixture_name(path: str) -> str:
+    return "_" + path.strip("/").replace("/", "_") + ".json"
+
+
+def _load_fixture(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _fixture_for(root: Path, redfish_path: str) -> Path:
+    return root / _path_to_fixture_name(redfish_path)
+
+
+def _action_names(value) -> set[str]:
+    if not isinstance(value, dict):
+        return set()
+
+    names = set()
+    if "target" in value:
+        return names
+
+    for key, nested in value.items():
+        if isinstance(nested, dict) and "target" in nested:
+            names.add(key)
+        names.update(_action_names(nested))
+    return names
+
+
+def _fixture_actions(root: Path) -> set[str]:
+    actions = set()
+    for path in root.glob("*.json"):
+        payload = _load_fixture(path)
+        actions.update(_action_names(payload.get("Actions", {})))
+    return actions
+
+
+@pytest.mark.parametrize("vendor", ("dell", "hpe", "supermicro"))
+def test_declared_resource_roots_exist_in_vendor_fixtures(vendor):
+    caps = get_vendor(vendor)
+    root = FIXTURE_ROOTS[vendor]
+
+    missing = [
+        resource
+        for resource in caps.supported_resources
+        if not _fixture_for(root, resource).is_file()
+    ]
+
+    assert missing == []
+
+@pytest.mark.parametrize("vendor", ("dell", "hpe", "supermicro"))
+def test_declared_actions_exist_in_vendor_fixtures(vendor):
+    caps = get_vendor(vendor)
+    fixture_actions = _fixture_actions(FIXTURE_ROOTS[vendor])
+
+    missing = [
+        action
+        for action in caps.supported_actions
+        if action not in fixture_actions
+    ]
+
+    assert missing == []


### PR DESCRIPTION
## Summary
- add fixture-backed resource and action claim fields to vendor capability profiles
- declare grounded Dell, HPE, and Supermicro claims from committed fixture trees
- add offline conformance tests that catch missing claimed resources or actions

## Tests
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD PYTHONDONTWRITEBYTECODE=1 pytest -q tests/test_conformance.py -o <cache-dir> -> `6 passed in 0.11s`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD PYTHONDONTWRITEBYTECODE=1 pytest -q tests/test_conformance.py tests/test_vendors.py tests/test_supermicro_profile.py tests/test_hpe_profile.py -o <cache-dir> -> `19 passed in 0.12s`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/vendors/base.py redfish_ctl/vendors/dell/capabilities.py redfish_ctl/vendors/hpe/capabilities.py redfish_ctl/vendors/supermicro/capabilities.py tests/test_conformance.py` -> `All checks passed!`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD PYTHONDONTWRITEBYTECODE=1 pytest -q -o <cache-dir> -> `869 passed, 57 skipped in 30.54s`