### PR TITLE
Add fixture catalog manifest

### DIFF
--- a/redfish_ctl/fixtures_catalog.py
+++ b/redfish_ctl/fixtures_catalog.py
@@ -1,0 +1,131 @@
+"""Manifest-backed index of committed Redfish fixture sets."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "tests" / "fixtures_catalog.json"
+_VALID_STATUSES = {"active", "pending"}
+
+
+class CatalogError(ValueError):
+    """Raised when the fixture catalog manifest is malformed."""
+
+
+@dataclass(frozen=True)
+class FixtureSet:
+    key: str
+    vendor: str
+    generation: str
+    path: str
+    status: str
+    redfish_version: str | None = None
+    oem_types: tuple[str, ...] = ()
+    source: str | None = None
+    reason: str | None = None
+    notes: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "FixtureSet":
+        required = ("key", "vendor", "generation", "path", "status")
+        missing = [field for field in required if not data.get(field)]
+        if missing:
+            raise CatalogError(f"fixture set missing required fields: {', '.join(missing)}")
+
+        status = str(data["status"])
+        if status not in _VALID_STATUSES:
+            raise CatalogError(f"invalid fixture set status {status!r}")
+        if status == "pending" and not data.get("reason"):
+            raise CatalogError("pending fixture sets must include a reason")
+
+        oem_types = data.get("oem_types") or []
+        if not isinstance(oem_types, list):
+            raise CatalogError("fixture set oem_types must be a list")
+
+        return cls(
+            key=str(data["key"]),
+            vendor=str(data["vendor"]),
+            generation=str(data["generation"]),
+            path=str(data["path"]),
+            status=status,
+            redfish_version=data.get("redfish_version"),
+            oem_types=tuple(str(value) for value in oem_types),
+            source=data.get("source"),
+            reason=data.get("reason"),
+            notes=data.get("notes"),
+        )
+
+    def resolve_path(self, repo_root: Path | None = None) -> Path:
+        base = repo_root or REPO_ROOT
+        return (base / self.path).resolve()
+
+    def json_file_count(self, repo_root: Path | None = None) -> int:
+        root = self.resolve_path(repo_root)
+        if not root.exists():
+            return 0
+        return sum(1 for _path in root.rglob("*.json"))
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == "active"
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == "pending"
+
+
+@dataclass(frozen=True)
+class FixtureCatalog:
+    manifest_path: Path
+    schema_version: int
+    sets: tuple[FixtureSet, ...]
+
+    @classmethod
+    def from_manifest(cls, manifest_path: Path = DEFAULT_MANIFEST) -> "FixtureCatalog":
+        try:
+            raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            raise CatalogError(f"cannot read fixture catalog manifest: {manifest_path}") from exc
+        except json.JSONDecodeError as exc:
+            raise CatalogError(f"fixture catalog manifest is not valid JSON: {manifest_path}") from exc
+
+        if raw.get("schema_version") != 1:
+            raise CatalogError("fixture catalog schema_version must be 1")
+        raw_sets = raw.get("sets")
+        if not isinstance(raw_sets, list):
+            raise CatalogError("fixture catalog sets must be a list")
+
+        fixture_sets = tuple(FixtureSet.from_mapping(item) for item in raw_sets)
+        seen: set[str] = set()
+        for fixture_set in fixture_sets:
+            if fixture_set.key in seen:
+                raise CatalogError(f"duplicate fixture set key: {fixture_set.key}")
+            seen.add(fixture_set.key)
+
+        return cls(
+            manifest_path=manifest_path,
+            schema_version=1,
+            sets=fixture_sets,
+        )
+
+    def require(self, key: str) -> FixtureSet:
+        for fixture_set in self.sets:
+            if fixture_set.key == key:
+                return fixture_set
+        raise CatalogError(f"unknown fixture set: {key}")
+
+    def active_sets(self) -> tuple[FixtureSet, ...]:
+        return tuple(fixture_set for fixture_set in self.sets if fixture_set.is_active)
+
+    def pending_sets(self) -> tuple[FixtureSet, ...]:
+        return tuple(fixture_set for fixture_set in self.sets if fixture_set.is_pending)
+
+    def by_vendor(self, vendor: str) -> tuple[FixtureSet, ...]:
+        return tuple(fixture_set for fixture_set in self.sets if fixture_set.vendor == vendor)
+
+
+def load_catalog(manifest_path: Path = DEFAULT_MANIFEST) -> FixtureCatalog:
+    return FixtureCatalog.from_manifest(manifest_path)

--- a/tests/fixtures_catalog.json
+++ b/tests/fixtures_catalog.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "sets": [
+    {
+      "key": "dell-idrac-overlay",
+      "vendor": "dell",
+      "generation": "idrac",
+      "path": "tests/idrac_fixtures",
+      "status": "active",
+      "redfish_version": "1.15.0",
+      "oem_types": ["Dell"],
+      "source": "Hand-authored Dell iDRAC-shaped overlay used by dual-mode command tests."
+    },
+    {
+      "key": "generic-dmtf-base",
+      "vendor": "generic",
+      "generation": "base-mockup",
+      "path": "redfish_ctl/json_responses",
+      "status": "active",
+      "oem_types": [],
+      "source": "Packaged Redfish mockup base served by the default requests-mock fixture."
+    },
+    {
+      "key": "generic-dmtf-public-rackmount1",
+      "vendor": "generic",
+      "generation": "public-rackmount1",
+      "path": "tests/generic_fixtures",
+      "status": "active",
+      "redfish_version": "1.15.0",
+      "oem_types": [],
+      "source": "DMTF public-rackmount1 fixture tree imported for product-neutral tests."
+    },
+    {
+      "key": "hpe-ilo-reference",
+      "vendor": "hpe",
+      "generation": "ilo",
+      "path": "tests/hpe_fixtures",
+      "status": "active",
+      "redfish_version": "1.20.0",
+      "oem_types": ["Hpe"],
+      "source": "Imported HPE iLO Redfish fixture tree with local license notes."
+    },
+    {
+      "key": "supermicro-gb300-overlay",
+      "vendor": "supermicro",
+      "generation": "gb300",
+      "path": "tests/supermicro_fixtures",
+      "status": "active",
+      "redfish_version": "1.17.0",
+      "oem_types": ["Supermicro", "Nvidia"],
+      "source": "Flattened Supermicro GB300 fixture overlay used by vendor-aware tests."
+    },
+    {
+      "key": "supermicro-gb300-corpus",
+      "vendor": "supermicro",
+      "generation": "gb300",
+      "path": "tests/supermicro_gb300_corpus/json_responses",
+      "status": "active",
+      "redfish_version": "1.17.0",
+      "oem_types": ["Supermicro", "Nvidia"],
+      "source": "Full committed GB300 crawl used by corpus-backed telemetry and controller tests."
+    },
+    {
+      "key": "supermicro-x10",
+      "vendor": "supermicro",
+      "generation": "x10",
+      "path": "tests/supermicro_x10_fixtures",
+      "status": "active",
+      "oem_types": ["Supermicro"],
+      "source": "Flattened Supermicro X10 fixture overlay."
+    },
+    {
+      "key": "supermicro-x10-119",
+      "vendor": "supermicro",
+      "generation": "x10",
+      "path": "tests/supermicro_x10_119_fixtures",
+      "status": "active",
+      "oem_types": ["Supermicro"],
+      "source": "Second Supermicro X10 fixture overlay for portability checks."
+    },
+    {
+      "key": "cisco-cimc-corpus",
+      "vendor": "cisco",
+      "generation": "ucs-c-series",
+      "path": "tests/cisco_fixtures",
+      "status": "pending",
+      "oem_types": ["Cisco"],
+      "reason": "Waiting for a sanitized Cisco CIMC Redfish crawl."
+    },
+    {
+      "key": "lenovo-xcc-doc-seeded",
+      "vendor": "lenovo",
+      "generation": "xcc",
+      "path": "tests/lenovo_fixtures",
+      "status": "pending",
+      "oem_types": ["Lenovo"],
+      "reason": "Waiting for the Lenovo XCC fixture/profile package to land."
+    }
+  ]
+}

--- a/tests/test_fixture_catalog.py
+++ b/tests/test_fixture_catalog.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.fixtures_catalog import (
+    DEFAULT_MANIFEST,
+    CatalogError,
+    FixtureCatalog,
+    load_catalog,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_default_fixture_catalog_lists_known_active_roots():
+    catalog = load_catalog()
+
+    assert catalog.require("dell-idrac-overlay").vendor == "dell"
+    assert catalog.require("generic-dmtf-public-rackmount1").vendor == "generic"
+    assert catalog.require("supermicro-gb300-corpus").generation == "gb300"
+
+
+def test_active_fixture_roots_resolve_to_non_empty_json_trees():
+    catalog = load_catalog()
+
+    active = catalog.active_sets()
+    assert active
+    for fixture_set in active:
+        root = fixture_set.resolve_path(REPO_ROOT)
+        assert root.is_dir(), fixture_set.key
+        assert fixture_set.json_file_count(REPO_ROOT) > 0, fixture_set.key
+
+
+def test_pending_fixture_sets_are_explicitly_reported():
+    catalog = load_catalog()
+
+    pending = {fixture_set.key: fixture_set for fixture_set in catalog.pending_sets()}
+    assert "cisco-cimc-corpus" in pending
+    assert "lenovo-xcc-doc-seeded" in pending
+    assert all(fixture_set.reason for fixture_set in pending.values())
+
+
+def test_catalog_lookup_fails_loudly_for_unknown_key():
+    catalog = load_catalog()
+
+    with pytest.raises(CatalogError, match="unknown fixture set"):
+        catalog.require("not-a-fixture-set")
+
+
+def test_catalog_rejects_duplicate_keys(tmp_path):
+    manifest = tmp_path / "fixtures.json"
+    manifest.write_text(
+        """
+        {
+          "schema_version": 1,
+          "sets": [
+            {
+              "key": "duplicate",
+              "vendor": "generic",
+              "generation": "one",
+              "path": "tests/generic_fixtures",
+              "status": "active"
+            },
+            {
+              "key": "duplicate",
+              "vendor": "generic",
+              "generation": "two",
+              "path": "tests/generic_fixtures",
+              "status": "active"
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CatalogError, match="duplicate fixture set key"):
+        FixtureCatalog.from_manifest(manifest)
+
+
+def test_default_manifest_is_repo_relative():
+    assert DEFAULT_MANIFEST == REPO_ROOT / "tests" / "fixtures_catalog.json"


### PR DESCRIPTION
## Summary
- Add a manifest-backed fixture catalog API for committed Redfish fixture sets.
- Catalog active Dell, generic DMTF, HPE, and Supermicro roots, with pending Cisco and Lenovo entries called out explicitly.
- Add tests for known roots, active path resolution, pending entries, duplicate keys, and unknown lookups.

## Tests
- `pytest -q tests/test_fixture_catalog.py` -> `6 passed in 0.05s`
- `pytest -q tests/test_fixture_catalog.py tests/test_vendors.py tests/test_supermicro_profile.py tests/test_hpe_profile.py tests/test_generic_vendor.py tests/test_supermicro_gb300_corpus.py` -> `23 passed in 0.49s`
- `ruff check redfish_ctl/fixtures_catalog.py tests/test_fixture_catalog.py` -> `All checks passed!`
- `pytest -q` -> `870 passed, 57 skipped in 28.12s`
- `git diff --cached --check` -> clean

No live BMC access or credentials were used.