### PR TITLE
Add vendor capability report

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -100,6 +100,7 @@ Safety labels:
 | `boot-source-update` | Stage boot source settings. | Write |
 | `boot-sources` | List boot source members. | Read |
 | `boot-state` | Infer what the host will boot (target/order/media). | Read |
+| `capability-report` | Export registered vendor capability profiles for IaC and inventory tooling. | Read |
 | `change-boot-order` | Change boot order and boot options. | Write |
 | `chassis` | Read chassis services. | Read |
 | `chassis-reset` | Change chassis power state. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -159,3 +159,4 @@ from .accounts.cmd_privilage_registry import *
 from .discovery.cmd_discovery import *
 from .discovery.cmd_bmc_scan import *
 from .fleet.cmd_fleet import *
+from .vendors.cmd_capability_report import *

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -177,6 +177,7 @@ class ApiRequestType(Enum):
 
     Discovery = auto()
     FleetInventory = auto()
+    CapabilityReport = auto()
 
 
 class ScheduleJobType(Enum):

--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -99,7 +99,7 @@ class TermColors:
 
 "note we do sub-string match"
 TermList = ["xterm", "linux", "ansi", "xterm-256color"]
-LOCAL_COMMANDS = {"bios-profile"}
+LOCAL_COMMANDS = {"bios-profile", "capability-report"}
 _QUERY_CAPABILITY_FLAGS = (
     ("$select", "select", "query_select"),
     ("$filter", "filter", "query_filter"),

--- a/redfish_ctl/vendors/__init__.py
+++ b/redfish_ctl/vendors/__init__.py
@@ -21,6 +21,7 @@ from .base import get as get_vendor
 from .dell import capabilities as _dell  # noqa: F401
 from .hpe import capabilities as _hpe  # noqa: F401
 from .lenovo import capabilities as _lenovo  # noqa: F401
+from .report import capability_report
 from .supermicro import capabilities as _supermicro  # noqa: F401
 
 
@@ -35,4 +36,5 @@ __all__ = [
     "get_vendor",
     "all_vendors",
     "capabilities_for_service_root",
+    "capability_report",
 ]

--- a/redfish_ctl/vendors/base.py
+++ b/redfish_ctl/vendors/base.py
@@ -44,6 +44,24 @@ class VendorCapabilities:
     def __post_init__(self):
         object.__setattr__(self, "evidence", MappingProxyType(dict(self.evidence)))
 
+    def to_dict(self) -> Dict[str, object]:
+        """Return a JSON-ready representation of the capability profile."""
+        return {
+            "vendor": self.vendor,
+            "oem_prefix": self.oem_prefix,
+            "query_select": self.query_select,
+            "query_filter": self.query_filter,
+            "query_expand": self.query_expand,
+            "query_top": self.query_top,
+            "query_only": self.query_only,
+            "one_query_param_per_uri": self.one_query_param_per_uri,
+            "job_scheduling": self.job_scheduling,
+            "one_recurring_job_per_type": self.one_recurring_job_per_type,
+            "schedulable_uris": list(self.schedulable_uris),
+            "lifecycle_events_sse": self.lifecycle_events_sse,
+            "evidence": dict(self.evidence),
+        }
+
 
 _REGISTRY: Dict[str, VendorCapabilities] = {}
 

--- a/redfish_ctl/vendors/cmd_capability_report.py
+++ b/redfish_ctl/vendors/cmd_capability_report.py
@@ -1,0 +1,50 @@
+"""Export registered vendor capability profiles."""
+
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_utils import save_if_needed
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+from .report import capability_report
+
+
+class CapabilityReport(IDracManager,
+                       scm_type=ApiRequestType.CapabilityReport,
+                       name="capability-report",
+                       metaclass=Singleton):
+    """Emit local vendor capability profiles as machine-readable data."""
+
+    def __init__(self, *args, **kwargs):
+        super(CapabilityReport, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the local capability-report subcommand."""
+        cmd_parser = cls.base_parser(is_async=False, is_expanded=False)
+        cmd_parser.add_argument(
+            "--vendor",
+            required=False,
+            default=None,
+            help="limit the report to one vendor profile",
+        )
+        return (
+            cmd_parser,
+            "capability-report",
+            "command export vendor capability profiles for IaC consumers",
+        )
+
+    def execute(self,
+                vendor: Optional[str] = None,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Return registered vendor capability profiles without BMC access."""
+        data = capability_report(vendor)
+        save_if_needed(filename, data, data_format=data_type)
+        return CommandResult(data, None, None, None)

--- a/redfish_ctl/vendors/report.py
+++ b/redfish_ctl/vendors/report.py
@@ -1,0 +1,25 @@
+"""Machine-readable vendor capability reports."""
+
+from typing import Optional
+
+from .base import all_vendors, get
+
+REPORT_SCHEMA = "redfish_ctl.capability_report.v1"
+
+
+def capability_report(vendor: Optional[str] = None) -> dict:
+    """Return registered vendor capability profiles for IaC consumers."""
+    if vendor:
+        caps = get(vendor)
+        vendors = {caps.vendor: caps.to_dict()}
+    else:
+        vendors = {
+            name: caps.to_dict()
+            for name, caps in sorted(all_vendors().items())
+        }
+
+    return {
+        "schema": REPORT_SCHEMA,
+        "summary": {"vendor_count": len(vendors)},
+        "vendors": vendors,
+    }

--- a/tests/test_capability_report.py
+++ b/tests/test_capability_report.py
@@ -1,0 +1,105 @@
+"""Offline tests for the vendor capability report."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.vendors import capability_report, get_vendor
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_vendor_capabilities_to_dict_is_json_ready():
+    """Vendor capability profiles serialize tuples as JSON arrays."""
+    payload = get_vendor("dell").to_dict()
+
+    json.dumps(payload, sort_keys=True)
+    assert payload["vendor"] == "dell"
+    assert payload["oem_prefix"] == "Dell"
+    assert isinstance(payload["schedulable_uris"], list)
+    assert any("ComputerSystem.Reset" in uri for uri in payload["schedulable_uris"])
+
+
+def test_capability_report_returns_machine_readable_vendor_profiles(redfish_mock):
+    """capability-report exposes every registered profile without BMC reads."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.CapabilityReport,
+        "capability-report",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.discovered is None
+    assert result.extra is None
+    json.dumps(result.data, sort_keys=True)
+
+    assert result.data["schema"] == "redfish_ctl.capability_report.v1"
+    assert result.data["summary"]["vendor_count"] >= 4
+    assert set(result.data["vendors"]) >= {"generic", "dell", "hpe", "supermicro"}
+    assert result.data["vendors"]["dell"]["query_select"] is True
+    assert isinstance(result.data["vendors"]["dell"]["schedulable_uris"], list)
+    assert result.data["vendors"]["supermicro"]["query_select"] is False
+
+
+def test_capability_report_helper_is_exported_for_library_consumers():
+    """Library users can import the same report helper as the CLI command."""
+    payload = capability_report("supermicro")
+
+    assert payload["summary"] == {"vendor_count": 1}
+    assert set(payload["vendors"]) == {"supermicro"}
+
+
+def test_capability_report_filters_one_vendor(redfish_mock):
+    """capability-report --vendor emits one named profile plus summary metadata."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.CapabilityReport,
+        "capability-report",
+        vendor="hpe",
+    )
+
+    assert result.error is None
+    assert result.data["summary"] == {"vendor_count": 1}
+    assert set(result.data["vendors"]) == {"hpe"}
+    assert result.data["vendors"]["hpe"]["query_expand"] is True
+
+
+def test_capability_report_cli_runs_without_bmc_credentials():
+    """capability-report is local and does not require endpoint credentials."""
+    env = os.environ.copy()
+    for name in (
+            "REDFISH_IP",
+            "REDFISH_USERNAME",
+            "REDFISH_PASSWORD",
+            "IDRAC_IP",
+            "IDRAC_USERNAME",
+            "IDRAC_PASSWORD",
+    ):
+        env.pop(name, None)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-B",
+            "-m",
+            "redfish_ctl.redfish_main",
+            "--json_only",
+            "--nocolor",
+            "capability-report",
+            "--vendor",
+            "dell",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["data"]["vendors"]["dell"]["job_scheduling"] is True


### PR DESCRIPTION
Summary:
- Add a local capability-report command for registered vendor profiles.
- Expose a JSON-ready vendor capability serializer for library and inventory consumers.
- Document the new read-only command in the command reference.

Validation:
- pytest -q tests/test_capability_report.py tests/test_vendors.py
- ruff check redfish_ctl/vendors/base.py redfish_ctl/vendors/report.py redfish_ctl/vendors/cmd_capability_report.py redfish_ctl/vendors/__init__.py redfish_ctl/idrac_shared.py redfish_ctl/redfish_main.py redfish_ctl/__init__.py tests/test_capability_report.py
- git diff --check
- python -B -m redfish_ctl.redfish_main --json_only --nocolor capability-report --vendor dell
- pytest -q