### PR TITLE
Bridge ServiceRoot classification to vendor capabilities

### DIFF
--- a/redfish_ctl/vendors/__init__.py
+++ b/redfish_ctl/vendors/__init__.py
@@ -12,10 +12,26 @@ every vendor's capability profile. See README.md for the convention.
 Author Mus spyroot@gmail.com
 """
 # Importing each vendor's capabilities module registers its profile.
+from typing import Any, Mapping, Optional
+
+from redfish_ctl.discover.classifier import classify_vendor
+
 from .base import VendorCapabilities, all_vendors
 from .base import get as get_vendor
 from .dell import capabilities as _dell  # noqa: F401
 from .hpe import capabilities as _hpe  # noqa: F401
 from .supermicro import capabilities as _supermicro  # noqa: F401
 
-__all__ = ["VendorCapabilities", "get_vendor", "all_vendors"]
+
+def capabilities_for_service_root(
+        service_root: Optional[Mapping[str, Any]]) -> VendorCapabilities:
+    """Return the capability profile for a parsed Redfish ServiceRoot."""
+    return get_vendor(classify_vendor(service_root))
+
+
+__all__ = [
+    "VendorCapabilities",
+    "get_vendor",
+    "all_vendors",
+    "capabilities_for_service_root",
+]

--- a/tests/test_vendors.py
+++ b/tests/test_vendors.py
@@ -2,7 +2,7 @@
 
 Author Mus spyroot@gmail.com
 """
-from redfish_ctl.vendors import all_vendors, get_vendor
+from redfish_ctl.vendors import all_vendors, capabilities_for_service_root, get_vendor
 from redfish_ctl.vendors.base import VendorCapabilities
 
 
@@ -40,6 +40,34 @@ def test_registry_contains_scaffolded_vendors():
     """Dell, HPE, Supermicro and generic are all registered."""
     names = set(all_vendors())
     assert {"dell", "hpe", "supermicro", "generic"} <= names
+
+
+def test_service_root_resolves_registered_vendor_profile():
+    """A ServiceRoot vendor signal resolves to the matching capability profile."""
+    caps = capabilities_for_service_root({"Oem": {"Dell": {}}})
+
+    assert caps is get_vendor("dell")
+    assert caps.job_scheduling is True
+
+
+def test_service_root_resolution_uses_classifier_ranking():
+    """The registry bridge keeps the classifier's OEM-over-text precedence."""
+    caps = capabilities_for_service_root(
+        {
+            "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+            "Oem": {"Hpe": {}},
+            "Vendor": "Dell",
+        }
+    )
+
+    assert caps is get_vendor("hpe")
+    assert caps.oem_prefix == "Hpe"
+
+
+def test_service_root_resolution_unknown_is_generic():
+    """Unidentifiable ServiceRoot input returns the conservative generic profile."""
+    assert capabilities_for_service_root(None) is get_vendor("generic")
+    assert capabilities_for_service_root({"Vendor": "Acme"}) is get_vendor("generic")
 
 
 def test_capabilities_are_immutable():


### PR DESCRIPTION
## Summary
- Add a vendor registry helper that maps a parsed ServiceRoot through the existing classifier to the matching capability profile.
- Cover registered vendor resolution, classifier precedence, and generic fallback behavior.

## Tests
- env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD conda run -n idrac_ctl pytest -q
- conda run -n idrac_ctl ruff check redfish_ctl/vendors/__init__.py tests/test_vendors.py
- git diff --check