### PR TITLE
Add guarded WorkloadPower action command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -184,6 +184,7 @@ Safety labels:
 | `volume-init` | Initialize a volume. | Write |
 | `volumes` | Read virtual disk data. | Read |
 | `wait` | Wait for the BMC Redfish service to be reachable (e.g. after a reboot). | Read |
+| `workload-power` | Enable or disable an NVIDIA WorkloadPower profile mask; previews by default and `--confirm` posts the action. | Guarded |
 
 ## Vendor-Neutral Telemetry Reads
 

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -83,6 +83,7 @@ from .sensors.cmd_sensors import *
 from .thermal.cmd_thermal import *
 from .power.cmd_power import *
 from .power.cmd_power_smoothing import *
+from .power.cmd_workload_power import *
 from .thermal.cmd_leak_detectors import *
 from .environment.cmd_environment_metrics import *
 from .metrics.cmd_processor_metrics import *

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -86,6 +86,7 @@ class ApiRequestType(Enum):
     Thermal = auto()
     Power = auto()
     PowerSmoothing = auto()
+    WorkloadPower = auto()
     LeakDetectors = auto()
     EnvironmentMetrics = auto()
     ProcessorMetrics = auto()

--- a/redfish_ctl/power/cmd_workload_power.py
+++ b/redfish_ctl/power/cmd_workload_power.py
@@ -1,0 +1,176 @@
+"""Guard NVIDIA WorkloadPower profile enable and disable actions."""
+
+import re
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+from ..redfish_shared import RedfishApi
+
+_PROFILE_MASK = re.compile(r"^0x[0-9a-fA-F]+$")
+_ACTION_TYPES = {
+    "enable": "#NvidiaWorkloadPower.EnableProfiles",
+    "disable": "#NvidiaWorkloadPower.DisableProfiles",
+}
+
+
+def _normalize_profile_mask(profile_mask: str) -> str:
+    mask = str(profile_mask or "").strip()
+    if not _PROFILE_MASK.fullmatch(mask):
+        raise InvalidArgument("profile mask must be a hex value like 0x1")
+    value = int(mask, 16)
+    if value <= 0:
+        raise InvalidArgument("profile mask must select at least one profile bit")
+    return f"0x{value:x}"
+
+
+class WorkloadPower(IDracManager,
+                    scm_type=ApiRequestType.WorkloadPower,
+                    name="workload-power",
+                    metaclass=Singleton):
+    """Preview or apply NVIDIA WorkloadPower profile actions."""
+
+    def __init__(self, *args, **kwargs):
+        super(WorkloadPower, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``workload-power`` subcommand."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--gpu", dest="gpu_id", required=True, metavar="ID",
+            help="GPU processor id exposing the WorkloadPowerProfile resource")
+        cmd_parser.add_argument(
+            "--profile-mask", dest="profile_mask", required=True, metavar="HEX",
+            help="profile bit mask to enable or disable, for example 0x1")
+        cmd_parser.add_argument(
+            "--mode", choices=sorted(_ACTION_TYPES), required=True,
+            help="choose whether to enable or disable the profile mask")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="POST the action; without it the command only previews")
+        cmd_parser.add_argument(
+            "--dry_run", action="store_true", dest="dry_run", default=False,
+            help="force preview mode even when --confirm is present")
+        help_text = "enable or disable NVIDIA WorkloadPower profile masks"
+        return cmd_parser, "workload-power", help_text
+
+    @staticmethod
+    def _members(data):
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        value = data.get(key) if isinstance(data, dict) else None
+        if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
+            return value["@odata.id"]
+        return None
+
+    @staticmethod
+    def _nested_link(data, *keys):
+        value = data
+        for key in keys:
+            if not isinstance(value, dict):
+                return None
+            value = value.get(key)
+        if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
+            return value["@odata.id"]
+        return None
+
+    @staticmethod
+    def _resource_id(uri):
+        return uri.rstrip("/").rsplit("/", 1)[-1]
+
+    def _get(self, uri, do_async=False):
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def _workload_power_resources(self, do_async=False):
+        resources = []
+        systems = self._get(RedfishApi.Systems, do_async=do_async)
+        for system_uri in self._members(systems):
+            system = self._get(system_uri, do_async=do_async)
+            processors_uri = self._link(system, "Processors")
+            if not processors_uri:
+                continue
+            processors = self._get(processors_uri, do_async=do_async)
+            for processor_uri in self._members(processors):
+                processor = self._get(processor_uri, do_async=do_async)
+                if processor.get("ProcessorType") != "GPU":
+                    continue
+                workload_uri = self._nested_link(
+                    processor,
+                    "Oem",
+                    "Nvidia",
+                    "WorkloadPowerProfile",
+                )
+                if workload_uri:
+                    resources.append({
+                        "System": self._resource_id(system_uri),
+                        "GPU": processor.get("Id") or self._resource_id(
+                            processor_uri),
+                        "Uri": workload_uri,
+                    })
+        return resources
+
+    def _select_workload_power(self, gpu_id, do_async=False):
+        if not gpu_id:
+            raise InvalidArgument("GPU id is required")
+        for resource in self._workload_power_resources(do_async=do_async):
+            if resource["GPU"] == gpu_id:
+                return resource
+        raise InvalidArgument(
+            f"GPU {gpu_id!r} has no NVIDIA WorkloadPowerProfile resource")
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                gpu_id: Optional[str] = None,
+                profile_mask: Optional[str] = None,
+                mode: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or POST one NVIDIA WorkloadPower profile-mask action."""
+        if mode not in _ACTION_TYPES:
+            raise InvalidArgument("mode must be 'enable' or 'disable'")
+
+        resource = self._select_workload_power(gpu_id, do_async=do_async)
+        payload = {"ProfileMask": _normalize_profile_mask(profile_mask)}
+        full_action_type = _ACTION_TYPES[mode]
+        result = self.invoke_action(
+            resource["Uri"],
+            full_action_type.rsplit(".", 1)[-1],
+            payload=payload,
+            full_action_type=full_action_type,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+
+        data = result.data if isinstance(result.data, dict) else {}
+        data.update({
+            "gpu": resource["GPU"],
+            "system": resource["System"],
+            "resource": resource["Uri"],
+            "mode": mode,
+            "profile_mask": payload["ProfileMask"],
+        })
+        return CommandResult(data, result.discovered, result.extra, result.error)

--- a/tests/test_workload_power_dualmode.py
+++ b/tests/test_workload_power_dualmode.py
@@ -1,0 +1,86 @@
+"""Dual-mode tests for guarded NVIDIA WorkloadPower profile actions."""
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.idrac_shared import ApiRequestType
+
+
+def _mutating_requests(service):
+    return [
+        request for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    ]
+
+
+def test_workload_power_enable_dry_run_resolves_gb300_target_without_post(
+        redfish_mock_factory):
+    """workload-power previews the GPU action target and sends no POST by default."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.WorkloadPower,
+        "workload-power",
+        gpu_id="GPU_0",
+        profile_mask="0x1",
+        mode="enable",
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["gpu"] == "GPU_0"
+    assert result.data["resource"] == (
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/"
+        "Nvidia/WorkloadPowerProfile"
+    )
+    assert result.data["action"] == "#NvidiaWorkloadPower.EnableProfiles"
+    assert result.data["target"] == (
+        "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/Oem/Nvidia/"
+        "WorkloadPowerProfile/Actions/NvidiaWorkloadPower.EnableProfiles"
+    )
+    assert result.data["payload"] == {"ProfileMask": "0x1"}
+    assert _mutating_requests(service) == []
+
+
+def test_workload_power_disable_confirm_posts_profile_mask_to_discovered_action(
+        redfish_mock_factory):
+    """workload-power --confirm POSTs only the requested profile-mask action."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.WorkloadPower,
+        "workload-power",
+        gpu_id="GPU_0",
+        profile_mask="0x1",
+        mode="disable",
+        confirm=True,
+    )
+
+    posts = [request for request in service.requests if request.method == "POST"]
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#NvidiaWorkloadPower.DisableProfiles"
+    assert len(posts) == 1
+    assert posts[0].path == (
+        "/redfish/v1/systems/hgx_baseboard_0/processors/gpu_0/oem/nvidia/"
+        "workloadpowerprofile/actions/nvidiaworkloadpower.disableprofiles"
+    )
+    assert posts[0].json() == {"ProfileMask": "0x1"}
+
+
+def test_workload_power_rejects_invalid_profile_mask_before_post(
+        redfish_mock_factory):
+    """The profile mask must be an explicit Redfish hex mask before any write."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument):
+        manager.sync_invoke(
+            ApiRequestType.WorkloadPower,
+            "workload-power",
+            gpu_id="GPU_0",
+            profile_mask="1",
+            mode="enable",
+            confirm=True,
+        )
+
+    assert _mutating_requests(service) == []


### PR DESCRIPTION
## Summary
- add a guarded workload-power command for NVIDIA WorkloadPower profile masks
- discover GPU WorkloadPowerProfile resources from the Redfish processor tree
- preview by default and POST only with --confirm

## Verification
- pytest -q tests/test_workload_power_dualmode.py
- pytest -q tests/test_workload_power_dualmode.py tests/test_power_smoothing_dualmode.py tests/test_action_commands.py tests/test_action_foundation.py
- ruff check redfish_ctl/idrac_shared.py redfish_ctl/power/cmd_workload_power.py redfish_ctl/__init__.py tests/test_workload_power_dualmode.py
- python -B -m redfish_ctl workload-power --help
- pytest -q