### PR TITLE
Add optional OpenTelemetry tracing scaffold for BMC operations

### DIFF
--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -65,6 +65,7 @@ from .idrac_shared import (
 from .idrac_shared import ResetType as ResetType
 from .redfish_exceptions import RedfishException, RedfishForbidden, RedfishUnauthorized
 from .redfish_manager import CommandResult, RedfishManager
+from .telemetry import tracing
 from .redfish_shared import RedfishApi, RedfishJson, RedfishJsonSpec, env_first
 from .redfish_task_state import TaskState, TaskStatus
 
@@ -393,16 +394,22 @@ class IDracManager(RedfishManager):
         # opening a fresh TLS connection per request wedges fragile BMCs.
         session = self._http_session()
 
+        get_kwargs = {"verify": self._is_verify_cert, "timeout": timeout}
         if self.x_auth is not None:
             headers.update({'X-Auth-Token': self.x_auth})
-            return session.get(
-                req, verify=self._is_verify_cert, headers=headers, timeout=timeout
-            )
         else:
-            return session.get(
-                req, verify=self._is_verify_cert,
-                auth=(self._username, self._password), timeout=timeout
-            )
+            get_kwargs["auth"] = (self._username, self._password)
+
+        # CLIENT span for the BMC call (no-op unless tracing is enabled); the BMC
+        # renders as one inferred downstream service via peer.service.
+        with tracing.client_span(req, "GET") as span:
+            try:
+                response = session.get(req, headers=headers, **get_kwargs)
+            except Exception as exc:  # timeout / connection error → failed span
+                tracing.record_exception(span, exc)
+                raise
+            tracing.record_response(span, response.status_code)
+            return response
 
     def sync_invoke(self, api_call: ApiRequestType, name: str, **kwargs) -> CommandResult:
         """Synchronous invocation of target command
@@ -431,7 +438,12 @@ class IDracManager(RedfishManager):
                 "is_http": self._is_http,
             }
         )
-        return self.invoke(api_call, name, **kwargs)
+        # Operation root span named by the command (no-op unless tracing is on);
+        # nested sync_invoke calls nest under it to form the trace waterfall.
+        with tracing.operation_span(name) as span:
+            result = self.invoke(api_call, name, **kwargs)
+            tracing.record_result(span, result)
+            return result
 
     def get_job(self,
                 job_id: str,

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -29,6 +29,7 @@ from .redfish_exceptions import (
 )
 from .redfish_query import RedfishQuery
 from .redfish_respond import RedfishRespondMessage
+from .telemetry import tracing
 from .redfish_respond_error import RedfishError
 from .redfish_shared import (
     RedfishApi,
@@ -254,20 +255,22 @@ class RedfishManager:
         # opening a fresh TLS connection per request wedges fragile BMCs.
         session = self._http_session()
 
+        get_kwargs = {"verify": self._is_verify_cert, "timeout": timeout}
         if self._x_auth is not None:
-            headers.update(
-                {
-                    'X-Auth-Token': self._x_auth
-                }
-            )
-            return session.get(
-                req, verify=self._is_verify_cert, headers=headers, timeout=timeout
-            )
+            headers.update({'X-Auth-Token': self._x_auth})
         else:
-            return session.get(
-                req, verify=self._is_verify_cert,
-                auth=(self._username, self._password), timeout=timeout
-            )
+            get_kwargs["auth"] = (self._username, self._password)
+
+        # CLIENT span for the BMC call (no-op unless tracing is enabled). The BMC
+        # renders as one inferred downstream service via peer.service in tracing.
+        with tracing.client_span(req, "GET") as span:
+            try:
+                response = session.get(req, headers=headers, **get_kwargs)
+            except Exception as exc:  # timeout / connection error → failed span
+                tracing.record_exception(span, exc)
+                raise
+            tracing.record_response(span, response.status_code)
+            return response
 
     def get_with_query(
             self, req: str,

--- a/redfish_ctl/telemetry/tracing.py
+++ b/redfish_ctl/telemetry/tracing.py
@@ -1,0 +1,118 @@
+"""Optional OpenTelemetry tracing for redfish_ctl (off by default).
+
+Emits spans so BMC operations render in an OTLP APM backend (for example Splunk
+APM) as a service map + trace waterfall:
+
+* ``sync_invoke`` wraps each command in an operation root span named by the
+  command, with status taken from the returned ``CommandResult.error``.
+* ``api_get_call`` (and, later, the write verbs) wrap each BMC HTTP call in a
+  ``SpanKind.CLIENT`` span. The BMC is uninstrumented, so an APM backend infers
+  it as a downstream service from ``peer.service`` — set to the constant
+  ``"bmc"`` so a whole fleet collapses into one downstream node, sliced by tag
+  rather than exploding into one node per address.
+
+The module is a no-op and does not import the OpenTelemetry SDK until tracing is
+explicitly enabled, so the default install and the offline test suite are
+unaffected and pay zero cost.
+
+Author Mus <spyroot@gmail.com>
+"""
+from __future__ import annotations
+
+import contextlib
+from typing import Any, Iterator, Optional
+from urllib.parse import urlsplit
+
+# Set by enable_tracing(); None means tracing is off and every helper no-ops.
+_TRACER: Any = None
+
+# The single downstream node name for every BMC. Setting peer.service (not just
+# server.address) is what makes an APM backend render one inferred "bmc" node
+# instead of one node per BMC IP.
+BMC_PEER_SERVICE = "bmc"
+
+
+def enable_tracing(tracer: Any) -> None:
+    """Turn tracing on with a ready OpenTelemetry tracer (or off with None)."""
+    global _TRACER
+    _TRACER = tracer
+
+
+def disable_tracing() -> None:
+    """Turn tracing off (used by tests to restore the default no-op state)."""
+    global _TRACER
+    _TRACER = None
+
+
+def is_enabled() -> bool:
+    """True when a tracer is installed."""
+    return _TRACER is not None
+
+
+@contextlib.contextmanager
+def operation_span(name: str) -> Iterator[Any]:
+    """Root/parent span for one command operation. No-op when tracing is off."""
+    if _TRACER is None:
+        yield None
+        return
+    from opentelemetry.trace import SpanKind
+
+    with _TRACER.start_as_current_span(name, kind=SpanKind.INTERNAL) as span:
+        yield span
+
+
+@contextlib.contextmanager
+def client_span(url: str, method: str) -> Iterator[Any]:
+    """CLIENT span for one BMC HTTP call. No-op when tracing is off.
+
+    The BMC becomes an inferred downstream service via ``peer.service``.
+    """
+    if _TRACER is None:
+        yield None
+        return
+    from opentelemetry.trace import SpanKind
+
+    host = urlsplit(url).hostname or ""
+    with _TRACER.start_as_current_span(
+        "redfish.bmc.request", kind=SpanKind.CLIENT
+    ) as span:
+        span.set_attribute("peer.service", BMC_PEER_SERVICE)
+        if host:
+            span.set_attribute("server.address", host)
+        span.set_attribute("http.request.method", method)
+        yield span
+
+
+def record_response(span: Any, status_code: Optional[int]) -> None:
+    """Attach the HTTP status to a CLIENT span; mark ERROR on a 4xx/5xx."""
+    if span is None or status_code is None:
+        return
+    from opentelemetry.trace import Status, StatusCode
+
+    span.set_attribute("http.response.status_code", int(status_code))
+    if int(status_code) >= 400:
+        span.set_status(Status(StatusCode.ERROR, f"HTTP {status_code}"))
+        span.set_attribute("error.type", f"http_{status_code}")
+
+
+def record_exception(span: Any, exc: BaseException) -> None:
+    """Mark a span failed from a transport exception (timeout, connect error)."""
+    if span is None:
+        return
+    from opentelemetry.trace import Status, StatusCode
+
+    span.record_exception(exc)
+    span.set_status(Status(StatusCode.ERROR, str(exc)))
+    span.set_attribute("error.type", type(exc).__name__)
+
+
+def record_result(span: Any, result: Any) -> None:
+    """Mark an operation span failed when its CommandResult carries an error."""
+    if span is None:
+        return
+    error = getattr(result, "error", None)
+    if error:
+        from opentelemetry.trace import Status, StatusCode
+
+        span.set_status(Status(StatusCode.ERROR, str(error)))
+        span.set_attribute("error.type", "command_error")

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,120 @@
+"""Offline tests for the optional OpenTelemetry tracing scaffold.
+
+A command run through ``sync_invoke`` should, when tracing is enabled, emit an
+operation root span named by the command plus a ``SpanKind.CLIENT`` span per BMC
+HTTP call. The CLIENT span carries ``peer.service="bmc"`` so an APM backend
+renders the BMC as one inferred downstream node. With tracing disabled (the
+default) commands must behave exactly as before and emit nothing.
+
+These use an in-memory span exporter — no collector, no network — and skip
+cleanly when the OpenTelemetry SDK (the ``[otlp]`` extra) is not installed.
+
+Author Mus <spyroot@gmail.com>
+"""
+import pytest
+
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.telemetry import tracing
+
+
+@pytest.fixture
+def span_exporter():
+    """Install an in-memory tracer for the duration of one test."""
+    pytest.importorskip("opentelemetry.sdk.trace")
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracing.enable_tracing(provider.get_tracer("redfish_ctl.test"))
+    try:
+        yield exporter
+    finally:
+        tracing.disable_tracing()
+
+
+def test_command_emits_operation_root_and_client_bmc_spans(span_exporter, redfish_mock):
+    """One command yields its operation span plus CLIENT spans to the BMC.
+
+    This is the whole feature on the smallest surface: the operation appears in
+    an APM service map as ``redfish-ctl -> bmc`` (via peer.service) with a
+    waterfall.
+    """
+    result = redfish_mock.sync_invoke(ApiRequestType.SystemQuery, "system_query")
+    assert isinstance(result, CommandResult)
+
+    spans = span_exporter.get_finished_spans()
+    names = [s.name for s in spans]
+
+    # Operation root span, named by the command.
+    assert "system_query" in names
+
+    # At least one CLIENT span representing a BMC HTTP call.
+    client_spans = [s for s in spans if s.name == "redfish.bmc.request"]
+    assert client_spans, f"no CLIENT bmc spans among {names}"
+
+    attrs = dict(client_spans[0].attributes)
+    # peer.service is the make-or-break attribute: it collapses all BMCs into
+    # one inferred downstream node instead of one node per address.
+    assert attrs.get("peer.service") == "bmc"
+    assert attrs.get("http.request.method") == "GET"
+    assert "server.address" in attrs
+
+
+def test_client_span_is_child_of_the_operation_span(span_exporter, redfish_mock):
+    """CLIENT bmc spans nest under the operation span (the waterfall shape)."""
+    redfish_mock.sync_invoke(ApiRequestType.SystemQuery, "system_query")
+    spans = span_exporter.get_finished_spans()
+
+    by_id = {s.context.span_id: s for s in spans}
+    op = next(s for s in spans if s.name == "system_query")
+    client = next(s for s in spans if s.name == "redfish.bmc.request")
+
+    # Walk the parent chain from the client span up to the operation span.
+    node = client
+    seen = set()
+    while node is not None and node.parent is not None and node.context.span_id not in seen:
+        seen.add(node.context.span_id)
+        node = by_id.get(node.parent.span_id)
+        if node is not None and node.context.span_id == op.context.span_id:
+            break
+    assert node is not None and node.context.span_id == op.context.span_id
+
+
+def test_disabled_tracing_emits_nothing_and_still_works(redfish_mock):
+    """The default (no tracer) path runs the command and records no spans."""
+    pytest.importorskip("opentelemetry.sdk.trace")
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    # Deliberately do NOT enable_tracing — the default no-op state.
+    tracing.disable_tracing()
+
+    result = redfish_mock.sync_invoke(ApiRequestType.SystemQuery, "system_query")
+    assert isinstance(result, CommandResult)
+    assert exporter.get_finished_spans() == ()
+
+
+def test_helpers_are_noop_without_a_tracer():
+    """The span helpers must be safe to call with tracing off."""
+    tracing.disable_tracing()
+    assert tracing.is_enabled() is False
+    with tracing.operation_span("x") as span:
+        assert span is None
+    with tracing.client_span("https://10.0.0.1/redfish/v1/", "GET") as span:
+        assert span is None
+    # record_* on a None span must not raise.
+    tracing.record_response(None, 500)
+    tracing.record_exception(None, RuntimeError("x"))
+    tracing.record_result(None, CommandResult(None, None, None, "err"))


### PR DESCRIPTION
## Summary
First slice of trace visibility (design: `.internal/design-notes/splunk-apm-traces/`, validated against Splunk's inferred-services + MetricSet docs). Makes a redfish_ctl operation render in an OTLP APM backend as **service map `redfish-ctl → bmc` + trace waterfall**, on the smallest surface.

- New `redfish_ctl/telemetry/tracing.py`: no-op-by-default helpers. `operation_span` (root, named by command) and `client_span` (per BMC HTTP call). The BMC is an **inferred downstream service** via `peer.service="bmc"` — the make-or-break attribute that collapses a whole fleet into one node instead of one-node-per-IP. Does not import the OTel SDK until enabled → zero cost for the default install and the offline suite.
- Two wrap points, no per-command edits: `sync_invoke` → operation root span (status from `CommandResult.error`); `api_get_call` (the IDracManager override — the one commands actually use) → CLIENT span with `peer.service`/`server.address`/`http.request.method`, ERROR on 4xx/5xx or transport exception.

## Tests
- New `tests/test_tracing.py` with an in-memory span exporter (no collector/network; skips without the `[otlp]` extra): asserts a command emits its operation root span + a CLIENT `redfish.bmc.request` child with `peer.service="bmc"`; that the CLIENT span nests under the operation span; that disabled tracing emits nothing and the command still works; and that the helpers no-op safely with no tracer.
- Full offline suite: **936 passed**; round-trip budget unchanged (tracing adds zero requests when off); ruff clean.

## Follow-ups (queued)
PR2 firmware/bios operation span trees; PR3 the indexed Tag Spotlight attribute set (vendor/action/profile — TMS-cardinality-aware); PR4 the k8s reconcile-lifecycle spans (fail/retry/wait); the OTLP span-export wiring reuses the corrected endpoint handling.