### PR TITLE
Wire --otlp-traces flag and document streaming to Splunk

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ See [Docker Images](docker/README.md) for the image contract and Linux test imag
 
 ## Connect
 
-The CLI reads these environment variables in `redfish_main.py`, so I set them once per shell:
+The CLI reads these environment variables in `redfish_main.py`; set them once per shell:
 
 ```bash
 export REDFISH_IP=10.0.0.42
@@ -230,7 +230,7 @@ covered by offline fixture corpora, with HPE also covered by the opt-in emulator
 ## Mutating Commands
 
 Some commands change real hardware: power, BIOS, boot order, storage conversion, virtual media,
-firmware update, and manager reset. I always read current state first, preview when the command has
+firmware update, and manager reset. Read current state first, preview when the command has
 `--show` or `--dry_run`, then verify after the job or task completes.
 
 ```bash
@@ -241,6 +241,42 @@ redfish_ctl firmware-update --image_uri https://example.invalid/firmware.exe --d
 
 Use `--confirm` only when you mean to perform a guarded action such as `system-reset` or
 `firmware-update`.
+
+## Observability with Splunk
+
+`redfish_ctl` streams what it does to Splunk Observability APM (or any OTLP backend) so a fleet of
+BMCs — and the operations run against them — are visible with no agent on the host and no code in the
+firmware. Full guide: [Observability](docs/observability.md).
+
+### Telemetry (metrics)
+
+The exporter turns out-of-band hardware state (power, thermal, fans, GPU, leak detection, fabric)
+into the stable `hw.*` metric family and pushes it over native OTLP. One exporter streams one BMC;
+scale by running more. See [Telemetry Exporter](docs/telemetry-exporter.md).
+
+```bash
+redfish_ctl exporter --output otlp --once
+```
+
+### Traces and spans
+
+Every command opens an operation span (`bios-change`, `firmware-update`, `reboot`), and every BMC
+call becomes a `CLIENT` span tagged `peer.service=bmc` — so the fleet renders in APM as a
+`redfish-ctl → bmc` service map with a trace waterfall, and per-operation error rate and latency in
+Tag Spotlight (sliceable by vendor, action, and profile). Failed writes show up red, so a failed BIOS
+apply or a slow firmware flash is one glance away.
+
+### Quick start — up and streaming in three commands
+
+```bash
+pip install "redfish-ctl[otlp]"
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://<collector-or-ingest>:4317"
+export OTEL_EXPORTER_OTLP_HEADERS="X-SF-Token=<splunk-access-token>"   # token via env, never argv
+redfish_ctl --otlp-traces system      # appears in APM as redfish-ctl → bmc
+```
+
+For Kubernetes (one exporter pod per BMC, the operator reconciling profiles, all streaming to an
+in-cluster Collector) see the [Kubernetes guide](k8s/README.md) and the Helm chart under `charts/`.
 
 ## Troubleshooting
 
@@ -266,6 +302,9 @@ First-run problems are almost always the connection, not the command:
 - [BIOS profiles](docs/bios-profiles.md) - low-latency, Dell System Profile, custom, Intel, and AMD
   profile examples.
 - [Vendors](docs/vendors.md) - Dell, Supermicro, HPE, and generic Redfish support.
+- [Observability](docs/observability.md) - stream BMC operations to Splunk APM as traces and metrics.
+- [Telemetry Exporter](docs/telemetry-exporter.md) - the `hw.*` metric exporter and deployment model.
+- [Simulation and replay](docs/simulation-and-replay.md) - the hardware-free mock and mutation replay.
 - [Testing](docs/testing.md) - offline mock tests, vendor corpora, emulator tests, and live-test safety.
 - [Docker](docker/README.md) - production image and Linux offline-test image usage.
 - [Fixture capture](docs/fixture-capture.md) - crawl a BMC with `discovery`, sanitize it, and contribute it as a vendor corpus.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,98 @@
+# Observability: streaming BMC operations to Splunk (and any OTLP backend)
+
+Author: Mus <spyroot@gmail.com>
+
+`redfish_ctl` emits OpenTelemetry **metrics** and **traces** over OTLP, so a fleet of server BMCs —
+and the operations run against them — become visible in Splunk Observability APM (or any OTLP
+backend: Grafana Tempo/Mimir, an OpenTelemetry Collector, etc.). No agent on the host, no code in the
+firmware; everything is read out-of-band over the Redfish API and shipped as standard telemetry.
+
+## What problem this addresses
+
+At fleet scale (hundreds to thousands of servers, each with a different tuning profile) a platform
+team mutates BMCs constantly — tuning BIOS, upgrading firmware, setting boot order, remediating
+drift — usually through a k8s operator. Without telemetry, that activity is invisible: which node's
+BIOS apply failed, which vendor's firmware flash is slow, which reconcile is stuck waiting on a
+reboot. `redfish_ctl` turns every read and every mutation into a span, so that activity shows up as a
+normal APM service map + trace waterfall + per-operation error/latency breakdown.
+
+## Who it is for
+
+- Platform / infrastructure teams operating bare-metal fleets from Kubernetes.
+- SREs who already run Splunk APM (or an OTel Collector) and want bare-metal lifecycle operations in
+  the same pane as their applications.
+- Anyone driving BMC mutations (BIOS/firmware/boot/power) who needs to see success rate, latency, and
+  the failing step across a fleet.
+
+## How it works
+
+```mermaid
+flowchart LR
+    subgraph driver["redfish_ctl (CLI, exporter, or k8s operator)"]
+      op["operation span\n(bios-change, firmware-update, reboot)"]
+      cli["CLIENT span\nredfish.bmc.request\npeer.service=bmc"]
+      op --> cli
+    end
+    cli -->|Redfish HTTPS| bmc[("BMC\n(Dell / HPE / Supermicro /\nNVIDIA / Cisco / Lenovo)")]
+    driver -->|OTLP spans + hw.* metrics| col["OpenTelemetry\nCollector"]
+    col -->|OTLP| splunk["Splunk Observability APM"]
+    splunk --> map["Service map\nredfish-ctl → bmc"]
+    splunk --> wf["Trace waterfall\n(which step, how long)"]
+    splunk --> tag["Tag Spotlight\nby vendor / action / profile"]
+```
+
+Two signals, one pipeline:
+
+- **Traces.** Each command run through the engine opens an **operation span** named by the command
+  (`firmware-update`, `bios-change`, `reboot`). Every BMC HTTP call inside it opens a `SpanKind.CLIENT`
+  span (`redfish.bmc.request`) carrying `peer.service="bmc"`. Because the BMC is uninstrumented, Splunk
+  infers it as a single downstream service node — so a whole fleet renders as `redfish-ctl → bmc`, not
+  one node per address. Failures set the span to ERROR (from the HTTP status or `CommandResult.error`),
+  which drives the red edges, error rate, and Root Cause in APM. See the span model in
+  [`.internal/design-notes/splunk-apm-traces/`] (design notes) and the code in
+  `redfish_ctl/telemetry/tracing.py`.
+- **Metrics.** The exporter samples hardware state (power, thermal, fans, GPU, leak detection, fabric)
+  into the stable `hw.*` metric family. Traces say *what operation ran and whether it failed*; metrics
+  say *what the hardware did* — a firmware-update span sits next to the `hw.power` spike it caused,
+  correlated by node in the same tenant. See [Telemetry Exporter](telemetry-exporter.md).
+
+At fleet scale the group-by dimensions (Splunk Tag Spotlight) stay low-cardinality on purpose —
+`vendor`, `model`, `action`, `profile`, `firmware.component` are indexed; per-node identifiers
+(`bmc.ip`, `node`, `task_id`) stay as searchable span attributes but are **not** indexed, to stay
+within the Troubleshooting MetricSet cardinality budget.
+
+## Quick start — stream to Splunk in three commands
+
+Install with the OTLP extra, point at your collector (or Splunk OTLP endpoint), and run any command
+with tracing on:
+
+```bash
+# 1. install with the OpenTelemetry extra
+pip install "redfish-ctl[otlp]"
+
+# 2. point at your OTLP collector / Splunk (token via env, never on argv)
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://<your-collector-or-ingest>:4317"
+export OTEL_EXPORTER_OTLP_HEADERS="X-SF-Token=<your-splunk-access-token>"
+
+# 3. run any operation with tracing enabled
+redfish_ctl --otlp-traces system            # a read; shows redfish-ctl → bmc in the service map
+redfish_ctl --otlp-traces reboot --dry_run   # a guarded mutation, previewed
+```
+
+Within seconds the operation appears in APM: a `redfish-ctl → bmc` service map, a trace waterfall of
+the BMC calls, and per-operation error/latency in Tag Spotlight. Metrics stream the same way via the
+exporter:
+
+```bash
+redfish_ctl exporter --output otlp --once     # one scrape of hw.* metrics to the same endpoint
+```
+
+For a **k8s deployment** (one exporter pod per BMC, the operator reconciling profiles, all streaming
+to an in-cluster Collector), see the [Kubernetes guide](../k8s/README.md) and the Helm chart under
+`charts/`.
+
+## Try it with zero hardware
+
+The mock BMC serves the committed GB300 corpus over HTTP and can replay mutations, so the full
+read-and-mutate path — and the traces it produces — can be exercised with no real BMC. See
+[Simulation and replay](simulation-and-replay.md).

--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -346,6 +346,11 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
     if insecure:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
+    # Optional OTLP span pipeline for this run; no-op unless --otlp-traces is set.
+    if getattr(cmd_args, "otlp_traces", False):
+        from .telemetry import tracing
+        tracing.setup_otlp("redfish-ctl")
+
     # idrac manager main interface main uses to interact with IDRAC.
     redfish_api = IDracManager(idrac_ip=cmd_args.idrac_ip,
                                idrac_username=cmd_args.idrac_username,
@@ -579,6 +584,11 @@ def redfish_main_ctl():
     verbose_group.add_argument(
         '--log', required=False, default=logging.NOTSET,
         help="log level.")
+    verbose_group.add_argument(
+        '--otlp-traces', action='store_true', required=False, default=False,
+        dest="otlp_traces",
+        help="emit OpenTelemetry spans for this run over OTLP "
+             "(honours OTEL_EXPORTER_OTLP_*; needs the [otlp] extra).")
 
     # controls for output
     output_controllers = parser.add_argument_group('output', '# output controller options')

--- a/redfish_ctl/telemetry/tracing.py
+++ b/redfish_ctl/telemetry/tracing.py
@@ -38,6 +38,46 @@ def enable_tracing(tracer: Any) -> None:
     _TRACER = tracer
 
 
+def setup_otlp(service_name: str = "redfish-ctl") -> None:
+    """Install an OTLP span pipeline and enable tracing.
+
+    Builds a ``TracerProvider`` + ``BatchSpanProcessor`` + ``OTLPSpanExporter``
+    and turns tracing on. The exporter resolves its endpoint from the standard
+    ``OTEL_EXPORTER_OTLP_*`` environment itself, so the ``/v1/traces`` path is
+    appended correctly for a generic endpoint (do not pre-pass one here).
+
+    Requires the OpenTelemetry SDK + OTLP exporter (the ``[otlp]`` extra);
+    raises a clear error otherwise. ``service.name`` becomes the APM service
+    map node.
+    """
+    try:
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError as exc:  # pragma: no cover - exercised via the CLI path
+        raise RuntimeError(
+            "OTLP tracing needs the OpenTelemetry SDK. Install redfish_ctl[otlp]."
+        ) from exc
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+            OTLPSpanExporter,
+        )
+    except ImportError:  # fall back to the HTTP exporter if grpc is absent
+        try:
+            from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+                OTLPSpanExporter,
+            )
+        except ImportError as exc:  # pragma: no cover - exercised via the CLI path
+            raise RuntimeError(
+                "OTLP tracing needs an OpenTelemetry OTLP exporter. "
+                "Install redfish_ctl[otlp]."
+            ) from exc
+
+    provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    enable_tracing(provider.get_tracer("redfish_ctl"))
+
+
 def disable_tracing() -> None:
     """Turn tracing off (used by tests to restore the default no-op state)."""
     global _TRACER


### PR DESCRIPTION
## Summary
Completes the trace path so the quickstart actually works, and documents it.
- `tracing.setup_otlp()`: builds TracerProvider + BatchSpanProcessor + OTLPSpanExporter; endpoint resolved from `OTEL_EXPORTER_OTLP_*` by the SDK (so `/v1/traces` is appended for a generic endpoint — the correct pattern, not the pre-passed-endpoint bug). Clear error if the `[otlp]` exporter is absent.
- `--otlp-traces` global flag installs it before dispatch; off by default.
- `docs/observability.md`: overview, problem space, target group, a mermaid architecture diagram, the span model, and a three-command quick start (pip install [otlp] → set OTEL endpoint/token → `redfish_ctl --otlp-traces system`).
- README `## Observability with Splunk` section (Telemetry + Traces subsections + quickstart); doc links added; two pre-existing first-person lines cleaned.

## Validation
- `--otlp-traces` appears in `--help`; `setup_otlp` builds a pipeline with the SDK and raises a clear install hint without the exporter.
- Tracing tests green; full offline suite 936 passed; ruff clean.