### PR TITLE
Add simulated 36-BMC GB300 fleet StatefulSet

### DIFF
--- a/docker/Dockerfile.mock-bmc
+++ b/docker/Dockerfile.mock-bmc
@@ -10,9 +10,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     MOCK_BMC_CORPUS_DIR=/corpus/172.25.230.37
 
-RUN groupadd --system mockbmc \
+# Pin a numeric uid/gid so Kubernetes can verify runAsNonRoot without a
+# runAsUser override (a named user cannot be checked at admission).
+RUN groupadd --system --gid 10001 mockbmc \
     && useradd \
         --system \
+        --uid 10001 \
         --gid mockbmc \
         --home-dir /home/mockbmc \
         --create-home \

--- a/k8s/sandbox/gb300-fleet.yaml
+++ b/k8s/sandbox/gb300-fleet.yaml
@@ -1,0 +1,92 @@
+# Simulated NV72 GB300 fleet: 36 mock BMCs (18 servers x 2 racks) from ONE corpus image.
+#
+# Each pod serves the committed GB300 Redfish corpus (baked into the image layer,
+# no per-pod copy) and overlays a distinct identity derived from its StatefulSet
+# ordinal, so inventory reads report a unique node (GB300-R<rack>-S<slot>) and an
+# APM backend sees 36 distinct servers behind the one inferred "bmc" service.
+#
+# Reads only in this manifest; the mutation path (write replay) is added with the
+# fleet's replay-trace ConfigMap in a follow-up. Deploy into the sandbox namespace.
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gb300-bmc
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: gb300-bmc
+    app.kubernetes.io/component: fleet-sim
+spec:
+  clusterIP: None            # headless: each pod gets a stable DNS name
+  selector:
+    app.kubernetes.io/name: gb300-bmc
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: gb300-bmc
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: gb300-bmc
+    app.kubernetes.io/component: fleet-sim
+spec:
+  serviceName: gb300-bmc
+  replicas: 36              # 18 slots x 2 racks; scale this to simulate a larger fleet
+  podManagementPolicy: Parallel
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gb300-bmc
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gb300-bmc
+        app.kubernetes.io/component: fleet-sim
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001        # matches the image's pinned mockbmc uid
+        runAsGroup: 10001
+      containers:
+        - name: mock-bmc
+          image: redfish-ctl-mock-bmc:local
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          # Derive rack/slot from the StatefulSet ordinal (pod name ends -<ordinal>)
+          # and inject them so the mock overlays a distinct identity per pod.
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              ORD="${HOSTNAME##*-}"
+              export MOCK_BMC_RACK=$(( ORD / 18 + 1 ))
+              export MOCK_BMC_SLOT=$(( ORD % 18 + 1 ))
+              exec python /app/mock_bmc_server.py --corpus-dir "$MOCK_BMC_CORPUS_DIR"
+          env:
+            - name: MOCK_BMC_CORPUS_DIR
+              value: /corpus/172.25.230.37
+          readinessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          # A static-JSON http.server is tiny; keep requests low so 36 pods fit
+          # on one kind node (36 x 16Mi = ~576Mi total requested).
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -252,10 +252,17 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
             return
 
         replay = self._replay_state()
-        overlay = replay.overlay_for(self.path) if replay is not None else {}
-        if overlay:
+        replay_overlay = replay.overlay_for(self.path) if replay is not None else {}
+        identity = getattr(type(self), "identity_overlay", {})
+        identity_overlay = identity.get(
+            _normalize_request_path(self.path).lower(), {}
+        )
+        if replay_overlay or identity_overlay:
             payload = json.loads(fixture.read_text(encoding="utf-8"))
-            _deep_update(payload, overlay)
+            if identity_overlay:
+                _deep_update(payload, identity_overlay)
+            if replay_overlay:
+                _deep_update(payload, replay_overlay)
             content = json.dumps(payload, sort_keys=True).encode("utf-8")
         else:
             content = fixture.read_bytes()
@@ -374,6 +381,30 @@ def _deep_update(target: dict[str, Any], overlay: dict[str, Any]) -> None:
             target[key] = value
 
 
+def identity_overlay_from_env() -> dict[str, dict[str, Any]]:
+    """Per-pod identity overlay from ``MOCK_BMC_RACK`` / ``MOCK_BMC_SLOT``.
+
+    Lets one committed corpus image serve as many DISTINCT BMCs: each pod
+    overlays its own serial and name onto the System and Manager resources so
+    inventory reads report a unique node (``GB300-R<rack>-S<slot>``). Only
+    non-structural fields are overlaid — never ``Id`` or ``@odata.id``, which
+    the link-walk depends on. Returns an empty overlay when neither env var is
+    set, so a single-node sandbox is unchanged.
+    """
+    rack = os.environ.get("MOCK_BMC_RACK", "").strip()
+    slot = os.environ.get("MOCK_BMC_SLOT", "").strip()
+    if not rack and not slot:
+        return {}
+    node = f"GB300-R{rack or '0'}-S{(slot or '0').zfill(2)}"
+    return {
+        "/redfish/v1/systems/system_0": {"SerialNumber": node, "Name": node},
+        "/redfish/v1/managers/bmc_0": {
+            "SerialNumber": node,
+            "Name": f"{node}-BMC",
+        },
+    }
+
+
 def make_handler(
     corpus_dir: Path,
     replay_trace: Path | None = None,
@@ -393,6 +424,7 @@ def make_handler(
         if replay_trace is not None
         else None
     )
+    Handler.identity_overlay = identity_overlay_from_env()
     return Handler
 
 

--- a/tests/test_gb300_fleet_manifests.py
+++ b/tests/test_gb300_fleet_manifests.py
@@ -1,0 +1,96 @@
+"""Offline contract tests for the simulated GB300 fleet (36 mock BMCs).
+
+These validate the fleet manifest and the mock's per-pod identity overlay
+without a cluster or a live BMC — the ordinal→rack/slot math, the 36-replica
+StatefulSet shape, and that different ordinals produce distinct node
+identities from the single committed corpus image.
+
+Author Mus <spyroot@gmail.com>
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLEET_MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "gb300-fleet.yaml"
+MOCK_SERVER = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+
+def _load_mock_module():
+    """Import the mock server module directly (it lives outside the package)."""
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", MOCK_SERVER)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _docs():
+    return [d for d in yaml.safe_load_all(FLEET_MANIFEST.read_text(encoding="utf-8")) if d]
+
+
+def test_fleet_is_a_36_replica_statefulset_with_a_headless_service():
+    """The fleet is one StatefulSet of 36 pods behind a headless Service."""
+    by_kind = {d["kind"]: d for d in _docs()}
+
+    service = by_kind["Service"]
+    assert service["spec"]["clusterIP"] == "None"      # headless → stable per-pod DNS
+    assert service["metadata"]["name"] == "gb300-bmc"
+
+    sts = by_kind["StatefulSet"]
+    assert sts["spec"]["replicas"] == 36               # 18 slots x 2 racks
+    assert sts["spec"]["serviceName"] == "gb300-bmc"
+    pod_spec = sts["spec"]["template"]["spec"]
+    container = pod_spec["containers"][0]
+    assert container["ports"][0]["containerPort"] == 8080
+    assert container["securityContext"]["readOnlyRootFilesystem"] is True
+    # Numeric runAsUser so runAsNonRoot is verifiable at admission (a named
+    # image user cannot be checked); must match the image's pinned uid.
+    assert pod_spec["securityContext"]["runAsNonRoot"] is True
+    assert pod_spec["securityContext"]["runAsUser"] == 10001
+    # Memory request stays small so 36 pods fit on one kind node.
+    assert container["resources"]["requests"]["memory"] == "16Mi"
+    # Corpus comes from the image layer, not a per-pod volume copy.
+    assert "volumeClaimTemplates" not in sts["spec"]
+    assert not pod_spec.get("volumes")
+
+
+def test_container_derives_rack_and_slot_from_the_ordinal():
+    """The startup command injects MOCK_BMC_RACK/SLOT from the pod ordinal."""
+    sts = next(d for d in _docs() if d["kind"] == "StatefulSet")
+    args = sts["spec"]["template"]["spec"]["containers"][0]["args"][0]
+    assert "MOCK_BMC_RACK" in args and "MOCK_BMC_SLOT" in args
+    assert "ORD" in args and "HOSTNAME" in args
+
+
+def test_identity_overlay_is_empty_without_env(monkeypatch):
+    """A single-node sandbox (no rack/slot env) is unchanged — no overlay."""
+    module = _load_mock_module()
+    monkeypatch.delenv("MOCK_BMC_RACK", raising=False)
+    monkeypatch.delenv("MOCK_BMC_SLOT", raising=False)
+    assert module.identity_overlay_from_env() == {}
+
+
+def test_identity_overlay_gives_distinct_nodes_per_ordinal(monkeypatch):
+    """Different rack/slot produce distinct serials/names — 36 nodes, one corpus."""
+    module = _load_mock_module()
+
+    monkeypatch.setenv("MOCK_BMC_RACK", "1")
+    monkeypatch.setenv("MOCK_BMC_SLOT", "1")
+    a = module.identity_overlay_from_env()
+
+    monkeypatch.setenv("MOCK_BMC_RACK", "2")
+    monkeypatch.setenv("MOCK_BMC_SLOT", "18")
+    b = module.identity_overlay_from_env()
+
+    sys_key = "/redfish/v1/systems/system_0"
+    assert a[sys_key]["SerialNumber"] == "GB300-R1-S01"
+    assert b[sys_key]["SerialNumber"] == "GB300-R2-S18"
+    assert a[sys_key]["SerialNumber"] != b[sys_key]["SerialNumber"]
+    # Never overlays structural fields that the link-walk depends on.
+    assert "Id" not in a[sys_key] and "@odata.id" not in a[sys_key]
+    # The manager resource also gets a distinct identity.
+    mgr_key = "/redfish/v1/managers/bmc_0"
+    assert a[mgr_key]["Name"] == "GB300-R1-S01-BMC"


### PR DESCRIPTION
## Summary
First slice of the GB300 fleet simulation (design: `.internal/design-notes/gb300-fleet-sim/`, Pro-designed + reviewed). One corpus image serves **36 distinct mock BMCs** (18 slots x 2 racks) so an APM backend sees a real-looking fleet with zero hardware.

- `k8s/sandbox/gb300-fleet.yaml` — 36-replica StatefulSet + headless Service; each pod derives rack/slot from its ordinal and injects `MOCK_BMC_RACK/SLOT`. Corpus read from the image layer (no per-pod volume copy).
- `mock_bmc_server.py` — `identity_overlay_from_env()`: overlays a distinct `SerialNumber`/`Name` (`GB300-R<rack>-S<slot>`) onto System_0 and BMC_0; never touches `Id`/`@odata.id` (link-walk safe). Empty overlay without the env, so single-node sandbox is unchanged.
- Pin the mock image to uid 10001 + `runAsUser` so `runAsNonRoot` is verifiable at admission.

## Pro critical review applied
- Memory request 48Mi → 16Mi (36 pods fit one kind node).
- Pinned uid / runAsUser (a named image user cannot be verified for runAsNonRoot).
- Deferred (follow-up): overlay identity onto the primary Chassis too.

## Tests
- New `tests/test_gb300_fleet_manifests.py`: 36-replica shape, ordinal→rack/slot injection, distinct-per-ordinal identity, link-walk-safe overlay, runAsUser, bounded memory. Offline (no kind/Splunk).
- Existing mock-server + sandbox tests still green (19 passed together); full suite 940 passed; ruff clean.

## Next
Splunk streaming + OTel Collector + `make fleet-sim`, and the mutation path via SIM2 write-trace ConfigMap.