### PR TITLE
Fix duplicate CLI subcommand names that break the parser on Python 3.11+

### DIFF
--- a/redfish_ctl/compute/cmd_update.py
+++ b/redfish_ctl/compute/cmd_update.py
@@ -11,21 +11,9 @@ Author Mus spyroot@gmail.com
 from abc import abstractmethod
 from typing import Optional
 
-from ..redfish_manager import CommandResult
-
-from ..cmd_exceptions import InvalidJsonSpec
-from ..cmd_utils import from_json_spec
-from ..idrac_shared import IdracApiRespond
-from ..redfish_shared import RedfishJson
-from ..cmd_utils import str2bool
-from ..idrac_shared import IdracApiRespond, ResetType
-from ..cmd_utils import save_if_needed
-from ..cmd_exceptions import InvalidArgument
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond, Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
-from ..idrac_shared import IDRAC_API
-from ..idrac_shared import IdracApiRespond
 
 
 class UpdateCompute(IDracManager,
@@ -47,8 +35,11 @@ class UpdateCompute(IDracManager,
         :return:
         """
         cmd_parser = cls.base_parser()
-        help_text = "command query compute settings."
-        return cmd_parser, "compute-query", help_text
+        help_text = "command update compute settings."
+        # Distinct from QueryCompute's "compute-query": a duplicate subcommand
+        # name silently clobbers dispatch on Python 3.10 and raises
+        # argparse.ArgumentError when the parser is built on 3.11+.
+        return cmd_parser, "compute-update", help_text
 
     def execute(self,
                 filename: Optional[str] = None,

--- a/redfish_ctl/system/cmd_system_one_time_boot.py
+++ b/redfish_ctl/system/cmd_system_one_time_boot.py
@@ -1,9 +1,11 @@
-"""iDRAC import system config from json file.
+"""iDRAC set a one-time boot device via a system-configuration import.
 
-Command provides the option to import configuration.
+Sends an ImportSystemConfiguration request whose buffer enables BootOnce and
+selects the first boot device, then optionally reboots. Distinct from the
+general ``system-import`` command, which imports the SCP file supplied by
+``--config`` verbatim.
 
-python redfish_ctl.py system-export --filename system.json
-python redfish_ctl.py system-import --config system.json
+python redfish_ctl.py system-onetime-boot --config system.json
 
 Author Mus spyroot@gmail.com
 """
@@ -12,10 +14,9 @@ from abc import abstractmethod
 from pathlib import Path
 from typing import Optional
 
-from ..cmd_exceptions import InvalidArgument
-from ..cmd_exceptions import PostRequestFailed
+from ..cmd_exceptions import InvalidArgument, PostRequestFailed
 from ..idrac_manager import IDracManager
-from ..idrac_shared import Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
 
 
@@ -57,8 +58,11 @@ class ImportOneTimeBoot(
                                   "Default and minimum value is 300 seconds. "
                                   "Maximum value is 3600 seconds..")
 
-        help_text = "command import system configuration"
-        return cmd_arg, "system-import", help_text
+        help_text = "command set a one-time boot device via system-config import"
+        # Distinct from ImportSystemConfig's "system-import": a shared subcommand
+        # name silently clobbers dispatch on Python 3.10 and raises
+        # argparse.ArgumentError when the parser is built on 3.11+.
+        return cmd_arg, "system-onetime-boot", help_text
 
     def execute(self,
                 config: str,
@@ -111,7 +115,7 @@ class ImportOneTimeBoot(
 
         path_config = Path(config).expanduser().resolve()
         if not path_config.is_file():
-            raise InvalidArgument(f"Invalid path to a config file.")
+            raise InvalidArgument("Invalid path to a config file.")
 
         buf = "<SystemConfiguration>""<Component FQDD=\"iDRAC.Embedded.1\">" \
               "<Attribute Name=\"ServerBoot.1#BootOnce\">Enabled</Attribute>" \

--- a/tests/test_cli_subcommand_uniqueness.py
+++ b/tests/test_cli_subcommand_uniqueness.py
@@ -1,0 +1,58 @@
+"""CLI subcommand-name uniqueness guard.
+
+Two commands that register the same argparse subcommand name are a latent
+bug: on Python 3.10 the second registration silently clobbers the first
+(one command becomes unreachable and dispatch is import-order dependent),
+and on Python 3.11+ building the parser raises ``argparse.ArgumentError:
+conflicting subparser``. That version-dependent split let a real duplicate
+(`compute-query` claimed by both ComputeQuery/query and ComputeUpdate/update)
+sit on main while the 3.10 CI leg stayed green.
+
+These tests detect the collision directly from the command registry so it is
+caught on every interpreter, not only 3.11+.
+
+Author Mus <spyroot@gmail.com>
+"""
+import argparse
+
+import redfish_ctl  # noqa: F401  — populates the registry with the wired commands
+import redfish_ctl.compute.cmd_update  # noqa: F401  — force-load the un-wired update cmd
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.redfish_main import create_cmd_tree
+
+
+def _registered_subcommand_names():
+    """Map each CLI subcommand name to the registry entries that claim it."""
+    registry = IDracManager().get_registry()
+    names = {}
+    for type_key in registry:
+        for sub_key in registry[type_key]:
+            cls = registry[type_key][sub_key]
+            if hasattr(cls, "register_subcommand"):
+                _, cmd_name, _ = cls.register_subcommand(cls)
+                names.setdefault(cmd_name, []).append(f"{type_key}/{sub_key}")
+    return names
+
+
+def test_no_two_commands_share_a_cli_subcommand_name():
+    """Every registered command must own a unique CLI subcommand name."""
+    names = _registered_subcommand_names()
+    duplicates = {name: owners for name, owners in names.items() if len(owners) > 1}
+    assert not duplicates, f"duplicate CLI subcommand names: {duplicates}"
+
+
+def test_compute_query_and_compute_update_are_distinct():
+    """The compute read and update commands keep separate subcommand names."""
+    names = _registered_subcommand_names()
+    assert "compute-query" in names
+    assert "compute-update" in names
+    assert names["compute-query"] != names["compute-update"]
+
+
+def test_full_parser_builds_without_conflict():
+    """create_cmd_tree assembles every subparser (raises on 3.11+ if duplicated)."""
+    parser = argparse.ArgumentParser(prog="redfish_ctl")
+    mapping = create_cmd_tree(parser)
+    # A well-formed tree maps each unique subcommand name to exactly one command.
+    assert "compute-update" in mapping
+    assert len(mapping) == len(set(mapping))


### PR DESCRIPTION
## Problem

Two pairs of distinct commands each registered the **same** argparse
subcommand name:

| Subcommand | Registered by |
| --- | --- |
| `compute-query` | `ComputeQuery/query` **and** `ComputeUpdate/update` |
| `system-import` | `ImportSystem` **and** `ImportOneTimeBoot` |

`redfish_main.create_cmd_tree` keys both the argparse subparser and the
CLI→command dispatch map on the name returned by `register_subcommand`, so a
duplicate name means:

- **Python 3.10:** the second `add_parser(name)` silently clobbers the first,
  so one command becomes unreachable and dispatch is import-order dependent.
- **Python 3.11+:** building the full parser raises
  `argparse.ArgumentError: conflicting subparser`, crashing any code path that
  assembles the command tree.

The offline suite stayed green only because the 3.10 CI leg tolerates the
collision and no existing test built the full parser on 3.11+.

## Fix

- Rename the update command's subcommand `compute-query` → `compute-update`
  (its own tests already document it as `compute-update`).
- Rename the one-time-boot command's subcommand `system-import` →
  `system-onetime-boot`, and correct its copy-pasted docstring/help so it no
  longer masquerades as the general SCP import.
- Add `tests/test_cli_subcommand_uniqueness.py`: a registry guard that fails
  on **any** duplicate subcommand name on every interpreter (independent of
  the 3.11+ argparse raise), plus a full-parser build smoke test.

Both renamed commands were only reachable via direct `ApiRequestType`
dispatch in tests (neither is wired into `__init__.py`'s CLI import list), so
no existing test asserts the old CLI strings — nothing else changes.

## Verification

- `pytest -q` → 959 passed, 58 skipped (local, Python 3.10).
- `ruff check` clean on all changed files (also cleaned pre-existing unused
  imports in the two touched modules).