### PR TITLE
Harden the k8s e2e: fix reconcile status warnings, chart CRD drift, weak gate

### DIFF
--- a/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
+++ b/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -17,6 +18,16 @@ spec:
       storage: true
       subresources:
         status: {}
+      additionalPrinterColumns:
+        - name: POWER
+          type: string
+          jsonPath: .status.powerState
+        - name: HEALTH
+          type: string
+          jsonPath: .status.health
+        - name: POLLED
+          type: date
+          jsonPath: .status.lastPolled
       schema:
         openAPIV3Schema:
           type: object
@@ -29,7 +40,9 @@ spec:
                 address:
                   type: string
                   minLength: 1
-                  description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                  description: >-
+                    BMC hostname, IP address, or URL for the Redfish
+                    ServiceRoot.
                 port:
                   type: integer
                   minimum: 1
@@ -39,7 +52,9 @@ spec:
                 insecure:
                   type: boolean
                   default: true
-                  description: Skip TLS certificate verification for self-signed BMC certificates.
+                  description: >-
+                    Skip TLS certificate verification for self-signed BMC
+                    certificates.
                 pollInterval:
                   type: string
                   default: 30s
@@ -53,7 +68,9 @@ spec:
                     name:
                       type: string
                       minLength: 1
-                      description: Secret in the same namespace containing BMC login data.
+                      description: >-
+                        Secret in the same namespace containing BMC login
+                        data.
                     usernameKey:
                       type: string
                       default: username
@@ -62,8 +79,6 @@ spec:
                       type: string
                       default: password
                       description: Secret data key containing the BMC password.
-                  additionalProperties: false
-              additionalProperties: false
             status:
               type: object
               properties:
@@ -82,8 +97,6 @@ spec:
                     maxCelsius:
                       type: number
                       nullable: true
-                  additionalProperties: false
                 lastPolled:
                   type: string
                   format: date-time
-              additionalProperties: false

--- a/charts/redfish-controller/crds/redfish-node-profile-crd.yaml
+++ b/charts/redfish-controller/crds/redfish-node-profile-crd.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -35,7 +36,9 @@ spec:
                     address:
                       type: string
                       minLength: 1
-                      description: BMC hostname, IP address, or URL for the Redfish ServiceRoot.
+                      description: >-
+                        BMC hostname, IP address, or URL for the Redfish
+                        ServiceRoot.
                     port:
                       type: integer
                       minimum: 1
@@ -45,7 +48,9 @@ spec:
                     insecure:
                       type: boolean
                       default: true
-                      description: Skip TLS certificate verification for self-signed BMC certificates.
+                      description: >-
+                        Skip TLS certificate verification for self-signed BMC
+                        certificates.
                     secretRef:
                       type: object
                       required:
@@ -54,24 +59,28 @@ spec:
                         name:
                           type: string
                           minLength: 1
-                          description: Secret in the same namespace containing BMC login data.
+                          description: >-
+                            Secret in the same namespace containing BMC login
+                            data.
                         usernameKey:
                           type: string
                           default: username
-                          description: Secret data key containing the BMC username.
+                          description: >-
+                            Secret data key containing the BMC username.
                         passwordKey:
                           type: string
                           default: password
-                          description: Secret data key containing the BMC password.
-                      additionalProperties: false
-                  additionalProperties: false
+                          description: >-
+                            Secret data key containing the BMC password.
                 desiredState:
                   type: object
                   properties:
                     biosProfile:
                       type: string
                       nullable: true
-                      description: Named BIOS profile to diff or stage through the reconciler.
+                      description: >-
+                        Named BIOS profile to diff or stage through the
+                        reconciler.
                     ntp:
                       type: object
                       properties:
@@ -83,7 +92,6 @@ spec:
                         managerId:
                           type: string
                           nullable: true
-                      additionalProperties: false
                     boot:
                       type: object
                       properties:
@@ -96,24 +104,30 @@ spec:
                         uefiTarget:
                           type: string
                           nullable: true
-                      additionalProperties: false
                     reboot:
                       type: object
                       properties:
                         resetType:
                           type: string
                           nullable: true
-                      additionalProperties: false
-                  additionalProperties: false
                 approve:
                   type: boolean
                   default: false
-                  description: Required approval gate before any desired-state changes are applied.
+                  description: >-
+                    Deprecated standing approval flag; use approvedPlanHash
+                    for one-shot applies.
+                approvedPlanHash:
+                  type: string
+                  nullable: true
+                  description: >-
+                    Current status.planHash value approved for exactly one
+                    apply attempt.
                 waitForReboot:
                   type: boolean
                   default: false
-                  description: Wait for the BMC to answer again after an approved reboot step.
-              additionalProperties: false
+                  description: >-
+                    Wait for the BMC to answer again after an approved reboot
+                    step.
             status:
               type: object
               properties:
@@ -121,6 +135,12 @@ spec:
                   type: boolean
                 drift:
                   type: boolean
+                  nullable: true
+                planHash:
+                  type: string
+                  nullable: true
+                consumedPlanHash:
+                  type: string
                   nullable: true
                 plannedSteps:
                   type: array
@@ -140,7 +160,6 @@ spec:
                       preview:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    additionalProperties: false
                 appliedChanges:
                   type: array
                   items:
@@ -156,7 +175,6 @@ spec:
                       result:
                         type: object
                         x-kubernetes-preserve-unknown-fields: true
-                    additionalProperties: false
                 conditions:
                   type: array
                   items:
@@ -182,8 +200,6 @@ spec:
                       lastTransitionTime:
                         type: string
                         format: date-time
-                    additionalProperties: false
                 lastReconciled:
                   type: string
                   format: date-time
-              additionalProperties: false

--- a/k8s/controller/redfish_endpoint_controller.py
+++ b/k8s/controller/redfish_endpoint_controller.py
@@ -192,15 +192,21 @@ def poll_redfish_endpoint(
     logger: Any | None = None,
     patch: MutableMapping[str, Any] | None = None,
     **_: Any,
-) -> dict[str, Any]:
-    """Kopf callback that updates only the RedfishEndpoint status subresource."""
+) -> None:
+    """Kopf callback that updates only the RedfishEndpoint status subresource.
+
+    Status is written through the injected ``patch`` object; the handler
+    returns ``None`` on purpose. Returning a value makes kopf persist it under
+    ``status.poll_redfish_endpoint``, a field the structural CRD schema
+    rejects, which surfaces a "merge-patching finished with inconsistencies"
+    warning on every poll.
+    """
     credentials = load_secret_credentials(namespace, spec.get("secretRef"))
     status = poll_endpoint(spec, credentials=credentials)
     if patch is not None:
         patch.setdefault("status", {}).update(status)
     if logger is not None:
         logger.info("polled RedfishEndpoint %s/%s", namespace or "", name or "")
-    return {"status": status}
 
 
 if kopf is not None:  # pragma: no cover - decorator wiring is runtime-only.

--- a/k8s/controller/redfish_node_profile_controller.py
+++ b/k8s/controller/redfish_node_profile_controller.py
@@ -365,8 +365,15 @@ def reconcile_redfish_node_profile(
     logger: Any | None = None,
     patch: MutableMapping[str, Any] | None = None,
     **_: Any,
-) -> dict[str, Any]:
-    """Kopf callback that updates only the RedfishNodeProfile status subresource."""
+) -> None:
+    """Kopf callback that updates only the RedfishNodeProfile status subresource.
+
+    Status is written through the injected ``patch`` object; the handler
+    returns ``None`` on purpose. Returning a value makes kopf persist it under
+    ``status.reconcile_redfish_node_profile``, a field the structural CRD
+    schema rejects, which surfaces a "merge-patching finished with
+    inconsistencies" warning on every reconcile.
+    """
     endpoint = _mapping(spec.get("endpoint"))
     credentials = load_secret_credentials(namespace, endpoint.get("secretRef"))
     try:
@@ -381,7 +388,6 @@ def reconcile_redfish_node_profile(
         patch.setdefault("status", {}).update(status)
     if logger is not None:
         logger.info("reconciled RedfishNodeProfile %s/%s", namespace or "", name or "")
-    return {"status": status}
 
 
 if kopf is not None:  # pragma: no cover - decorator wiring is runtime-only.

--- a/k8s/sandbox/run-sandbox.sh
+++ b/k8s/sandbox/run-sandbox.sh
@@ -76,8 +76,20 @@ wait_for_endpoint() {
 				-o 'jsonpath={.status.powerState}' 2>/dev/null || true
 		)"
 		if [ -n "$power_state" ]; then
-			printf 'RedfishEndpoint %s powerState=%s\n' "$endpoint_name" "$power_state"
-			return 0
+			case "$power_state" in
+			On | Off | PoweringOn | PoweringOff | Paused)
+				printf 'RedfishEndpoint %s powerState=%s\n' \
+					"$endpoint_name" "$power_state"
+				return 0
+				;;
+			*)
+				# A populated but non-Redfish value means the controller
+				# wrote garbage; fail instead of passing on any non-empty string.
+				printf 'RedfishEndpoint %s reported invalid powerState=%s\n' \
+					"$endpoint_name" "$power_state" >&2
+				return 1
+				;;
+			esac
 		fi
 		sleep 5
 	done
@@ -87,6 +99,38 @@ wait_for_endpoint() {
 	kubectl_sandbox -n "${NAMESPACE}" get redfishendpoint "$endpoint_name" \
 		-o yaml || true
 	return 1
+}
+
+assert_corpus_status() {
+	# The corpus-mock backend is deterministic: the committed GB300 system_0
+	# reports health OK and a non-empty thermal set. Assert the controller
+	# surfaced those, not just that some status was written.
+	local endpoint_name="$1"
+	local health temp_count
+
+	health="$(
+		kubectl_sandbox -n "${NAMESPACE}" \
+			get redfishendpoint "$endpoint_name" \
+			-o 'jsonpath={.status.health}' 2>/dev/null || true
+	)"
+	temp_count="$(
+		kubectl_sandbox -n "${NAMESPACE}" \
+			get redfishendpoint "$endpoint_name" \
+			-o 'jsonpath={.status.temperature.count}' 2>/dev/null || true
+	)"
+
+	if [ "$health" != "OK" ]; then
+		printf 'RedfishEndpoint %s expected health=OK, got %s\n' \
+			"$endpoint_name" "$health" >&2
+		return 1
+	fi
+	if ! [ "$temp_count" -ge 1 ] 2>/dev/null; then
+		printf 'RedfishEndpoint %s expected temperature.count>=1, got %s\n' \
+			"$endpoint_name" "$temp_count" >&2
+		return 1
+	fi
+	printf 'RedfishEndpoint %s status verified: health=%s temperature.count=%s\n' \
+		"$endpoint_name" "$health" "$temp_count"
 }
 
 validate_backends
@@ -166,6 +210,7 @@ kubectl_sandbox -n "${NAMESPACE}" \
 section "waiting for RedfishEndpoint status"
 if has_backend "corpus-mock"; then
 	wait_for_endpoint gb300-mock
+	assert_corpus_status gb300-mock
 fi
 if has_backend "ilo-sim"; then
 	wait_for_endpoint ilo-sim

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -184,7 +184,7 @@ def test_poll_endpoint_reads_gb300_corpus_without_mutating_requests() -> None:
 
 
 def test_kopf_handler_patches_status_only(monkeypatch) -> None:
-    """The resource handler returns a status patch and never mutates the BMC."""
+    """The handler writes status through the kopf patch, returns None, never mutates."""
     module = _load_controller_module()
     calls: list[tuple[dict, dict]] = []
 
@@ -199,14 +199,20 @@ def test_kopf_handler_patches_status_only(monkeypatch) -> None:
 
     monkeypatch.setattr(module, "poll_endpoint", fake_poll_endpoint)
 
-    patch = module.poll_redfish_endpoint(
+    patch: dict = {}
+    result = module.poll_redfish_endpoint(
         spec={"address": "mock-bmc", "secretRef": {"name": "bmc-login"}},
         body={},
         namespace="default",
         name="node-a",
         logger=None,
+        patch=patch,
     )
 
+    # Status is applied via the injected patch; the handler returns None so kopf
+    # does not persist a result under a status field the structural CRD rejects
+    # (the source of the "merge-patching inconsistencies" warning every poll).
+    assert result is None
     assert patch == {
         "status": {
             "powerState": "On",

--- a/tests/test_k8s_crd_chart_sync.py
+++ b/tests/test_k8s_crd_chart_sync.py
@@ -1,0 +1,92 @@
+"""Guard: the Helm chart CRDs must not drift from the controller CRDs.
+
+The controller manifests in ``k8s/controller/*-crd.yaml`` are the single source
+of truth. The Helm chart ships its own copies under
+``charts/redfish-controller/crds/``; if they drift, a ``helm install`` provisions
+a different API contract than the raw sandbox does. That already bit the
+node-profile CRD once: the chart copy omitted ``spec.approvedPlanHash`` and
+``status.planHash``/``status.consumedPlanHash`` while keeping a structural
+schema, so the API server would have rejected the operator's approval field and
+pruned the status fields the controller depends on — silently breaking one-shot
+approval on any chart-based deploy.
+
+These tests assert the functional API surface (group, scope, names,
+subresources, the openAPIV3 schema, and printer columns) is identical between
+each controller CRD and its chart copy, so drift fails CI instead of a cluster.
+
+Author Mus <spyroot@gmail.com>
+"""
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+CRD_PAIRS = [
+    (
+        REPO_ROOT / "k8s" / "controller" / "redfish-endpoint-crd.yaml",
+        REPO_ROOT / "charts" / "redfish-controller" / "crds" / "redfish-endpoint-crd.yaml",
+    ),
+    (
+        REPO_ROOT / "k8s" / "controller" / "redfish-node-profile-crd.yaml",
+        REPO_ROOT / "charts" / "redfish-controller" / "crds" / "redfish-node-profile-crd.yaml",
+    ),
+]
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _api_surface(crd: dict) -> dict:
+    """The parts of a CRD that define its runtime API contract."""
+    spec = crd["spec"]
+    return {
+        "group": spec["group"],
+        "scope": spec["scope"],
+        "names": spec["names"],
+        "versions": [
+            {
+                "name": v["name"],
+                "served": v.get("served"),
+                "storage": v.get("storage"),
+                "subresources": v.get("subresources"),
+                "schema": v["schema"],
+                "printerColumns": v.get("additionalPrinterColumns", []),
+            }
+            for v in spec["versions"]
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "controller_crd, chart_crd",
+    CRD_PAIRS,
+    ids=[p[0].stem for p in CRD_PAIRS],
+)
+def test_chart_crd_matches_controller_crd(controller_crd: Path, chart_crd: Path) -> None:
+    """Each chart CRD exposes the exact API contract of the controller CRD."""
+    controller = _api_surface(_load(controller_crd))
+    chart = _api_surface(_load(chart_crd))
+    assert chart == controller, (
+        f"{chart_crd.relative_to(REPO_ROOT)} drifted from "
+        f"{controller_crd.relative_to(REPO_ROOT)} — regenerate the chart CRD from "
+        f"the controller CRD (single source of truth)."
+    )
+
+
+def test_node_profile_chart_crd_keeps_the_approval_fields() -> None:
+    """Regression: the chart node-profile CRD must carry the plan-hash approval fields."""
+    chart = _load(CRD_PAIRS[1][1])
+    schema = chart["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]
+    assert "approvedPlanHash" in schema["spec"]["properties"], (
+        "spec.approvedPlanHash missing — a structural schema would reject the "
+        "operator's approval field, breaking gated mutations on helm install."
+    )
+    status_props = schema["status"]["properties"]
+    assert "planHash" in status_props and "consumedPlanHash" in status_props, (
+        "status.planHash/consumedPlanHash missing — the controller reads "
+        "consumedPlanHash to avoid re-applying; pruning it breaks one-shot approval."
+    )

--- a/tests/test_k8s_node_profile_controller.py
+++ b/tests/test_k8s_node_profile_controller.py
@@ -280,7 +280,8 @@ def test_kopf_handler_reports_reconciler_load_errors_as_status(monkeypatch) -> N
 
     monkeypatch.setattr(module, "reconcile_profile", fake_reconcile_profile)
 
-    patch = module.reconcile_redfish_node_profile(
+    patch: dict = {}
+    result = module.reconcile_redfish_node_profile(
         spec={
             "endpoint": {"address": "mock-bmc"},
             "desiredState": {"biosProfile": "gb300-power-capped"},
@@ -289,8 +290,12 @@ def test_kopf_handler_reports_reconciler_load_errors_as_status(monkeypatch) -> N
         namespace="default",
         name="node-a",
         logger=None,
+        patch=patch,
     )
 
+    # Status is applied via the injected patch; the handler returns None so kopf
+    # does not persist a result under a status field the structural CRD rejects.
+    assert result is None
     assert patch["status"]["dryRun"] is True
     assert patch["status"]["drift"] is None
     conditions = {item["type"]: item for item in patch["status"]["conditions"]}


### PR DESCRIPTION
Three defects surfaced by running the Kubernetes sandbox end to end in a local kind cluster (`make k8s-sandbox`). All three are fixed here and validated live.

## 1. kopf reconcile logged a merge-patch inconsistency on every poll

Both controllers wrote status through the kopf `patch` object **and** did `return {"status": status}`. kopf persists any non-`None` handler result under `status.<handler_id>`; the structural CRD schema has no such field, so the API server strips it and kopf logs `Merge-patching finished with inconsistencies … ('remove', ('status', 'poll_redfish_endpoint'), …)` on every 30s tick.

Fix: write status only through `patch` and `return None`. The handler tests now inject a `patch` mapping (as kopf does at runtime) and assert on it — a more faithful test than the old return-value assertion.

**Live proof:** after restarting the controller with the fix, `kubectl logs | grep -c inconsistencies` → `0` (was one per poll), and the CR status still reconciles to `powerState=On, health=OK, temperature.count=56`.

## 2. Helm chart CRDs had drifted from the controller CRDs (breaks gated mutations)

The chart's node-profile CRD omitted `spec.approvedPlanHash` and `status.planHash`/`status.consumedPlanHash` while keeping a structural schema. On a `helm install` the API server would **reject** the operator's approval field and **prune** the status fields the controller reads to avoid re-applying — silently breaking one-shot approval. The chart endpoint CRD had also dropped the `POWER/HEALTH/POLLED` printer columns.

Fix: sync the chart CRDs from `k8s/controller/*-crd.yaml` (single source of truth) and add `tests/test_k8s_crd_chart_sync.py`, which asserts the chart CRDs' full API surface (group, scope, names, subresources, schema, printer columns) matches the controller CRDs — so drift fails CI instead of a cluster.

## 3. The e2e success gate was too weak

`run-sandbox.sh` passed on **any** non-empty `.status.powerState`, so a controller writing garbage would still pass. Now it requires a valid Redfish power state (`On/Off/PoweringOn/PoweringOff/Paused`) and, for the deterministic corpus backend, asserts `health=OK` and `temperature.count>=1`.

**Live proof:** `RedfishEndpoint gb300-mock powerState=On` / `status verified: health=OK temperature.count=56`.

## Verification
- `pytest -q` offline suite green (controllers, new CRD-sync guard, helm-chart, sandbox harness: 33 passed in the touched set; full suite green).
- `ruff` + `shellcheck` clean on changed files.
- Full `make k8s-sandbox` re-run in a kind cluster exits 0 with the strengthened assertions.