### PR TITLE
Add an order-independent mutation-rules mode to the mock BMC

### DIFF
--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import fnmatch
 import json
 import os
 import sys
@@ -77,97 +78,27 @@ def _body_contains(actual: Any, expected: Any) -> bool:
     return actual == expected
 
 
-class ReplayState:
-    """Ordered write replay with in-memory state overlays for corpus reads."""
+class _OverlayStore:
+    """Shared corpus-overlay + state-transition machinery for write engines.
 
-    def __init__(self, trace: dict[str, Any]) -> None:
-        self.scenario = str(trace.get("scenario") or "default")
-        steps = trace.get("steps") or []
-        if not isinstance(steps, list):
-            raise ValueError("replay trace steps must be a list")
-        self.steps = steps
-        self._matched: set[int] = set()
+    Both the ordered ``ReplayState`` and the order-independent ``MutationRules``
+    build the same kind of in-memory overlay: a per-resource dict that is
+    deep-merged onto the corpus fixture at read time and mutated by
+    ``state_transitions`` (``op`` = set/delete, ``path`` = resource,
+    ``field``/``json_path`` = key, ``value``).
+    """
+
+    def __init__(self) -> None:
         self._overlays: dict[str, dict[str, Any]] = {}
         self._lock = threading.Lock()
-
-    @classmethod
-    def from_file(cls, trace_path: Path) -> "ReplayState":
-        return cls(_load_trace(trace_path))
-
-    def status(self) -> dict[str, Any]:
-        with self._lock:
-            pending = [
-                str(step.get("name") or f"step-{index}")
-                for index, step in enumerate(self.steps)
-                if index not in self._matched
-            ]
-            matched_steps = len(self._matched)
-        return {
-            "scenario": self.scenario,
-            "matched_steps": matched_steps,
-            "pending_steps": pending,
-            "total_steps": len(self.steps),
-            "complete": not pending,
-        }
-
-    def reset(self, scenario: str | None = None) -> bool:
-        if scenario is not None and scenario != self.scenario:
-            return False
-        with self._lock:
-            self._matched.clear()
-            self._overlays.clear()
-        return True
 
     def overlay_for(self, request_path: str) -> dict[str, Any]:
         path = _normalize_request_path(request_path)
         with self._lock:
             return copy.deepcopy(self._overlays.get(path, {}))
 
-    def match_write(
-        self,
-        method: str,
-        request_path: str,
-        body: Any,
-    ) -> dict[str, Any] | None:
-        path = _normalize_request_path(request_path)
-        with self._lock:
-            next_index = self._next_pending_index()
-            if next_index is None:
-                return None
-            step = self.steps[next_index]
-            if not self._matches(step, method, path, body):
-                return None
-            self._matched.add(next_index)
-            self._apply_transitions(step.get("state_transitions") or [])
-            response = step.get("response") or {}
-            return response if isinstance(response, dict) else {"status": 204}
-
-    def _next_pending_index(self) -> int | None:
-        for index in range(len(self.steps)):
-            if index not in self._matched:
-                return index
-        return None
-
-    @staticmethod
-    def _matches(
-        step: dict[str, Any],
-        method: str,
-        path: str,
-        body: Any,
-    ) -> bool:
-        if str(step.get("method", "")).upper() != method.upper():
-            return False
-        if _normalize_request_path(str(step.get("path", ""))) != path:
-            return False
-        if "body" in step and body != step["body"]:
-            return False
-        if "body_contains" in step and not _body_contains(
-            body, step["body_contains"]
-        ):
-            return False
-        return True
-
     def _apply_transitions(self, transitions: list[Any]) -> None:
+        # Callers hold ``self._lock``; this only mutates ``self._overlays``.
         for transition in transitions:
             if not isinstance(transition, dict):
                 continue
@@ -216,6 +147,225 @@ class ReplayState:
         cursor.pop(parts[-1], None)
 
 
+class ReplayState(_OverlayStore):
+    """Ordered write replay with in-memory state overlays for corpus reads."""
+
+    def __init__(self, trace: dict[str, Any]) -> None:
+        super().__init__()
+        self.scenario = str(trace.get("scenario") or "default")
+        steps = trace.get("steps") or []
+        if not isinstance(steps, list):
+            raise ValueError("replay trace steps must be a list")
+        self.steps = steps
+        self._matched: set[int] = set()
+
+    @classmethod
+    def from_file(cls, trace_path: Path) -> "ReplayState":
+        return cls(_load_trace(trace_path))
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            pending = [
+                str(step.get("name") or f"step-{index}")
+                for index, step in enumerate(self.steps)
+                if index not in self._matched
+            ]
+            matched_steps = len(self._matched)
+        return {
+            "scenario": self.scenario,
+            "matched_steps": matched_steps,
+            "pending_steps": pending,
+            "total_steps": len(self.steps),
+            "complete": not pending,
+        }
+
+    def reset(self, scenario: str | None = None) -> bool:
+        if scenario is not None and scenario != self.scenario:
+            return False
+        with self._lock:
+            self._matched.clear()
+            self._overlays.clear()
+        return True
+
+    def match_write(
+        self,
+        method: str,
+        request_path: str,
+        body: Any,
+        corpus_state: Any = None,
+    ) -> dict[str, Any] | None:
+        path = _normalize_request_path(request_path)
+        with self._lock:
+            next_index = self._next_pending_index()
+            if next_index is None:
+                return None
+            step = self.steps[next_index]
+            if not self._matches(step, method, path, body):
+                return None
+            self._matched.add(next_index)
+            self._apply_transitions(step.get("state_transitions") or [])
+            response = step.get("response") or {}
+            return response if isinstance(response, dict) else {"status": 204}
+
+    def _next_pending_index(self) -> int | None:
+        for index in range(len(self.steps)):
+            if index not in self._matched:
+                return index
+        return None
+
+    @staticmethod
+    def _matches(
+        step: dict[str, Any],
+        method: str,
+        path: str,
+        body: Any,
+    ) -> bool:
+        if str(step.get("method", "")).upper() != method.upper():
+            return False
+        if _normalize_request_path(str(step.get("path", ""))) != path:
+            return False
+        if "body" in step and body != step["body"]:
+            return False
+        if "body_contains" in step and not _body_contains(
+            body, step["body_contains"]
+        ):
+            return False
+        return True
+
+
+class MutationRules(_OverlayStore):
+    """Order-independent write rules keyed on (method, path, precondition).
+
+    Where ``ReplayState`` accepts only the next step of a fixed trace, every
+    rule here is evaluated against each write, so a controller may drive the
+    same mutations in any order (and repeatedly). A rule fires when the method
+    and normalized path match, its optional ``body_contains`` subset matches,
+    and every ``when`` precondition holds against the CURRENT effective state
+    (corpus fixture + overlays already applied). All matching rules apply their
+    ``state_transitions``; the first match's ``response`` is returned. This lets
+    conditional side effects compose — e.g. a reset both powers the system off
+    and, only when ``BootSourceOverrideEnabled == Once``, reverts the one-shot
+    boot.
+    """
+
+    def __init__(self, spec: dict[str, Any]) -> None:
+        super().__init__()
+        self.vendor = str(spec.get("vendor") or "generic")
+        rules = spec.get("rules") or []
+        if not isinstance(rules, list):
+            raise ValueError("mutation rules must be a list")
+        self.rules = rules
+        self._applied: list[str] = []
+
+    @classmethod
+    def from_file(cls, path: Path) -> "MutationRules":
+        return cls(_load_trace(path))
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "mode": "mutation-rules",
+                "vendor": self.vendor,
+                "total_rules": len(self.rules),
+                "applied": list(self._applied),
+            }
+
+    def reset(self, scenario: str | None = None) -> bool:
+        if scenario is not None and scenario != self.vendor:
+            return False
+        with self._lock:
+            self._overlays.clear()
+            self._applied.clear()
+        return True
+
+    def match_write(
+        self,
+        method: str,
+        request_path: str,
+        body: Any,
+        corpus_state: Any = None,
+    ) -> dict[str, Any] | None:
+        path = _normalize_request_path(request_path)
+        corpus_lookup = corpus_state if callable(corpus_state) else (lambda _p: {})
+        with self._lock:
+            matched = [
+                rule
+                for rule in self.rules
+                if isinstance(rule, dict)
+                and self._rule_matches(rule, method, path, body, corpus_lookup)
+            ]
+            if not matched:
+                return None
+            for rule in matched:
+                self._apply_transitions(rule.get("state_transitions") or [])
+                self._applied.append(str(rule.get("name") or "unnamed"))
+            response = matched[0].get("response") or {}
+            return response if isinstance(response, dict) else {"status": 204}
+
+    def _effective_state(self, resource_path: str, corpus_lookup: Any) -> dict[str, Any]:
+        path = _normalize_request_path(resource_path)
+        base = copy.deepcopy(corpus_lookup(path) or {})
+        overlay = self._overlays.get(path)
+        if overlay:
+            _deep_update(base, overlay)
+        return base
+
+    def _rule_matches(
+        self,
+        rule: dict[str, Any],
+        method: str,
+        path: str,
+        body: Any,
+        corpus_lookup: Any,
+    ) -> bool:
+        if str(rule.get("method", "")).upper() != method.upper():
+            return False
+        rule_path = _normalize_request_path(str(rule.get("path", "")))
+        if any(ch in rule_path for ch in "*?["):
+            # A glob path-pattern matches a family of resources (e.g. every
+            # VirtualMedia slot) in one rule.
+            if not fnmatch.fnmatchcase(path, rule_path):
+                return False
+        elif rule_path != path:
+            return False
+        if "body" in rule and body != rule["body"]:
+            return False
+        if "body_contains" in rule and not _body_contains(body, rule["body_contains"]):
+            return False
+        for condition in rule.get("when") or []:
+            if not isinstance(condition, dict):
+                return False
+            if not self._precondition_holds(condition, corpus_lookup):
+                return False
+        return True
+
+    def _precondition_holds(self, condition: dict[str, Any], corpus_lookup: Any) -> bool:
+        resource_path = condition.get("path")
+        if not isinstance(resource_path, str):
+            return False
+        state = self._effective_state(resource_path, corpus_lookup)
+        keys = self._path_parts(condition.get("json_path", condition.get("field")))
+        cursor: Any = state
+        present = True
+        for key in keys:
+            if isinstance(cursor, dict) and key in cursor:
+                cursor = cursor[key]
+            else:
+                present = False
+                break
+        if "exists" in condition:
+            return present == bool(condition["exists"])
+        if "absent" in condition:
+            return present == (not bool(condition["absent"]))
+        if not present:
+            return False
+        if "equals" in condition:
+            return cursor == condition["equals"]
+        if "not_equals" in condition:
+            return cursor != condition["not_equals"]
+        return present
+
+
 class CorpusRequestHandler(BaseHTTPRequestHandler):
     """HTTP handler that serves a flattened Redfish corpus."""
 
@@ -229,8 +379,35 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
         key = "_" + path.strip("/").replace("/", "_") + ".json"
         return fixture_index.get(key.lower())
 
-    def _replay_state(self) -> ReplayState | None:
-        return getattr(type(self), "replay_state", None)
+    def _active_writer(self) -> "ReplayState | MutationRules | None":
+        """The write engine in effect (mutation-rules takes precedence)."""
+        return getattr(type(self), "mutation_rules", None) or getattr(
+            type(self), "replay_state", None
+        )
+
+    def _corpus_state(self, request_path: str) -> dict[str, Any]:
+        """Corpus fixture (+identity overlay) for a resource, for preconditions.
+
+        Deliberately excludes the write engine's own overlay: the engine holds
+        its lock and merges that overlay itself, so returning it here would
+        double-apply it (and risk re-entrancy on the engine lock).
+        """
+        fixture_index = getattr(type(self), "fixture_index")
+        path = _normalize_request_path(request_path)
+        if not path.startswith("/redfish/v1"):
+            return {}
+        key = "_" + path.strip("/").replace("/", "_") + ".json"
+        fixture = fixture_index.get(key.lower())
+        if fixture is None:
+            return {}
+        payload = json.loads(fixture.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            return {}
+        identity = getattr(type(self), "identity_overlay", {})
+        identity_overlay = identity.get(path.lower(), {})
+        if identity_overlay:
+            _deep_update(payload, identity_overlay)
+        return payload
 
     def _send_json(self, status: int, payload: dict[str, object]) -> None:
         content = json.dumps(payload, sort_keys=True).encode("utf-8")
@@ -251,8 +428,8 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
             self._send_json(404, {"error": f"no fixture for {self.path}"})
             return
 
-        replay = self._replay_state()
-        replay_overlay = replay.overlay_for(self.path) if replay is not None else {}
+        writer = self._active_writer()
+        replay_overlay = writer.overlay_for(self.path) if writer is not None else {}
         identity = getattr(type(self), "identity_overlay", {})
         identity_overlay = identity.get(
             _normalize_request_path(self.path).lower(), {}
@@ -275,11 +452,11 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
 
     def do_GET(self) -> None:
         if _normalize_request_path(self.path) == "/__replay_status":
-            replay = self._replay_state()
-            if replay is None:
+            writer = self._active_writer()
+            if writer is None:
                 self._send_json(404, {"error": "replay is not enabled"})
                 return
-            self._send_json(200, replay.status())
+            self._send_json(200, writer.status())
             return
         self._serve_fixture(send_body=True)
 
@@ -289,7 +466,7 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
     def do_OPTIONS(self) -> None:
         self.send_response(204)
         allow = "GET, HEAD, OPTIONS"
-        if self._replay_state() is not None:
+        if self._active_writer() is not None:
             allow = f"{allow}, POST, PATCH, PUT, DELETE"
         self.send_header("Allow", allow)
         self.send_header("Content-Length", "0")
@@ -318,8 +495,8 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
         return json.loads(content) if content else {}
 
     def _handle_set_scenario(self) -> None:
-        replay = self._replay_state()
-        if replay is None:
+        writer = self._active_writer()
+        if writer is None:
             self._send_json(404, {"error": "replay is not enabled"})
             return
         body = self._read_json_body()
@@ -327,26 +504,26 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
         if scenario is not None and not isinstance(scenario, str):
             self._send_json(400, {"error": "scenario must be a string"})
             return
-        if not replay.reset(scenario):
+        if not writer.reset(scenario):
             self._send_json(404, {"error": f"unknown scenario {scenario}"})
             return
-        self._send_json(200, replay.status())
+        self._send_json(200, writer.status())
 
     def _handle_replay_write(self, method: str) -> None:
-        replay = self._replay_state()
-        if replay is None:
+        writer = self._active_writer()
+        if writer is None:
             self._send_method_not_allowed()
             return
         body = self._read_json_body()
-        response = replay.match_write(method, self.path, body)
+        response = writer.match_write(method, self.path, body, self._corpus_state)
         if response is None:
             self._send_json(
                 409,
                 {
-                    "error": "request did not match the next replay step",
+                    "error": "no write rule matched the request",
                     "method": method,
                     "path": _normalize_request_path(self.path),
-                    "status": replay.status(),
+                    "status": writer.status(),
                 },
             )
             return
@@ -408,10 +585,13 @@ def identity_overlay_from_env() -> dict[str, dict[str, Any]]:
 def make_handler(
     corpus_dir: Path,
     replay_trace: Path | None = None,
+    mutation_rules: Path | None = None,
 ) -> type[CorpusRequestHandler]:
     root = Path(corpus_dir)
     if not root.is_dir():
         raise FileNotFoundError(f"corpus directory not found: {root}")
+    if replay_trace is not None and mutation_rules is not None:
+        raise ValueError("choose either --replay or --mutation-rules, not both")
 
     class Handler(CorpusRequestHandler):
         pass
@@ -424,6 +604,11 @@ def make_handler(
         if replay_trace is not None
         else None
     )
+    Handler.mutation_rules = (
+        MutationRules.from_file(mutation_rules)
+        if mutation_rules is not None
+        else None
+    )
     Handler.identity_overlay = identity_overlay_from_env()
     return Handler
 
@@ -434,10 +619,15 @@ def run_server(
     port: int,
     corpus_dir: Path,
     replay_trace: Path | None = None,
+    mutation_rules: Path | None = None,
 ) -> Iterator[ThreadingHTTPServer]:
     server = ThreadingHTTPServer(
         (host, port),
-        make_handler(corpus_dir, replay_trace=replay_trace),
+        make_handler(
+            corpus_dir,
+            replay_trace=replay_trace,
+            mutation_rules=mutation_rules,
+        ),
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -465,7 +655,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--replay",
         type=Path,
         default=None,
-        help="Optional write replay trace file.",
+        help="Optional ordered write-replay trace file (fixed step sequence).",
+    )
+    parser.add_argument(
+        "--mutation-rules",
+        type=Path,
+        default=None,
+        help="Optional order-independent mutation-rules file "
+        "(matches on method/path/precondition; applies writes in any order).",
     )
     return parser.parse_args(argv)
 
@@ -476,7 +673,11 @@ def main(argv: list[str] | None = None) -> int:
     try:
         server = ThreadingHTTPServer(
             (args.host, args.port),
-            make_handler(args.corpus_dir, replay_trace=args.replay),
+            make_handler(
+                args.corpus_dir,
+                replay_trace=args.replay,
+                mutation_rules=args.mutation_rules,
+            ),
         )
         host, port = server.server_address
         print(f"Serving Redfish corpus from {args.corpus_dir} on {host}:{port}")

--- a/tests/mutation_rules/supermicro_gb300.yaml
+++ b/tests/mutation_rules/supermicro_gb300.yaml
@@ -1,0 +1,117 @@
+# Order-independent mutation rules for the Supermicro GB300 (NVIDIA HGX) BMC.
+#
+# Consumed by the mock BMC server's MutationRules engine
+# (k8s/sandbox/mock_bmc_server.py, --mutation-rules). Unlike an ordered replay
+# trace, each rule is matched against every write on its own terms:
+#
+#   method         HTTP verb (POST/PATCH/PUT/DELETE)
+#   path           normalized Redfish path; may be an fnmatch glob (*, ?, [])
+#   body_contains  optional subset the request body must contain
+#   when           optional preconditions over the CURRENT effective state
+#                  (corpus fixture + overlays already applied); each is
+#                  {path, field|json_path, equals|not_equals|exists|absent}
+#   state_transitions  overlays applied on match, reusing the replay vocabulary
+#                      ({op: set|delete, path, field|json_path, value})
+#   response       {status, body?} returned to the caller (default 204)
+#
+# All matching rules apply, so conditional side effects compose: a reset both
+# powers the system down and, only when a one-time boot is armed, reverts it.
+# Every path/field below exists in tests/supermicro_gb300_corpus.
+#
+# The GB300 is a GPU compute node; its corpus has no Volumes collection or
+# clearable LogService, so storage-volume and log-clear classes are covered by
+# a vendor whose corpus has those resources (see the HPE rules).
+vendor: supermicro-gb300
+rules:
+  # --- power reset ---------------------------------------------------------
+  - name: power-off-on-forceoff
+    method: POST
+    path: /redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset
+    body_contains: {ResetType: ForceOff}
+    when:
+      - {path: /redfish/v1/Systems/System_0, field: PowerState, equals: "On"}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0, field: PowerState, value: "Off"}
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Status, State], value: "Disabled"}
+    response: {status: 204}
+
+  - name: power-on
+    method: POST
+    path: /redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset
+    body_contains: {ResetType: "On"}
+    when:
+      - {path: /redfish/v1/Systems/System_0, field: PowerState, equals: "Off"}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0, field: PowerState, value: "On"}
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Status, State], value: "Enabled"}
+    response: {status: 204}
+
+  # --- boot source override ------------------------------------------------
+  - name: boot-override-pxe-once
+    method: PATCH
+    path: /redfish/v1/Systems/System_0
+    body_contains: {Boot: {BootSourceOverrideTarget: Pxe, BootSourceOverrideEnabled: Once}}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Boot, BootSourceOverrideTarget], value: "Pxe"}
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Boot, BootSourceOverrideEnabled], value: "Once"}
+    response: {status: 200}
+
+  - name: boot-override-disable
+    method: PATCH
+    path: /redfish/v1/Systems/System_0
+    body_contains: {Boot: {BootSourceOverrideEnabled: Disabled}}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Boot, BootSourceOverrideEnabled], value: "Disabled"}
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Boot, BootSourceOverrideTarget], value: "None"}
+    response: {status: 200}
+
+  # --- one-time (boot-once) revert: a reset consumes an armed Once override --
+  - name: boot-once-revert-on-reset
+    method: POST
+    path: /redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset
+    when:
+      - {path: /redfish/v1/Systems/System_0, json_path: [Boot, BootSourceOverrideEnabled], equals: "Once"}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Boot, BootSourceOverrideEnabled], value: "Disabled"}
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Boot, BootSourceOverrideTarget], value: "None"}
+    response: {status: 204}
+
+  # --- BIOS pending + apply-on-reset ---------------------------------------
+  - name: bios-stage-above4g-disabled
+    method: PATCH
+    path: /redfish/v1/Systems/System_0/Bios/Settings
+    body_contains: {Attributes: {Above4GDecoding: Disabled}}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0/Bios/Settings, json_path: [Attributes, Above4GDecoding], value: "Disabled"}
+    response: {status: 200}
+
+  - name: bios-apply-pending-on-reset
+    method: POST
+    path: /redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset
+    when:
+      - {path: /redfish/v1/Systems/System_0/Bios/Settings, json_path: [Attributes, Above4GDecoding], equals: "Disabled"}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0/Bios, json_path: [Attributes, Above4GDecoding], value: "Disabled"}
+      - {op: delete, path: /redfish/v1/Systems/System_0/Bios/Settings, json_path: [Attributes, Above4GDecoding]}
+    response: {status: 204}
+
+  # --- virtual media insert / eject ----------------------------------------
+  - name: vmedia-insert-usb1
+    method: POST
+    path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1/Actions/VirtualMedia.InsertMedia
+    when:
+      - {path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: Inserted, equals: false}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: Inserted, value: true}
+      - {op: set, path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: ConnectedVia, value: "URI"}
+    response: {status: 204}
+
+  - name: vmedia-eject-usb1
+    method: POST
+    path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1/Actions/VirtualMedia.EjectMedia
+    when:
+      - {path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: Inserted, equals: true}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: Inserted, value: false}
+      - {op: delete, path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: Image}
+    response: {status: 204}

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -15,6 +16,7 @@ SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
 DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.mock-bmc"
 MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "mock-bmc.yaml"
 GRACEFUL_RESTART_TRACE = REPO_ROOT / "tests" / "write_traces" / "graceful_restart.yaml"
+SUPERMICRO_RULES = REPO_ROOT / "tests" / "mutation_rules" / "supermicro_gb300.yaml"
 GB300_CORPUS = (
     REPO_ROOT
     / "tests"
@@ -23,6 +25,12 @@ GB300_CORPUS = (
     / "172.25.230.37"
 )
 
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+BIOS = f"{SYSTEM}/Bios"
+BIOS_SETTINGS = f"{BIOS}/Settings"
+USB1 = "/redfish/v1/Managers/BMC_0/VirtualMedia/USB1"
+
 
 def _load_server_module():
     spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
@@ -30,6 +38,20 @@ def _load_server_module():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+def _http(base: str, path: str, method: str = "GET", body=None):
+    """Issue an HTTP request to the mock, returning (status, decoded-json-or-None)."""
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    request = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, (json.loads(raw) if raw else None)
 
 
 def test_mock_bmc_maps_redfish_paths_to_gb300_corpus() -> None:
@@ -151,3 +173,196 @@ def test_mock_bmc_manifest_exposes_read_only_service_without_secrets() -> None:
     assert container["readinessProbe"]["httpGet"]["path"] == "/redfish/v1/"
     assert service["spec"]["ports"][0]["targetPort"] == "http"
     assert not {name for name in env_names if "PASSWORD" in name or "SECRET" in name}
+
+
+# --- order-independent mutation-rules mode -------------------------------------
+
+
+def test_mutation_rules_power_reset_cycles_power_state() -> None:
+    """A ForceOff reset powers System_0 down; an On reset brings it back."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, mutation_rules=SUPERMICRO_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        _, before = _http(base, SYSTEM)
+        assert before["PowerState"] == "On"
+
+        status, _ = _http(base, RESET, "POST", {"ResetType": "ForceOff"})
+        assert status == 204
+        _, after = _http(base, SYSTEM)
+        assert after["PowerState"] == "Off"
+        assert after["Status"]["State"] == "Disabled"
+
+        status, _ = _http(base, RESET, "POST", {"ResetType": "On"})
+        assert status == 204
+        _, restored = _http(base, SYSTEM)
+        assert restored["PowerState"] == "On"
+
+
+def test_mutation_rules_boot_override_reverts_one_time_boot_on_reset() -> None:
+    """A one-time PXE override is armed, then a reset consumes it (composed with power-off)."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, mutation_rules=SUPERMICRO_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        _, before = _http(base, SYSTEM)
+        assert before["Boot"]["BootSourceOverrideEnabled"] == "Disabled"
+
+        status, _ = _http(
+            base, SYSTEM, "PATCH",
+            {"Boot": {"BootSourceOverrideTarget": "Pxe", "BootSourceOverrideEnabled": "Once"}},
+        )
+        assert status == 200
+        _, armed = _http(base, SYSTEM)
+        assert armed["Boot"]["BootSourceOverrideTarget"] == "Pxe"
+        assert armed["Boot"]["BootSourceOverrideEnabled"] == "Once"
+
+        # One ForceOff reset fires BOTH the power-off rule and the one-time revert.
+        status, _ = _http(base, RESET, "POST", {"ResetType": "ForceOff"})
+        assert status == 204
+        _, after = _http(base, SYSTEM)
+        assert after["PowerState"] == "Off"
+        assert after["Boot"]["BootSourceOverrideEnabled"] == "Disabled"
+        assert after["Boot"]["BootSourceOverrideTarget"] == "None"
+
+
+def test_mutation_rules_bios_pending_applies_on_reset() -> None:
+    """A staged BIOS attribute stays pending until a reset moves it to the live resource."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, mutation_rules=SUPERMICRO_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        _, bios_before = _http(base, BIOS)
+        assert bios_before["Attributes"]["Above4GDecoding"] == "Enabled"
+
+        status, _ = _http(
+            base, BIOS_SETTINGS, "PATCH", {"Attributes": {"Above4GDecoding": "Disabled"}}
+        )
+        assert status == 200
+        # Pending only: the live BIOS resource is unchanged until a reset.
+        _, staged = _http(base, BIOS_SETTINGS)
+        assert staged["Attributes"]["Above4GDecoding"] == "Disabled"
+        _, bios_mid = _http(base, BIOS)
+        assert bios_mid["Attributes"]["Above4GDecoding"] == "Enabled"
+
+        status, _ = _http(base, RESET, "POST", {"ResetType": "GracefulRestart"})
+        assert status == 204
+        _, bios_after = _http(base, BIOS)
+        assert bios_after["Attributes"]["Above4GDecoding"] == "Disabled"
+
+
+def test_mutation_rules_virtual_media_insert_and_eject() -> None:
+    """Virtual media inserts then ejects, matched by state precondition not order."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, mutation_rules=SUPERMICRO_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        _, before = _http(base, USB1)
+        assert before["Inserted"] is False
+
+        status, _ = _http(
+            base, f"{USB1}/Actions/VirtualMedia.InsertMedia", "POST",
+            {"Image": "http://boot.example/iso"},
+        )
+        assert status == 204
+        _, inserted = _http(base, USB1)
+        assert inserted["Inserted"] is True
+        assert inserted["ConnectedVia"] == "URI"
+
+        status, _ = _http(base, f"{USB1}/Actions/VirtualMedia.EjectMedia", "POST", {})
+        assert status == 204
+        _, ejected = _http(base, USB1)
+        assert ejected["Inserted"] is False
+
+
+def test_mutation_rules_are_order_independent() -> None:
+    """Unrelated mutations apply regardless of the order they arrive in."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, mutation_rules=SUPERMICRO_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        # Insert media, THEN stage BIOS, THEN power off — none depends on the others.
+        assert _http(base, f"{USB1}/Actions/VirtualMedia.InsertMedia", "POST", {"Image": "x"})[0] == 204
+        assert _http(base, BIOS_SETTINGS, "PATCH", {"Attributes": {"Above4GDecoding": "Disabled"}})[0] == 200
+        assert _http(base, RESET, "POST", {"ResetType": "ForceOff"})[0] == 204
+
+        assert _http(base, USB1)[1]["Inserted"] is True
+        assert _http(base, SYSTEM)[1]["PowerState"] == "Off"
+        # The reset also applied the pending BIOS change (compose, any order).
+        assert _http(base, BIOS)[1]["Attributes"]["Above4GDecoding"] == "Disabled"
+
+
+def test_mutation_rules_reject_unmatched_write_with_409() -> None:
+    """A write no rule matches is refused with 409, not silently accepted."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, mutation_rules=SUPERMICRO_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+        status, payload = _http(base, SYSTEM, "PATCH", {"AssetTag": "nope"})
+        assert status == 409
+        assert payload["error"] == "no write rule matched the request"
+
+
+def test_mutation_rules_status_reports_mode_and_applied_rules() -> None:
+    """The status endpoint reflects the mutation-rules mode and applied rule names."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, mutation_rules=SUPERMICRO_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+        _http(base, RESET, "POST", {"ResetType": "ForceOff"})
+        _, status = _http(base, "/__replay_status")
+        assert status["mode"] == "mutation-rules"
+        assert status["vendor"] == "supermicro-gb300"
+        assert "power-off-on-forceoff" in status["applied"]
+
+
+def test_mutation_rules_every_transition_targets_a_real_corpus_resource() -> None:
+    """Every rule's precondition/transition path resolves to a committed fixture."""
+    module = _load_server_module()
+    spec = yaml.safe_load(SUPERMICRO_RULES.read_text(encoding="utf-8"))
+    assert spec["vendor"] == "supermicro-gb300"
+    for rule in spec["rules"]:
+        resource_paths = [t["path"] for t in rule.get("state_transitions", [])]
+        resource_paths += [c["path"] for c in rule.get("when", [])]
+        for resource_path in resource_paths:
+            fixture = module.fixture_for_redfish_path(GB300_CORPUS, resource_path)
+            assert fixture is not None, f"rule {rule['name']} targets missing {resource_path}"
+
+
+def test_mutation_rules_glob_path_matches_a_media_family() -> None:
+    """A glob rule path matches every member of a resource family (engine feature)."""
+    module = _load_server_module()
+    rules = module.MutationRules(
+        {
+            "vendor": "glob-demo",
+            "rules": [
+                {
+                    "name": "eject-any-slot",
+                    "method": "POST",
+                    "path": "/redfish/v1/Managers/BMC_0/VirtualMedia/*/Actions/VirtualMedia.EjectMedia",
+                    "state_transitions": [
+                        {"op": "set", "path": "/redfish/v1/Managers/BMC_0/VirtualMedia/USB2",
+                         "field": "Inserted", "value": False},
+                    ],
+                    "response": {"status": 204},
+                }
+            ],
+        }
+    )
+    matched = rules.match_write(
+        "POST",
+        "/redfish/v1/Managers/BMC_0/VirtualMedia/USB2/Actions/VirtualMedia.EjectMedia",
+        {},
+        lambda _p: {},
+    )
+    assert matched == {"status": 204}
+    assert rules.match_write("POST", "/redfish/v1/Systems/System_0", {}, lambda _p: {}) is None
+
+
+def test_make_handler_rejects_replay_and_mutation_rules_together() -> None:
+    """The two write modes are mutually exclusive."""
+    module = _load_server_module()
+    with pytest.raises(ValueError, match="not both"):
+        module.make_handler(
+            GB300_CORPUS,
+            replay_trace=GRACEFUL_RESTART_TRACE,
+            mutation_rules=SUPERMICRO_RULES,
+        )


### PR DESCRIPTION
## Why

The mock BMC's existing `--replay` engine (`ReplayState`) matches writes **strictly in trace order** — a good fit for a scripted scenario, a poor fit for a Kubernetes controller that issues mutations in whatever order its reconcile loop decides. This adds a parallel **`--mutation-rules`** engine that matches each write on its own terms, so the mock can back an order-independent write/CONVERGE e2e.

## What

`MutationRules` — each rule fires when:
- `method` matches,
- `path` matches (exact, or an `fnmatch` glob like `.../VirtualMedia/*/Actions/...`),
- optional `body_contains` subset matches, and
- every `when` precondition holds against the **current effective state** (corpus fixture + overlays already applied).

All matching rules apply their `state_transitions`, so conditional side effects **compose**: a `ForceOff` reset both powers the system down and, *only when* `BootSourceOverrideEnabled == Once`, reverts the one-time boot.

Rules are a **data sidecar** — `tests/mutation_rules/<vendor>.yaml` — reusing the existing replay `op`/`path`/`field`|`json_path`/`value` transition vocabulary. The corpus and its flattened index are untouched.

`tests/mutation_rules/supermicro_gb300.yaml` covers the GB300 mutation classes whose resources exist in the committed corpus:

| Class | Rules |
| --- | --- |
| Power reset | `power-off-on-forceoff`, `power-on` |
| Boot-source override | `boot-override-pxe-once`, `boot-override-disable` |
| One-time-boot revert | `boot-once-revert-on-reset` |
| BIOS pending + apply-on-reset | `bios-stage-above4g-disabled`, `bios-apply-pending-on-reset` |
| Virtual media insert/eject | `vmedia-insert-usb1`, `vmedia-eject-usb1` |

The GB300 is a GPU (HGX) node — its corpus has no `Volumes` collection or clearable `LogService` — so **storage-volume create/delete** and **log-clear** are deferred to a vendor whose corpus carries those resources (HPE), which is the next rules file.

Shared overlay/transition machinery is factored into an `_OverlayStore` base reused by both `ReplayState` and `MutationRules`.

## Verification
- `pytest -q` → 981 passed, 58 skipped (full offline suite; the ordered-replay path still passes after the refactor).
- `tests/test_k8s_mock_bmc_server.py` adds 10 tests: each class validated against the corpus **before/after**, order-independence, rule composition, glob path matching, unmatched-write → 409, status endpoint, a static check that every rule targets a real corpus resource, and mutual exclusion of `--replay` / `--mutation-rules`.
- `ruff` clean on changed files.