### PR TITLE
Drive the RedfishNodeProfile write path in the kind sandbox

### DIFF
--- a/docker/Dockerfile.mock-bmc
+++ b/docker/Dockerfile.mock-bmc
@@ -10,6 +10,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     MOCK_BMC_CORPUS_DIR=/corpus/172.25.230.37
 
+# PyYAML lets the mock load YAML replay traces and mutation-rules files; the
+# server itself is otherwise stdlib-only. Without it the mock can only read
+# plain-JSON traces (see mock_bmc_server._load_trace).
+RUN pip install --no-cache-dir "pyyaml>=6,<7"
+
 # Pin a numeric uid/gid so Kubernetes can verify runAsNonRoot without a
 # runAsUser override (a named user cannot be checked at admission).
 RUN groupadd --system --gid 10001 mockbmc \

--- a/k8s/controller/deployment.yaml
+++ b/k8s/controller/deployment.yaml
@@ -34,7 +34,11 @@ spec:
             # Watch only this namespace: the RBAC grant is a namespaced Role,
             # so a cluster-wide watch would be rejected with 403s.
             - --namespace=redfish-sandbox
+            # Both controllers run in one kopf process: the endpoint controller
+            # polls read status, the node-profile controller drives the gated
+            # plan/approve/apply write path.
             - /app/k8s/controller/redfish_endpoint_controller.py
+            - /app/k8s/controller/redfish_node_profile_controller.py
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/controller/rbac.yaml
+++ b/k8s/controller/rbac.yaml
@@ -36,6 +36,27 @@ rules:
       - get
       - patch
       - update
+  # The node-profile controller runs in the same process and watches
+  # RedfishNodeProfile objects, patching their /status subresource with the
+  # plan/approve/apply outcome. Same shape as the endpoint grant above.
+  - apiGroups:
+      - redfish.ctl.dev
+    resources:
+      - redfishnodeprofiles
+    verbs:
+      - get
+      - list
+      - watch
+      - patch
+      - update
+  - apiGroups:
+      - redfish.ctl.dev
+    resources:
+      - redfishnodeprofiles/status
+    verbs:
+      - get
+      - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/k8s/sandbox/mock-bmc.yaml
+++ b/k8s/sandbox/mock-bmc.yaml
@@ -27,12 +27,27 @@ spec:
         - name: mock-bmc
           image: redfish-ctl-mock-bmc:local
           imagePullPolicy: IfNotPresent
+          # Serve the corpus AND accept order-independent writes so the
+          # node-profile controller's plan/approve/apply path has somewhere to
+          # write. Mutation-rules mode is transparent to reads (overlays are
+          # empty until a write), so the endpoint read path is unaffected.
+          args:
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8080"
+            - --mutation-rules
+            - /rules/supermicro_gb300.yaml
           ports:
             - name: http
               containerPort: 8080
           env:
             - name: MOCK_BMC_CORPUS_DIR
               value: /corpus/172.25.230.37
+          volumeMounts:
+            - name: mutation-rules
+              mountPath: /rules
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /redfish/v1/
@@ -58,6 +73,11 @@ spec:
             limits:
               cpu: 250m
               memory: 256Mi
+      volumes:
+        # Populated by run-sandbox.sh from tests/mutation_rules/supermicro_gb300.yaml
+        - name: mutation-rules
+          configMap:
+            name: mock-bmc-mutation-rules
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/sandbox/redfish-node-profile-sample.yaml
+++ b/k8s/sandbox/redfish-node-profile-sample.yaml
@@ -1,0 +1,28 @@
+# A RedfishNodeProfile that drives the write/CONVERGE path against the mock BMC.
+#
+# desiredState arms a one-time PXE boot. The node-profile controller
+# (k8s/controller/redfish_node_profile_controller.py) plans it as a dry run,
+# reports a plan hash in .status, and applies nothing until an operator copies
+# that hash into spec.approvedPlanHash. On approval it issues one BootOneShot
+# PATCH to the mock (matched by the boot-override-pxe-once mutation rule), then
+# converges: the mock now reports the override, so the next plan shows no drift.
+#
+# endpoint/secretRef point at the same in-cluster mock and Secret the
+# RedfishEndpoint read path uses (mock-bmc Service, mock-bmc-credentials Secret).
+apiVersion: redfish.ctl.dev/v1alpha1
+kind: RedfishNodeProfile
+metadata:
+  name: gb300-mock
+  namespace: redfish-sandbox
+spec:
+  endpoint:
+    address: http://mock-bmc.redfish-sandbox.svc.cluster.local
+    port: 80
+    insecure: true
+    secretRef:
+      name: mock-bmc-credentials
+      usernameKey: username
+      passwordKey: password
+  desiredState:
+    boot:
+      device: Pxe

--- a/k8s/sandbox/run-sandbox.sh
+++ b/k8s/sandbox/run-sandbox.sh
@@ -133,6 +133,100 @@ assert_corpus_status() {
 		"$endpoint_name" "$health" "$temp_count"
 }
 
+node_profile_field() {
+	kubectl_sandbox -n "${NAMESPACE}" \
+		get redfishnodeprofile "$1" -o "jsonpath=$2" 2>/dev/null || true
+}
+
+wait_for_node_profile_plan() {
+	# Wait until the controller has produced a dry-run plan hash for the profile.
+	local name="$1"
+	local deadline
+	local plan_hash
+
+	deadline=$((SECONDS + STATUS_TIMEOUT_SECONDS))
+	while [ "$SECONDS" -lt "$deadline" ]; do
+		plan_hash="$(node_profile_field "$name" '{.status.planHash}')"
+		if [ -n "$plan_hash" ]; then
+			printf '%s\n' "$plan_hash"
+			return 0
+		fi
+		sleep 3
+	done
+
+	printf 'timed out waiting for RedfishNodeProfile %s plan\n' "$name" >&2
+	kubectl_sandbox -n "${NAMESPACE}" get redfishnodeprofile "$name" -o yaml >&2 || true
+	return 1
+}
+
+wait_for_node_profile_applied() {
+	# Wait until the approved plan is applied and consumed (one-shot approval).
+	local name="$1"
+	local plan_hash="$2"
+	local deadline
+	local applied
+	local consumed
+
+	deadline=$((SECONDS + STATUS_TIMEOUT_SECONDS))
+	while [ "$SECONDS" -lt "$deadline" ]; do
+		applied="$(node_profile_field "$name" \
+			'{.status.conditions[?(@.type=="Applied")].status}')"
+		consumed="$(node_profile_field "$name" '{.status.consumedPlanHash}')"
+		if [ "$applied" = "True" ] && [ "$consumed" = "$plan_hash" ]; then
+			printf 'RedfishNodeProfile %s applied (consumedPlanHash=%s)\n' \
+				"$name" "$consumed"
+			return 0
+		fi
+		sleep 3
+	done
+
+	printf 'timed out waiting for RedfishNodeProfile %s apply\n' "$name" >&2
+	kubectl_sandbox -n "${NAMESPACE}" get redfishnodeprofile "$name" -o yaml >&2 || true
+	return 1
+}
+
+wait_for_node_profile_converged() {
+	# After apply the mock reflects the change, so the next plan finds no drift.
+	local name="$1"
+	local deadline
+	local drift
+
+	deadline=$((SECONDS + STATUS_TIMEOUT_SECONDS))
+	while [ "$SECONDS" -lt "$deadline" ]; do
+		drift="$(node_profile_field "$name" \
+			'{.status.conditions[?(@.type=="DriftDetected")].status}')"
+		if [ "$drift" = "False" ]; then
+			printf 'RedfishNodeProfile %s converged (no drift after apply)\n' "$name"
+			return 0
+		fi
+		sleep 3
+	done
+
+	printf 'timed out waiting for RedfishNodeProfile %s to converge\n' "$name" >&2
+	kubectl_sandbox -n "${NAMESPACE}" get redfishnodeprofile "$name" -o yaml >&2 || true
+	return 1
+}
+
+drive_node_profile() {
+	# Exercise the gated write path end to end: plan -> approve -> apply -> converge.
+	local name="$1"
+	local plan_hash
+
+	section "waiting for RedfishNodeProfile ${name} plan"
+	plan_hash="$(wait_for_node_profile_plan "$name")"
+	printf 'RedfishNodeProfile %s planHash=%s (drift detected, approving)\n' \
+		"$name" "$plan_hash"
+
+	kubectl_sandbox -n "${NAMESPACE}" patch redfishnodeprofile "$name" \
+		--type=merge -p "{\"spec\":{\"approvedPlanHash\":\"${plan_hash}\"}}"
+
+	section "waiting for RedfishNodeProfile ${name} apply"
+	wait_for_node_profile_applied "$name" "$plan_hash"
+
+	section "waiting for RedfishNodeProfile ${name} convergence"
+	wait_for_node_profile_converged "$name"
+}
+
 validate_backends
 require_tool docker
 require_tool kind
@@ -156,8 +250,10 @@ docker build \
 	-t redfish-ctl-controller:local \
 	.
 
+cluster_reused=0
 if kind get clusters | grep -Fxq "${KIND_CLUSTER_NAME}"; then
 	section "using existing kind cluster ${KIND_CLUSTER_NAME}"
+	cluster_reused=1
 else
 	section "creating kind cluster ${KIND_CLUSTER_NAME}"
 	kind create cluster --name "${KIND_CLUSTER_NAME}" --config "${KIND_CONFIG}"
@@ -175,7 +271,13 @@ kind load docker-image redfish-ctl-controller:local --name "${KIND_CLUSTER_NAME}
 section "applying sandbox resources"
 kubectl_sandbox apply -f k8s/sandbox/namespace.yaml
 kubectl_sandbox apply -f k8s/controller/redfish-endpoint-crd.yaml
+kubectl_sandbox apply -f k8s/controller/redfish-node-profile-crd.yaml
 if has_backend "corpus-mock"; then
+	# Publish the mutation rules the mock Deployment mounts at /rules so the
+	# write path has somewhere to apply changes.
+	kubectl_sandbox -n "${NAMESPACE}" create configmap mock-bmc-mutation-rules \
+		--from-file=supermicro_gb300.yaml=tests/mutation_rules/supermicro_gb300.yaml \
+		--dry-run=client -o yaml | kubectl_sandbox apply -f -
 	kubectl_sandbox apply -f k8s/sandbox/mock-bmc.yaml
 	kubectl_sandbox apply -f k8s/sandbox/mock-credentials.yaml
 fi
@@ -187,9 +289,29 @@ kubectl_sandbox apply -f k8s/controller/rbac.yaml
 kubectl_sandbox apply -f k8s/controller/deployment.yaml
 if has_backend "corpus-mock"; then
 	kubectl_sandbox apply -f k8s/sandbox/redfish-endpoint-sample.yaml
+	# Recreate the profile so each run starts from a clean approval state: a
+	# status.consumedPlanHash left by a prior run would block re-approval and
+	# the apply would never fire.
+	kubectl_sandbox -n "${NAMESPACE}" delete redfishnodeprofile gb300-mock \
+		--ignore-not-found
+	kubectl_sandbox apply -f k8s/sandbox/redfish-node-profile-sample.yaml
 fi
 if has_backend "ilo-sim"; then
 	kubectl_sandbox apply -f k8s/sandbox/redfish-endpoint-ilo-sim.yaml
+fi
+
+if [ "$cluster_reused" = "1" ]; then
+	# On a reused cluster the :local image tag is unchanged, so `kubectl apply`
+	# alone will not recreate pods to pick up a freshly built image. Force a
+	# restart so a re-run always runs the newly loaded images.
+	section "restarting workloads to pick up rebuilt images"
+	if has_backend "corpus-mock"; then
+		kubectl_sandbox -n "${NAMESPACE}" rollout restart deploy/mock-bmc
+	fi
+	if has_backend "ilo-sim"; then
+		kubectl_sandbox -n "${NAMESPACE}" rollout restart deploy/ilo-sim
+	fi
+	kubectl_sandbox -n "${NAMESPACE}" rollout restart deploy/redfish-endpoint-controller
 fi
 
 section "waiting for deployments"
@@ -214,4 +336,9 @@ if has_backend "corpus-mock"; then
 fi
 if has_backend "ilo-sim"; then
 	wait_for_endpoint ilo-sim
+fi
+
+# Write/CONVERGE leg: drive the RedfishNodeProfile plan -> approve -> apply path.
+if has_backend "corpus-mock"; then
+	drive_node_profile gb300-mock
 fi

--- a/tests/test_k8s_sandbox_harness.py
+++ b/tests/test_k8s_sandbox_harness.py
@@ -21,6 +21,8 @@ ILO_SIM_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.ilo-sim"
 MAKEFILE = REPO_ROOT / "Makefile"
 SANDBOX_README = REPO_ROOT / "k8s" / "sandbox" / "README.md"
 K8S_README = REPO_ROOT / "k8s" / "README.md"
+NODE_PROFILE_SAMPLE = REPO_ROOT / "k8s" / "sandbox" / "redfish-node-profile-sample.yaml"
+MOCK_BMC_MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "mock-bmc.yaml"
 
 
 def _yaml_documents(path: Path) -> list[dict]:
@@ -128,7 +130,7 @@ def test_ilo_sim_manifest_deploys_hpe_emulator_service() -> None:
 
 
 def test_controller_deployment_is_read_only_and_uses_local_image() -> None:
-    """The sandbox controller can patch status but has no BMC write path."""
+    """Both controllers run in one pod with minimal, namespaced Kubernetes RBAC."""
     docs = _yaml_documents(CONTROLLER_RBAC)
     deployment = yaml.safe_load(CONTROLLER_DEPLOYMENT.read_text(encoding="utf-8"))
     role = next(doc for doc in docs if doc["kind"] == "Role")
@@ -147,7 +149,10 @@ def test_controller_deployment_is_read_only_and_uses_local_image() -> None:
         # The watch stays scoped to the sandbox namespace so the namespaced
         # Role is sufficient for the resource watch itself.
         "--namespace=redfish-sandbox",
+        # Both controllers run in one kopf process: the endpoint controller
+        # polls read status, the node-profile controller drives gated writes.
         "/app/k8s/controller/redfish_endpoint_controller.py",
+        "/app/k8s/controller/redfish_node_profile_controller.py",
     ]
 
     cluster_role = next(doc for doc in docs if doc["kind"] == "ClusterRole")
@@ -274,3 +279,85 @@ def test_make_k8s_sandbox_invokes_smoke_harness() -> None:
 
     assert "k8s/sandbox/run-sandbox.sh" in makefile
     assert "kind-config.yaml is not present yet" not in makefile
+
+
+# --- write/CONVERGE leg (RedfishNodeProfile) -----------------------------------
+
+
+def test_node_profile_sample_arms_pxe_boot_via_secret_ref() -> None:
+    """The sample profile drives a gated one-time PXE boot with no inline secrets."""
+    profile = yaml.safe_load(NODE_PROFILE_SAMPLE.read_text(encoding="utf-8"))
+
+    assert profile["kind"] == "RedfishNodeProfile"
+    assert profile["metadata"]["namespace"] == "redfish-sandbox"
+    spec = profile["spec"]
+    assert spec["endpoint"]["address"].startswith("http://mock-bmc.redfish-sandbox")
+    assert spec["endpoint"]["secretRef"]["name"] == "mock-bmc-credentials"
+    assert spec["desiredState"]["boot"]["device"] == "Pxe"
+    # Credentials come only through the Secret reference (a key name, never a
+    # value); no approval is baked in — an operator sets approvedPlanHash after
+    # seeing the plan.
+    assert "approvedPlanHash" not in spec
+    assert set(spec["endpoint"]["secretRef"]) >= {"name", "usernameKey", "passwordKey"}
+    assert "password" not in {k.lower() for k in spec["endpoint"].keys()}
+
+
+def test_controller_rbac_grants_node_profile_status_but_not_delete() -> None:
+    """The controller can watch/patch RedfishNodeProfiles and their status only."""
+    role = next(
+        doc for doc in _yaml_documents(CONTROLLER_RBAC) if doc["kind"] == "Role"
+    )
+    resources = {
+        resource
+        for rule in role["rules"]
+        for resource in rule.get("resources", [])
+    }
+    assert "redfishnodeprofiles" in resources
+    assert "redfishnodeprofiles/status" in resources
+
+    profile_verbs = set().union(
+        *(
+            set(rule["verbs"])
+            for rule in role["rules"]
+            if "redfishnodeprofiles" in rule.get("resources", [])
+        )
+    )
+    assert {"get", "list", "watch", "patch", "update"} <= profile_verbs
+    assert "delete" not in profile_verbs
+    assert "create" not in profile_verbs
+
+
+def test_mock_bmc_runs_with_mounted_mutation_rules() -> None:
+    """The mock accepts writes via a ConfigMap-mounted mutation-rules file."""
+    deployment = next(
+        doc
+        for doc in _yaml_documents(MOCK_BMC_MANIFEST)
+        if doc["kind"] == "Deployment"
+    )
+    pod = deployment["spec"]["template"]["spec"]
+    container = pod["containers"][0]
+
+    assert "--mutation-rules" in container["args"]
+    rules_path = container["args"][container["args"].index("--mutation-rules") + 1]
+    mount = next(m for m in container["volumeMounts"] if m["mountPath"] == "/rules")
+    assert rules_path.startswith("/rules/")
+    assert mount["readOnly"] is True
+    volume = next(v for v in pod["volumes"] if v["name"] == mount["name"])
+    assert volume["configMap"]["name"] == "mock-bmc-mutation-rules"
+
+
+def test_run_sandbox_drives_the_node_profile_write_leg() -> None:
+    """The harness applies the profile CRD/CR and runs the plan->approve->apply flow."""
+    script = SMOKE_SCRIPT.read_text(encoding="utf-8")
+
+    assert "redfish-node-profile-crd.yaml" in script
+    assert "redfish-node-profile-sample.yaml" in script
+    assert "configmap mock-bmc-mutation-rules" in script
+    assert "supermicro_gb300.yaml=tests/mutation_rules/supermicro_gb300.yaml" in script
+    # The approval flow: read the plan hash, patch approvedPlanHash, wait applied.
+    assert "wait_for_node_profile_plan" in script
+    assert "approvedPlanHash" in script
+    assert "wait_for_node_profile_applied" in script
+    # Convergence: after apply the mock reflects the change, so drift clears.
+    assert "wait_for_node_profile_converged" in script
+    assert "drive_node_profile gb300-mock" in script


### PR DESCRIPTION
The kind sandbox previously exercised only the **read** path (endpoint controller → `.status.powerState`). This wires the **write/CONVERGE** path end to end in the same throwaway cluster — the node-profile controller's gated `plan → approve → apply → converge` loop — with no real BMC.

## What runs now

1. **Both controllers in one kopf process.** The namespaced Role gains `redfishnodeprofiles` + `redfishnodeprofiles/status` (`get/list/watch/patch/update`) — still no `create`/`delete`, cluster-scope stays read-only.
2. **The mock accepts writes.** It runs with `--mutation-rules` (the committed GB300 rules from #91), published as a ConfigMap the pod mounts at `/rules`. Mutation-rules mode is **transparent to reads** (overlays are empty until a write), so the endpoint read path is unchanged. The mock image now installs PyYAML so it can load the YAML rules in-cluster.
3. **A sample `RedfishNodeProfile`** arms a one-time PXE boot. `run-sandbox.sh` drives the approval flow:
   - waits for the dry-run **plan hash** in `.status.planHash`,
   - patches `spec.approvedPlanHash` to it,
   - waits for `Applied=True` + `consumedPlanHash` (one-shot approval consumed),
   - asserts **convergence**: `DriftDetected` clears because the mock now reflects the override (the `BootOneShot` PATCH is matched by the `boot-override-pxe-once` rule, and `CurrentBoot` reads it back).

## Reliability on re-runs

Reusing a kind cluster hit two footguns, both fixed:
- the unchanged `:local` image tag means `kubectl apply` won't recreate pods — so the harness now `rollout restart`s workloads to pick up freshly loaded images;
- a `RedfishNodeProfile`'s `consumedPlanHash` persists across runs and would block re-approval — so the harness recreates the profile each run.

## Verification
- Live in a kind cluster: read path `powerState=On / health=OK / temperature.count=56`; write path `plan → approve → apply → converged (no drift)`.
- `pytest -q` → 990 passed, 58 skipped; `ruff` + `shellcheck` clean; new offline manifest/harness assertions for the node-profile CRD/CR, RBAC, mounted mutation rules, and the approval flow.