### PR TITLE
Add seeded failure injection to the mock BMC mutation rules

### DIFF
--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -8,6 +8,7 @@ import copy
 import fnmatch
 import json
 import os
+import random
 import sys
 import threading
 from contextlib import contextmanager
@@ -248,7 +249,7 @@ class MutationRules(_OverlayStore):
     boot.
     """
 
-    def __init__(self, spec: dict[str, Any]) -> None:
+    def __init__(self, spec: dict[str, Any], *, seed: int = 0) -> None:
         super().__init__()
         self.vendor = str(spec.get("vendor") or "generic")
         rules = spec.get("rules") or []
@@ -256,10 +257,16 @@ class MutationRules(_OverlayStore):
             raise ValueError("mutation rules must be a list")
         self.rules = rules
         self._applied: list[str] = []
+        self._failed: list[str] = []
+        # Seeded RNG so stochastic failure injection is reproducible: the same
+        # seed replays the same sequence of injected failures (an RL harness
+        # varies the seed per episode). reset() re-seeds to the same value.
+        self._seed = int(seed)
+        self._rng = random.Random(self._seed)
 
     @classmethod
-    def from_file(cls, path: Path) -> "MutationRules":
-        return cls(_load_trace(path))
+    def from_file(cls, path: Path, *, seed: int = 0) -> "MutationRules":
+        return cls(_load_trace(path), seed=seed)
 
     def status(self) -> dict[str, Any]:
         with self._lock:
@@ -268,6 +275,8 @@ class MutationRules(_OverlayStore):
                 "vendor": self.vendor,
                 "total_rules": len(self.rules),
                 "applied": list(self._applied),
+                "failed": list(self._failed),
+                "seed": self._seed,
             }
 
     def reset(self, scenario: str | None = None) -> bool:
@@ -276,6 +285,8 @@ class MutationRules(_OverlayStore):
         with self._lock:
             self._overlays.clear()
             self._applied.clear()
+            self._failed.clear()
+            self._rng = random.Random(self._seed)
         return True
 
     def match_write(
@@ -296,11 +307,35 @@ class MutationRules(_OverlayStore):
             ]
             if not matched:
                 return None
+            # Stochastic failure injection: if a matched rule rolls a failure the
+            # whole write fails and no transitions apply (models e.g. a flaky
+            # reboot). Rules with no failure block never touch the RNG, so purely
+            # deterministic rules stay deterministic regardless of seed.
+            failure_response = self._roll_failure(matched)
+            if failure_response is not None:
+                return failure_response
             for rule in matched:
                 self._apply_transitions(rule.get("state_transitions") or [])
                 self._applied.append(str(rule.get("name") or "unnamed"))
             response = matched[0].get("response") or {}
             return response if isinstance(response, dict) else {"status": 204}
+
+    def _roll_failure(self, matched: list[dict[str, Any]]) -> dict[str, Any] | None:
+        for rule in matched:
+            failure = rule.get("failure")
+            if not isinstance(failure, dict):
+                continue
+            try:
+                probability = float(failure.get("probability", 0) or 0)
+            except (TypeError, ValueError):
+                probability = 0.0
+            if probability <= 0:
+                continue
+            if self._rng.random() < probability:
+                self._failed.append(str(rule.get("name") or "unnamed"))
+                response = failure.get("response") or {"status": 500}
+                return response if isinstance(response, dict) else {"status": 500}
+        return None
 
     def _effective_state(self, resource_path: str, corpus_lookup: Any) -> dict[str, Any]:
         path = _normalize_request_path(resource_path)
@@ -586,6 +621,7 @@ def make_handler(
     corpus_dir: Path,
     replay_trace: Path | None = None,
     mutation_rules: Path | None = None,
+    seed: int = 0,
 ) -> type[CorpusRequestHandler]:
     root = Path(corpus_dir)
     if not root.is_dir():
@@ -605,7 +641,7 @@ def make_handler(
         else None
     )
     Handler.mutation_rules = (
-        MutationRules.from_file(mutation_rules)
+        MutationRules.from_file(mutation_rules, seed=seed)
         if mutation_rules is not None
         else None
     )
@@ -620,6 +656,7 @@ def run_server(
     corpus_dir: Path,
     replay_trace: Path | None = None,
     mutation_rules: Path | None = None,
+    seed: int = 0,
 ) -> Iterator[ThreadingHTTPServer]:
     server = ThreadingHTTPServer(
         (host, port),
@@ -627,6 +664,7 @@ def run_server(
             corpus_dir,
             replay_trace=replay_trace,
             mutation_rules=mutation_rules,
+            seed=seed,
         ),
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -664,6 +702,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional order-independent mutation-rules file "
         "(matches on method/path/precondition; applies writes in any order).",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=int(os.environ.get("MOCK_BMC_SEED", "0") or "0"),
+        help="Seed for mutation-rules failure injection (default 0, "
+        "overridable via MOCK_BMC_SEED). Same seed replays the same failures.",
+    )
     return parser.parse_args(argv)
 
 
@@ -677,6 +722,7 @@ def main(argv: list[str] | None = None) -> int:
                 args.corpus_dir,
                 replay_trace=args.replay,
                 mutation_rules=args.mutation_rules,
+                seed=args.seed,
             ),
         )
         host, port = server.server_address

--- a/tests/mutation_rules/supermicro_gb300_flaky.yaml
+++ b/tests/mutation_rules/supermicro_gb300_flaky.yaml
@@ -1,0 +1,50 @@
+# Stochastic variant of the GB300 mutation rules for RL training.
+#
+# Same mutations as supermicro_gb300.yaml, but the reset and virtual-media
+# insert carry a `failure` block: with the given probability the mock rejects
+# the write and applies NO state change, modelling a flaky BMC (e.g. a reset
+# that does not take, or a media insert that fails). Failures are reproducible
+# for a given --seed (MOCK_BMC_SEED); the mock re-seeds on scenario reset, so an
+# RL episode replays the same failure sequence and can vary it per episode by
+# choosing a different seed.
+#
+#   failure:
+#     probability: 0.0..1.0   # chance this write fails instead of applying
+#     response: {status, body?}  # returned on a failed roll
+vendor: supermicro-gb300-flaky
+rules:
+  - name: power-off-on-forceoff
+    method: POST
+    path: /redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset
+    body_contains: {ResetType: ForceOff}
+    when:
+      - {path: /redfish/v1/Systems/System_0, field: PowerState, equals: "On"}
+    failure:
+      probability: 0.3
+      response:
+        status: 503
+        body:
+          error:
+            code: "Base.1.0.GeneralError"
+            message: "Reset action failed; the system did not transition."
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/System_0, field: PowerState, value: "Off"}
+      - {op: set, path: /redfish/v1/Systems/System_0, json_path: [Status, State], value: "Disabled"}
+    response: {status: 204}
+
+  - name: vmedia-insert-usb1
+    method: POST
+    path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1/Actions/VirtualMedia.InsertMedia
+    when:
+      - {path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: Inserted, equals: false}
+    failure:
+      probability: 0.2
+      response:
+        status: 500
+        body:
+          error:
+            code: "Base.1.0.InternalError"
+            message: "Virtual media insert failed."
+    state_transitions:
+      - {op: set, path: /redfish/v1/Managers/BMC_0/VirtualMedia/USB1, field: Inserted, value: true}
+    response: {status: 204}

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -366,3 +366,100 @@ def test_make_handler_rejects_replay_and_mutation_rules_together() -> None:
             replay_trace=GRACEFUL_RESTART_TRACE,
             mutation_rules=SUPERMICRO_RULES,
         )
+
+
+# --- stochastic failure injection (RL) -----------------------------------------
+
+FLAKY_RULES = REPO_ROOT / "tests" / "mutation_rules" / "supermicro_gb300_flaky.yaml"
+
+
+def _prob_engine(module, seed: int, probability: float):
+    """A one-rule engine whose write always matches and fails with `probability`."""
+    return module.MutationRules(
+        {
+            "vendor": "t",
+            "rules": [
+                {
+                    "name": "flaky",
+                    "method": "POST",
+                    "path": "/x",
+                    "failure": {"probability": probability, "response": {"status": 503}},
+                    "state_transitions": [
+                        {"op": "set", "path": "/x", "field": "n", "value": 1}
+                    ],
+                    "response": {"status": 204},
+                }
+            ],
+        },
+        seed=seed,
+    )
+
+
+def _sequence(engine, n: int) -> list[int]:
+    return [engine.match_write("POST", "/x", {}, lambda _p: {})["status"] for _ in range(n)]
+
+
+def test_failure_injection_is_reproducible_and_seed_dependent() -> None:
+    """The same seed replays the same failure sequence; a different seed differs."""
+    module = _load_server_module()
+    assert _sequence(_prob_engine(module, 0, 0.5), 40) == _sequence(
+        _prob_engine(module, 0, 0.5), 40
+    )
+    assert _sequence(_prob_engine(module, 0, 0.5), 40) != _sequence(
+        _prob_engine(module, 1, 0.5), 40
+    )
+
+
+def test_probability_one_always_fails_and_never_mutates_state() -> None:
+    """A certain failure returns the error and applies no state transition."""
+    module = _load_server_module()
+    engine = _prob_engine(module, 0, 1.0)
+    assert _sequence(engine, 5) == [503, 503, 503, 503, 503]
+    assert engine.overlay_for("/x") == {}  # no transition ever applied
+    assert engine.status()["failed"] == ["flaky"] * 5
+
+
+def test_zero_probability_and_missing_failure_block_stay_deterministic() -> None:
+    """Rules without an active failure block never touch the RNG or fail."""
+    module = _load_server_module()
+    assert _sequence(_prob_engine(module, 7, 0.0), 5) == [204, 204, 204, 204, 204]
+    # The committed GB300 rules carry no failure block, so any seed is deterministic.
+    rules = module.MutationRules.from_file(SUPERMICRO_RULES, seed=99)
+    resp = rules.match_write(
+        "POST",
+        "/redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset",
+        {"ResetType": "ForceOff"},
+        lambda _p: {"PowerState": "On"},
+    )
+    assert resp == {"status": 204}
+    assert rules.status()["failed"] == []
+
+
+def test_reset_replays_the_same_failure_sequence() -> None:
+    """Scenario reset re-seeds the RNG so an episode replays identically."""
+    module = _load_server_module()
+    engine = _prob_engine(module, 3, 0.5)
+    first = _sequence(engine, 20)
+    engine.reset()
+    assert _sequence(engine, 20) == first
+
+
+def test_flaky_reboot_fails_over_http_without_changing_power_state() -> None:
+    """With a seed that fails the first roll, a reset is rejected and power holds."""
+    module = _load_server_module()
+    # random.Random(1).random() ~= 0.134 < 0.3, so the first ForceOff reset fails.
+    with module.run_server(
+        "127.0.0.1", 0, GB300_CORPUS, mutation_rules=FLAKY_RULES, seed=1
+    ) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+        assert _http(base, SYSTEM)[1]["PowerState"] == "On"
+
+        status, payload = _http(base, RESET, "POST", {"ResetType": "ForceOff"})
+        assert status == 503
+        assert payload["error"]["message"].startswith("Reset action failed")
+        # A failed reboot leaves the system exactly as it was.
+        assert _http(base, SYSTEM)[1]["PowerState"] == "On"
+
+        _, replay_status = _http(base, "/__replay_status")
+        assert replay_status["seed"] == 1
+        assert "power-off-on-forceoff" in replay_status["failed"]


### PR DESCRIPTION
Extends the order-independent mutation-rules engine (#91) so the corpus-backed sandbox becomes a richer **reinforcement-learning environment**: an agent (or the k8s controller) must handle non-deterministic failures, not only clean transitions.

## What

A mutation rule may now carry a `failure` block:

```yaml
- name: power-off-on-forceoff
  method: POST
  path: /redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset
  body_contains: {ResetType: ForceOff}
  failure:
    probability: 0.3
    response: {status: 503, body: {error: {message: "Reset action failed..."}}}
  state_transitions: [ ... ]
  response: {status: 204}
```

On a matched write, if a rule rolls a failure the **whole write fails** — the failure `response` is returned and **no state transition applies** (a failed reboot leaves power exactly as it was).

## Deterministic yet stochastic

- The engine uses a **seeded RNG** (`--seed` / `MOCK_BMC_SEED`, default `0`). The same seed replays the same failure sequence; `reset()` re-seeds it, so an RL episode is reproducible and a harness varies failures per episode by choosing a different seed.
- Rules **without** a failure block never touch the RNG, so purely deterministic rules stay deterministic regardless of seed. The committed `supermicro_gb300.yaml` rules are unchanged and remain failure-free (the write-leg e2e stays deterministic).

## Files
- `tests/mutation_rules/supermicro_gb300_flaky.yaml` — stochastic variant (reset ~30%, media insert ~20%) for RL.
- The `/__replay_status` endpoint now reports `failed` (injected-failure rule names) and `seed`.

## Verification
- `pytest -q` → 990 passed, 58 skipped; `ruff` clean.
- New tests: reproducibility for a seed, seed dependence, `probability: 1.0` always fails and never mutates state, `probability: 0` / no-block stays deterministic, scenario-reset replays the sequence, and an over-HTTP `seed=1` case where the first reset returns 503 and `PowerState` holds at `On`.