### PR TITLE
Add the Supermicro X10 vendor corpus and mutation rules

### DIFF
--- a/tests/mutation_rules/supermicro_x10.yaml
+++ b/tests/mutation_rules/supermicro_x10.yaml
@@ -1,0 +1,65 @@
+# Order-independent mutation rules for a Supermicro X10 (ASPEED BMC) board.
+#
+# Consumed by the mock BMC server against tests/supermicro_x10_corpus. This is
+# the home-lab X10 hardware, captured from a real board. It uses the numeric
+# Redfish scheme (Systems/1, Managers/1) and an ASPEED BMC. The ComputerSystem
+# exposes no Bios resource and only a Supermicro-proprietary VirtualMedia
+# (VM1/CfgCD) with no standard slots, so those classes are absent here.
+#
+# Coverage: power reset, boot-source override, one-time-boot revert, log clear.
+vendor: supermicro-x10
+rules:
+  - name: power-off-on-forceoff
+    method: POST
+    path: /redfish/v1/Systems/1/Actions/ComputerSystem.Reset
+    body_contains: {ResetType: ForceOff}
+    when:
+      - {path: /redfish/v1/Systems/1, field: PowerState, equals: "On"}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/1, field: PowerState, value: "Off"}
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Status, State], value: "Disabled"}
+    response: {status: 204}
+
+  - name: power-on
+    method: POST
+    path: /redfish/v1/Systems/1/Actions/ComputerSystem.Reset
+    body_contains: {ResetType: "On"}
+    when:
+      - {path: /redfish/v1/Systems/1, field: PowerState, equals: "Off"}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/1, field: PowerState, value: "On"}
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Status, State], value: "Enabled"}
+    response: {status: 204}
+
+  - name: boot-override-pxe-once
+    method: PATCH
+    path: /redfish/v1/Systems/1
+    body_contains: {Boot: {BootSourceOverrideTarget: Pxe, BootSourceOverrideEnabled: Once}}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Boot, BootSourceOverrideTarget], value: "Pxe"}
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Boot, BootSourceOverrideEnabled], value: "Once"}
+    response: {status: 200}
+
+  - name: boot-override-disable
+    method: PATCH
+    path: /redfish/v1/Systems/1
+    body_contains: {Boot: {BootSourceOverrideEnabled: Disabled}}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Boot, BootSourceOverrideEnabled], value: "Disabled"}
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Boot, BootSourceOverrideTarget], value: "None"}
+    response: {status: 200}
+
+  - name: boot-once-revert-on-reset
+    method: POST
+    path: /redfish/v1/Systems/1/Actions/ComputerSystem.Reset
+    when:
+      - {path: /redfish/v1/Systems/1, json_path: [Boot, BootSourceOverrideEnabled], equals: "Once"}
+    state_transitions:
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Boot, BootSourceOverrideEnabled], value: "Disabled"}
+      - {op: set, path: /redfish/v1/Systems/1, json_path: [Boot, BootSourceOverrideTarget], value: "None"}
+    response: {status: 204}
+
+  - name: system-log-clear
+    method: POST
+    path: /redfish/v1/Systems/1/LogServices/Log1/Actions/LogService.ClearLog
+    response: {status: 204}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1.json
@@ -1,0 +1,29 @@
+{
+  "@odata.id": "/redfish/v1",
+  "@odata.type": "#ServiceRoot.v1_5_0.ServiceRoot",
+  "Id": "RootService",
+  "Name": "Root Service",
+  "RedfishVersion": "1.6.0",
+  "Vendor": "Supermicro",
+  "Systems": {
+    "@odata.id": "/redfish/v1/Systems"
+  },
+  "Managers": {
+    "@odata.id": "/redfish/v1/Managers"
+  },
+  "Chassis": {
+    "@odata.id": "/redfish/v1/Chassis"
+  },
+  "SessionService": {
+    "@odata.id": "/redfish/v1/SessionService"
+  },
+  "AccountService": {
+    "@odata.id": "/redfish/v1/AccountService"
+  },
+  "Oem": {
+    "redfish_ctl": {
+      "Synthesized": true,
+      "Reason": "partial crawl missing /redfish/v1"
+    }
+  }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService.json
@@ -1,0 +1,25 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#AccountService.AccountService",
+    "@odata.type": "#AccountService.v1_0_0.AccountService",
+    "@odata.id": "/redfish/v1/AccountService",
+    "Id": "AccountService",
+    "Name": "Account Service",
+    "Description": "Account Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "MinPasswordLength": 8,
+    "MaxPasswordLength": 19,
+    "AuthFailureLoggingThreshold": 3,
+    "AccountLockoutThreshold": 5,
+    "AccountLockoutDuration": 30,
+    "AccountLockoutCounterResetAfter": 30,
+    "Accounts": {
+        "@odata.id": "/redfish/v1/AccountService/Accounts"
+    },
+    "Roles": {
+        "@odata.id": "/redfish/v1/AccountService/Roles"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Accounts.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Accounts.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccountCollection.ManagerAccountCollection",
+    "@odata.type": "#ManagerAccountCollection.ManagerAccountCollection",
+    "@odata.id": "/redfish/v1/AccountService/Accounts",
+    "Name": "Accounts Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Accounts/2"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Accounts_2.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Accounts_2.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerAccount.ManagerAccount",
+    "@odata.type": "#ManagerAccount.v1_0_0.ManagerAccount",
+    "@odata.id": "/redfish/v1/AccountService/Accounts/2",
+    "Id": "2",
+    "Name": "User Account",
+    "Description": "User Account",
+    "Password": "null",
+    "UserName": "ADMIN",
+    "Locked": false,
+    "RoleId": "Administrator",
+    "Enabled": true,
+    "Links": {
+        "Role": {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#RoleCollection.RoleCollection",
+    "@odata.type": "#RoleCollection.RoleCollection",
+    "@odata.id": "/redfish/v1/AccountService/Roles",
+    "Name": "Roles Collection",
+    "Members@odata.count": 3,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Administrator"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/Operator"
+        },
+        {
+            "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnly"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles_Administrator.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles_Administrator.json
@@ -1,0 +1,20 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.type": "#Role.v1_0_0.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Administrator",
+    "Id": "Administrator",
+    "Name": "User Role",
+    "IsPredefined": true,
+    "Description": "Administrator User Role",
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureManager",
+        "ConfigureUsers",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "OemPrivileges": [
+        "OemClearLog",
+        "OemPowerControl"
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles_Operator.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles_Operator.json
@@ -1,0 +1,15 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.type": "#Role.v1_0_0.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/Operator",
+    "Id": "Operator",
+    "Name": "User Role",
+    "IsPredefined": true,
+    "Description": "Operator User Role",
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureSelf",
+        "ConfigureComponents"
+    ],
+    "OemPrivileges": []
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles_ReadOnly.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_AccountService_Roles_ReadOnly.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Role.Role",
+    "@odata.type": "#Role.v1_0_0.Role",
+    "@odata.id": "/redfish/v1/AccountService/Roles/ReadOnly",
+    "Id": "ReadOnly",
+    "Name": "User Role",
+    "IsPredefined": true,
+    "Description": "ReadOnly User Role",
+    "AssignedPrivileges": [
+        "Login",
+        "ConfigureSelf"
+    ],
+    "OemPrivileges": []
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis.json
@@ -1,0 +1,12 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ChassisCollection.ChassisCollection",
+    "@odata.type": "#ChassisCollection.ChassisCollection",
+    "@odata.id": "/redfish/v1/Chassis",
+    "Name": "Chassis Collection",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1"
+        }
+    ],
+    "Members@odata.count": 1
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis_1.json
@@ -1,0 +1,51 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Chassis.Chassis",
+    "@odata.type": "#Chassis.v1_4_0.Chassis",
+    "@odata.id": "/redfish/v1/Chassis/1",
+    "Id": "1",
+    "Name": "Computer System Chassis",
+    "ChassisType": "RackMount",
+    "Manufacturer": "Supermicro",
+    "Model": "",
+    "SKU": "",
+    "SerialNumber": "",
+    "PartNumber": "",
+    "AssetTag": "",
+    "IndicatorLED": "Off",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK",
+        "HealthRollup": "OK"
+    },
+    "PhysicalSecurity": {
+        "IntrusionSensorNumber": 170,
+        "IntrusionSensor": "Normal",
+        "IntrusionSensorReArm": "Manual"
+    },
+    "Power": {
+        "@odata.id": "/redfish/v1/Chassis/1/Power"
+    },
+    "Thermal": {
+        "@odata.id": "/redfish/v1/Chassis/1/Thermal"
+    },
+    "Links": {
+        "ComputerSystems": [
+            {
+                "@odata.id": "/redfish/v1/Systems/1"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/1"
+            }
+        ]
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcChassisExtensions.v1_0_0.Chassis",
+            "BoardSerialNumber": "          ",
+            "GUID": "43303031-4D53-AC1F-6B18-A24100000000",
+            "BoardID": "0x86d"
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis_1_Power.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis_1_Power.json
@@ -1,0 +1,276 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Power.Power",
+    "@odata.type": "#Power.v1_1_0.Power",
+    "@odata.id": "/redfish/v1/Chassis/1/Power",
+    "Id": "Power",
+    "Name": "Power",
+    "PowerControl": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/PowerControl/0",
+            "@odata.type": "#Power.v1_0_0.PowerControl",
+            "MemberId": "0",
+            "Name": "System Power Control",
+            "PowerConsumedWatts": 0,
+            "PowerMetrics": {
+                "IntervalInMin": 5,
+                "MinConsumedWatts": 0,
+                "MaxConsumedWatts": 0,
+                "AverageConsumedWatts": 0
+            },
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1/Processors/1"
+                }
+            ],
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "Oem": {}
+        }
+    ],
+    "Voltages": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/0",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "VCCP",
+            "MemberId": "0",
+            "SensorNumber": 32,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/1",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "VDIMM",
+            "MemberId": "1",
+            "SensorNumber": 36,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/2",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "12V",
+            "MemberId": "2",
+            "SensorNumber": 48,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/3",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "5VCC",
+            "MemberId": "3",
+            "SensorNumber": 49,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/4",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "3.3VCC",
+            "MemberId": "4",
+            "SensorNumber": 50,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/5",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "VBAT",
+            "MemberId": "5",
+            "SensorNumber": 51,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/6",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "5V Dual",
+            "MemberId": "6",
+            "SensorNumber": 56,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Voltages/7",
+            "@odata.type": "#Power.v1_0_0.Voltage",
+            "Name": "3.3V AUX",
+            "MemberId": "7",
+            "SensorNumber": 57,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingVolts": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "PhysicalContext": "VoltageRegulator",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        }
+    ],
+    "PowerSupplies": [],
+    "Redundancy": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Power#/Redundancy/0",
+            "@odata.type": "#Redundancy.v1_2_0.Redundancy",
+            "MemberId": "0",
+            "Name": "PowerSupply Redundancy Group 1",
+            "Mode": "Failover",
+            "MaxNumSupported": 4,
+            "MinNumNeeded": 1,
+            "Status": {
+                "State": "Enabled",
+                "Health": "OK"
+            },
+            "RedundancySet": []
+        }
+    ],
+    "Oem": {}
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis_1_Thermal.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Chassis_1_Thermal.json
@@ -1,0 +1,336 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
+    "@odata.type": "#Thermal.v1_4_0.Thermal",
+    "@odata.id": "/redfish/v1/Chassis/1/Thermal",
+    "Id": "Thermal",
+    "Name": "Thermal",
+    "Temperatures": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/0",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "0",
+            "Name": "CPU Temp",
+            "SensorNumber": 1,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1/Processors/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/1",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "1",
+            "Name": "System Temp",
+            "SensorNumber": 11,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/2",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "2",
+            "Name": "Peripheral Temp",
+            "SensorNumber": 12,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/3",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "3",
+            "Name": "MB_10G Temp",
+            "SensorNumber": 13,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "CPU",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/4",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "4",
+            "Name": "DIMMA1 Temp",
+            "SensorNumber": 176,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "Memory",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1/Processors/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/5",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "5",
+            "Name": "DIMMA2 Temp",
+            "SensorNumber": 177,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "Memory",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1/Processors/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/6",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "6",
+            "Name": "DIMMB1 Temp",
+            "SensorNumber": 180,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "Memory",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1/Processors/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Temperatures/7",
+            "@odata.type": "#Thermal.v1_4_0.Temperature",
+            "MemberId": "7",
+            "Name": "DIMMB2 Temp",
+            "SensorNumber": 181,
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingCelsius": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRangeTemp": 0,
+            "MaxReadingRangeTemp": 0,
+            "PhysicalContext": "Memory",
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1/Processors/1"
+                }
+            ]
+        }
+    ],
+    "Fans": [
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/0",
+            "@odata.type": "#Thermal.v1_4_0.Fan",
+            "MemberId": "0",
+            "Name": "FAN1",
+            "SensorNumber": 65,
+            "PhysicalContext": "Fan",
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingUnits": "RPM",
+            "Reading": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/1",
+            "@odata.type": "#Thermal.v1_4_0.Fan",
+            "MemberId": "1",
+            "Name": "FAN2",
+            "SensorNumber": 66,
+            "PhysicalContext": "Fan",
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingUnits": "RPM",
+            "Reading": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/2",
+            "@odata.type": "#Thermal.v1_4_0.Fan",
+            "MemberId": "2",
+            "Name": "FAN3",
+            "SensorNumber": 67,
+            "PhysicalContext": "Fan",
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingUnits": "RPM",
+            "Reading": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                }
+            ]
+        },
+        {
+            "@odata.id": "/redfish/v1/Chassis/1/Thermal#/Fans/3",
+            "@odata.type": "#Thermal.v1_4_0.Fan",
+            "MemberId": "3",
+            "Name": "FAN4",
+            "SensorNumber": 68,
+            "PhysicalContext": "Fan",
+            "Status": {
+                "State": "Absent"
+            },
+            "ReadingUnits": "RPM",
+            "Reading": 0,
+            "UpperThresholdNonCritical": 0,
+            "UpperThresholdCritical": 0,
+            "UpperThresholdFatal": 0,
+            "LowerThresholdNonCritical": 0,
+            "LowerThresholdCritical": 0,
+            "LowerThresholdFatal": 0,
+            "MinReadingRange": 0,
+            "MaxReadingRange": 0,
+            "RelatedItem": [
+                {
+                    "@odata.id": "/redfish/v1/Systems/1"
+                },
+                {
+                    "@odata.id": "/redfish/v1/Chassis/1"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_EventService.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_EventService.json
@@ -1,0 +1,38 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EventService.EventService",
+    "@odata.type": "#EventService.v1_1_0.EventService",
+    "@odata.id": "/redfish/v1/EventService",
+    "Id": "EventService",
+    "Name": "Event Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "DeliveryRetryAttempts": 3,
+    "DeliveryRetryIntervalSeconds": 60,
+    "EventTypesForSubscription": [
+        "StatusChange",
+        "ResourceUpdated",
+        "ResourceAdded",
+        "ResourceRemoved",
+        "Alert"
+    ],
+    "Subscriptions": {
+        "@odata.id": "/redfish/v1/EventService/Subscriptions"
+    },
+    "Actions": {
+        "Oem": {},
+        "#EventService.SubmitTestEvent": {
+            "target": "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent",
+            "EventType@Redfish.AllowableValues": [
+                "StatusChange",
+                "ResourceUpdated",
+                "ResourceAdded",
+                "ResourceRemoved",
+                "Alert"
+            ]
+        }
+    },
+    "Oem": {}
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_EventService_Subscriptions.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_EventService_Subscriptions.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EventDestinationCollection.EventDestinationCollection",
+    "@odata.type": "#EventDestinationCollection.EventDestinationCollection",
+    "@odata.id": "/redfish/v1/EventService/Subscriptions",
+    "Name": "Event Subscriptions Collection",
+    "Members": [],
+    "Members@odata.count": 0
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_JsonSchemas.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_JsonSchemas.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#JsonSchemaFileCollection.JsonSchemaFileCollection",
+    "@odata.type": "#JsonSchemaFileCollection.JsonSchemaFileCollection",
+    "@odata.id": "/redfish/v1/JsonSchemas",
+    "Name": "Schema Repository",
+    "Description": "Schema Repository",
+    "Members@odata.count": 0
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerCollection.ManagerCollection",
+    "@odata.type": "#ManagerCollection.ManagerCollection",
+    "@odata.id": "/redfish/v1/Managers",
+    "Name": "Manager Collection",
+    "Description": "Manager Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/1"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1.json
@@ -1,0 +1,119 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Manager.Manager",
+    "@odata.type": "#Manager.v1_3_2.Manager",
+    "@odata.id": "/redfish/v1/Managers/1",
+    "Id": "1",
+    "Name": "Manager",
+    "Description": "BMC",
+    "ManagerType": "BMC",
+    "UUID": "00000000-0000-0000-0000-AC1F6B18A241",
+    "Model": "ASPEED",
+    "FirmwareVersion": "4.0",
+    "DateTime": "2017-04-26T04:30:51+00:00",
+    "DateTimeLocalOffset": "+00:00",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "GraphicalConsole": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 4,
+        "ConnectTypesSupported": [
+            "KVMIP"
+        ]
+    },
+    "SerialConsole": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 1,
+        "ConnectTypesSupported": [
+            "SSH",
+            "IPMI"
+        ]
+    },
+    "CommandShell": {
+        "ServiceEnabled": true,
+        "MaxConcurrentSessions": 0,
+        "ConnectTypesSupported": [
+            "SSH"
+        ]
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces"
+    },
+    "SerialInterfaces": {
+        "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces"
+    },
+    "NetworkProtocol": {
+        "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol"
+    },
+    "VirtualMedia": {
+        "@odata.id": "/redfish/v1/Managers/1/VM1"
+    },
+    "Links": {
+        "ManagerForServers": [
+            {
+                "@odata.id": "/redfish/v1/Systems/1"
+            }
+        ],
+        "ManagerForChassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ],
+        "Oem": {}
+    },
+    "Actions": {
+        "Oem": {
+            "#ManagerConfig.Reset": {
+                "target": "/redfish/v1/Managers/1/Actions/Oem/ManagerConfig.Reset"
+            }
+        },
+        "#Manager.Reset": {
+            "target": "/redfish/v1/Managers/1/Actions/Manager.Reset"
+        }
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcManagerExtensions.v1_0_0.Manager",
+            "ActiveDirectory": {
+                "@odata.id": "/redfish/v1/Managers/1/ActiveDirectory"
+            },
+            "SMTP": {
+                "@odata.id": "/redfish/v1/Managers/1/SMTP"
+            },
+            "RADIUS": {
+                "@odata.id": "/redfish/v1/Managers/1/RADIUS"
+            },
+            "MouseMode": {
+                "@odata.id": "/redfish/v1/Managers/1/MouseMode"
+            },
+            "NTP": {
+                "@odata.id": "/redfish/v1/Managers/1/NTP"
+            },
+            "LDAP": {
+                "@odata.id": "/redfish/v1/Managers/1/LDAP"
+            },
+            "IPAccessControl": {
+                "@odata.id": "/redfish/v1/Managers/1/IPAccessControl"
+            },
+            "SMCRAKP": {
+                "@odata.id": "/redfish/v1/Managers/1/SMCRAKP"
+            },
+            "SNMP": {
+                "@odata.id": "/redfish/v1/Managers/1/SNMP"
+            },
+            "Syslog": {
+                "@odata.id": "/redfish/v1/Managers/1/Syslog"
+            },
+            "Snooping": {
+                "@odata.id": "/redfish/v1/Managers/1/Snooping"
+            },
+            "FanMode": {
+                "@odata.id": "/redfish/v1/Managers/1/FanMode"
+            },
+            "IKVM": {
+                "@odata.id": "/redfish/v1/Managers/1/IKVM"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_ActiveDirectory.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_ActiveDirectory.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ActiveDirectory.ActiveDirectory",
+    "@odata.type": "#ActiveDirectory.v1_0_0.ActiveDirectory",
+    "@odata.id": "/redfish/v1/Managers/1/ActiveDirectory",
+    "Id": "Active Directory",
+    "Name": "Active Directory",
+    "AuthenticationEnabled": false,
+    "AuthenticationOverSSLEnabled": false,
+    "PortNumber": 389,
+    "UserDomainName": "",
+    "Timeout": 0,
+    "DCSAddress1": "0.0.0.0",
+    "DCSAddress2": "0.0.0.0",
+    "DCSAddress3": "0.0.0.0",
+    "RoleGroups": {
+        "@odata.id": "/redfish/v1/Managers/1/ActiveDirectory/RoleGroups"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_ActiveDirectory_RoleGroups.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_ActiveDirectory_RoleGroups.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#RoleGroupCollection.RoleGroupCollection",
+    "@odata.type": "#RoleGroupCollection.RoleGroupCollection",
+    "@odata.id": "/redfish/v1/Managers/1/ActiveDirectory/RoleGroups",
+    "Name": "Role Group Collection",
+    "Members": [],
+    "Members@odata.count": 0
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_EthernetInterfaces.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_EthernetInterfaces.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces",
+    "Name": "Ethernet Network Interface Collection",
+    "Description": "Collection of EthernetInterfaces for this Manager",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/1"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_EthernetInterfaces_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_EthernetInterfaces_1.json
@@ -1,0 +1,62 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EthernetInterface.EthernetInterface",
+    "@odata.type": "#EthernetInterface.v1_0_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Managers/1/EthernetInterfaces/1",
+    "Id": "1",
+    "Name": "EthernetInterface",
+    "Description": "Management Network Interface",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "InterfaceEnabled": true,
+    "MACAddress": "AC:1F:6B:18:A2:41",
+    "SpeedMbps": 1000,
+    "AutoNeg": true,
+    "FullDuplex": true,
+    "MTUSize": 1500,
+    "HostName": "blade01.vmwarelab.edu",
+    "VLAN": {
+        "VLANEnable": false,
+        "VLANId": 0
+    },
+    "IPv4Addresses": [
+        {
+            "Address": "192.168.254.120",
+            "SubnetMask": "255.255.255.0",
+            "AddressOrigin": "Static",
+            "Gateway": "192.168.254.100"
+        }
+    ],
+    "IPv6AddressPolicyTable": [
+        {
+            "Prefix": "::1/128",
+            "Precedence": 50,
+            "Label": 0
+        }
+    ],
+    "IPv6Addresses": [
+        {
+            "Address": "fd99:218:50cc:402c:ae1f:6bff:fe18:a241",
+            "PrefixLength": 64,
+            "AddressOrigin": "SLAAC",
+            "AddressState": "Preferred"
+        },
+        {
+            "Address": "fe80::ae1f:6bff:fe18:a241",
+            "PrefixLength": 64,
+            "AddressOrigin": "SLAAC",
+            "AddressState": "Preferred"
+        }
+    ],
+    "IPv6StaticAddresses": [
+        {
+            "Address": "fe80::ae1f:6bff:fe18:a241",
+            "PrefixLength": 64
+        }
+    ],
+    "IPv6DefaultGateway": "fe80::ae1f:6bff:fe18:a241",
+    "NameServers": [
+        "172.16.254.201"
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_FanMode.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_FanMode.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#FanMode.FanMode",
+    "@odata.type": "#FanMode.v1_0_0.FanMode",
+    "@odata.id": "/redfish/v1/Managers/1/FanMode",
+    "Name": "FanMode",
+    "Id": "Fan Mode",
+    "Mode": "Optimal",
+    "Mode@Redfish.AllowableValues": [
+        "Standard",
+        "FullSpeed",
+        "Optimal",
+        "HeavyIO"
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_IPAccessControl.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_IPAccessControl.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#IPAccessControl.IPAccessControl",
+    "@odata.type": "#IPAccessControl.v1_0_0.IPAccessControl",
+    "@odata.id": "/redfish/v1/Managers/1/IPAccessControl",
+    "Id": "IP Access Control",
+    "Name": "IP Access Control",
+    "ServiceEnabled": false,
+    "FilterRules": {
+        "@odata.id": "/redfish/v1/Managers/1/IPAccessControl/FilterRules"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_IPAccessControl_FilterRules.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_IPAccessControl_FilterRules.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#FilterRuleCollection.FilterRuleCollection",
+    "@odata.type": "#FilterRuleCollection.FilterRuleCollection",
+    "@odata.id": "/redfish/v1/Managers/1/IPAccessControl/FilterRules",
+    "Name": "Filter Rule Collection",
+    "Members": [],
+    "Members@odata.count": 0
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_LDAP.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_LDAP.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LDAP.LDAP",
+    "@odata.type": "#LDAP.v1_0_0.LDAP",
+    "@odata.id": "/redfish/v1/Managers/1/LDAP",
+    "Id": "LDAP",
+    "Name": "LDAP",
+    "LDAPEnabled": false,
+    "LDAPAuthOverSSL": false,
+    "LDAPPortNumber": 389,
+    "LDAPServerIP": "0.0.0.0",
+    "LDAPPassword": "",
+    "LDAPDN": "",
+    "LDAPSearchbase": ""
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_MouseMode.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_MouseMode.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#MouseMode.MouseMode",
+    "@odata.type": "#MouseMode.v1_0_0.MouseMode",
+    "@odata.id": "/redfish/v1/Managers/1/MouseMode",
+    "Name": "MouseMode",
+    "Id": "Mouse Mode",
+    "Mode": "Absolute",
+    "Mode@Redfish.AllowableValues": [
+        "Absolute",
+        "Relative",
+        "Single"
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_NTP.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_NTP.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#NTP.NTP",
+    "@odata.type": "#NTP.v1_0_0.NTP",
+    "@odata.id": "/redfish/v1/Managers/1/NTP",
+    "Id": "NTP",
+    "Name": "NTP Service",
+    "NTPEnable": false,
+    "PrimaryNTPServer": "localhost",
+    "SecondaryNTPServer": "127.0.0.1",
+    "DaylightSavingTime": false
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_NetworkProtocol.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_NetworkProtocol.json
@@ -1,0 +1,42 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ManagerNetworkProtocol.ManagerNetworkProtocol",
+    "@odata.type": "#ManagerNetworkProtocol.v1_0_0.ManagerNetworkProtocol",
+    "@odata.id": "/redfish/v1/Managers/1/NetworkProtocol",
+    "Id": "NetworkProtocol",
+    "Name": "Manager Network Protocol",
+    "Description": "Manager Network Service Status",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "HostName": "blade01.vmwarelab.edu",
+    "FQDN": "",
+    "HTTP": {
+        "ProtocolEnabled": true,
+        "Port": 80
+    },
+    "HTTPS": {
+        "ProtocolEnabled": true,
+        "Port": 443
+    },
+    "SNMP": {
+        "ProtocolEnabled": false,
+        "Port": 161
+    },
+    "IPMI": {
+        "ProtocolEnabled": true,
+        "Port": 623
+    },
+    "SSH": {
+        "ProtocolEnabled": true,
+        "Port": 22
+    },
+    "VirtualMedia": {
+        "ProtocolEnabled": true,
+        "Port": 623
+    },
+    "KVMIP": {
+        "ProtocolEnabled": true,
+        "Port": 5900
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_RADIUS.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_RADIUS.json
@@ -1,0 +1,11 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#RADIUS.RADIUS",
+    "@odata.type": "#RADIUS.v1_0_1.RADIUS",
+    "@odata.id": "/redfish/v1/Managers/1/RADIUS",
+    "Id": "RADIUS",
+    "Name": "RADIUS",
+    "RadiusEnabled": false,
+    "RadiusServerIP": "0.0.0.0",
+    "RadiusPortNumber": 1812,
+    "RadiusSecret": "null"
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SMCRAKP.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SMCRAKP.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SMCRAKP.SMCRAKP",
+    "@odata.type": "#SMCRAKP.v1_0_0.SMCRAKP",
+    "@odata.id": "/redfish/v1/Managers/1/SMCRAKP",
+    "Name": "SMCRAKP",
+    "Id": "SMC RAKP",
+    "Mode": "Disabled"
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SMTP.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SMTP.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SMTP.SMTP",
+    "@odata.type": "#SMTP.v1_0_0.SMTP",
+    "@odata.id": "/redfish/v1/Managers/1/SMTP",
+    "Id": "SMTP",
+    "Name": "SMTP",
+    "SmtpSSLEnabled": false,
+    "SmtpServer": "",
+    "SmtpPortNumber": 587,
+    "SmtpUserName": "",
+    "SmtpPassword": "null",
+    "SmtpSenderAddress": ""
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SNMP.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SNMP.json
@@ -1,0 +1,14 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SNMP.SNMP",
+    "@odata.type": "#SNMP.v1_0_0.SNMP",
+    "@odata.id": "/redfish/v1/Managers/1/SNMP",
+    "Id": "1",
+    "Name": "SNMP",
+    "SnmpEnabled": false,
+    "SNMPv2": {
+        "@odata.id": "/redfish/v1/Managers/1/SNMP/SNMPv2"
+    },
+    "SNMPv3": {
+        "@odata.id": "/redfish/v1/Managers/1/SNMP/SNMPv3"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SNMP_SNMPv2.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SNMP_SNMPv2.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SNMPv2.SNMPv2",
+    "@odata.type": "#SNMPv2.v1_0_0.SNMPv2",
+    "@odata.id": "/redfish/v1/Managers/1/SNMP/SNMPv2",
+    "Id": "1",
+    "Name": "SNMPv2",
+    "Snmpv2Enabled": true,
+    "ROCommunity": "public",
+    "RWCommunity": "private"
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SNMP_SNMPv3.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SNMP_SNMPv3.json
@@ -1,0 +1,21 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SNMPv3.SNMPv3",
+    "@odata.type": "#SNMPv3.v1_0_0.SNMPv3",
+    "@odata.id": "/redfish/v1/Managers/1/SNMP/SNMPv3",
+    "Id": "1",
+    "Name": "SNMPv3",
+    "Snmpv3Enabled": false,
+    "UserName": "",
+    "AuthProtocol": "MD5",
+    "AuthProtocol@Redfish.AllowableValues": [
+        "SHA1",
+        "MD5"
+    ],
+    "PrivateProtocol": "DES",
+    "PrivateProtocol@Redfish.AllowableValues": [
+        "AES",
+        "DES"
+    ],
+    "AuthKey": "",
+    "PrivateKey": ""
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SerialInterfaces.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SerialInterfaces.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SerialInterfaceCollection.SerialInterfaceCollection",
+    "@odata.type": "#SerialInterfaceCollection.SerialInterfaceCollection",
+    "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces",
+    "Name": "Serial Interface Collection",
+    "Description": "Collection of Serial Interfaces for this Manager",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces/1"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SerialInterfaces_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_SerialInterfaces_1.json
@@ -1,0 +1,15 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SerialInterface.SerialInterface",
+    "@odata.type": "#SerialInterface.v1_0_0.SerialInterface",
+    "@odata.id": "/redfish/v1/Managers/1/SerialInterfaces/1",
+    "Id": "1",
+    "Name": "SerialInterface",
+    "Description": "Serial over LAN",
+    "InterfaceEnabled": true,
+    "SignalType": "Rs232",
+    "BitRate": "115200",
+    "Parity": "None",
+    "DataBits": "8",
+    "StopBits": "1",
+    "FlowControl": "None"
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_Snooping.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_Snooping.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Snooping.Snooping",
+    "@odata.type": "#Snooping.v1_0_0.Snooping",
+    "@odata.id": "/redfish/v1/Managers/1/Snooping",
+    "Name": "Snooping",
+    "Id": "Snooping",
+    "PostCode": "b4"
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_Syslog.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_Syslog.json
@@ -1,0 +1,10 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Syslog.Syslog",
+    "@odata.type": "#Syslog.v1_0_0.Syslog",
+    "@odata.id": "/redfish/v1/Managers/1/Syslog",
+    "Id": "Syslog",
+    "Name": "Syslog",
+    "EnableSyslog": false,
+    "SyslogServerIP": "",
+    "SyslogPortNumber": 0
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_VM1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Managers_1_VM1.json
@@ -1,0 +1,16 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#VirtualMediaCollection.VirtualMediaCollection",
+    "@odata.type": "#VirtualMediaCollection.VirtualMediaCollection",
+    "@odata.id": "/redfish/v1/Managers/1/VM1",
+    "Name": "Virtual Media Collection",
+    "Description": "Collection of Virtual Media for this System",
+    "Members@odata.count": 0,
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcVirtualMediaExtensions.v1_0_0.VirtualMediaCollection",
+            "VirtualMediaConfig": {
+                "@odata.id": "/redfish/v1/Managers/1/VM1/CfgCD"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Registries.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Registries.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#MessageRegistryFileCollection.MessageRegistryFileCollection",
+    "@odata.type": "#MessageRegistryFileCollection.MessageRegistryFileCollection",
+    "@odata.id": "/redfish/v1/Registries",
+    "Name": "Registry File Collection",
+    "Description": "Registry Repository",
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Registries/Base.v1_4_0"
+        }
+    ],
+    "Members@odata.count": 1
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Registries_Base.v1_4_0.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Registries_Base.v1_4_0.json
@@ -1,0 +1,19 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#MessageRegistryFile.MessageRegistryFile",
+    "@odata.type": "#MessageRegistryFile.v1_0_0.MessageRegistryFile",
+    "@odata.id": "/redfish/v1/Registries/Base.v1_4_0",
+    "Id": "Base.v1_4_0",
+    "Name": "Base Message Registry File",
+    "Description": "Base Message Registry File locations",
+    "Languages": [
+        "en"
+    ],
+    "Registry": "Base.v1_4_0",
+    "Location": [
+        {
+            "Language": "en",
+            "Uri": "/registries/Base.v1_4_0.json"
+        }
+    ],
+    "Oem": {}
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_SessionService.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_SessionService.json
@@ -1,0 +1,17 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SessionService.SessionService",
+    "@odata.type": "#SessionService.v1_0_0.SessionService",
+    "@odata.id": "/redfish/v1/SessionService",
+    "Id": "SessionService",
+    "Name": "Session Service",
+    "Description": "Session Service",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": true,
+    "SessionTimeout": 300,
+    "Sessions": {
+        "@odata.id": "/redfish/v1/SessionService/Sessions"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_SessionService_Sessions.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_SessionService_Sessions.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SessionCollection.SessionCollection",
+    "@odata.type": "#SessionCollection.SessionCollection",
+    "@odata.id": "/redfish/v1/SessionService/Sessions",
+    "Name": "Session Collection",
+    "Members": [],
+    "Members@odata.count": 0
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystemCollection.ComputerSystemCollection",
+    "@odata.type": "#ComputerSystemCollection.ComputerSystemCollection",
+    "@odata.id": "/redfish/v1/Systems",
+    "Name": "Computer System Collection",
+    "Description": "Computer System Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1.json
@@ -1,0 +1,112 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ComputerSystem.ComputerSystem",
+    "@odata.type": "#ComputerSystem.v1_3_0.ComputerSystem",
+    "@odata.id": "/redfish/v1/Systems/1",
+    "Id": "1",
+    "Name": "System",
+    "Description": "Description of server",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "SerialNumber": "          ",
+    "PartNumber": "",
+    "SystemType": "Physical",
+    "BiosVersion": "1.2",
+    "Manufacturer": "Supermicro",
+    "Model": "Super Server",
+    "SKU": "To be filled by O.E.M.",
+    "UUID": "00000000-0000-0000-0000-AC1F6B18A45A",
+    "ProcessorSummary": {
+        "Count": 1,
+        "Model": "Intel(R) Xeon(R) processor",
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK"
+        }
+    },
+    "MemorySummary": {
+        "TotalSystemMemoryGiB": 64,
+        "Status": {
+            "State": "Enabled",
+            "Health": "OK"
+        }
+    },
+    "IndicatorLED": "Off",
+    "PowerState": "On",
+    "Boot": {
+        "BootSourceOverrideEnabled": "Disabled",
+        "BootSourceOverrideTarget": "None",
+        "BootSourceOverrideTarget@Redfish.AllowableValues": [
+            "None",
+            "Pxe",
+            "Hdd",
+            "Diags",
+            "CD/DVD",
+            "BiosSetup",
+            "FloppyRemovableMedia",
+            "UsbKey",
+            "UsbHdd",
+            "UsbFloppy",
+            "UsbCd",
+            "UefiUsbKey",
+            "UefiCd",
+            "UefiHdd",
+            "UefiUsbHdd",
+            "UefiUsbCd"
+        ]
+    },
+    "Processors": {
+        "@odata.id": "/redfish/v1/Systems/1/Processors"
+    },
+    "Memory": {
+        "@odata.id": "/redfish/v1/Systems/1/Memory"
+    },
+    "EthernetInterfaces": {
+        "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces"
+    },
+    "SimpleStorage": {
+        "@odata.id": "/redfish/v1/Systems/1/SimpleStorage"
+    },
+    "Storage": {
+        "@odata.id": "/redfish/v1/Systems/1/Storage"
+    },
+    "LogServices": {
+        "@odata.id": "/redfish/v1/Systems/1/LogServices"
+    },
+    "Links": {
+        "Chassis": [
+            {
+                "@odata.id": "/redfish/v1/Chassis/1"
+            }
+        ],
+        "ManagedBy": [
+            {
+                "@odata.id": "/redfish/v1/Managers/1"
+            }
+        ],
+        "Oem": {}
+    },
+    "Actions": {
+        "#ComputerSystem.Reset": {
+            "target": "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            "ResetType@Redfish.AllowableValues": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn"
+            ]
+        }
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcSystemExtensions.v1_0_0.System",
+            "SmcNodeManager": {
+                "@odata.id": "/redfish/v1/Systems/1/SmcNodeManager"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces.json
@@ -1,0 +1,22 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.type": "#EthernetInterfaceCollection.EthernetInterfaceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces",
+    "Name": "Ethernet Network Interface Collection",
+    "Description": "Simple Network Collection",
+    "Members@odata.count": 4,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/4"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_1.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EthernetInterface.EthernetInterface",
+    "@odata.type": "#EthernetInterface.v1_0_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/1",
+    "Id": "1",
+    "Name": "OnBoard LAN 1",
+    "Description": "OnBoard #1",
+    "Status": {
+        "State": "Disabled",
+        "Health": "OK"
+    },
+    "MACAddress": "ac:1f:6b:18:a4:5a",
+    "SpeedMbps": 0,
+    "FQDN": "",
+    "NameServers": [
+        ""
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_2.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_2.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EthernetInterface.EthernetInterface",
+    "@odata.type": "#EthernetInterface.v1_0_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/2",
+    "Id": "2",
+    "Name": "OnBoard LAN 2",
+    "Description": "OnBoard #2",
+    "Status": {
+        "State": "Disabled",
+        "Health": "OK"
+    },
+    "MACAddress": "ac:1f:6b:18:a4:5b",
+    "SpeedMbps": 0,
+    "FQDN": "",
+    "NameServers": [
+        ""
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_3.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_3.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EthernetInterface.EthernetInterface",
+    "@odata.type": "#EthernetInterface.v1_0_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/3",
+    "Id": "3",
+    "Name": "OnBoard LAN 3",
+    "Description": "OnBoard #3",
+    "Status": {
+        "State": "Disabled",
+        "Health": "OK"
+    },
+    "MACAddress": "ac:1f:6b:18:a6:b2",
+    "SpeedMbps": 0,
+    "FQDN": "",
+    "NameServers": [
+        ""
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_4.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_EthernetInterfaces_4.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#EthernetInterface.EthernetInterface",
+    "@odata.type": "#EthernetInterface.v1_0_0.EthernetInterface",
+    "@odata.id": "/redfish/v1/Systems/1/EthernetInterfaces/4",
+    "Id": "4",
+    "Name": "OnBoard LAN 4",
+    "Description": "OnBoard #4",
+    "Status": {
+        "State": "Disabled",
+        "Health": "OK"
+    },
+    "MACAddress": "ac:1f:6b:18:a6:b3",
+    "SpeedMbps": 0,
+    "FQDN": "",
+    "NameServers": [
+        ""
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogServiceCollection.LogServiceCollection",
+    "@odata.type": "#LogServiceCollection.LogServiceCollection",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices",
+    "Name": "Health Event Log Service Collection",
+    "Description": "Collection of Health Event Logs",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1.json
@@ -1,0 +1,26 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogService.LogService",
+    "@odata.type": "#LogService.v1_1_0.LogService",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1",
+    "Id": "Log1",
+    "Name": "Health Event Log Service",
+    "MaxNumberOfRecords": 512,
+    "OverWritePolicy": "WrapsWhenFull",
+    "DateTime": "2017-04-26T04:30:19+00:00",
+    "DateTimeLocalOffset": "+00:00",
+    "ServiceEnabled": true,
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    },
+    "Oem": {},
+    "Entries": {
+        "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries"
+    },
+    "Actions": {
+        "Oem": {},
+        "#LogService.ClearLog": {
+            "target": "/redfish/v1/Systems/1/LogServices/Log1/Actions/LogService.ClearLog"
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries.json
@@ -1,0 +1,2025 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntryCollection.LogEntryCollection",
+    "@odata.type": "#LogEntryCollection.LogEntryCollection",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries",
+    "Name": "Health Event Log Service Collection",
+    "Description": "Collection of Health Event Logs",
+    "Members@odata.count": 65,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/1",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "1",
+            "Name": "Log Entry 1",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:14+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/2",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "2",
+            "Name": "Log Entry 2",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:14+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/3",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "3",
+            "Name": "Log Entry 3",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:15+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/4",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "4",
+            "Name": "Log Entry 4",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:15+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/5",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "5",
+            "Name": "Log Entry 5",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:15+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/6",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "6",
+            "Name": "Log Entry 6",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:16+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/7",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "7",
+            "Name": "Log Entry 7",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:16+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/8",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "8",
+            "Name": "Log Entry 8",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:16+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/9",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "9",
+            "Name": "Log Entry 9",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:17+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/10",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "10",
+            "Name": "Log Entry 10",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:17+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/11",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "11",
+            "Name": "Log Entry 11",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:17+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/12",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "12",
+            "Name": "Log Entry 12",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:17+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/13",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "13",
+            "Name": "Log Entry 13",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:18+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/14",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "14",
+            "Name": "Log Entry 14",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:18+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/15",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "15",
+            "Name": "Log Entry 15",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:18+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/16",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "16",
+            "Name": "Log Entry 16",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:19+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/17",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "17",
+            "Name": "Log Entry 17",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:19+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/18",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "18",
+            "Name": "Log Entry 18",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:19+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/19",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "19",
+            "Name": "Log Entry 19",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:20+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/20",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "20",
+            "Name": "Log Entry 20",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:20+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/21",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "21",
+            "Name": "Log Entry 21",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:20+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/22",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "22",
+            "Name": "Log Entry 22",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:20+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/23",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "23",
+            "Name": "Log Entry 23",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:21+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/24",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "24",
+            "Name": "Log Entry 24",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:21+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/25",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "25",
+            "Name": "Log Entry 25",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:21+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/26",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "26",
+            "Name": "Log Entry 26",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:22+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/27",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "27",
+            "Name": "Log Entry 27",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:22+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/28",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "28",
+            "Name": "Log Entry 28",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:22+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/29",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "29",
+            "Name": "Log Entry 29",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:23+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/30",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "30",
+            "Name": "Log Entry 30",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:23+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/31",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "31",
+            "Name": "Log Entry 31",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:23+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/32",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "32",
+            "Name": "Log Entry 32",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:23+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/33",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "33",
+            "Name": "Log Entry 33",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:24+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/34",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "34",
+            "Name": "Log Entry 34",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:24+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/35",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "35",
+            "Name": "Log Entry 35",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:24+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/36",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "36",
+            "Name": "Log Entry 36",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:25+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/37",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "37",
+            "Name": "Log Entry 37",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:25+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/38",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "38",
+            "Name": "Log Entry 38",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:25+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/39",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "39",
+            "Name": "Log Entry 39",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:26+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/40",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "40",
+            "Name": "Log Entry 40",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:26+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/41",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "41",
+            "Name": "Log Entry 41",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:26+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/42",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "42",
+            "Name": "Log Entry 42",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:26+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/43",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "43",
+            "Name": "Log Entry 43",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:27+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/44",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "44",
+            "Name": "Log Entry 44",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:27+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/45",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "45",
+            "Name": "Log Entry 45",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:27+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/46",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "46",
+            "Name": "Log Entry 46",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:28+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/47",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "47",
+            "Name": "Log Entry 47",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:28+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/48",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "48",
+            "Name": "Log Entry 48",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:28+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/49",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "49",
+            "Name": "Log Entry 49",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:29+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/50",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "50",
+            "Name": "Log Entry 50",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:31+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/51",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "51",
+            "Name": "Log Entry 51",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:38+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/52",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "52",
+            "Name": "Log Entry 52",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:51+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/53",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "53",
+            "Name": "Log Entry 53",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:57+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/54",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "54",
+            "Name": "Log Entry 54",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:57+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/55",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "55",
+            "Name": "Log Entry 55",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:58+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/56",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "56",
+            "Name": "Log Entry 56",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:58+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/57",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "57",
+            "Name": "Log Entry 57",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:58+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/58",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "58",
+            "Name": "Log Entry 58",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:59+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/59",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "59",
+            "Name": "Log Entry 59",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:46:59+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/60",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "60",
+            "Name": "Log Entry 60",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:47:06+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/61",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "61",
+            "Name": "Log Entry 61",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:47:06+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/62",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "62",
+            "Name": "Log Entry 62",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:47:53+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/63",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "63",
+            "Name": "Log Entry 63",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:51:20+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/64",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "64",
+            "Name": "Log Entry 64",
+            "EntryType": "Event",
+            "Created": "2018-08-12T12:57:47+00:00",
+            "EntryCode": "Assert",
+            "SensorType": "Memory",
+            "SensorNumber": 0,
+            "Message": "[ OEM ] Correctable ECC @DIMMB1",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0x0C",
+                        "SensorName": "OEM",
+                        "EventData1": "0xA0",
+                        "EventData2": "0x2A",
+                        "EventData3": "0x80"
+                    }
+                }
+            }
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/65",
+            "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+            "Id": "65",
+            "Name": "Log Entry 65",
+            "EntryType": "Event",
+            "Created": "2020-02-25T17:13:16+00:00",
+            "EntryCode": "Assert",
+            "OemSensorType": "OOB",
+            "SensorNumber": 255,
+            "Message": "[ OEM ] Activate Node Product Key",
+            "MessageArgs": [
+                "ArrayOfMessageArgs"
+            ],
+            "Links": {
+                "Oem": {}
+            },
+            "Oem": {
+                "Supermicro": {
+                    "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+                    "RawEventData": {
+                        "EventDirAndType": "0x6F",
+                        "SensorType": "0xCA",
+                        "SensorName": "OEM",
+                        "EventData1": "0x18",
+                        "EventData2": "0x00",
+                        "EventData3": "0xFF"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_1.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/1",
+    "Id": "1",
+    "Name": "Log Entry 1",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:14+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_10.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_10.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/10",
+    "Id": "10",
+    "Name": "Log Entry 10",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:17+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_11.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_11.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/11",
+    "Id": "11",
+    "Name": "Log Entry 11",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:17+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_12.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_12.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/12",
+    "Id": "12",
+    "Name": "Log Entry 12",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:17+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_13.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_13.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/13",
+    "Id": "13",
+    "Name": "Log Entry 13",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:18+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_14.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_14.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/14",
+    "Id": "14",
+    "Name": "Log Entry 14",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:18+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_15.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_15.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/15",
+    "Id": "15",
+    "Name": "Log Entry 15",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:18+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_16.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_16.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/16",
+    "Id": "16",
+    "Name": "Log Entry 16",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:19+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_17.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_17.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/17",
+    "Id": "17",
+    "Name": "Log Entry 17",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:19+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_18.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_18.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/18",
+    "Id": "18",
+    "Name": "Log Entry 18",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:19+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_19.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_19.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/19",
+    "Id": "19",
+    "Name": "Log Entry 19",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:20+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_2.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_2.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/2",
+    "Id": "2",
+    "Name": "Log Entry 2",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:14+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_20.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_20.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/20",
+    "Id": "20",
+    "Name": "Log Entry 20",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:20+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_21.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_21.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/21",
+    "Id": "21",
+    "Name": "Log Entry 21",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:20+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_22.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_22.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/22",
+    "Id": "22",
+    "Name": "Log Entry 22",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:20+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_23.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_23.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/23",
+    "Id": "23",
+    "Name": "Log Entry 23",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:21+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_24.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_24.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/24",
+    "Id": "24",
+    "Name": "Log Entry 24",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:21+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_25.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_25.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/25",
+    "Id": "25",
+    "Name": "Log Entry 25",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:21+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_26.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_26.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/26",
+    "Id": "26",
+    "Name": "Log Entry 26",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:22+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_27.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_27.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/27",
+    "Id": "27",
+    "Name": "Log Entry 27",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:22+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_28.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_28.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/28",
+    "Id": "28",
+    "Name": "Log Entry 28",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:22+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_29.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_29.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/29",
+    "Id": "29",
+    "Name": "Log Entry 29",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:23+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_3.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_3.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/3",
+    "Id": "3",
+    "Name": "Log Entry 3",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:15+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_30.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_30.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/30",
+    "Id": "30",
+    "Name": "Log Entry 30",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:23+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_31.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_31.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/31",
+    "Id": "31",
+    "Name": "Log Entry 31",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:23+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_32.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_32.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/32",
+    "Id": "32",
+    "Name": "Log Entry 32",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:23+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_33.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_33.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/33",
+    "Id": "33",
+    "Name": "Log Entry 33",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:24+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_34.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_34.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/34",
+    "Id": "34",
+    "Name": "Log Entry 34",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:24+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_35.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_35.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/35",
+    "Id": "35",
+    "Name": "Log Entry 35",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:24+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_36.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_36.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/36",
+    "Id": "36",
+    "Name": "Log Entry 36",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:25+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_37.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_37.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/37",
+    "Id": "37",
+    "Name": "Log Entry 37",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:25+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_38.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_38.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/38",
+    "Id": "38",
+    "Name": "Log Entry 38",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:25+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_39.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_39.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/39",
+    "Id": "39",
+    "Name": "Log Entry 39",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:26+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_4.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_4.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/4",
+    "Id": "4",
+    "Name": "Log Entry 4",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:15+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_40.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_40.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/40",
+    "Id": "40",
+    "Name": "Log Entry 40",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:26+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_41.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_41.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/41",
+    "Id": "41",
+    "Name": "Log Entry 41",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:26+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_42.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_42.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/42",
+    "Id": "42",
+    "Name": "Log Entry 42",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:26+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_43.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_43.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/43",
+    "Id": "43",
+    "Name": "Log Entry 43",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:27+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_44.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_44.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/44",
+    "Id": "44",
+    "Name": "Log Entry 44",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:27+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_45.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_45.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/45",
+    "Id": "45",
+    "Name": "Log Entry 45",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:27+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_46.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_46.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/46",
+    "Id": "46",
+    "Name": "Log Entry 46",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:28+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_47.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_47.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/47",
+    "Id": "47",
+    "Name": "Log Entry 47",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:28+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_48.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_48.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/48",
+    "Id": "48",
+    "Name": "Log Entry 48",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:28+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_49.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_49.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/49",
+    "Id": "49",
+    "Name": "Log Entry 49",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:29+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_5.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_5.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/5",
+    "Id": "5",
+    "Name": "Log Entry 5",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:15+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_50.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_50.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/50",
+    "Id": "50",
+    "Name": "Log Entry 50",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:31+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_51.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_51.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/51",
+    "Id": "51",
+    "Name": "Log Entry 51",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:38+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_52.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_52.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/52",
+    "Id": "52",
+    "Name": "Log Entry 52",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:51+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_53.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_53.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/53",
+    "Id": "53",
+    "Name": "Log Entry 53",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:57+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_54.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_54.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/54",
+    "Id": "54",
+    "Name": "Log Entry 54",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:57+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_55.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_55.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/55",
+    "Id": "55",
+    "Name": "Log Entry 55",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:58+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_56.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_56.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/56",
+    "Id": "56",
+    "Name": "Log Entry 56",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:58+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_57.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_57.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/57",
+    "Id": "57",
+    "Name": "Log Entry 57",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:58+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_58.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_58.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/58",
+    "Id": "58",
+    "Name": "Log Entry 58",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:59+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_59.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_59.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/59",
+    "Id": "59",
+    "Name": "Log Entry 59",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:59+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_6.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_6.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/6",
+    "Id": "6",
+    "Name": "Log Entry 6",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:16+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_60.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_60.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/60",
+    "Id": "60",
+    "Name": "Log Entry 60",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:47:06+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_61.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_61.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/61",
+    "Id": "61",
+    "Name": "Log Entry 61",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:47:06+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_62.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_62.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/62",
+    "Id": "62",
+    "Name": "Log Entry 62",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:47:53+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_63.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_63.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/63",
+    "Id": "63",
+    "Name": "Log Entry 63",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:51:20+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_64.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_64.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/64",
+    "Id": "64",
+    "Name": "Log Entry 64",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:57:47+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_65.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_65.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/65",
+    "Id": "65",
+    "Name": "Log Entry 65",
+    "EntryType": "Event",
+    "Created": "2020-02-25T17:13:16+00:00",
+    "EntryCode": "Assert",
+    "OemSensorType": "OOB",
+    "SensorNumber": 255,
+    "Message": "[ OEM ] Activate Node Product Key",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0xCA",
+                "SensorName": "OEM",
+                "EventData1": "0x18",
+                "EventData2": "0x00",
+                "EventData3": "0xFF"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_7.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_7.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/7",
+    "Id": "7",
+    "Name": "Log Entry 7",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:16+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_8.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_8.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/8",
+    "Id": "8",
+    "Name": "Log Entry 8",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:16+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_9.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_LogServices_Log1_Entries_9.json
@@ -1,0 +1,32 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#LogEntry.LogEntry",
+    "@odata.type": "#LogEntry.v1_3_0.LogEntry",
+    "@odata.id": "/redfish/v1/Systems/1/LogServices/Log1/Entries/9",
+    "Id": "9",
+    "Name": "Log Entry 9",
+    "EntryType": "Event",
+    "Created": "2018-08-12T12:46:17+00:00",
+    "EntryCode": "Assert",
+    "SensorType": "Memory",
+    "SensorNumber": 0,
+    "Message": "[ OEM ] Correctable ECC @DIMMB1",
+    "MessageArgs": [
+        "ArrayOfMessageArgs"
+    ],
+    "Links": {
+        "Oem": {}
+    },
+    "Oem": {
+        "Supermicro": {
+            "@odata.type": "#SmcLogEntryExtensions.v1_0_0.LogEntry",
+            "RawEventData": {
+                "EventDirAndType": "0x6F",
+                "SensorType": "0x0C",
+                "SensorName": "OEM",
+                "EventData1": "0xA0",
+                "EventData2": "0x2A",
+                "EventData3": "0x80"
+            }
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory.json
@@ -1,0 +1,22 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#MemoryCollection.MemoryCollection",
+    "@odata.type": "#MemoryCollection.MemoryCollection",
+    "@odata.id": "/redfish/v1/Systems/1/Memory",
+    "Name": "Memory Collection",
+    "Description": "Memory Collection",
+    "Members@odata.count": 4,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Memory/1"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Memory/2"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Memory/3"
+        },
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Memory/4"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_1.json
@@ -1,0 +1,35 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.type": "#Memory.v1_1_0.Memory",
+    "@odata.id": "/redfish/v1/Systems/1/Memory/1",
+    "Id": "1",
+    "Name": "DIMMA1",
+    "RankCount": 1,
+    "Description": "Memory",
+    "CapacityMiB": 16384,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "OperatingSpeedMhz": 2133,
+    "AllowedSpeedsMHz": [
+        2133
+    ],
+    "DeviceLocator": "DIMMA1",
+    "MemoryLocation": {
+        "Socket": 0,
+        "MemoryController": 0,
+        "Channel": 0,
+        "Slot": 0
+    },
+    "Manufacturer": "Micron",
+    "SerialNumber": "16E1FD76",
+    "PartNumber": "36ASF2G72PZ-2G1B1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_2.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_2.json
@@ -1,0 +1,35 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.type": "#Memory.v1_1_0.Memory",
+    "@odata.id": "/redfish/v1/Systems/1/Memory/2",
+    "Id": "2",
+    "Name": "DIMMA2",
+    "RankCount": 2,
+    "Description": "Memory",
+    "CapacityMiB": 16384,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "OperatingSpeedMhz": 2133,
+    "AllowedSpeedsMHz": [
+        2133
+    ],
+    "DeviceLocator": "DIMMA2",
+    "MemoryLocation": {
+        "Socket": 0,
+        "MemoryController": 0,
+        "Channel": 0,
+        "Slot": 1
+    },
+    "Manufacturer": "Micron",
+    "SerialNumber": "16E203D3",
+    "PartNumber": "36ASF2G72PZ-2G1B1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_3.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_3.json
@@ -1,0 +1,35 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.type": "#Memory.v1_1_0.Memory",
+    "@odata.id": "/redfish/v1/Systems/1/Memory/3",
+    "Id": "3",
+    "Name": "DIMMB1",
+    "RankCount": 3,
+    "Description": "Memory",
+    "CapacityMiB": 16384,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "OperatingSpeedMhz": 2133,
+    "AllowedSpeedsMHz": [
+        2133
+    ],
+    "DeviceLocator": "DIMMB1",
+    "MemoryLocation": {
+        "Socket": 0,
+        "MemoryController": 0,
+        "Channel": 1,
+        "Slot": 0
+    },
+    "Manufacturer": "Micron",
+    "SerialNumber": "16E1FD2E",
+    "PartNumber": "36ASF2G72PZ-2G1B1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_4.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Memory_4.json
@@ -1,0 +1,35 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Memory.Memory",
+    "@odata.type": "#Memory.v1_1_0.Memory",
+    "@odata.id": "/redfish/v1/Systems/1/Memory/4",
+    "Id": "4",
+    "Name": "DIMMB2",
+    "RankCount": 4,
+    "Description": "Memory",
+    "CapacityMiB": 16384,
+    "DataWidthBits": 64,
+    "BusWidthBits": 72,
+    "MemoryMedia": [
+        "DRAM"
+    ],
+    "MemoryType": "DRAM",
+    "MemoryDeviceType": "DDR4",
+    "OperatingSpeedMhz": 2133,
+    "AllowedSpeedsMHz": [
+        2133
+    ],
+    "DeviceLocator": "DIMMB2",
+    "MemoryLocation": {
+        "Socket": 0,
+        "MemoryController": 0,
+        "Channel": 1,
+        "Slot": 1
+    },
+    "Manufacturer": "Micron",
+    "SerialNumber": "16E1F6F3",
+    "PartNumber": "36ASF2G72PZ-2G1B1",
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Processors.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Processors.json
@@ -1,0 +1,13 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#ProcessorCollection.ProcessorCollection",
+    "@odata.type": "#ProcessorCollection.ProcessorCollection",
+    "@odata.id": "/redfish/v1/Systems/1/Processors",
+    "Name": "Processors Collection",
+    "Description": "Processors Collection",
+    "Members@odata.count": 1,
+    "Members": [
+        {
+            "@odata.id": "/redfish/v1/Systems/1/Processors/1"
+        }
+    ]
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Processors_1.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_Processors_1.json
@@ -1,0 +1,28 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#Processor.Processor",
+    "@odata.type": "#Processor.v1_0_0.Processor",
+    "@odata.id": "/redfish/v1/Systems/1/Processors/1",
+    "Id": "1",
+    "Name": "Processor1",
+    "Description": "Processor",
+    "Socket": "CPU1",
+    "Manufacturer": "Intel",
+    "Model": "Intel(R) Xeon(R) CPU D-1541 @ 2.10GHz",
+    "MaxSpeedMHz": 4000,
+    "TotalCores": 8,
+    "TotalThreads": 16,
+    "ProcessorType": "CPU",
+    "ProcessorArchitecture": "x86",
+    "InstructionSet": "x86-64",
+    "ProcessorId": {
+        "VendorId": "GenuineIntel",
+        "IdentificationRegisters": "0xBFEBFBFF00050663",
+        "EffectiveFamily": "0x6",
+        "EffectiveModel": "0x56",
+        "Step": "0x3"
+    },
+    "Status": {
+        "State": "Enabled",
+        "Health": "OK"
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_SimpleStorage.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_SimpleStorage.json
@@ -1,0 +1,9 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SimpleStorageCollection.SimpleStorageCollection",
+    "@odata.type": "#SimpleStorageCollection.SimpleStorageCollection",
+    "@odata.id": "/redfish/v1/Systems/1/SimpleStorage",
+    "Name": "Simple Storage Collection",
+    "Members@odata.count": 0,
+    "Description": "Simple Storage Collection",
+    "Members": []
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_SmcNodeManager.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_Systems_1_SmcNodeManager.json
@@ -1,0 +1,62 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#SmcNodeManager.SmcNodeManager",
+    "@odata.type": "#SmcNodeManager.v1_0_0.SmcNodeManager",
+    "@odata.id": "/redfish/v1/Systems/1/SmcNodeManager",
+    "Id": "Node Manager",
+    "Name": "Node Manager",
+    "Capabilities": [
+        {
+            "DomainID": "Entire platform",
+            "PolicyType": "Power Control Policy",
+            "MaxConcurrentSettings": 16,
+            "MaxValueAfterReset": 32767,
+            "MinValueAfterReset": 1,
+            "MaxCorrectionTime": 600000,
+            "MinCorrectionTime": 6000,
+            "MaxReportingPeriod": 3600,
+            "MinReportingPeriod": 1,
+            "DomainLimitingScope": 0
+        }
+    ],
+    "Statistics": [
+        {
+            "Mode": "Global power statistics",
+            "DomainID": "Entire platform",
+            "Timestamp": "2017-04-26T04:31:02+00:00",
+            "CurrentValue": 0,
+            "MaximumValue": 0,
+            "MinimumValue": 0,
+            "AverageValue": 0,
+            "ReportingPeriod": 385869
+        }
+    ],
+    "Version": {
+        "IntelNMVersion": "Supported Intel NM 3.0",
+        "IPMIVersion": "Intel NM IPMI version 3.0",
+        "PatchVersion": 0,
+        "MajorRevision": 3,
+        "MinorRevision": 3
+    },
+    "Selftest": {
+        "MajorCode": 85,
+        "MinorCode": 0,
+        "ImageFlags": "Operational"
+    },
+    "Policy": [
+        {
+            "DomainID": "Entire platform",
+            "PolicyID": 1,
+            "PolicyType": 0,
+            "PolicyExceptionActions": 0,
+            "PowerLimit": 0,
+            "CorrectionTimeLimit": 0,
+            "PolicyTriggerLimit": 0,
+            "StatReportingPeriod": 0
+        }
+    ],
+    "Actions": {
+        "#SmcNodeManager.ClearAllPolicies": {
+            "target": "/redfish/v1/Systems/1/SmcNodeManager/Actions/SmcNodeManager.ClearAllPolicies"
+        }
+    }
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_TaskService.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_TaskService.json
@@ -1,0 +1,18 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#TaskService.TaskService",
+    "@odata.type": "#TaskService.v1_0_0.TaskService",
+    "@odata.id": "/redfish/v1/TaskService",
+    "Id": "TaskService",
+    "Name": "Tasks Service",
+    "DateTime": "2017-04-26T04:31:04+00:00",
+    "CompletedTaskOverWritePolicy": "Manual",
+    "Status": {
+        "State": "Disabled",
+        "Health": "OK"
+    },
+    "ServiceEnabled": false,
+    "Tasks": {
+        "@odata.id": "/redfish/v1/TaskService/Tasks"
+    },
+    "Oem": {}
+}

--- a/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_TaskService_Tasks.json
+++ b/tests/supermicro_x10_corpus/json_responses/192.168.254.120/_redfish_v1_TaskService_Tasks.json
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "/redfish/v1/$metadata#TaskCollection.TaskCollection",
+    "@odata.type": "#TaskCollection.TaskCollection",
+    "@odata.id": "/redfish/v1/TaskService/Tasks",
+    "Name": "Task Collection",
+    "Members@odata.count": 0,
+    "Members": []
+}

--- a/tests/test_supermicro_x10_vendor_corpus.py
+++ b/tests/test_supermicro_x10_vendor_corpus.py
@@ -1,0 +1,100 @@
+"""Contracts for the Supermicro X10 (ASPEED BMC) vendor corpus + mutation rules.
+
+The corpus under tests/supermicro_x10_corpus is a real capture from a home-lab
+X10 board. The crawl did not capture the ServiceRoot, so a minimal synthetic
+_redfish_v1.json links the collections that WERE captured (and is marked as
+synthesized); everything else is the untouched capture. This board exposes no
+Bios and only a proprietary VirtualMedia, so the rules cover power/boot/log.
+
+Author Mus <spyroot@gmail.com>
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+X10_CORPUS = REPO_ROOT / "tests" / "supermicro_x10_corpus" / "json_responses" / "192.168.254.120"
+X10_RULES = REPO_ROOT / "tests" / "mutation_rules" / "supermicro_x10.yaml"
+
+SYSTEM = "/redfish/v1/Systems/1"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+LOG_CLEAR = f"{SYSTEM}/LogServices/Log1/Actions/LogService.ClearLog"
+
+
+def _load_server_module():
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _http(base: str, path: str, method: str = "GET", body=None):
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    request = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, (json.loads(raw) if raw else None)
+
+
+def test_x10_corpus_is_discoverable_via_a_synthesized_root() -> None:
+    """The corpus serves as a Supermicro X10; the synthetic root is marked as such."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, X10_CORPUS) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+        _, root = _http(base, "/redfish/v1")
+        assert root["Vendor"] == "Supermicro"
+        # The synthetic root is transparently flagged, never passed off as captured.
+        assert root["Oem"]["redfish_ctl"]["Synthesized"] is True
+        members = [m["@odata.id"] for m in _http(base, "/redfish/v1/Systems")[1]["Members"]]
+        assert SYSTEM in members
+        _, system = _http(base, SYSTEM)
+        assert system["Manufacturer"] == "Supermicro"
+        assert system["PowerState"] == "On"
+
+
+def test_x10_power_boot_and_log_mutations() -> None:
+    """Power cycle, one-time boot revert, and log clear reconcile on the corpus."""
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, X10_CORPUS, mutation_rules=X10_RULES) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        assert _http(base, RESET, "POST", {"ResetType": "ForceOff"})[0] == 204
+        assert _http(base, SYSTEM)[1]["PowerState"] == "Off"
+        assert _http(base, RESET, "POST", {"ResetType": "On"})[0] == 204
+        assert _http(base, SYSTEM)[1]["PowerState"] == "On"
+
+        assert _http(base, SYSTEM, "PATCH",
+                     {"Boot": {"BootSourceOverrideTarget": "Pxe",
+                               "BootSourceOverrideEnabled": "Once"}})[0] == 200
+        assert _http(base, SYSTEM)[1]["Boot"]["BootSourceOverrideEnabled"] == "Once"
+        assert _http(base, RESET, "POST", {"ResetType": "GracefulRestart"})[0] == 204
+        assert _http(base, SYSTEM)[1]["Boot"]["BootSourceOverrideEnabled"] == "Disabled"
+
+        assert _http(base, LOG_CLEAR, "POST", {})[0] == 204
+
+
+def test_x10_rules_every_path_resolves_to_a_corpus_fixture() -> None:
+    """Each rule's precondition/transition path exists in the committed corpus."""
+    module = _load_server_module()
+    spec = yaml.safe_load(X10_RULES.read_text(encoding="utf-8"))
+    assert spec["vendor"] == "supermicro-x10"
+    for rule in spec["rules"]:
+        paths = [t["path"] for t in rule.get("state_transitions", [])]
+        paths += [c["path"] for c in rule.get("when", [])]
+        for resource_path in paths:
+            assert module.fixture_for_redfish_path(X10_CORPUS, resource_path) is not None, (
+                f"rule {rule['name']} targets missing {resource_path}"
+            )


### PR DESCRIPTION
A real **Supermicro X10** (ASPEED BMC) capture — the home-lab hardware — committed as a mock corpus with `supermicro_x10.yaml` rules covering power reset, boot-source override, one-time-boot revert, and log clear. The board's ComputerSystem exposes no Bios and only a proprietary VirtualMedia (VM1/CfgCD, no standard slots), so those classes are absent.

The crawl did not capture the ServiceRoot, so a minimal synthetic `_redfish_v1.json` links only the captured collections and is flagged `Oem.redfish_ctl.Synthesized` (never passed off as captured); everything else is the untouched capture.

Verification: `pytest -q` green; the test serves the corpus as a Supermicro X10 through the synthetic root, validates power/boot/log mutations before/after, and guards that every rule path resolves to a fixture. Secret scan clean.