### PR TITLE
Use neutral mock BMC corpus mount path

### DIFF
--- a/charts/redfish-controller/values.yaml
+++ b/charts/redfish-controller/values.yaml
@@ -26,7 +26,7 @@ mockBmc:
     repository: spyroot/redfish-ctl-mock-bmc
     tag: v1.2.0
     pullPolicy: IfNotPresent
-  corpusDir: /corpus/172.25.230.37
+  corpusDir: /corpus/gb300
   resources:
     requests:
       cpu: 25m

--- a/docker/Dockerfile.mock-bmc
+++ b/docker/Dockerfile.mock-bmc
@@ -8,7 +8,7 @@ FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    MOCK_BMC_CORPUS_DIR=/corpus/172.25.230.37
+    MOCK_BMC_CORPUS_DIR=/corpus/gb300
 
 # PyYAML lets the mock load YAML replay traces and mutation-rules files; the
 # server itself is otherwise stdlib-only. Without it the mock can only read
@@ -32,7 +32,7 @@ COPY --chown=mockbmc:mockbmc k8s/sandbox/mock_bmc_server.py \
     /app/mock_bmc_server.py
 COPY --chown=mockbmc:mockbmc \
     tests/supermicro_gb300_corpus/json_responses/172.25.230.37 \
-    /corpus/172.25.230.37
+    /corpus/gb300
 
 USER mockbmc
 

--- a/docs/simulation-and-replay.md
+++ b/docs/simulation-and-replay.md
@@ -38,10 +38,11 @@ Reads alone cannot exercise a mutation. Layer 3 teaches the mock BMC to accept w
 served state exactly as observed on real hardware, driven by a **trace** captured from a mutation
 that was already verified live. This turns a static corpus into a *mutate-able* environment.
 
-The mock BMC enters replay mode when started with a trace file:
+The mock BMC enters replay mode when started with a trace file. In the container image, the
+committed GB300 corpus is mounted at `/corpus/gb300`:
 
 ```bash
-python k8s/sandbox/mock_bmc_server.py --corpus-dir tests/supermicro_gb300_corpus/json_responses/172.25.230.37 \
+python /app/mock_bmc_server.py --corpus-dir /corpus/gb300 \
   --replay tests/write_traces/graceful_restart.yaml
 ```
 

--- a/k8s/sandbox/gb300-fleet.yaml
+++ b/k8s/sandbox/gb300-fleet.yaml
@@ -68,7 +68,7 @@ spec:
               exec python /app/mock_bmc_server.py --corpus-dir "$MOCK_BMC_CORPUS_DIR"
           env:
             - name: MOCK_BMC_CORPUS_DIR
-              value: /corpus/172.25.230.37
+              value: /corpus/gb300
           readinessProbe:
             httpGet:
               path: /redfish/v1/

--- a/k8s/sandbox/mock-bmc.yaml
+++ b/k8s/sandbox/mock-bmc.yaml
@@ -43,7 +43,7 @@ spec:
               containerPort: 8080
           env:
             - name: MOCK_BMC_CORPUS_DIR
-              value: /corpus/172.25.230.37
+              value: /corpus/gb300
           volumeMounts:
             - name: mutation-rules
               mountPath: /rules

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -20,7 +20,7 @@ from urllib.parse import unquote, urlsplit
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8080
 DEFAULT_CORPUS_DIR = Path(
-    os.environ.get("MOCK_BMC_CORPUS_DIR", "/corpus/172.25.230.37")
+    os.environ.get("MOCK_BMC_CORPUS_DIR", "/corpus/gb300")
 )
 
 

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -150,7 +150,7 @@ def test_mock_bmc_can_be_enabled() -> None:
     assert container["env"] == [
         {
             "name": "MOCK_BMC_CORPUS_DIR",
-            "value": "/corpus/172.25.230.37",
+            "value": "/corpus/gb300",
         }
     ]
     assert mock_service["spec"]["ports"] == [{"name": "http", "port": 80, "targetPort": "http"}]

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -15,6 +15,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
 DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.mock-bmc"
 MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "mock-bmc.yaml"
+FLEET_MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "gb300-fleet.yaml"
+HELM_VALUES = REPO_ROOT / "charts" / "redfish-controller" / "values.yaml"
+SIMULATION_DOC = REPO_ROOT / "docs" / "simulation-and-replay.md"
 GRACEFUL_RESTART_TRACE = REPO_ROOT / "tests" / "write_traces" / "graceful_restart.yaml"
 SUPERMICRO_RULES = REPO_ROOT / "tests" / "mutation_rules" / "supermicro_gb300.yaml"
 GB300_CORPUS = (
@@ -145,6 +148,9 @@ def test_mock_bmc_container_builds_from_corpus_without_credentials() -> None:
     assert "--chown=mockbmc:mockbmc" in dockerfile
     assert "k8s/sandbox/mock_bmc_server.py" in dockerfile
     assert "tests/supermicro_gb300_corpus/json_responses/172.25.230.37" in dockerfile
+    assert "MOCK_BMC_CORPUS_DIR=/corpus/gb300" in dockerfile
+    assert "/corpus/gb300" in dockerfile
+    assert "/corpus/172.25.230.37" not in dockerfile
     assert "USER mockbmc" in dockerfile
     assert "EXPOSE 8080" in dockerfile
     assert "ENTRYPOINT" in dockerfile
@@ -170,9 +176,32 @@ def test_mock_bmc_manifest_exposes_read_only_service_without_secrets() -> None:
     assert service["metadata"]["name"] == "mock-bmc"
     assert container["image"] == "redfish-ctl-mock-bmc:local"
     assert container["ports"][0]["containerPort"] == 8080
+    assert container["env"] == [
+        {
+            "name": "MOCK_BMC_CORPUS_DIR",
+            "value": "/corpus/gb300",
+        }
+    ]
     assert container["readinessProbe"]["httpGet"]["path"] == "/redfish/v1/"
     assert service["spec"]["ports"][0]["targetPort"] == "http"
     assert not {name for name in env_names if "PASSWORD" in name or "SECRET" in name}
+
+
+def test_public_runtime_paths_do_not_embed_lab_addresses() -> None:
+    """Public image, manifest, chart, and doc paths use a neutral corpus mount."""
+    public_files = [
+        DOCKERFILE,
+        SERVER_MODULE,
+        MANIFEST,
+        FLEET_MANIFEST,
+        HELM_VALUES,
+        SIMULATION_DOC,
+    ]
+
+    for path in public_files:
+        text = path.read_text(encoding="utf-8")
+        assert "/corpus/172.25.230.37" not in text, path
+        assert "/corpus/gb300" in text, path
 
 
 # --- order-independent mutation-rules mode -------------------------------------


### PR DESCRIPTION
## Summary
- Switch the mock-BMC image, sandbox manifests, Helm default, and replay docs to the neutral `/corpus/gb300` runtime mount path.
- Keep the source fixture copy path unchanged while adding tests that reject lab-address runtime mount paths in public files.

## Tests
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD PYTHONDONTWRITEBYTECODE=1 pytest -q tests/test_k8s_mock_bmc_server.py tests/test_helm_chart.py -o cache_dir=/private/tmp/idrac-corpus-path-pytest-cache` -> `29 passed in 5.61s`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD PYTHONDONTWRITEBYTECODE=1 pytest -q -o cache_dir=/private/tmp/idrac-corpus-path-full-pytest-cache` -> `995 passed, 58 skipped in 38.45s`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check k8s/sandbox/mock_bmc_server.py tests/test_k8s_mock_bmc_server.py tests/test_helm_chart.py` -> `All checks passed!`
- `git diff --check`