### PR TITLE
Add mock BMC concurrency benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TWINE ?= twine
 DOCKER ?= docker
 IMAGE ?= redfish-ctl
 
-.PHONY: help test lint typecheck build docker-test docker-image docs-voice-check k8s-sandbox clean
+.PHONY: help test lint typecheck build bench-concurrency docker-test docker-image docs-voice-check k8s-sandbox clean
 
 help: ## Show available developer targets.
 	@awk 'BEGIN { \
@@ -31,6 +31,13 @@ typecheck: ## Run mypy over source and tests.
 build: ## Build sdist/wheel locally and validate package metadata.
 	$(PYTHON) setup.py sdist bdist_wheel
 	$(TWINE) check dist/*
+
+bench-concurrency: ## Run the opt-in mock-BMC concurrency benchmark.
+	$(PYTHON) tests/request_benchmark.py \
+		--levels 1,8,32,128 \
+		--requests-per-level 128 \
+		--concurrency-report reports/concurrency-benchmark.json \
+		--summary-report reports/concurrency-benchmark.md
 
 docker-test: ## Build and run the Linux offline test image.
 	./docker/run-tests.sh

--- a/docs/scaling-and-benchmarks.md
+++ b/docs/scaling-and-benchmarks.md
@@ -4,7 +4,7 @@ Author: Mus <spyroot@gmail.com>
 
 The design target is for `redfish_ctl` to grow past one server and drive roughly 1,000 BMCs to a
 desired state with numbers that show it is fast, correct, and stable. This page defines the fleet
-engine, simulator, and benchmark gate. Those runnable artifacts are not in the repository yet.
+engine, simulator, and benchmark gate.
 
 ## What Exists Today
 
@@ -15,6 +15,21 @@ themselves.
 
 The discover package has a small fake-async harness in tests around scanner behavior. It is useful
 seed material for a simulator because it exercises Redfish reads without live hardware.
+
+`tests/request_benchmark.py`, the local benchmark helper used by request-count tests, also includes
+an opt-in mock-BMC concurrency benchmark. It serves the committed GB300 corpus through
+`k8s/sandbox/mock_bmc_server.py`, ramps clients at `1, 8, 32, 128`, and records request throughput plus
+p50/p95/p99 latency for a read-only Redfish path.
+
+Run it locally from the repository root:
+
+```bash
+make bench-concurrency
+```
+
+The target writes `reports/concurrency-benchmark.json` for machine comparison and
+`reports/concurrency-benchmark.md` for review. It does not contact live BMCs, publish artifacts, or
+upload images.
 
 ## Planned Concurrency Engine
 
@@ -42,7 +57,7 @@ one generic server. It is not wired as a fleet benchmark gate.
 
 ## Metrics And Targets
 
-Each benchmark would write a result under `reports/`, such as `reports/bench-fleet-1000.json`, so
+Each benchmark writes a result under `reports/`, such as `reports/concurrency-benchmark.json`, so
 regressions are visible.
 
 | Metric | Target |

--- a/reports/concurrency-benchmark.json
+++ b/reports/concurrency-benchmark.json
@@ -1,0 +1,100 @@
+{
+  "samples": [
+    {
+      "concurrency": 1,
+      "duration_seconds": 0.074,
+      "error_counts": {},
+      "errors": 0,
+      "latency_ms": {
+        "max": 4.762,
+        "min": 0.358,
+        "p50": 0.538,
+        "p95": 0.719,
+        "p99": 0.941
+      },
+      "ok": 128,
+      "requests": 128,
+      "status_counts": {
+        "200": 128
+      },
+      "throughput_rps": 1724.292
+    },
+    {
+      "concurrency": 8,
+      "duration_seconds": 0.07,
+      "error_counts": {},
+      "errors": 0,
+      "latency_ms": {
+        "max": 56.523,
+        "min": 1.797,
+        "p50": 2.964,
+        "p95": 3.988,
+        "p99": 31.039
+      },
+      "ok": 128,
+      "requests": 128,
+      "status_counts": {
+        "200": 128
+      },
+      "throughput_rps": 1826.9
+    },
+    {
+      "concurrency": 32,
+      "duration_seconds": 0.107,
+      "error_counts": {},
+      "errors": 0,
+      "latency_ms": {
+        "max": 94.015,
+        "min": 1.855,
+        "p50": 4.332,
+        "p95": 62.66,
+        "p99": 93.466
+      },
+      "ok": 128,
+      "requests": 128,
+      "status_counts": {
+        "200": 128
+      },
+      "throughput_rps": 1198.485
+    },
+    {
+      "concurrency": 128,
+      "duration_seconds": 0.097,
+      "error_counts": {},
+      "errors": 0,
+      "latency_ms": {
+        "max": 65.558,
+        "min": 4.056,
+        "p50": 31.517,
+        "p95": 64.161,
+        "p99": 65.114
+      },
+      "ok": 128,
+      "requests": 128,
+      "status_counts": {
+        "200": 128
+      },
+      "throughput_rps": 1316.171
+    }
+  ],
+  "settings": {
+    "concurrency_levels": [
+      1,
+      8,
+      32,
+      128
+    ],
+    "latency_ceiling_ms": 5000.0,
+    "requests_per_level": 128,
+    "timeout_seconds": 5.0
+  },
+  "summary": {
+    "max_sustained_concurrency": 128,
+    "total_errors": 0,
+    "total_requests": 512
+  },
+  "target": {
+    "base_url": "local mock BMC",
+    "path": "/redfish/v1/Systems/System_0"
+  }
+}

--- a/reports/concurrency-benchmark.md
+++ b/reports/concurrency-benchmark.md
@@ -1,0 +1,13 @@
+# Concurrency Benchmark
+
+- Target path: `/redfish/v1/Systems/System_0`
+- Total requests: 512
+- Total errors: 0
+- Max sustained concurrency: 128
+
+| Clients | Requests | Errors | Throughput req/s | p50 ms | p95 ms | p99 ms |
+|---:|---:|---:|---:|---:|---:|---:|
+| 1 | 128 | 0 | 1724.292 | 0.538 | 0.719 | 0.941 |
+| 8 | 128 | 0 | 1826.900 | 2.964 | 3.988 | 31.039 |
+| 32 | 128 | 0 | 1198.485 | 4.332 | 62.66 | 93.466 |
+| 128 | 128 | 0 | 1316.171 | 31.517 | 64.161 | 65.114 |

--- a/tests/request_benchmark.py
+++ b/tests/request_benchmark.py
@@ -1,7 +1,17 @@
-"""Helpers for request-count benchmarks over mocked Redfish services."""
+"""Helpers for request-count and concurrency benchmarks over mocked Redfish services."""
 
 from __future__ import annotations
 
+import argparse
+import concurrent.futures
+import importlib.util
+import json
+import math
+import statistics
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
 from typing import Any
 
 from redfish_ctl.idrac_shared import ApiRequestType
@@ -71,3 +81,260 @@ def assert_read_budget(
         <= max_india_vpn_seconds
     )
     return result
+
+
+def _percentile(values: list[float], percentile: int) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = math.ceil((percentile / 100) * len(ordered)) - 1
+    return round(ordered[min(max(index, 0), len(ordered) - 1)], 3)
+
+
+def _target_url(base_url: str, path: str) -> str:
+    return f"{base_url.rstrip('/')}/{path.lstrip('/')}"
+
+
+def _fetch_once(url: str, timeout: float) -> dict[str, Any]:
+    started = time.perf_counter()
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            raw = response.read()
+            status = response.status
+        json.loads(raw.decode("utf-8") if raw else "{}")
+        error = None if status == 200 else f"HTTP {status}"
+    except (OSError, ValueError, urllib.error.HTTPError) as exc:
+        status = getattr(exc, "code", None)
+        error = type(exc).__name__
+    latency_ms = (time.perf_counter() - started) * 1000
+    return {"error": error, "latency_ms": latency_ms, "status": status}
+
+
+def _status_counts(results: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for result in results:
+        status = result["status"]
+        key = str(status if status is not None else "error")
+        counts[key] = counts.get(key, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _error_counts(results: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for result in results:
+        error = result["error"]
+        if error is None:
+            continue
+        counts[str(error)] = counts.get(str(error), 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def run_concurrency_benchmark(
+    base_url: str,
+    path: str,
+    *,
+    concurrency_levels: tuple[int, ...] = (1, 8, 32, 128),
+    requests_per_level: int = 128,
+    timeout_seconds: float = 5.0,
+    latency_ceiling_ms: float | None = 5000.0,
+) -> dict[str, Any]:
+    """Hammer one Redfish path and return throughput and latency percentiles."""
+    if not concurrency_levels:
+        raise ValueError("at least one concurrency level is required")
+    if any(level < 1 for level in concurrency_levels):
+        raise ValueError("concurrency levels must be positive")
+    if requests_per_level < 1:
+        raise ValueError("requests_per_level must be positive")
+
+    url = _target_url(base_url, path)
+    samples = []
+    for level in concurrency_levels:
+        request_count = max(requests_per_level, level)
+        started = time.perf_counter()
+        with concurrent.futures.ThreadPoolExecutor(max_workers=level) as pool:
+            results = list(
+                pool.map(lambda _: _fetch_once(url, timeout_seconds), range(request_count))
+            )
+        duration = max(time.perf_counter() - started, 0.000001)
+        ok_latencies = [
+            result["latency_ms"]
+            for result in results
+            if result["error"] is None and result["status"] == 200
+        ]
+        errors = request_count - len(ok_latencies)
+        latency = {
+            "min": round(min(ok_latencies), 3) if ok_latencies else None,
+            "p50": round(statistics.median(ok_latencies), 3) if ok_latencies else None,
+            "p95": _percentile(ok_latencies, 95),
+            "p99": _percentile(ok_latencies, 99),
+            "max": round(max(ok_latencies), 3) if ok_latencies else None,
+        }
+        samples.append(
+            {
+                "concurrency": level,
+                "requests": request_count,
+                "ok": len(ok_latencies),
+                "errors": errors,
+                "duration_seconds": round(duration, 3),
+                "throughput_rps": round(request_count / duration, 3),
+                "latency_ms": latency,
+                "status_counts": _status_counts(results),
+                "error_counts": _error_counts(results),
+            }
+        )
+
+    max_sustained = 0
+    for sample in samples:
+        p99 = sample["latency_ms"]["p99"]
+        within_latency = latency_ceiling_ms is None or (
+            p99 is not None and p99 <= latency_ceiling_ms
+        )
+        if sample["errors"] == 0 and within_latency:
+            max_sustained = sample["concurrency"]
+
+    total_requests = sum(sample["requests"] for sample in samples)
+    total_errors = sum(sample["errors"] for sample in samples)
+    return {
+        "target": {"base_url": base_url, "path": path},
+        "settings": {
+            "concurrency_levels": list(concurrency_levels),
+            "requests_per_level": requests_per_level,
+            "timeout_seconds": timeout_seconds,
+            "latency_ceiling_ms": latency_ceiling_ms,
+        },
+        "summary": {
+            "total_requests": total_requests,
+            "total_errors": total_errors,
+            "max_sustained_concurrency": max_sustained,
+        },
+        "samples": samples,
+    }
+
+
+def write_concurrency_report(report: dict[str, Any], output: Path) -> None:
+    """Write a benchmark report as stable, pretty JSON."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def format_concurrency_summary(report: dict[str, Any]) -> str:
+    """Return a short Markdown summary for humans reading benchmark output."""
+    target = report["target"]
+    summary = report["summary"]
+    lines = [
+        "# Concurrency Benchmark",
+        "",
+        f"- Target path: `{target['path']}`",
+        f"- Total requests: {summary['total_requests']}",
+        f"- Total errors: {summary['total_errors']}",
+        f"- Max sustained concurrency: {summary['max_sustained_concurrency']}",
+        "",
+        "| Clients | Requests | Errors | Throughput req/s | p50 ms | p95 ms | p99 ms |",
+        "|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for sample in report["samples"]:
+        latency = sample["latency_ms"]
+        lines.append(
+            "| {concurrency} | {requests} | {errors} | {throughput:.3f} | "
+            "{p50} | {p95} | {p99} |".format(
+                concurrency=sample["concurrency"],
+                requests=sample["requests"],
+                errors=sample["errors"],
+                throughput=sample["throughput_rps"],
+                p50=latency["p50"],
+                p95=latency["p95"],
+                p99=latency["p99"],
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _load_mock_server(repo_root: Path) -> Any:
+    server_module = repo_root / "k8s" / "sandbox" / "mock_bmc_server.py"
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", server_module)
+    module = importlib.util.module_from_spec(spec)
+    if spec.loader is None:
+        raise RuntimeError(f"could not load {server_module}")
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse_levels(value: str) -> tuple[int, ...]:
+    try:
+        levels = tuple(int(part.strip()) for part in value.split(",") if part.strip())
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("levels must be comma-separated integers") from exc
+    if not levels or any(level < 1 for level in levels):
+        raise argparse.ArgumentTypeError("levels must contain positive integers")
+    return levels
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Run an opt-in mock-BMC concurrency benchmark."
+    )
+    repo_root = Path(__file__).resolve().parents[1]
+    parser.add_argument("--levels", type=_parse_levels, default=(1, 8, 32, 128))
+    parser.add_argument("--requests-per-level", type=int, default=128)
+    parser.add_argument("--timeout-seconds", type=float, default=5.0)
+    parser.add_argument("--latency-ceiling-ms", type=float, default=5000.0)
+    parser.add_argument("--path", default="/redfish/v1/Systems/System_0")
+    parser.add_argument(
+        "--corpus-tarball",
+        type=Path,
+        default=repo_root / "tests" / "supermicro_gb300_corpus.tar.gz",
+    )
+    parser.add_argument("--corpus-leaf", default="172.25.230.37")
+    parser.add_argument(
+        "--concurrency-report",
+        type=Path,
+        default=repo_root / "reports" / "concurrency-benchmark.json",
+    )
+    parser.add_argument(
+        "--summary-report",
+        type=Path,
+        default=repo_root / "reports" / "concurrency-benchmark.md",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    repo_root = Path(__file__).resolve().parents[1]
+
+    from vendor_corpus import corpus_dir
+
+    corpus = corpus_dir(args.corpus_tarball, args.corpus_leaf)
+    server_module = _load_mock_server(repo_root)
+    with server_module.run_server("127.0.0.1", 0, corpus) as server:
+        base_url = "http://{}:{}".format(*server.server_address)
+        report = run_concurrency_benchmark(
+            base_url,
+            args.path,
+            concurrency_levels=args.levels,
+            requests_per_level=args.requests_per_level,
+            timeout_seconds=args.timeout_seconds,
+            latency_ceiling_ms=args.latency_ceiling_ms,
+        )
+    report["target"]["base_url"] = "local mock BMC"
+
+    write_concurrency_report(report, args.concurrency_report)
+    summary = format_concurrency_summary(report)
+    args.summary_report.parent.mkdir(parents=True, exist_ok=True)
+    args.summary_report.write_text(summary, encoding="utf-8")
+    print(summary)
+
+    expected_max = max(args.levels)
+    if report["summary"]["total_errors"]:
+        return 1
+    if report["summary"]["max_sustained_concurrency"] < expected_max:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_concurrency_benchmark.py
+++ b/tests/test_concurrency_benchmark.py
@@ -1,0 +1,84 @@
+"""Smoke tests for the opt-in mock-BMC concurrency benchmark."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+from tests.request_benchmark import (
+    run_concurrency_benchmark,
+    write_concurrency_report,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+SYSTEM = "/redfish/v1/Systems/System_0"
+
+
+def _load_server_module():
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _tiny_corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "_redfish_v1.json").write_text(
+        json.dumps(
+            {
+                "@odata.id": "/redfish/v1",
+                "Systems": {"@odata.id": "/redfish/v1/Systems"},
+                "RedfishVersion": "1.17.0",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (corpus / "_redfish_v1_Systems_System_0.json").write_text(
+        json.dumps(
+            {
+                "@odata.id": SYSTEM,
+                "Id": "System_0",
+                "Name": "Tiny System",
+                "PowerState": "On",
+                "Status": {"Health": "OK", "State": "Enabled"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return corpus
+
+
+def test_concurrency_benchmark_records_latency_and_throughput(tmp_path: Path) -> None:
+    module = _load_server_module()
+    with module.run_server("127.0.0.1", 0, _tiny_corpus(tmp_path)) as server:
+        base_url = "http://{}:{}".format(*server.server_address)
+        report = run_concurrency_benchmark(
+            base_url,
+            SYSTEM,
+            concurrency_levels=(1, 4),
+            requests_per_level=8,
+            latency_ceiling_ms=1000.0,
+        )
+
+    assert report["target"]["path"] == SYSTEM
+    assert report["summary"]["max_sustained_concurrency"] == 4
+    assert report["summary"]["total_errors"] == 0
+
+    samples = report["samples"]
+    assert [sample["concurrency"] for sample in samples] == [1, 4]
+    for sample in samples:
+        assert sample["requests"] == 8
+        assert sample["errors"] == 0
+        assert sample["throughput_rps"] > 0
+        assert sample["latency_ms"]["p50"] >= 0
+        assert sample["latency_ms"]["p95"] <= 1000.0
+        assert sample["latency_ms"]["p99"] <= 1000.0
+
+    output = tmp_path / "reports" / "concurrency-benchmark.json"
+    write_concurrency_report(report, output)
+    persisted = json.loads(output.read_text(encoding="utf-8"))
+    assert persisted["summary"] == report["summary"]

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -8,6 +8,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 REQUIRED_TARGETS = {
+    "bench-concurrency",
     "help",
     "test",
     "lint",
@@ -44,6 +45,7 @@ def test_make_dry_run_uses_expected_safe_local_commands() -> None:
             "make",
             "-n",
             "build",
+            "bench-concurrency",
             "docker-test",
             "docker-image",
             "docs-voice-check",
@@ -58,6 +60,7 @@ def test_make_dry_run_uses_expected_safe_local_commands() -> None:
 
     assert result.returncode == 0, result.stderr
     assert "setup.py sdist bdist_wheel" in result.stdout
+    assert "concurrency-benchmark.json" in result.stdout
     assert "twine check" in result.stdout
     assert "docker/run-tests.sh" in result.stdout
     assert "docker build" in result.stdout


### PR DESCRIPTION
$## Summary\n- extend the request benchmark helper with a local mock-BMC concurrency harness and JSON/Markdown report output\n- add a make bench-concurrency target for opt-in capacity measurement\n- add a smoke test covering throughput and latency report shape on a tiny local corpus\n- document the benchmark flow and include the current local mock-BMC report\n\n## Validation\n- pytest -q tests/test_concurrency_benchmark.py tests/test_makefile_targets.py\n- ruff check tests/request_benchmark.py tests/test_concurrency_benchmark.py tests/test_makefile_targets.py\n- make bench-concurrency PYTHON="/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python"\n- pytest -q