### PR TITLE
Use conda env for local Makefile tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
 SHELL := /bin/sh
 .DEFAULT_GOAL := help
 
-PYTHON ?= python
-PYTEST ?= pytest
-RUFF ?= ruff
-MYPY ?= mypy
-TWINE ?= twine
+CONDA_ENV ?= redfish_ctl
+CONDA ?= $(shell \
+	if command -v conda >/dev/null 2>&1; then \
+		command -v conda; \
+	elif [ -x "$$HOME/miniconda3/condabin/conda" ]; then \
+		printf '%s' "$$HOME/miniconda3/condabin/conda"; \
+	elif [ -x "$$HOME/miniconda3/bin/conda" ]; then \
+		printf '%s' "$$HOME/miniconda3/bin/conda"; \
+	else \
+		printf '%s' conda; \
+	fi)
+CONDA_RUN ?= $(CONDA) run -n $(CONDA_ENV)
+
+PYTHON ?= $(CONDA_RUN) python
+PYTEST ?= $(CONDA_RUN) pytest
+RUFF ?= $(CONDA_RUN) ruff
+MYPY ?= $(CONDA_RUN) mypy
+TWINE ?= $(CONDA_RUN) twine
 DOCKER ?= docker
 IMAGE ?= redfish-ctl
 

--- a/environment.yml
+++ b/environment.yml
@@ -22,6 +22,7 @@ dependencies:
   - requests-mock>=1.10
   - ruff
   - mypy
+  - twine
   # Schema validation (tools/redfish_validate.py)
   - jsonschema>=4.18
   - referencing

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -24,6 +24,11 @@ DEFAULT_CORPUS_DIR = Path(
 )
 
 
+class MockBMCServer(ThreadingHTTPServer):
+    request_queue_size = 128
+    daemon_threads = True
+
+
 def _build_fixture_index(corpus_dir: Path) -> dict[str, Path]:
     root = Path(corpus_dir)
     return {path.name.lower(): path for path in root.glob("*.json")}
@@ -658,7 +663,7 @@ def run_server(
     mutation_rules: Path | None = None,
     seed: int = 0,
 ) -> Iterator[ThreadingHTTPServer]:
-    server = ThreadingHTTPServer(
+    server = MockBMCServer(
         (host, port),
         make_handler(
             corpus_dir,
@@ -716,7 +721,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv)
     server = None
     try:
-        server = ThreadingHTTPServer(
+        server = MockBMCServer(
             (args.host, args.port),
             make_handler(
                 args.corpus_dir,

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -71,3 +71,36 @@ def test_make_dry_run_uses_expected_safe_local_commands() -> None:
     makefile_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
     assert "twine upload" not in makefile_text
     assert "docker push" not in makefile_text
+
+
+def test_makefile_local_python_targets_use_project_conda_env_by_default() -> None:
+    """Python tooling targets should use the checked-in conda environment by default."""
+    result = subprocess.run(
+        [
+            "make",
+            "-n",
+            "test",
+            "lint",
+            "typecheck",
+            "build",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert " run -n redfish_ctl pytest -q" in result.stdout
+    assert " run -n redfish_ctl ruff check redfish_ctl tests" in result.stdout
+    assert " run -n redfish_ctl mypy redfish_ctl tests" in result.stdout
+    assert " run -n redfish_ctl python setup.py sdist bdist_wheel" in result.stdout
+    assert " run -n redfish_ctl twine check dist/*" in result.stdout
+
+
+def test_conda_environment_includes_make_build_tools() -> None:
+    """The project environment should include every tool used by local Makefile targets."""
+    environment_text = (REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+
+    assert "  - twine" in environment_text

--- a/tests/test_mock_bmc_concurrency.py
+++ b/tests/test_mock_bmc_concurrency.py
@@ -20,6 +20,7 @@ NETWORK_PROTOCOL = "/redfish/v1/Managers/BMC_0/NetworkProtocol"
 CHASSIS = "/redfish/v1/Chassis/Chassis_0"
 
 MAX_CONCURRENT_SECONDS = 20.0
+MIN_REQUEST_QUEUE_SIZE = 64
 
 
 def _load_server_module() -> Any:
@@ -155,6 +156,15 @@ def test_mock_bmc_serves_many_concurrent_reads(tmp_path: Path) -> None:
     for status, payload in results:
         assert status == 200
         assert payload == expected_payloads[payload["@odata.id"]]
+
+
+def test_mock_bmc_server_backlog_covers_concurrency_contract(tmp_path: Path) -> None:
+    """The listen backlog should not reset clients in the concurrency tests."""
+    module = _load_server_module()
+    corpus, _ = _tiny_corpus(tmp_path)
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        assert server.request_queue_size >= MIN_REQUEST_QUEUE_SIZE
 
 
 def test_mutation_rules_serialize_concurrent_writes_with_reads(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Default local Makefile Python tooling through the project conda environment.
- Add twine to the development environment because the build target runs twine check.
- Extend Makefile contract tests for the conda-backed dry-run output and build-tool dependency.
- Increase the mock BMC HTTP listen backlog to keep concurrent read/write tests from resetting client connections on Linux.

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest tests/test_makefile_targets.py -q
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest tests/test_mock_bmc_concurrency.py::test_mock_bmc_server_backlog_covers_concurrency_contract tests/test_mock_bmc_concurrency.py::test_mutation_rules_serialize_concurrent_writes_with_reads -q
- 20x focused loop: /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest tests/test_mock_bmc_concurrency.py::test_mutation_rules_serialize_concurrent_writes_with_reads -q
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check tests/test_makefile_targets.py tests/test_mock_bmc_concurrency.py k8s/sandbox/mock_bmc_server.py