### PR TITLE
Fix invalid JSON and drop demo credential in add_read_only_user spec

### DIFF
--- a/specs/add_read_only_user.json
+++ b/specs/add_read_only_user.json
@@ -13,11 +13,8 @@
     "Users.3.UseEmail": "Disabled",
     "Users.3.EmailAddress": "",
     "Users.3.RSASecurID2FA": "Disabled",
-    "Users.3.UserName": "test",
-    "Users.3.Password": "test123",
+    "Users.3.UserName": "readonly",
+    "Users.3.Password": "REPLACE_WITH_STRONG_PASSWORD",
     "Users.3.PrivacyProtocol": "AES"
   }
 }
-
-
-//https://10.252.252.209/redfish/v1/Managers/iDRAC.Embedded.1/Attributes


### PR DESCRIPTION
`specs/add_read_only_user.json` failed to parse (a trailing `//` line — JSON allows no comments) and carried a copyable demo username/password. This makes it valid JSON, removes the comment, and replaces the demo credential with a clear `REPLACE_WITH_STRONG_PASSWORD` placeholder. It stays a runnable sample attr-update payload; operators set a real password before use.