### PR TITLE
Add certificate inventory command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Author: Mus <spyroot@gmail.com>
 When connecting to a new BMC, run `redfish_ctl system` first. It proves the endpoint, credentials, and
 basic Redfish path before deeper inventory or any staged change.
 
-The table below follows the 116 command names imported by `redfish_ctl/__init__.py`. Run
+The table below follows the 122 command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
 backward-compatible alias for the `redfish_ctl` command, and `IDRAC_*` env vars are still read.)
 
@@ -101,6 +101,7 @@ Safety labels:
 | `boot-sources` | List boot source members. | Read |
 | `boot-state` | Infer what the host will boot (target/order/media). | Read |
 | `capability-report` | Export registered vendor capability profiles for IaC and inventory tooling. | Read |
+| `certificates` | Read CertificateService and linked certificate inventory metadata without certificate bodies. | Read |
 | `change-boot-order` | Change boot order and boot options. | Write |
 | `chassis` | Read chassis services. | Read |
 | `chassis-reset` | Change chassis power state. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -103,6 +103,7 @@ from .compute.cmd_system_reset import *
 from .logs.cmd_logs import *
 from .network.cmd_ethernet_interfaces import *
 from .security.cmd_secure_boot import *
+from .security.cmd_certificates import *
 from .firmware.cmd_firmware_update import *
 from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -108,6 +108,7 @@ class ApiRequestType(Enum):
     Logs = auto()
     EthernetInterfaces = auto()
     SecureBoot = auto()
+    CertificatesQuery = auto()
     FirmwareUpdate = auto()
     Triggers = auto()
     NetworkPorts = auto()

--- a/redfish_ctl/security/cmd_certificates.py
+++ b/redfish_ctl/security/cmd_certificates.py
@@ -1,0 +1,202 @@
+"""Read Redfish certificate inventory without returning certificate bodies."""
+
+from abc import abstractmethod
+from typing import Optional
+
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+from ..redfish_shared import RedfishApi
+
+
+class Certificates(IDracManager,
+                   scm_type=ApiRequestType.CertificatesQuery,
+                   name="certificates",
+                   metaclass=Singleton):
+    """Read CertificateService and linked certificate collection metadata."""
+
+    def __init__(self, *args, **kwargs):
+        super(Certificates, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the read-only certificates subcommand."""
+        cmd_parser = cls.base_parser()
+        return cmd_parser, "certificates", "command read Redfish certificate inventory"
+
+    @staticmethod
+    def _members(data):
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _links(data, key):
+        value = (data or {}).get(key)
+        if isinstance(value, dict):
+            uri = value.get("@odata.id")
+            return [uri] if isinstance(uri, str) else []
+        if isinstance(value, list):
+            return [
+                item["@odata.id"]
+                for item in value
+                if isinstance(item, dict)
+                and isinstance(item.get("@odata.id"), str)
+            ]
+        return []
+
+    @staticmethod
+    def _key_usage(data):
+        usage = (data or {}).get("KeyUsage")
+        if isinstance(usage, list):
+            return usage
+        if isinstance(usage, str):
+            return [usage]
+        return []
+
+    @staticmethod
+    def _resource_id(uri):
+        return uri.rstrip("/").rsplit("/", 1)[-1]
+
+    def _get(self, uri, do_async):
+        if not uri:
+            return {}
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _discover(self, discover):
+        try:
+            return discover() or []
+        except Exception:
+            return []
+
+    def _certificate_locations(self, locations):
+        found = []
+
+        def visit(value):
+            if isinstance(value, dict):
+                uri = value.get("@odata.id")
+                if isinstance(uri, str) and uri.rstrip("/").endswith("/Certificates"):
+                    found.append(uri)
+                for child in value.values():
+                    visit(child)
+            elif isinstance(value, list):
+                for child in value:
+                    visit(child)
+
+        visit(locations)
+        return found
+
+    def _certificate_row(self, cert, cert_uri, collection_uri):
+        links = cert.get("Links") if isinstance(cert.get("Links"), dict) else {}
+        return {
+            "Id": cert.get("Id") or self._resource_id(cert_uri),
+            "Name": cert.get("Name"),
+            "CertificateType": cert.get("CertificateType"),
+            "Issuer": cert.get("Issuer"),
+            "Subject": cert.get("Subject"),
+            "ValidNotBefore": cert.get("ValidNotBefore"),
+            "ValidNotAfter": cert.get("ValidNotAfter"),
+            "KeyUsage": self._key_usage(cert),
+            "Uri": cert.get("@odata.id", cert_uri),
+            "CollectionUri": collection_uri,
+            "IssuerUri": self._link(links, "Issuer"),
+            "SubjectUris": self._links(links, "Subjects"),
+        }
+
+    @staticmethod
+    def _summary(certificate_service, collections, certificates):
+        return {
+            "certificate_service": certificate_service is not None,
+            "collections": len(collections),
+            "certificates": len(certificates),
+        }
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Read certificate service and linked certificate collections."""
+        certificate_service = None
+        certificate_collections = []
+        certificates = []
+        collection_links = []
+        seen_collections = set()
+
+        def add_collection(uri, source):
+            if uri and uri not in seen_collections:
+                seen_collections.add(uri)
+                collection_links.append((uri, source))
+
+        service = self._get(f"{RedfishApi.Version}/CertificateService", do_async)
+        if service:
+            locations_uri = self._link(service, "CertificateLocations")
+            certificate_service = {
+                "Id": service.get("Id"),
+                "Name": service.get("Name"),
+                "Uri": service.get("@odata.id", f"{RedfishApi.Version}/CertificateService"),
+                "CertificateLocationsUri": locations_uri,
+            }
+            for uri in self._certificate_locations(self._get(locations_uri, do_async)):
+                add_collection(uri, "CertificateService")
+
+        for system_uri in self._discover(self.discover_computer_system_ids):
+            system = self._get(system_uri, do_async)
+            add_collection(
+                self._link(system, "Certificates"),
+                f"System {system.get('Id') or self._resource_id(system_uri)}",
+            )
+
+        for manager_uri in self._discover(self.discover_manager_ids):
+            manager = self._get(manager_uri, do_async)
+            add_collection(
+                self._link(manager, "Certificates"),
+                f"Manager {manager.get('Id') or self._resource_id(manager_uri)}",
+            )
+
+        for collection_uri, source in collection_links:
+            collection = self._get(collection_uri, do_async)
+            if not collection:
+                continue
+            members = self._members(collection)
+            certificate_collections.append({
+                "Source": source,
+                "Uri": collection.get("@odata.id", collection_uri),
+                "Name": collection.get("Name"),
+                "MemberCount": collection.get("Members@odata.count", len(members)),
+            })
+            for cert_uri in members:
+                cert = self._get(cert_uri, do_async)
+                if cert:
+                    certificates.append(
+                        self._certificate_row(cert, cert_uri, collection_uri)
+                    )
+
+        data = {
+            "summary": self._summary(
+                certificate_service,
+                certificate_collections,
+                certificates,
+            ),
+            "certificate_service": certificate_service,
+            "collections": certificate_collections,
+            "certificates": certificates,
+        }
+        return CommandResult(data, None, None, None)

--- a/tests/test_certificates_dualmode.py
+++ b/tests/test_certificates_dualmode.py
@@ -1,0 +1,130 @@
+"""Dual-mode tests for the read-only certificates command."""
+import json
+
+import pytest
+
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+
+def test_certificates_reads_generic_inventory_without_secret_material(
+    redfish_mock_factory,
+):
+    """certificates returns safe metadata from generic certificate fixtures."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(ApiRequestType.CertificatesQuery, "certificates")
+
+    assert isinstance(result, CommandResult)
+    assert result.discovered is None
+    assert result.extra is None
+    assert result.error is None
+    json.dumps(result.data, sort_keys=True)
+
+    assert result.data["summary"] == {
+        "certificate_service": True,
+        "collections": 1,
+        "certificates": 2,
+    }
+    assert result.data["certificate_service"] == {
+        "Id": "CertificateService",
+        "Name": "Certificate Service",
+        "Uri": "/redfish/v1/CertificateService",
+        "CertificateLocationsUri": (
+            "/redfish/v1/CertificateService/CertificateLocations"
+        ),
+    }
+    assert result.data["collections"] == [
+        {
+            "Source": "System 437XR1138R2",
+            "Uri": "/redfish/v1/Systems/437XR1138R2/Certificates",
+            "Name": "Certificates Collection",
+            "MemberCount": 3,
+        }
+    ]
+
+    certificates = {row["Id"]: row for row in result.data["certificates"]}
+    assert certificates["contoso-root"] == {
+        "Id": "contoso-root",
+        "Name": "Contoso Root CA",
+        "CertificateType": "PEM",
+        "Issuer": None,
+        "Subject": None,
+        "ValidNotBefore": None,
+        "ValidNotAfter": None,
+        "KeyUsage": [],
+        "Uri": "/redfish/v1/Systems/437XR1138R2/Certificates/contoso-root",
+        "CollectionUri": "/redfish/v1/Systems/437XR1138R2/Certificates",
+        "IssuerUri": None,
+        "SubjectUris": [
+            "/redfish/v1/Systems/437XR1138R2/Certificates/contoso-subca"
+        ],
+    }
+    assert certificates["contoso-subca"]["IssuerUri"] == (
+        "/redfish/v1/Systems/437XR1138R2/Certificates/contoso-root"
+    )
+    assert all("CertificateString" not in row for row in result.data["certificates"])
+    assert all(
+        request.method not in {"POST", "PATCH", "DELETE"}
+        for request in service.requests
+    )
+
+
+def test_certificates_tolerates_root_without_certificate_links():
+    """certificates returns an empty inventory when no certificate links exist."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        payloads = {
+            "/redfish/v1/Systems": {
+                "Members": [],
+                "@odata.id": "/redfish/v1/Systems",
+            },
+            "/redfish/v1/Managers": {
+                "Members": [],
+                "@odata.id": "/redfish/v1/Managers",
+            },
+        }
+        payload = payloads.get(request.path)
+        if payload is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return json.dumps(payload)
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.patch(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=get_cb)
+        mocker.delete(requests_mock.ANY, text=get_cb)
+        manager = IDracManager(
+            idrac_ip="mock-no-certs",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+
+        result = manager.sync_invoke(
+            ApiRequestType.CertificatesQuery,
+            "certificates",
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {
+        "summary": {
+            "certificate_service": False,
+            "collections": 0,
+            "certificates": 0,
+        },
+        "certificate_service": None,
+        "collections": [],
+        "certificates": [],
+    }
+    assert all(
+        request.method not in {"POST", "PATCH", "DELETE"}
+        for request in requests
+    )


### PR DESCRIPTION
## Summary

- Add a read-only `certificates` command for CertificateService and linked certificate collections.
- Return safe certificate metadata while omitting certificate bodies.
- Cover generic fixture inventory, missing-link tolerance, read-only transport behavior, registration, and command docs.

## Tests

- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q tests/test_certificates_dualmode.py tests/test_cli_subcommand_uniqueness.py`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/security/cmd_certificates.py redfish_ctl/idrac_shared.py redfish_ctl/__init__.py tests/test_certificates_dualmode.py`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl pytest -q`
