### PR TITLE
Add corpus manifest, pull tooling, and library docs

### DIFF
--- a/docs/corpus-library.md
+++ b/docs/corpus-library.md
@@ -1,0 +1,119 @@
+# Redfish Corpus Library
+
+The corpus library is the shared set of captured Redfish trees ("corpora") that
+back every offline surface in this project: the dual-mode unit tests, the mock
+BMC server (`k8s/sandbox/mock_bmc_server.py --corpus-dir`), the fleet/proxy
+tests, the request benchmarks, and the k8s sandbox. One capture per physical box
+drives all of them, so the same JSON is reused everywhere instead of being
+re-captured or forked per test.
+
+Each corpus is a single Git-LFS `.tar.gz` under `tests/`, built by
+`tools/pack_corpus.py` and indexed by `tests/corpus/manifest.json`. Consumers
+that need the raw JSON extract a tarball rather than committing thousands of
+loose files.
+
+## What is in the library
+
+| Vendor | Model | Redfish | JSON files | Surface |
+| --- | --- | --- | ---: | --- |
+| Dell iDRAC | PowerEdge XR8620t | 1.15.1 | 995 | full device + telemetry |
+| HPE iLO 5 | ProLiant DL360 | 1.6.0 | 72 | curated read set |
+| Supermicro | X10SDV-TLN4F | 1.6.0 | 61 | curated read set |
+| Supermicro | GB300 | 1.17.0 | 1235 | full device + telemetry |
+| NVIDIA / Supermicro | GB300 (node2) | 1.15.0 | 1646 | full device + telemetry |
+
+That is **4009 JSON resources** across five boxes. The table is generated from
+`tests/corpus/manifest.json`; run `python tools/corpus.py list` to print the
+current index (it stays in sync with the manifest as more boxes are added).
+
+## Pull the entire corpus (all vendors, all JSON)
+
+The tarballs are Git-LFS objects, so a fresh clone holds only pointers until they
+are fetched. Downstream consumers that need the full JSON tree — for example an
+ML/analytics pipeline that trains on every captured resource — run two steps:
+
+```bash
+# 1. Fetch every corpus tarball (LFS objects, not just pointers).
+python tools/corpus.py pull
+
+# 2. Materialize every corpus as JSON under one directory, grouped by vendor/model.
+python tools/corpus.py extract-all --dest /path/to/redfish_corpus
+```
+
+`extract-all` writes one subdirectory per box:
+
+```text
+/path/to/redfish_corpus/
+  dell_xr8620t/        # 995 *.json
+  hpe_dl360/           #  72 *.json
+  supermicro_x10sdv/   #  61 *.json
+  supermicro_gb300/    # 1235 *.json
+  nvidia_gb300-node2/  # 1646 *.json
+```
+
+`pull` wraps `git lfs pull --include=<tarballs>`, so `git lfs` must be installed
+(`git lfs install` once per machine). To confirm the download succeeded and every
+count matches the manifest:
+
+```bash
+python tools/corpus.py verify
+```
+
+`verify` reports `ok` per corpus, or `pointer` for a tarball that has not been
+pulled yet (it does not fail on un-pulled pointers, so the check is safe on a
+fresh checkout).
+
+### Pull or extract a single vendor
+
+Every subcommand takes optional `--vendor` and `--model` filters:
+
+```bash
+python tools/corpus.py pull --vendor supermicro --model gb300
+python tools/corpus.py extract-all --vendor dell --dest /tmp/dell_corpus
+```
+
+## Use a corpus from a test
+
+Tests do not unpack tarballs by hand — they call the shared extractor
+`tests/vendor_corpus.py::corpus_dir`, which extracts a tarball once per process
+and caches it:
+
+```python
+from pathlib import Path
+from tests.vendor_corpus import corpus_dir
+from tools import corpus
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+row = corpus.resolve("dell", "xr8620t")          # look a corpus up by vendor/model
+d = corpus_dir(REPO_ROOT / row["tarball"], row["arcname"])  # -> dir of *.json
+```
+
+`corpus.resolve(vendor, model)` returns the manifest row (with `tarball` and
+`arcname`), so tests locate a corpus by vendor/model instead of hardcoding the
+capture path.
+
+## Add a new capture
+
+Adding the next box is a small, repeatable step:
+
+1. Capture and **sanitize** the full tree following the canonical SOP in
+   [fixture-capture.md](fixture-capture.md) — that document defines the crawl,
+   the redaction checklist, and the schema-validation step. A full crawl carries
+   device identifiers, so sanitization is mandatory; never commit a real
+   credential or token.
+2. Pack the sanitized tree into a tarball with `tools/pack_corpus.py`.
+3. Add one row to `tests/corpus/manifest.json` (`vendor`, `model`,
+   `redfish_version`, `json_count`, `tarball`, `arcname`, `source_note`).
+4. Run `python tools/corpus.py verify` and `pytest -q tests/test_corpus_manifest.py`
+   — the manifest count must match the tarball, and the tarball must be LFS-tracked.
+
+## Notes
+
+- Redfish never returns account passwords, so `Password` fields in a capture read
+  `null`. The library carries device identifiers (serials, MACs, the capture host
+  as each tarball's internal root) because captures come from decommissioned or
+  lab gear; production captures must go through the redaction SOP first.
+- The internal root of each tarball is currently the raw capture host. Resolving
+  every consumer through the manifest (this document's `resolve()` path) is the
+  first step of normalizing that root to a stable `vendor/model` slug; until that
+  lands, `arcname` records the current root so lookups stay exact.

--- a/tests/corpus/manifest.json
+++ b/tests/corpus/manifest.json
@@ -1,0 +1,61 @@
+{
+  "schema": 1,
+  "note": "Machine-readable index of the committed Redfish corpora. One row per captured box. `tarball` is the repo-relative Git-LFS artifact; `arcname` is the tarball's current internal root directory (the raw capture host, being normalized to a vendor/model slug by W5-corpus-library slices 4-5). Consumed by tools/corpus.py and tests/test_corpus_manifest.py; see docs/corpus-library.md.",
+  "corpora": [
+    {
+      "vendor": "dell",
+      "model": "xr8620t",
+      "product": "Dell iDRAC (PowerEdge XR8620t)",
+      "redfish_version": "1.15.1",
+      "json_count": 995,
+      "surface": "full device + telemetry",
+      "tarball": "tests/dell_xr8620t_corpus.tar.gz",
+      "arcname": "10.252.252.209",
+      "source_note": "Full-tree iDRAC crawl of a decommissioned lab XR8620t; all Password fields null (Redfish never returns account secrets)."
+    },
+    {
+      "vendor": "hpe",
+      "model": "dl360",
+      "product": "HPE iLO 5 (ProLiant DL360)",
+      "redfish_version": "1.6.0",
+      "json_count": 72,
+      "surface": "curated read set",
+      "tarball": "tests/hpe_dl360_corpus.tar.gz",
+      "arcname": "10.43.3.209",
+      "source_note": "Curated read-only iLO 5 capture (DL360)."
+    },
+    {
+      "vendor": "supermicro",
+      "model": "x10sdv",
+      "product": "Supermicro X10 (X10SDV-TLN4F)",
+      "redfish_version": "1.6.0",
+      "json_count": 61,
+      "surface": "curated read set",
+      "tarball": "tests/supermicro_x10_corpus.tar.gz",
+      "arcname": "192.168.254.120",
+      "source_note": "Curated read-only Supermicro X10SDV capture."
+    },
+    {
+      "vendor": "supermicro",
+      "model": "gb300",
+      "product": "Supermicro GB300",
+      "redfish_version": "1.17.0",
+      "json_count": 1235,
+      "surface": "full device + telemetry",
+      "tarball": "tests/supermicro_gb300_corpus.tar.gz",
+      "arcname": "172.25.230.37",
+      "source_note": "Full-tree Supermicro GB300 crawl; includes TelemetryService MetricReports and the BIOS attribute registry."
+    },
+    {
+      "vendor": "nvidia",
+      "model": "gb300-node2",
+      "product": "NVIDIA/Supermicro GB300 (node2)",
+      "redfish_version": "1.15.0",
+      "json_count": 1646,
+      "surface": "full device + telemetry",
+      "tarball": "tests/nvidia_gb300_node2_corpus.tar.gz",
+      "arcname": "172.25.230.20",
+      "source_note": "Full-tree GB300 node2 crawl; largest corpus, includes accelerator MetricReports and LeakDetection."
+    }
+  ]
+}

--- a/tests/test_corpus_manifest.py
+++ b/tests/test_corpus_manifest.py
@@ -1,0 +1,87 @@
+"""Contract tests for the Redfish corpus manifest (tests/corpus/manifest.json).
+
+The manifest is the machine-readable index every sim/test/mock and the
+``tools/corpus.py`` CLI resolve corpora through (see docs/corpus-library.md).
+These tests pin its shape and keep the recorded JSON counts honest against the
+actual tarball contents. A tarball that is still a bare Git-LFS pointer (not
+``git lfs pull``ed on this machine) is skipped for the count check rather than
+failing, so the offline suite stays green on a fresh checkout.
+"""
+from __future__ import annotations
+
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from tools import corpus
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REQUIRED_KEYS = {
+    "vendor", "model", "product", "redfish_version",
+    "json_count", "surface", "tarball", "arcname", "source_note",
+}
+
+
+def _lfs_tracked_paths() -> set[str]:
+    """Repo-relative paths Git-LFS tracks (empty if git/lfs unavailable)."""
+    try:
+        out = subprocess.check_output(
+            ["git", "lfs", "ls-files", "--name-only"],
+            cwd=REPO_ROOT, text=True, stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):  # pragma: no cover - env-dependent
+        return set()
+    return {line.strip() for line in out.splitlines() if line.strip()}
+
+
+def test_manifest_parses_and_has_rows():
+    """The manifest loads and lists at least the five known corpora."""
+    rows = corpus.load_manifest()
+    assert len(rows) >= 5
+    vendors = {r["vendor"] for r in rows}
+    assert {"dell", "hpe", "supermicro", "nvidia"} <= vendors
+
+
+@pytest.mark.parametrize("row", corpus.load_manifest(), ids=lambda r: f"{r['vendor']}-{r['model']}")
+def test_row_shape(row):
+    """Every row carries the required keys with sane types."""
+    assert REQUIRED_KEYS <= set(row), f"missing keys: {REQUIRED_KEYS - set(row)}"
+    assert isinstance(row["json_count"], int) and row["json_count"] > 0
+    assert row["tarball"].startswith("tests/") and row["tarball"].endswith(".tar.gz")
+    # arcname must be the tarball's real internal root (see count check below).
+    assert row["arcname"]
+
+
+@pytest.mark.parametrize("row", corpus.load_manifest(), ids=lambda r: f"{r['vendor']}-{r['model']}")
+def test_tarball_exists_and_is_lfs_tracked(row):
+    """Each declared tarball is present on disk and tracked by Git-LFS."""
+    path = REPO_ROOT / row["tarball"]
+    assert path.exists(), f"{row['tarball']} missing"
+    tracked = _lfs_tracked_paths()
+    if tracked:  # only assert when git-lfs is queryable in this environment
+        assert row["tarball"] in tracked, f"{row['tarball']} not LFS-tracked"
+
+
+@pytest.mark.parametrize("row", corpus.load_manifest(), ids=lambda r: f"{r['vendor']}-{r['model']}")
+def test_json_count_and_root_match(row):
+    """json_count and arcname match the tarball (skipped for un-pulled pointers)."""
+    path = REPO_ROOT / row["tarball"]
+    if corpus._is_lfs_pointer(path):
+        pytest.skip(f"{row['tarball']} is a bare LFS pointer; run `git lfs pull`")
+    with tarfile.open(path) as tar:
+        names = tar.getnames()
+    actual = sum(1 for n in names if n.endswith(".json"))
+    assert actual == row["json_count"], (
+        f"{row['tarball']}: manifest={row['json_count']} actual={actual}")
+    roots = {n.split("/", 1)[0] for n in names if n}
+    assert row["arcname"] in roots, (
+        f"{row['tarball']}: arcname {row['arcname']!r} not the tarball root {roots}")
+
+
+def test_resolve_by_vendor_model():
+    """resolve() maps a vendor/model pair to its row and returns None otherwise."""
+    row = corpus.resolve("dell", "xr8620t")
+    assert row and row["tarball"] == "tests/dell_xr8620t_corpus.tar.gz"
+    assert corpus.resolve("nope", "nope") is None

--- a/tools/corpus.py
+++ b/tools/corpus.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Manage the committed Redfish corpus library.
+
+The corpora are one Git-LFS ``.tar.gz`` per captured box under ``tests/`` (built
+by ``tools/pack_corpus.py``), indexed by ``tests/corpus/manifest.json``. This CLI
+is the single documented entry point for pulling every corpus and materializing
+the JSON — see ``docs/corpus-library.md``.
+
+Subcommands
+-----------
+list          Print the manifest (vendor, model, Redfish version, JSON count).
+pull          ``git lfs pull`` the corpus tarballs (all, or --vendor/--model).
+extract-all   Extract every corpus into ``<dest>/<vendor>_<model>/`` (full JSON
+              tree for consumers such as the igc pipeline that need all files).
+verify        Assert every tarball exists, is LFS-tracked, and its ``.json``
+              count matches the manifest (bare LFS pointers are skipped, not
+              failed, so the check works before ``git lfs pull``).
+
+The module is also importable: :func:`load_manifest` returns the parsed rows and
+:func:`resolve` maps ``(vendor, model)`` to a row, so callers can locate a corpus
+by vendor/model instead of the raw capture-IP ``arcname``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "tests" / "corpus" / "manifest.json"
+
+
+def load_manifest(path: Path = MANIFEST_PATH) -> list[dict]:
+    """Return the corpus rows from the manifest JSON."""
+    data = json.loads(Path(path).read_text())
+    return list(data.get("corpora", []))
+
+
+def resolve(vendor: str, model: str, path: Path = MANIFEST_PATH) -> Optional[dict]:
+    """Return the manifest row for ``(vendor, model)`` (case-insensitive), or None."""
+    vendor, model = vendor.lower(), model.lower()
+    for row in load_manifest(path):
+        if row["vendor"].lower() == vendor and row["model"].lower() == model:
+            return row
+    return None
+
+
+def _select(rows: list[dict], vendor: Optional[str], model: Optional[str]) -> list[dict]:
+    """Filter rows by optional vendor and/or model (case-insensitive)."""
+    out = rows
+    if vendor:
+        out = [r for r in out if r["vendor"].lower() == vendor.lower()]
+    if model:
+        out = [r for r in out if r["model"].lower() == model.lower()]
+    return out
+
+
+def _tarball_path(row: dict) -> Path:
+    """Absolute path to a row's tarball."""
+    return REPO_ROOT / row["tarball"]
+
+
+def _is_lfs_pointer(path: Path) -> bool:
+    """True if ``path`` is still a bare Git-LFS pointer (not yet ``git lfs pull``ed)."""
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(120)
+    except OSError:
+        return False
+    return head.startswith(b"version https://git-lfs.github.com/spec")
+
+
+def _count_json(path: Path) -> int:
+    """Count ``.json`` members in a corpus tarball."""
+    with tarfile.open(path) as tar:
+        return sum(1 for name in tar.getnames() if name.endswith(".json"))
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    """Print the manifest as a table."""
+    rows = _select(load_manifest(), args.vendor, args.model)
+    if not rows:
+        print("no corpora match the filter", file=sys.stderr)
+        return 1
+    total = 0
+    print(f"{'VENDOR':<11} {'MODEL':<12} {'REDFISH':<8} {'JSON':>6}  TARBALL")
+    for row in rows:
+        total += int(row["json_count"])
+        print(f"{row['vendor']:<11} {row['model']:<12} "
+              f"{row['redfish_version']:<8} {row['json_count']:>6}  {row['tarball']}")
+    print(f"{'':<11} {'':<12} {'total':<8} {total:>6}")
+    return 0
+
+
+def cmd_pull(args: argparse.Namespace) -> int:
+    """``git lfs pull`` the selected corpus tarballs."""
+    rows = _select(load_manifest(), args.vendor, args.model)
+    if not rows:
+        print("no corpora match the filter", file=sys.stderr)
+        return 1
+    includes = ",".join(row["tarball"] for row in rows)
+    cmd = ["git", "lfs", "pull", f"--include={includes}"]
+    print("running:", " ".join(cmd))
+    return subprocess.call(cmd, cwd=REPO_ROOT)
+
+
+def cmd_extract_all(args: argparse.Namespace) -> int:
+    """Extract selected corpora into ``<dest>/<vendor>_<model>/``."""
+    rows = _select(load_manifest(), args.vendor, args.model)
+    if not rows:
+        print("no corpora match the filter", file=sys.stderr)
+        return 1
+    dest = Path(args.dest).resolve()
+    dest.mkdir(parents=True, exist_ok=True)
+    pending = [r for r in rows if _is_lfs_pointer(_tarball_path(r))]
+    if pending:
+        names = ", ".join(f"{r['vendor']}/{r['model']}" for r in pending)
+        print(f"error: not pulled (bare LFS pointer): {names}\n"
+              f"run `python tools/corpus.py pull` first", file=sys.stderr)
+        return 1
+    for row in rows:
+        out = dest / f"{row['vendor']}_{row['model']}"
+        out.mkdir(parents=True, exist_ok=True)
+        with tarfile.open(_tarball_path(row)) as tar:
+            try:
+                tar.extractall(out, filter="data")  # py3.12+ path-safe filter
+            except TypeError:  # pragma: no cover - py<3.12 lacks the kwarg
+                tar.extractall(out)
+        print(f"extracted {row['json_count']:>5} json  {row['vendor']}/{row['model']} -> {out}")
+    return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    """Check tarballs exist and their JSON counts match the manifest."""
+    rows = _select(load_manifest(), args.vendor, args.model)
+    ok = True
+    for row in rows:
+        path = _tarball_path(row)
+        if not path.exists():
+            print(f"MISSING  {row['tarball']}")
+            ok = False
+            continue
+        if _is_lfs_pointer(path):
+            print(f"pointer  {row['tarball']} (not pulled; skipped count check)")
+            continue
+        actual = _count_json(path)
+        if actual != int(row["json_count"]):
+            print(f"MISMATCH {row['tarball']}: manifest={row['json_count']} actual={actual}")
+            ok = False
+        else:
+            print(f"ok       {row['tarball']} ({actual} json)")
+    return 0 if ok else 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argparse CLI."""
+    parser = argparse.ArgumentParser(description="Manage the Redfish corpus library.")
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name, func, needs_dest in (
+        ("list", cmd_list, False),
+        ("pull", cmd_pull, False),
+        ("extract-all", cmd_extract_all, True),
+        ("verify", cmd_verify, False),
+    ):
+        p = sub.add_parser(name, help=func.__doc__.splitlines()[0])
+        p.add_argument("--vendor", help="filter to one vendor (e.g. dell)")
+        p.add_argument("--model", help="filter to one model (e.g. gb300)")
+        if needs_dest:
+            p.add_argument("--dest", required=True, help="destination directory")
+        p.set_defaults(func=func)
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Index the five committed Redfish corpora in `tests/corpus/manifest.json` (Dell XR8620t, HPE DL360, Supermicro X10SDV, Supermicro GB300, NVIDIA GB300-node2 — 4009 JSON total).
- Add `tools/corpus.py` with `list` / `pull` / `extract-all` / `verify` and importable `load_manifest`/`resolve` helpers, so consumers fetch every corpus and materialize all JSON grouped by vendor/model.
- Document the full pull workflow in `docs/corpus-library.md` (cross-links the fixture-capture SOP).
- Pin manifest counts against the actual tarballs with `tests/test_corpus_manifest.py` (bare LFS pointers are skipped, so the offline suite stays green on a fresh checkout).

Delivers slices 1-3 of the W5-corpus-library program.

## Tests
- `pytest -q tests/test_corpus_manifest.py` (17 passed), full `pytest -q` green (1041 passed, 58 skipped), `ruff check` clean on the new Python.
- `python tools/corpus.py list/verify/extract-all` exercised end-to-end (verify: all counts match; extract-all dell: 995 JSON on disk).