### PR TITLE
Link corpus library docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ First-run problems are almost always the connection, not the command:
 - [Telemetry Exporter](docs/telemetry-exporter.md) - the `hw.*` metric exporter and deployment model.
 - [Simulation and replay](docs/simulation-and-replay.md) - the hardware-free mock and mutation replay.
 - [Testing](docs/testing.md) - offline mock tests, vendor corpora, emulator tests, and live-test safety.
+- [Corpus library](docs/corpus-library.md) - manifest-indexed Redfish corpus tarballs and pull-all extraction.
 - [Docker](docker/README.md) - production image and Linux offline-test image usage.
 - [Fixture capture](docs/fixture-capture.md) - crawl a BMC with `discovery`, sanitize it, and contribute it as a vendor corpus.
 - [CI/CD](docs/ci.md) - the GitHub Actions test + release pipeline, the runner, and the Node.js runtime.

--- a/docs/fixture-capture.md
+++ b/docs/fixture-capture.md
@@ -18,6 +18,9 @@ Pick the path that matches what you are contributing — the two are deliberatel
 - **Path B — a curated fixture set.** Hand-pick, sanitize, and import only the *handful* of resources
   one specific test needs. Best when adding or fixing **one command on an already-covered vendor**.
 
+For the existing shared archive, see the [Redfish Corpus Library](corpus-library.md), the repository
+index for committed corpus tarballs and pull-all extraction commands.
+
 ## Path A — Full BMC crawl (whole tree → vendor corpus)
 
 `redfish_ctl` can capture its own test data. The `discovery` command does a deep crawl of a BMC and


### PR DESCRIPTION
## Summary

- Add the corpus library to the README documentation index.
- Link the fixture-capture guide back to the corpus library so full-crawl contributors can find the pull-all workflow.

## Validation

- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python3 -m pytest -q` (`1041 passed, 58 skipped`)
- `git diff --check`
- `rg -n '\b(I|my|me)\b' README.md docs/fixture-capture.md` (no matches)

Ruff was not run because no Python files changed.