### PR TITLE
Redact leaked credential attributes from the Dell corpus

### DIFF
--- a/docs/fixture-capture.md
+++ b/docs/fixture-capture.md
@@ -178,6 +178,21 @@ secret_pattern="${secret_pattern}|[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}"
 rg -n "$secret_pattern" /tmp/fixture-candidates
 ```
 
+A bare `Password`-is-null check is **not** enough: vendor OEM attribute maps store
+credentials under dotted attribute keys the generic pattern misses. On Dell the
+`DellAttributes` file (`_redfish_v1_Managers_*_Oem_Dell_DellAttributes_*.json`)
+carries live `Users.<n>.SHA256Password`, `Users.<n>.SHA256PasswordSalt`,
+`Users.<n>.IPMIKey`, `Users.<n>.MD5v3Key`, and SNMP `IPMILan.1.CommunityName` /
+`SNMP.1.AgentCommunity` values. `tools/redact_corpus.py` catches these by matching
+the last dotted segment against its credential-suffix set, and
+`tests/test_corpus_no_secrets.py` fails the build if any committed corpus still
+carries a non-empty credential value — run both before adding a capture:
+
+```bash
+rg -n 'SHA256Password|SHA256PasswordSalt|IPMIKey|MD5v3Key|CommunityName|AgentCommunity' \
+  /tmp/fixture-candidates
+```
+
 This scan is only a guardrail. Read the files yourself before committing them.
 
 ### Validate

--- a/tests/dell_xr8620t_corpus.tar.gz
+++ b/tests/dell_xr8620t_corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c97de4ffffef535b0c24406321db0e903706015186fd59ee4c3f646f5e596256
-size 269933
+oid sha256:c8cb181ce22e6955b266bc4c0363daef431837f23444120e96c066456d3de3bb
+size 269600

--- a/tests/test_corpus_no_secrets.py
+++ b/tests/test_corpus_no_secrets.py
@@ -1,0 +1,73 @@
+"""Guard: no committed corpus tarball may carry a real credential value.
+
+A full Redfish crawl can include vendor OEM credential material — Dell exposes
+salted password hashes, per-user IPMI keys, SNMPv3 keys, and SNMP community
+strings as flat dotted attribute keys (``Users.2.SHA256Password`` etc.) inside a
+DellAttributes object. A naive "is the ``Password`` field null" scan misses those,
+so this test scans every committed corpus for any key whose last dotted segment is
+a known credential suffix (:data:`tools.redact_corpus.SECRET_SUFFIXES`) and fails if
+the value is a non-empty non-placeholder string. It is the regression guard for the
+Dell credential redaction. A tarball that is still a bare LFS pointer is skipped.
+"""
+from __future__ import annotations
+
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from tools import corpus
+from tools.redact_corpus import SECRET_SUFFIXES
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_PLACEHOLDERS = {"REDACTED", "", "null", "0", "0.0.0.0"}
+
+
+def _real_secret(key: str, value) -> bool:
+    """True if key is a credential suffix and value is a real (non-placeholder) string."""
+    if not isinstance(value, str):
+        return False
+    last = key.lower().rsplit(".", 1)[-1]
+    if last not in SECRET_SUFFIXES:
+        return False
+    return value.strip() and value.strip() not in _PLACEHOLDERS
+
+
+def _scan(obj, hits: list[str], where: str) -> None:
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if _real_secret(k, v):
+                hits.append(f"{where}:{k}")  # key only — never the value
+            _scan(v, hits, where)
+    elif isinstance(obj, list):
+        for item in obj:
+            _scan(item, hits, where)
+
+
+@pytest.mark.parametrize(
+    "row", corpus.load_manifest(), ids=lambda r: f"{r['vendor']}-{r['model']}"
+)
+def test_corpus_has_no_real_credentials(row):
+    """Every JSON in the committed corpus tarball is free of real credential values."""
+    import json
+
+    path = REPO_ROOT / row["tarball"]
+    if corpus._is_lfs_pointer(path):
+        pytest.skip(f"{row['tarball']} is a bare LFS pointer; run `git lfs pull`")
+    hits: list[str] = []
+    with tarfile.open(path) as tar:
+        for member in tar.getmembers():
+            if not member.name.endswith(".json"):
+                continue
+            fh = tar.extractfile(member)
+            if fh is None:
+                continue
+            try:
+                data = json.loads(fh.read().decode("utf-8", "replace"))
+            except (ValueError, UnicodeDecodeError):
+                continue
+            _scan(data, hits, Path(member.name).name)
+    assert not hits, (
+        f"{row['tarball']} carries {len(hits)} real credential value(s) "
+        f"(keys, values withheld): {sorted(set(hits))[:10]}"
+    )

--- a/tools/redact_corpus.py
+++ b/tools/redact_corpus.py
@@ -52,6 +52,45 @@ SENSITIVE_KEYS: dict[str, str] = {
     "token": "REDACTED",
 }
 
+# Credential attribute names whose VALUE is always a secret, matched on the last
+# dotted segment of the key so vendor OEM attribute maps (Dell stores flat dotted
+# keys like ``Users.2.SHA256Password`` / ``IPMILan.1.CommunityName`` inside an
+# ``Attributes`` object) are caught even though the exact key is not a bare name.
+# Last-segment (not substring) matching avoids scrubbing benign toggles such as
+# ``EnableSNMPv3Passphrase`` (a boolean flag, not the passphrase itself).
+SECRET_SUFFIXES: dict[str, str] = {
+    "password": "REDACTED",
+    "sha256password": "REDACTED",
+    "sha256passwordsalt": "REDACTED",
+    "ipmikey": "REDACTED",
+    "md5v3key": "REDACTED",
+    "shav3key": "REDACTED",
+    "communityname": "REDACTED",
+    "agentcommunity": "REDACTED",
+    "snmpv3passphrase": "REDACTED",
+    "passphrase": "REDACTED",
+    "token": "REDACTED",
+    "authtoken": "REDACTED",
+    "privatekey": "REDACTED",
+    "sharedsecret": "REDACTED",
+    "presharedkey": "REDACTED",
+    "chapsecret": "REDACTED",
+    "chapsecretreverse": "REDACTED",
+}
+
+
+def secret_placeholder(key: str, sensitive_keys: dict[str, str]) -> str | None:
+    """Placeholder for a key that is a secret, or None.
+
+    A key matches when its exact lowercased form is in ``sensitive_keys`` OR the
+    last dotted segment is a known credential suffix (:data:`SECRET_SUFFIXES`).
+    """
+    kl = key.lower()
+    if kl in sensitive_keys:
+        return sensitive_keys[kl]
+    return SECRET_SUFFIXES.get(kl.rsplit(".", 1)[-1])
+
+
 # Any MAC-shaped string anywhere is scrubbed as a safety net for unexpected fields.
 _MAC_RE = re.compile(r"\b([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}\b")
 _MAC_PLACEHOLDER = "00:00:00:00:00:00"
@@ -92,7 +131,7 @@ def redact_obj(obj, source_ips: list[str], placeholder_ip: str,
     if isinstance(obj, dict):
         out = {}
         for key, value in obj.items():
-            placeholder = sensitive_keys.get(key.lower())
+            placeholder = secret_placeholder(key, sensitive_keys)
             if placeholder is not None and isinstance(value, str):
                 out[key] = placeholder
                 counts.key_redactions += 1


### PR DESCRIPTION
## Security fix
The committed `tests/dell_xr8620t_corpus.tar.gz` carried **live iDRAC credential material** in the DellAttributes OEM file: per-user SHA256 password hashes + salts, IPMI keys, SNMPv3 (MD5) keys, and SNMP community strings. The redactor matched only bare key names, so these dotted OEM attribute keys (`Users.2.SHA256Password`, `IPMILan.1.CommunityName`, ...) were never scrubbed.

## Changes
- `tools/redact_corpus.py`: match credentials by the **last dotted segment** of a key so vendor OEM attribute maps are caught (avoids over-redacting benign toggles like `EnableSNMPv3Passphrase`).
- Re-pack the Dell corpus with the **14** credential values redacted (same 995 files, same arcname — no consumer change).
- `tests/test_corpus_no_secrets.py`: guard that fails if any committed corpus carries a real credential.
- `docs/fixture-capture.md`: document the OEM-attribute case in the secret-scan checklist.

The other four corpora (HPE, Supermicro X10/GB300, NVIDIA node2) scanned clean.

## Tests
- Full offline suite green (1046 passed, 58 skipped); `ruff` clean.
- Guard proven to catch the leak (14 hits on the pre-fix tarball, 0 after).