### PR TITLE
Freeze simulator contract

### DIFF
--- a/docs/simulation-and-replay.md
+++ b/docs/simulation-and-replay.md
@@ -6,6 +6,7 @@ Author: Mus <spyroot@gmail.com>
 against captured real-hardware behavior. This exists for three reasons: fast offline tests, an
 end-to-end Kubernetes sandbox with no BMC, and a deterministic Redfish environment that a
 reinforcement-learning agent can train against. The three layers below build on each other.
+The frozen surface is documented in [Redfish Simulator Contract](simulator-contract.md).
 
 ## Layer 1: corpus as simulator (reads)
 

--- a/docs/simulator-contract.md
+++ b/docs/simulator-contract.md
@@ -1,0 +1,142 @@
+# Redfish Simulator Contract
+
+This document freezes the current simulator surface before the simulator is
+refactored into a public package. It describes the behavior that existing
+tests, the Kubernetes sandbox, and downstream consumers can rely on today.
+
+## Scope
+
+`k8s/sandbox/mock_bmc_server.py`, the current simulator implementation, serves a
+flattened Redfish corpus over HTTP and can optionally accept grounded writes.
+It has two mutually exclusive write engines:
+
+- `ReplayState`, created by the `--replay` argument in
+  `k8s/sandbox/mock_bmc_server.py`, replays an ordered mutation trace from
+  `tests/write_traces/`.
+- `MutationRules`, created by the `--mutation-rules` argument in
+  `k8s/sandbox/mock_bmc_server.py`, applies order-independent rules from
+  `tests/mutation_rules/`.
+
+Reads are always corpus-backed. A write may only be treated as supported when a
+trace or rule file grounds the method, path, request body, response, and state
+transition. A discovered Redfish Action in a corpus is not enough by itself.
+Operations not listed in the matrix below are unverified.
+
+## Current Runtime Surface
+
+`_OverlayStore`, defined in `k8s/sandbox/mock_bmc_server.py`, owns the in-memory
+overlays that both write engines merge into served corpus JSON. Its transition
+vocabulary is `set` and `delete`, each targeting a Redfish resource path and a
+field or `json_path`.
+
+`ReplayState`, defined in `k8s/sandbox/mock_bmc_server.py`, accepts only the next
+pending step from an ordered trace. An out-of-order write returns `409` with the
+remaining pending steps. `reset()` clears matched steps and overlays when the
+requested scenario matches.
+
+`MutationRules`, defined in `k8s/sandbox/mock_bmc_server.py`, evaluates every
+rule against each write. All matching rules apply, so independent side effects
+compose. A write with no matching rule returns `409`. Seeded failure injection is
+reproducible: the same seed produces the same failure sequence, and `reset()`
+re-seeds the sequence.
+
+`CorpusRequestHandler`, defined in `k8s/sandbox/mock_bmc_server.py`, exposes:
+
+- `GET`, `HEAD`, and `OPTIONS` for corpus resources under `/redfish/v1`.
+- `GET /__replay_status`, which reports replay or mutation-rule status when a
+  write engine is enabled.
+- `POST /__set_scenario`, which calls the active engine's `reset()` and returns
+  the reset status.
+- `POST`, `PATCH`, `PUT`, and `DELETE` only when a write engine is enabled.
+  Read-only mode returns `405` for mutating methods.
+
+`run_server`, defined in `k8s/sandbox/mock_bmc_server.py`, is the local test
+entrypoint used by the offline suite. It starts a `ThreadingHTTPServer` on a
+requested host and port, then shuts it down on context exit.
+
+## Sandbox And Emulator Entrypoints
+
+`docker/Dockerfile.mock-bmc`, the mock-BMC image definition, copies
+`k8s/sandbox/mock_bmc_server.py`, unpacks
+`tests/supermicro_gb300_corpus.tar.gz` into `/corpus/gb300`, runs as non-root
+UID `10001`, exposes port `8080`, and uses
+`ENTRYPOINT ["python", "/app/mock_bmc_server.py"]`.
+
+`k8s/sandbox/mock-bmc.yaml`, the single-node sandbox manifest, starts
+`redfish-ctl-mock-bmc:local` with
+`--mutation-rules /rules/supermicro_gb300.yaml`. The rule file is supplied from
+a ConfigMap created from `tests/mutation_rules/supermicro_gb300.yaml`.
+
+`k8s/sandbox/gb300-fleet.yaml`, the fleet sandbox manifest, starts a 36-pod
+StatefulSet from the same mock-BMC image and overlays per-pod identity with
+`MOCK_BMC_RACK` and `MOCK_BMC_SLOT`.
+
+`docker/Dockerfile.ilo-sim`, the HPE iLO emulator image definition, builds the
+HPE `ilo-redfish-emulator` source into a non-root Python container and uses
+`ENTRYPOINT ["python3", "emulator.py"]`.
+
+`k8s/sandbox/ilo-sim.yaml`, the iLO sandbox manifest, exposes the emulator over
+HTTPS on port `8443`.
+
+`tests/test_emulator_smoke.py`, the optional emulator smoke lane, is skipped
+unless `REDFISH_EMULATOR_URL` is set. It validates the real Redfish client
+against a local emulator, not live hardware.
+
+## Grounded Artifacts
+
+`tests/write_traces/graceful_restart.yaml`, the committed ordered trace, grounds
+one Supermicro GB300 host reset: `ComputerSystem.Reset` with
+`ResetType=GracefulRestart` returns `204` and updates `LastResetTime`.
+
+`tests/mutation_rules/supermicro_gb300.yaml`, the Supermicro GB300 rules file,
+grounds power reset, boot-source override, one-time boot revert, BIOS pending
+apply-on-reset, and standard VirtualMedia insert/eject.
+
+`tests/mutation_rules/supermicro_gb300_flaky.yaml`, the stochastic Supermicro
+GB300 rules file, grounds seeded failures for reset and standard VirtualMedia
+insert.
+
+`tests/mutation_rules/nvidia_gb300_node2.yaml`, the second GB300 rules file,
+grounds the same GB300 mutation classes plus SEL log clear.
+
+`tests/mutation_rules/dell_xr8620t.yaml`, the Dell XR8620t rules file, grounds
+power reset, boot-source override, one-time boot revert, BIOS pending
+apply-on-reset, SEL log clear, and storage volume create/delete.
+
+`tests/mutation_rules/hpe_dl360.yaml`, the HPE DL360 rules file, grounds power
+reset, boot-source override, one-time boot revert, BIOS pending apply-on-reset,
+and IML log clear.
+
+`tests/mutation_rules/supermicro_x10.yaml`, the Supermicro X10 rules file,
+grounds power reset, boot-source override, one-time boot revert, and system log
+clear for the early Redfish corpus.
+
+## Mutating Capability Matrix
+
+Status values:
+
+- `supported`: a committed trace or mutation-rule file grounds the operation.
+- `unsupported`: the committed corpus/rule notes explicitly state the resource
+  class is absent for that vendor/model.
+- `unverified`: no committed trace or mutation-rule file grounds the operation.
+
+| Vendor/model | Host reset | Boot override | BIOS pending apply | Standard VirtualMedia | Log clear | Storage volume |
+| --- | --- | --- | --- | --- | --- | --- |
+| Dell XR8620t | supported | supported | supported | unsupported | supported | supported |
+| Supermicro GB300 | supported | supported | supported | supported | unsupported | unsupported |
+| HPE DL360 | supported | supported | supported | unsupported | supported | unsupported |
+| Supermicro X10 | supported | supported | unsupported | unsupported | supported | unsupported |
+| NVIDIA GB300 node2 | supported | supported | supported | supported | supported | unsupported |
+
+The matrix is intentionally conservative. For example, firmware update,
+manager reset, NTP set, account mutation, and RAID operations outside Dell
+storage volume create/delete remain `unverified` until a trace or rule file
+grounds them.
+
+## Freeze Tests
+
+`tests/test_simulator_contract_freeze.py`, the RF-SIM-00 freeze test file, pins
+the contract described here. It asserts ordered replay behavior, out-of-order
+write rejection, mutation-rule composition, unmatched-write `409` responses,
+scenario reset behavior, seeded failure reproducibility, runtime entrypoints,
+and the capability matrix above.

--- a/tests/test_simulator_contract_freeze.py
+++ b/tests/test_simulator_contract_freeze.py
@@ -1,0 +1,253 @@
+"""Freeze the current Redfish simulator contract for later refactors."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+from vendor_corpus import corpus_dir
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+MOCK_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.mock-bmc"
+ILO_DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile.ilo-sim"
+MOCK_MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "mock-bmc.yaml"
+FLEET_MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "gb300-fleet.yaml"
+ILO_MANIFEST = REPO_ROOT / "k8s" / "sandbox" / "ilo-sim.yaml"
+CONTRACT_DOC = REPO_ROOT / "docs" / "simulator-contract.md"
+GB300_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz", "172.25.230.37"
+)
+SUPERMICRO_RULES = REPO_ROOT / "tests" / "mutation_rules" / "supermicro_gb300.yaml"
+FLAKY_RULES = REPO_ROOT / "tests" / "mutation_rules" / "supermicro_gb300_flaky.yaml"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _http(
+    base: str,
+    path: str,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> tuple[int, Any]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    request = urllib.request.Request(
+        base + path,
+        data=data,
+        headers=headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, json.loads(raw) if raw else None
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, json.loads(raw) if raw else None
+
+
+def _write_two_step_replay(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "scenario": "two_step_power",
+                "steps": [
+                    {
+                        "name": "force_off_first",
+                        "method": "POST",
+                        "path": RESET,
+                        "body": {"ResetType": "ForceOff"},
+                        "response": {"status": 204},
+                        "state_transitions": [
+                            {
+                                "op": "set",
+                                "path": SYSTEM,
+                                "field": "PowerState",
+                                "value": "Off",
+                            }
+                        ],
+                    },
+                    {
+                        "name": "power_on_second",
+                        "method": "POST",
+                        "path": RESET,
+                        "body": {"ResetType": "On"},
+                        "response": {"status": 204},
+                        "state_transitions": [
+                            {
+                                "op": "set",
+                                "path": SYSTEM,
+                                "field": "PowerState",
+                                "value": "On",
+                            }
+                        ],
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_replay_state_is_ordered_and_resettable(tmp_path: Path) -> None:
+    module = _load_server_module()
+    trace = tmp_path / "two-step-replay.json"
+    _write_two_step_replay(trace)
+
+    with module.run_server("127.0.0.1", 0, GB300_CORPUS, replay_trace=trace) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        assert _http(base, SYSTEM)[1]["PowerState"] == "On"
+
+        status, payload = _http(base, RESET, "POST", {"ResetType": "On"})
+        assert status == 409
+        assert payload["status"]["pending_steps"] == [
+            "force_off_first",
+            "power_on_second",
+        ]
+
+        assert _http(base, RESET, "POST", {"ResetType": "ForceOff"})[0] == 204
+        assert _http(base, SYSTEM)[1]["PowerState"] == "Off"
+        assert _http(base, RESET, "POST", {"ResetType": "On"})[0] == 204
+        assert _http(base, SYSTEM)[1]["PowerState"] == "On"
+        assert _http(base, "/__replay_status")[1]["complete"] is True
+
+        status, payload = _http(
+            base,
+            "/__set_scenario",
+            "POST",
+            {"scenario": "two_step_power"},
+        )
+        assert status == 200
+        assert payload["matched_steps"] == 0
+        assert payload["pending_steps"] == ["force_off_first", "power_on_second"]
+        assert _http(base, SYSTEM)[1]["PowerState"] == "On"
+
+
+def test_mutation_rules_compose_and_reject_unmatched_writes() -> None:
+    module = _load_server_module()
+
+    with module.run_server(
+        "127.0.0.1",
+        0,
+        GB300_CORPUS,
+        mutation_rules=SUPERMICRO_RULES,
+    ) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+
+        assert _http(
+            base,
+            SYSTEM,
+            "PATCH",
+            {"Boot": {"BootSourceOverrideTarget": "Pxe", "BootSourceOverrideEnabled": "Once"}},
+        )[0] == 200
+        assert _http(base, RESET, "POST", {"ResetType": "ForceOff"})[0] == 204
+
+        system = _http(base, SYSTEM)[1]
+        assert system["PowerState"] == "Off"
+        assert system["Boot"]["BootSourceOverrideEnabled"] == "Disabled"
+        assert system["Boot"]["BootSourceOverrideTarget"] == "None"
+
+        status, payload = _http(base, SYSTEM, "PATCH", {"AssetTag": "unsupported"})
+        assert status == 409
+        assert payload["error"] == "no write rule matched the request"
+        assert payload["status"]["mode"] == "mutation-rules"
+
+
+def test_mutation_rule_seed_reset_replays_failure_sequence() -> None:
+    module = _load_server_module()
+
+    with module.run_server(
+        "127.0.0.1",
+        0,
+        GB300_CORPUS,
+        mutation_rules=FLAKY_RULES,
+        seed=1,
+    ) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+        first_status, first_payload = _http(
+            base,
+            RESET,
+            "POST",
+            {"ResetType": "ForceOff"},
+        )
+        assert first_status == 503
+        assert "Reset action failed" in first_payload["error"]["message"]
+        assert _http(base, SYSTEM)[1]["PowerState"] == "On"
+
+        reset_status, reset_payload = _http(
+            base,
+            "/__set_scenario",
+            "POST",
+            {"scenario": "supermicro-gb300-flaky"},
+        )
+        assert reset_status == 200
+        assert reset_payload["failed"] == []
+
+        second_status, second_payload = _http(
+            base,
+            RESET,
+            "POST",
+            {"ResetType": "ForceOff"},
+        )
+        assert second_status == first_status
+        assert second_payload == first_payload
+
+
+def test_runtime_entrypoints_and_control_endpoints_are_frozen() -> None:
+    module = _load_server_module()
+    dockerfile = MOCK_DOCKERFILE.read_text(encoding="utf-8")
+    ilo_dockerfile = ILO_DOCKERFILE.read_text(encoding="utf-8")
+    mock_manifest = yaml.safe_load_all(MOCK_MANIFEST.read_text(encoding="utf-8"))
+    fleet_manifest = yaml.safe_load_all(FLEET_MANIFEST.read_text(encoding="utf-8"))
+    ilo_manifest = yaml.safe_load_all(ILO_MANIFEST.read_text(encoding="utf-8"))
+
+    assert 'ENTRYPOINT ["python", "/app/mock_bmc_server.py"]' in dockerfile
+    assert 'CMD ["--host", "0.0.0.0", "--port", "8080"]' in dockerfile
+    assert 'ENTRYPOINT ["python3", "emulator.py"]' in ilo_dockerfile
+    assert any(doc["kind"] == "Deployment" for doc in mock_manifest if doc)
+    assert any(doc["kind"] == "StatefulSet" for doc in fleet_manifest if doc)
+    assert any(doc["kind"] == "Deployment" for doc in ilo_manifest if doc)
+
+    with module.run_server(
+        "127.0.0.1",
+        0,
+        GB300_CORPUS,
+        mutation_rules=SUPERMICRO_RULES,
+    ) as srv:
+        base = "http://{}:{}".format(*srv.server_address)
+        assert _http(base, "/__replay_status")[1]["mode"] == "mutation-rules"
+        assert _http(base, "/__set_scenario", "POST", {"scenario": "supermicro-gb300"})[0] == 200
+
+
+def test_contract_doc_records_current_rule_matrix() -> None:
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+
+    for expected in [
+        "`k8s/sandbox/mock_bmc_server.py`",
+        "`ReplayState`",
+        "`MutationRules`",
+        "`tests/write_traces/graceful_restart.yaml`",
+        "`tests/mutation_rules/supermicro_gb300.yaml`",
+        "| Dell XR8620t | supported | supported | supported | unsupported | supported | supported |",
+        "| Supermicro GB300 | supported | supported | supported | supported | unsupported | unsupported |",
+        "| HPE DL360 | supported | supported | supported | unsupported | supported | unsupported |",
+        "| Supermicro X10 | supported | supported | unsupported | unsupported | supported | unsupported |",
+        "| NVIDIA GB300 node2 | supported | supported | supported | supported | supported | unsupported |",
+    ]:
+        assert expected in text


### PR DESCRIPTION
## Summary

- add a simulator contract document for the current mock-BMC runtime surface
- pin replay ordering, scenario reset, mutation-rule composition, unmatched-write rejection, seeded failures, and sandbox entrypoints with characterization tests
- cross-link the frozen contract from the existing simulation and replay guide

Refs #114.

## Verification

- targeted simulator contract tests passed: `5 passed`
- scoped Ruff passed for `tests/test_simulator_contract_freeze.py`
- full offline pytest passed with live Redfish variables unset: `1051 passed, 58 skipped`
