### PR TITLE
Generalize virtual media manager discovery

### DIFF
--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -65,9 +65,9 @@ from .idrac_shared import (
 from .idrac_shared import ResetType as ResetType
 from .redfish_exceptions import RedfishException, RedfishForbidden, RedfishUnauthorized
 from .redfish_manager import CommandResult, RedfishManager
-from .telemetry import tracing
 from .redfish_shared import RedfishApi, RedfishJson, RedfishJsonSpec, env_first
 from .redfish_task_state import TaskState, TaskStatus
+from .telemetry import tracing
 
 module_logger = logging.getLogger('redfish_ctl.idrac_manager')
 
@@ -1570,13 +1570,30 @@ class IDracManager(RedfishManager):
         the first that advertises a VirtualMedia link. Falls back to the Dell
         ``{system}/VirtualMedia`` subpath so existing Dell behavior is unchanged.
         """
-        # System first (Dell exposes VirtualMedia there), then Managers (iLO and
-        # Supermicro expose it under a Manager). Return the first with the link.
-        roots = [self.idrac_manage_servers]
+        # Managers first for iLO/Supermicro/OpenBMC; keep the historical Dell
+        # System.Embedded.1 preference when both System and Manager advertise it.
+        manager_roots = []
         try:
-            roots.extend(self.discover_manager_ids() or [])
+            manager_roots.extend(self.discover_manager_ids() or [])
         except Exception:
             pass
+        try:
+            host_system = self.idrac_manage_servers
+        except Exception:
+            host_system = ""
+        system_roots = []
+        if not host_system:
+            try:
+                system_roots.extend(self.discover_computer_system_ids() or [])
+            except Exception:
+                pass
+        roots = []
+        if host_system.endswith("/System.Embedded.1"):
+            roots.append(host_system)
+        roots.extend(root for root in manager_roots if root not in roots)
+        if host_system and host_system not in roots:
+            roots.append(host_system)
+        roots.extend(root for root in system_roots if root not in roots)
         for root in roots:
             try:
                 data = self.base_query(root, do_async=do_async).data or {}
@@ -1586,7 +1603,10 @@ class IDracManager(RedfishManager):
             uri = link.get("@odata.id") if isinstance(link, dict) else None
             if uri:
                 return uri
-        return f"{self.idrac_manage_servers}/VirtualMedia"
+        fallback_system = host_system or (system_roots[0] if system_roots else "")
+        if fallback_system:
+            return f"{fallback_system}/VirtualMedia"
+        raise ResourceNotFound("VirtualMedia collection not found in Managers or Systems")
 
     @staticmethod
     def _flatten_action_targets(resource):

--- a/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
@@ -71,6 +71,8 @@ class VirtualMediaEject(IDracManager,
             ApiRequestType.VirtualMediaGet,
             "virtual_disk_query"
         )
+        if virtual_media.error is not None:
+            return virtual_media
 
         members = virtual_media.data['Members']
         actions = [

--- a/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
@@ -10,14 +10,12 @@ Will eject virtual device id 1
 Author Mus spyroot@gmail.com
 """
 import argparse
-import warnings
 from abc import abstractmethod
 from typing import Optional
 
 from ..cmd_exceptions import InvalidArgument
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond
-from ..idrac_shared import Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, IdracApiRespond, Singleton
 from ..redfish_manager import CommandResult
 
 
@@ -69,16 +67,10 @@ class VirtualMediaEject(IDracManager,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        new_api = False
         virtual_media = self.sync_invoke(
             ApiRequestType.VirtualMediaGet,
             "virtual_disk_query"
         )
-        if self.version_api:
-            new_api = True
-
-        if new_api is False:
-            warnings.warn("Old api")
 
         members = virtual_media.data['Members']
         actions = [
@@ -98,7 +90,7 @@ class VirtualMediaEject(IDracManager,
 
         if 'image' in inserted:
             if do_strict:
-                raise InvalidArgument(f"Image already ejected")
+                raise InvalidArgument("Image already ejected")
             else:
                 return CommandResult(
                     {

--- a/redfish_ctl/virtual_media/cmd_virtual_media_get.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_get.py
@@ -24,6 +24,7 @@ import argparse
 from abc import abstractmethod
 from typing import Optional
 
+from ..cmd_exceptions import ResourceNotFound
 from ..cmd_utils import save_if_needed
 from ..idrac_manager import IDracManager
 from ..idrac_shared import ApiRequestType, Singleton
@@ -90,7 +91,11 @@ class VirtualMediaGet(IDracManager,
 
         # Resolve the VirtualMedia collection from whichever resource exposes it
         # (a Manager on iLO/Supermicro, the ComputerSystem on Dell) — no hardcoded id.
-        vm_uri = self.discover_virtual_media_uri()
+        try:
+            vm_uri = self.discover_virtual_media_uri()
+        except ResourceNotFound as exc:
+            status = str(exc)
+            return CommandResult({"Status": status}, None, None, status)
         r = f"{self._default_method}{self.idrac_ip}{vm_uri}?$expand=*($levels=1)"
 
         response = self.api_get_call(r, headers)

--- a/redfish_ctl/virtual_media/cmd_virtual_media_get.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_get.py
@@ -24,22 +24,11 @@ import argparse
 from abc import abstractmethod
 from typing import Optional
 
-
-from ..cmd_exceptions import InvalidJsonSpec
-from ..cmd_utils import from_json_spec
-from ..idrac_shared import IdracApiRespond
-from ..redfish_shared import RedfishJson
-from ..cmd_utils import str2bool
-from ..idrac_shared import IdracApiRespond, ResetType
 from ..cmd_utils import save_if_needed
-from ..cmd_exceptions import InvalidArgument
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond, Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
-from ..idrac_shared import IDRAC_API
-from ..idrac_shared import IdracApiRespond
-
-
+from ..redfish_shared import RedfishJson
 
 
 class VirtualMediaGet(IDracManager,
@@ -107,6 +96,9 @@ class VirtualMediaGet(IDracManager,
         response = self.api_get_call(r, headers)
         self.default_error_handler(response)
         data = response.json()
+        data["Members"] = self._hydrate_member_links(
+            data.get("Members"), do_async=do_async
+        )
         if device_id is not None and len(device_id) > 0:
             member_data = data['Members']
             target_device = None
@@ -131,3 +123,27 @@ class VirtualMediaGet(IDracManager,
 
         save_if_needed(filename, data)
         return CommandResult(data, None, None, None)
+
+    def _hydrate_member_links(self, members, do_async: Optional[bool] = False):
+        """Fetch linked VirtualMedia members when the service did not expand them."""
+        if not isinstance(members, list):
+            return members
+        hydrated = []
+        for member in members:
+            if not isinstance(member, dict):
+                hydrated.append(member)
+                continue
+            if "Id" in member and "Actions" in member:
+                hydrated.append(member)
+                continue
+            uri = member.get(RedfishJson.Data_id)
+            if not isinstance(uri, str):
+                hydrated.append(member)
+                continue
+            try:
+                detail = self.base_query(uri, do_async=do_async).data
+            except Exception:
+                hydrated.append(member)
+                continue
+            hydrated.append(detail if isinstance(detail, dict) else member)
+        return hydrated

--- a/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
@@ -73,25 +73,13 @@ python redfish_ctl.py insert_virtual_media --uri_path http://my_ip/ubuntu-22.04.
 Author Mus spyroot@gmail.com
 """
 import argparse
-import warnings
 from abc import abstractmethod
 from typing import Optional
 
-
-from ..cmd_exceptions import InvalidJsonSpec
-from ..cmd_utils import from_json_spec
-from ..idrac_shared import IdracApiRespond
-from ..redfish_shared import RedfishJson
-from ..cmd_utils import str2bool
-from ..idrac_shared import IdracApiRespond, ResetType
-from ..cmd_utils import save_if_needed
 from ..cmd_exceptions import InvalidArgument
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IdracApiRespond, Singleton, ApiRequestType
+from ..idrac_shared import ApiRequestType, IdracApiRespond, Singleton
 from ..redfish_manager import CommandResult
-from ..idrac_shared import IDRAC_API
-from ..idrac_shared import IdracApiRespond
-
 
 
 class VirtualMediaInsert(IDracManager,
@@ -166,17 +154,10 @@ class VirtualMediaInsert(IDracManager,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        new_api = False
         virtual_media = self.sync_invoke(
             ApiRequestType.VirtualMediaGet,
             "virtual_disk_query"
         )
-        if self.version_api:
-            new_api = True
-            # this for a future issue if old API doesn't work
-
-        if new_api is False:
-            warnings.warn("Detected old rest API.")
 
         members = virtual_media.data['Members']
         actions = [self.discover_redfish_actions(self, m) for m

--- a/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
@@ -158,6 +158,8 @@ class VirtualMediaInsert(IDracManager,
             ApiRequestType.VirtualMediaGet,
             "virtual_disk_query"
         )
+        if virtual_media.error is not None:
+            return virtual_media
 
         members = virtual_media.data['Members']
         actions = [self.discover_redfish_actions(self, m) for m

--- a/scripts/live_sanity_check/supermicro/gb300/virtual_media_roundtrip.sh
+++ b/scripts/live_sanity_check/supermicro/gb300/virtual_media_roundtrip.sh
@@ -1,0 +1,139 @@
+#!/opt/homebrew/bin/bash
+# GB300 / OpenBMC VirtualMedia mount-eject round trip.
+#
+# Target and credentials come from REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD
+# env only. The only tool that talks to the BMC is redfish_ctl.
+set -euo pipefail
+
+: "${REDFISH_IP:?set REDFISH_IP}"
+: "${REDFISH_USERNAME:?set REDFISH_USERNAME}"
+: "${REDFISH_PASSWORD:?set REDFISH_PASSWORD}"
+: "${VM_IMAGE_URI:?set VM_IMAGE_URI to an ISO URI reachable by the BMC}"
+
+RCTL=(redfish_ctl --nocolor --json_only)
+DEVICE_ID="${VM_DEVICE_ID:-USB1}"
+CAPTURE_DIR="${CAPTURE_DIR:-scripts/live_sanity_check/captures/supermicro/gb300}"
+OK_CAPTURE="$CAPTURE_DIR/virtual_media.ok.json"
+ERR_CAPTURE="$CAPTURE_DIR/virtual_media.err.json"
+
+mkdir -p "$CAPTURE_DIR"
+
+json_get() {
+  local expr="$1"
+  jq -r "$expr"
+}
+
+capture() {
+  local file="$1"
+  local step="$2"
+  local command="$3"
+  local output="$4"
+  jq -n \
+    --arg step "$step" \
+    --arg command "$command" \
+    --argjson output "$output" \
+    '{step: $step, command: $command, output: $output}' >> "$file"
+}
+
+read_device() {
+  "${RCTL[@]}" get_vm --device_id "$DEVICE_ID"
+}
+
+restore_original() {
+  set +e
+  if [ "${ORIGINAL_INSERTED:-false}" = "true" ] && [ -n "${ORIGINAL_IMAGE:-}" ] &&
+     [ "$ORIGINAL_IMAGE" != "null" ]; then
+    "${RCTL[@]}" insert_vm --device_id "$DEVICE_ID" --uri_path "$ORIGINAL_IMAGE" --eject >/dev/null
+  else
+    "${RCTL[@]}" eject_vm --device_id "$DEVICE_ID" >/dev/null
+  fi
+}
+trap restore_original EXIT
+
+assert_original_restored() {
+  local restored="$1"
+  local restored_inserted
+  local restored_image
+
+  restored_inserted="$(printf '%s' "$restored" | json_get '.data.Inserted // false')"
+  restored_image="$(printf '%s' "$restored" | json_get '.data.Image // ""')"
+
+  if [ "$ORIGINAL_INSERTED" = "true" ] && [ "$restored_image" = "$ORIGINAL_IMAGE" ]; then
+    return
+  fi
+  if [ "$ORIGINAL_INSERTED" != "true" ] && [ "$restored_inserted" = "false" ]; then
+    return
+  fi
+
+  echo "FAIL: original VirtualMedia state was not restored" >&2
+  printf '%s\n' "$restored" >&2
+  exit 1
+}
+
+echo "[gb300] VirtualMedia round trip on device $DEVICE_ID -> $REDFISH_IP"
+before="$(read_device)"
+ORIGINAL_INSERTED="$(printf '%s' "$before" | json_get '.data.Inserted // false')"
+ORIGINAL_IMAGE="$(printf '%s' "$before" | json_get '.data.Image // ""')"
+
+: > "$OK_CAPTURE"
+: > "$ERR_CAPTURE"
+capture "$OK_CAPTURE" "read-before" "redfish_ctl get_vm --device_id $DEVICE_ID" "$before"
+
+inserted="$(printf '%s' "$before" | json_get '.data.Inserted // false')"
+if [ "$inserted" = "true" ]; then
+  echo "[gb300] Existing media detected; it will be restored on exit."
+fi
+
+insert_out="$("${RCTL[@]}" insert_vm --device_id "$DEVICE_ID" --uri_path "$VM_IMAGE_URI" --eject)"
+capture \
+  "$OK_CAPTURE" \
+  "insert" \
+  "redfish_ctl insert_vm --device_id $DEVICE_ID --uri_path <VM_IMAGE_URI> --eject" \
+  "$insert_out"
+
+after_insert="$(read_device)"
+capture "$OK_CAPTURE" "read-after-insert" "redfish_ctl get_vm --device_id $DEVICE_ID" "$after_insert"
+after_inserted="$(printf '%s' "$after_insert" | json_get '.data.Inserted // false')"
+after_image="$(printf '%s' "$after_insert" | json_get '.data.Image // ""')"
+if [ "$after_inserted" != "true" ] || [ "$after_image" != "$VM_IMAGE_URI" ]; then
+  echo "FAIL: expected inserted media image '$VM_IMAGE_URI'" >&2
+  printf '%s\n' "$after_insert" >&2
+  exit 1
+fi
+
+if [ "${RUN_NEGATIVE:-0}" = "1" ]; then
+  set +e
+  negative_out="$("${RCTL[@]}" insert_vm --device_id "__invalid__" --uri_path "$VM_IMAGE_URI" 2>&1)"
+  negative_rc=$?
+  set -e
+  jq -n \
+    --arg step "insert-invalid-device" \
+    --arg command "redfish_ctl insert_vm --device_id __invalid__ --uri_path <VM_IMAGE_URI>" \
+    --arg output "$negative_out" \
+    --argjson exit_code "$negative_rc" \
+    '{step: $step, command: $command, exit_code: $exit_code, output: $output}' >> "$ERR_CAPTURE"
+  if [ "$negative_rc" -eq 0 ]; then
+    echo "FAIL: invalid device insert unexpectedly succeeded" >&2
+    exit 1
+  fi
+fi
+
+eject_out="$("${RCTL[@]}" eject_vm --device_id "$DEVICE_ID")"
+capture "$OK_CAPTURE" "eject" "redfish_ctl eject_vm --device_id $DEVICE_ID" "$eject_out"
+
+after_eject="$(read_device)"
+capture "$OK_CAPTURE" "read-after-eject" "redfish_ctl get_vm --device_id $DEVICE_ID" "$after_eject"
+after_ejected="$(printf '%s' "$after_eject" | json_get '.data.Inserted // false')"
+if [ "$after_ejected" != "false" ]; then
+  echo "FAIL: expected media to be ejected" >&2
+  printf '%s\n' "$after_eject" >&2
+  exit 1
+fi
+
+restore_original
+restored="$(read_device)"
+capture "$OK_CAPTURE" "read-after-restore" "redfish_ctl get_vm --device_id $DEVICE_ID" "$restored"
+assert_original_restored "$restored"
+trap - EXIT
+
+echo "PASS: VirtualMedia mounted, verified, ejected, restored, and verified."

--- a/scripts/live_sanity_check/supermicro/gb300/virtual_media_roundtrip.sh
+++ b/scripts/live_sanity_check/supermicro/gb300/virtual_media_roundtrip.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 : "${REDFISH_PASSWORD:?set REDFISH_PASSWORD}"
 : "${VM_IMAGE_URI:?set VM_IMAGE_URI to an ISO URI reachable by the BMC}"
 
-RCTL=(redfish_ctl --nocolor --json_only)
+RCTL=(redfish_ctl --nocolor --json_only --confirm)
 DEVICE_ID="${VM_DEVICE_ID:-USB1}"
 CAPTURE_DIR="${CAPTURE_DIR:-scripts/live_sanity_check/captures/supermicro/gb300}"
 OK_CAPTURE="$CAPTURE_DIR/virtual_media.ok.json"
@@ -101,21 +101,19 @@ if [ "$after_inserted" != "true" ] || [ "$after_image" != "$VM_IMAGE_URI" ]; the
   exit 1
 fi
 
-if [ "${RUN_NEGATIVE:-0}" = "1" ]; then
-  set +e
-  negative_out="$("${RCTL[@]}" insert_vm --device_id "__invalid__" --uri_path "$VM_IMAGE_URI" 2>&1)"
-  negative_rc=$?
-  set -e
-  jq -n \
-    --arg step "insert-invalid-device" \
-    --arg command "redfish_ctl insert_vm --device_id __invalid__ --uri_path <VM_IMAGE_URI>" \
-    --arg output "$negative_out" \
-    --argjson exit_code "$negative_rc" \
-    '{step: $step, command: $command, exit_code: $exit_code, output: $output}' >> "$ERR_CAPTURE"
-  if [ "$negative_rc" -eq 0 ]; then
-    echo "FAIL: invalid device insert unexpectedly succeeded" >&2
-    exit 1
-  fi
+set +e
+negative_out="$("${RCTL[@]}" insert_vm --device_id "__invalid__" --uri_path "$VM_IMAGE_URI" 2>&1)"
+negative_rc=$?
+set -e
+jq -n \
+  --arg step "insert-invalid-device" \
+  --arg command "redfish_ctl insert_vm --device_id __invalid__ --uri_path <VM_IMAGE_URI>" \
+  --arg output "$negative_out" \
+  --argjson exit_code "$negative_rc" \
+  '{step: $step, command: $command, exit_code: $exit_code, output: $output}' >> "$ERR_CAPTURE"
+if [ "$negative_rc" -eq 0 ]; then
+  echo "FAIL: invalid device insert unexpectedly succeeded" >&2
+  exit 1
 fi
 
 eject_out="$("${RCTL[@]}" eject_vm --device_id "$DEVICE_ID")"

--- a/tests/test_ast_conventions.py
+++ b/tests/test_ast_conventions.py
@@ -58,8 +58,8 @@ LEGACY_UNGUARDED_MUTATION_CALLS = {
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:122 execute base_post",
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:135 execute base_patch",
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:142 execute base_post",
-    "redfish_ctl/virtual_media/cmd_virtual_media_eject.py:110 execute base_post",
-    "redfish_ctl/virtual_media/cmd_virtual_media_insert.py:224 execute base_post",
+    "redfish_ctl/virtual_media/cmd_virtual_media_eject.py:102 execute base_post",
+    "redfish_ctl/virtual_media/cmd_virtual_media_insert.py:205 execute base_post",
     "redfish_ctl/volumes/cmd_initilize.py:78 execute base_post",
 }
 

--- a/tests/test_ast_conventions.py
+++ b/tests/test_ast_conventions.py
@@ -58,8 +58,8 @@ LEGACY_UNGUARDED_MUTATION_CALLS = {
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:122 execute base_post",
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:135 execute base_patch",
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:142 execute base_post",
-    "redfish_ctl/virtual_media/cmd_virtual_media_eject.py:102 execute base_post",
-    "redfish_ctl/virtual_media/cmd_virtual_media_insert.py:205 execute base_post",
+    "redfish_ctl/virtual_media/cmd_virtual_media_eject.py:104 execute base_post",
+    "redfish_ctl/virtual_media/cmd_virtual_media_insert.py:207 execute base_post",
     "redfish_ctl/volumes/cmd_initilize.py:78 execute base_post",
 }
 

--- a/tests/test_live_sanity_scripts.py
+++ b/tests/test_live_sanity_scripts.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+GB300_VIRTUAL_MEDIA_SCRIPT = (
+    ROOT / "scripts/live_sanity_check/supermicro/gb300/virtual_media_roundtrip.sh"
+)
+
+
+def _script_text() -> str:
+    return GB300_VIRTUAL_MEDIA_SCRIPT.read_text(encoding="utf-8")
+
+
+def test_gb300_virtual_media_roundtrip_passes_confirm_to_mutating_commands():
+    script = _script_text()
+    rctl_line = next(
+        line for line in script.splitlines()
+        if line.startswith("RCTL=(")
+    )
+
+    assert "--confirm" in rctl_line
+
+
+def test_gb300_virtual_media_roundtrip_always_captures_invalid_device_error():
+    script = _script_text()
+
+    assert 'RUN_NEGATIVE' not in script
+    assert 'insert_vm --device_id "__invalid__"' in script

--- a/tests/test_virtual_media_dualmode.py
+++ b/tests/test_virtual_media_dualmode.py
@@ -1,6 +1,9 @@
 """Dual-mode tests for virtual-media commands."""
 import json
 
+import pytest
+
+from redfish_ctl.cmd_exceptions import ResourceNotFound
 from redfish_ctl.idrac_manager import IDracManager
 from redfish_ctl.idrac_shared import ApiRequestType, IdracApiRespond
 from redfish_ctl.redfish_manager import CommandResult
@@ -124,6 +127,16 @@ def test_virtual_media_query_hydrates_manager_members(redfish_mock_factory):
     )
 
 
+def test_virtual_media_discovery_reports_missing_roots(redfish_mock, monkeypatch):
+    """Discovery raises the shared not-found exception when no root is available."""
+    redfish_mock.__dict__["idrac_manage_servers"] = ""
+    monkeypatch.setattr(redfish_mock, "discover_manager_ids", lambda: [])
+    monkeypatch.setattr(redfish_mock, "discover_computer_system_ids", lambda: [])
+
+    with pytest.raises(ResourceNotFound):
+        redfish_mock.discover_virtual_media_uri()
+
+
 def test_virtual_media_insert_uses_manager_action_target(
     redfish_mock_factory, monkeypatch
 ):
@@ -153,6 +166,38 @@ def test_virtual_media_insert_uses_manager_action_target(
         "Inserted": True,
         "WriteProtected": True,
     }
+
+
+def test_virtual_media_eject_uses_hydrated_manager_action_target(
+    redfish_mock_factory, monkeypatch
+):
+    """eject_vm uses hydrated member links from the Manager VirtualMedia collection."""
+    manager, service = redfish_mock_factory("supermicro")
+    device_path = "/redfish/v1/Managers/BMC_0/VirtualMedia/USB1"
+    device_state = dict(service._state(device_path))
+    device_state["Inserted"] = True
+    device_state["Image"] = "http://example.test/gb300.iso"
+    service._overlay[device_path] = device_state
+    service._overlay[device_path.lower()] = device_state
+    monkeypatch.setattr(
+        IDracManager,
+        "fetch_task",
+        lambda self, task_id: {"TaskState": "Completed"},
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.VirtualMediaEject,
+        "virtual_disk_eject",
+        device_id="USB1",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["task_id"] == service.JOB_ID
+    assert service.last_request.path == (
+        "/redfish/v1/managers/bmc_0/virtualmedia/usb1/"
+        "actions/virtualmedia.ejectmedia"
+    )
+    assert service.last_request.json() == {}
 
 
 def test_virtual_media_insert_posts_action_payload(

--- a/tests/test_virtual_media_dualmode.py
+++ b/tests/test_virtual_media_dualmode.py
@@ -22,6 +22,37 @@ def test_virtual_media_query_returns_collection(redfish_api):
     assert [member["Id"] for member in result.data["Members"]] == ["1", "2"]
 
 
+def test_virtual_media_query_prefers_dell_system_link_when_both_exist(
+    redfish_mock, redfish_service
+):
+    """Dell-shaped resources keep the historical System VirtualMedia path."""
+    manager_path = "/redfish/v1/Managers/iDRAC.Embedded.1"
+    system_path = "/redfish/v1/Systems/System.Embedded.1"
+    manager_state = dict(redfish_service._state(manager_path))
+    system_state = dict(redfish_service._state(system_path))
+    manager_state["VirtualMedia"] = {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/VirtualMedia"
+    }
+    system_state["VirtualMedia"] = {
+        "@odata.id": "/redfish/v1/Systems/System.Embedded.1/VirtualMedia"
+    }
+    for path, state in (
+        (manager_path, manager_state),
+        (manager_path.lower(), manager_state),
+        (system_path, system_state),
+        (system_path.lower(), system_state),
+    ):
+        redfish_service._overlay[path] = state
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.VirtualMediaGet, "virtual_disk_query"
+    )
+
+    assert result.data["@odata.id"] == (
+        "/redfish/v1/Systems/System.Embedded.1/VirtualMedia"
+    )
+
+
 def test_virtual_media_query_filters_by_device_id(redfish_api):
     """device_id returns the matching virtual-media member."""
     result = redfish_api.sync_invoke(
@@ -72,6 +103,56 @@ def test_virtual_media_query_reports_missing_device(redfish_api):
 
     assert isinstance(result, CommandResult)
     assert result.data == {"Status": "device id 99 not found"}
+
+
+def test_virtual_media_query_hydrates_manager_members(redfish_mock_factory):
+    """Supermicro exposes VirtualMedia under the Manager and returns member links."""
+    manager, _service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.VirtualMediaGet,
+        "virtual_disk_query",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["@odata.id"] == "/redfish/v1/Managers/BMC_0/VirtualMedia"
+    members = {member["Id"]: member for member in result.data["Members"]}
+    assert {"USB1", "USB2", "Slot_0"} <= members.keys()
+    assert members["USB1"]["Actions"]["#VirtualMedia.InsertMedia"]["target"] == (
+        "/redfish/v1/Managers/BMC_0/VirtualMedia/USB1/"
+        "Actions/VirtualMedia.InsertMedia"
+    )
+
+
+def test_virtual_media_insert_uses_manager_action_target(
+    redfish_mock_factory, monkeypatch
+):
+    """insert_vm uses the discovered Manager VirtualMedia action target."""
+    manager, service = redfish_mock_factory("supermicro")
+    monkeypatch.setattr(
+        IDracManager,
+        "fetch_task",
+        lambda self, task_id: {"TaskState": "Completed"},
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.VirtualMediaInsert,
+        "virtual_disk_insert",
+        uri_path="http://example.test/gb300.iso",
+        device_id="USB1",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["task_id"] == service.JOB_ID
+    assert service.last_request.path == (
+        "/redfish/v1/managers/bmc_0/virtualmedia/usb1/"
+        "actions/virtualmedia.insertmedia"
+    )
+    assert service.last_request.json() == {
+        "Image": "http://example.test/gb300.iso",
+        "Inserted": True,
+        "WriteProtected": True,
+    }
 
 
 def test_virtual_media_insert_posts_action_payload(

--- a/tests/test_virtual_media_dualmode.py
+++ b/tests/test_virtual_media_dualmode.py
@@ -137,6 +137,41 @@ def test_virtual_media_discovery_reports_missing_roots(redfish_mock, monkeypatch
         redfish_mock.discover_virtual_media_uri()
 
 
+@pytest.mark.parametrize(
+    ("api_call", "name", "kwargs"),
+    [
+        (ApiRequestType.VirtualMediaGet, "virtual_disk_query", {}),
+        (
+            ApiRequestType.VirtualMediaInsert,
+            "virtual_disk_insert",
+            {"uri_path": "http://example.test/gb300.iso", "device_id": "USB1"},
+        ),
+        (
+            ApiRequestType.VirtualMediaEject,
+            "virtual_disk_eject",
+            {"device_id": "USB1"},
+        ),
+    ],
+)
+def test_virtual_media_commands_report_missing_collection(
+    redfish_mock, monkeypatch, api_call, name, kwargs
+):
+    """Commands report missing VirtualMedia as a command error, not a traceback."""
+    monkeypatch.setattr(IDracManager, "idrac_manage_servers", property(lambda self: ""))
+    monkeypatch.setattr(redfish_mock, "discover_manager_ids", lambda: [])
+    monkeypatch.setattr(redfish_mock, "discover_computer_system_ids", lambda: [])
+    monkeypatch.setattr(IDracManager, "discover_manager_ids", lambda self: [])
+    monkeypatch.setattr(IDracManager, "discover_computer_system_ids", lambda self: [])
+
+    result = redfish_mock.sync_invoke(api_call, name, **kwargs)
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {
+        "Status": "VirtualMedia collection not found in Managers or Systems"
+    }
+    assert result.error == "VirtualMedia collection not found in Managers or Systems"
+
+
 def test_virtual_media_insert_uses_manager_action_target(
     redfish_mock_factory, monkeypatch
 ):


### PR DESCRIPTION
Summary
- Prefer Manager VirtualMedia links for Supermicro/OpenBMC while preserving the historical Dell System path when both Dell System and Manager resources advertise VirtualMedia.
- Hydrate linked VirtualMedia collection members when services return member refs instead of expanded records.
- Remove the Dell-specific version preflight from insert/eject and add a GB300 round-trip live sanity harness.

Validation
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python3 -m pytest -q -o cache_dir=/private/tmp/idrac-codex-worker-pytest-cache -> 1049 passed, 58 skipped in 49.65s
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/idrac_manager.py redfish_ctl/virtual_media/cmd_virtual_media_get.py redfish_ctl/virtual_media/cmd_virtual_media_insert.py redfish_ctl/virtual_media/cmd_virtual_media_eject.py tests/test_virtual_media_dualmode.py tests/test_ast_conventions.py -> All checks passed!
- /opt/homebrew/bin/bash -n scripts/live_sanity_check/supermicro/gb300/virtual_media_roundtrip.sh
- /opt/homebrew/bin/shellcheck scripts/live_sanity_check/supermicro/gb300/virtual_media_roundtrip.sh
- git diff --cached --check

Note: live round-trip script was syntax/static checked only; no live BMC was touched.