### PR TITLE
Add generic Redfish get command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Author: Mus <spyroot@gmail.com>
 When connecting to a new BMC, run `redfish_ctl system` first. It proves the endpoint, credentials, and
 basic Redfish path before deeper inventory or any staged change.
 
-The table below follows the 122 command names imported by `redfish_ctl/__init__.py`. Run
+The table below follows the 124 command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
 backward-compatible alias for the `redfish_ctl` command, and `IDRAC_*` env vars are still read.)
 
@@ -53,11 +53,14 @@ redfish_ctl logs
 redfish_ctl accounts --usernames
 redfish_ctl storage-list
 redfish_ctl get_vm
+redfish_ctl get /redfish/v1/Managers
 ```
 
 `system` returns the host ComputerSystem. `manager` returns the BMC manager. `sensors`, defined in
 `redfish_ctl/sensors/cmd_sensors.py`, follows Chassis sensor links and returns readings with units.
 `logs`, defined in `redfish_ctl/logs/cmd_logs.py`, follows system and manager LogService entries.
+`get`, defined in `redfish_ctl/cmd_get.py`, reads any Redfish resource URI when a dedicated command
+does not exist yet.
 
 ## Registered Commands
 
@@ -122,6 +125,7 @@ Safety labels:
 | `firmware-update` | Run UpdateService SimpleUpdate or a discovered push upload URI; `--dry_run` previews, `--confirm` writes. | Guarded |
 | `firmware_inventory` | Read firmware inventory. | Read |
 | `fleet` | Read a YAML fleet inventory and summarize per-node health, sensor count, and temperature max. | Read |
+| `get` | Read an arbitrary Redfish resource URI. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
 | `insert_vm` | Insert virtual media from a URI. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -67,6 +67,7 @@ from .virtual_media.cmd_smc_virtual_media import *
 from .cmd_current_boot import *
 
 from .cmd_query import *
+from .cmd_get import *
 from .cmd_wait import *
 
 # storage

--- a/redfish_ctl/cmd_get.py
+++ b/redfish_ctl/cmd_get.py
@@ -1,0 +1,50 @@
+"""Generic Redfish resource GET command."""
+from abc import abstractmethod
+from typing import Optional
+
+from .idrac_manager import IDracManager
+from .idrac_shared import ApiRequestType, Singleton
+from .redfish_manager import CommandResult
+
+
+class RawGet(
+    IDracManager,
+    scm_type=ApiRequestType.RawGet,
+    name="raw_get",
+    metaclass=Singleton,
+):
+    """Read an arbitrary Redfish resource path."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``get`` command parser."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "uri",
+            type=str,
+            help="Redfish resource URI, for example /redfish/v1/Managers",
+        )
+        help_text = "read an arbitrary Redfish resource URI."
+        return cmd_parser, "get", help_text
+
+    def execute(
+            self,
+            uri: str,
+            filename: Optional[str] = None,
+            data_type: Optional[str] = "json",
+            verbose: Optional[bool] = False,
+            do_async: Optional[bool] = False,
+            do_expanded: Optional[bool] = False,
+            **kwargs,
+    ) -> CommandResult:
+        """Read the caller-provided Redfish resource path."""
+        return self.base_query(
+            uri,
+            filename=filename,
+            do_async=do_async,
+            do_expanded=do_expanded,
+        )

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -47,6 +47,7 @@ class ApiRequestType(Enum):
     OemAttach = auto()
     DellOemActions = auto()
     QueryIdrac = auto()
+    RawGet = auto()
 
     BootOptions = auto()
     SystemConfigQuery = auto()

--- a/scripts/live_sanity_check/README.md
+++ b/scripts/live_sanity_check/README.md
@@ -68,7 +68,7 @@ enumeration is task X10-ENUM.
 
 ## Engine gaps to IMPLEMENT (prerequisites — one PR each, mutating = Claude-gated)
 1. **generalize `insert_vm`/`eject_vm`** — discover Manager id (kills the `iDRAC.Embedded.1` 404).
-2. **`redfish_ctl get <uri>` / `raw`** — generic read so no script ever needs curl.
+2. **`redfish_ctl get <uri>` / `raw`** — generic read so no script ever needs curl. ✅
 3. **`identify-led`** — PATCH LocationIndicatorActive/IndicatorLED on Chassis/System.
 4. **`ntp-set --clear`** — restore an empty NTP list.
 5. **`subscription-create` / `subscription-delete`** — EventDestination lifecycle.

--- a/tests/test_query_idrac_dualmode.py
+++ b/tests/test_query_idrac_dualmode.py
@@ -1,8 +1,10 @@
 """Dual-mode tests for the raw query command."""
+import argparse
 import json
 from urllib.parse import unquote, urlsplit
 
 from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_main import create_cmd_tree
 from redfish_ctl.redfish_manager import CommandResult
 
 SYSTEM_RESOURCE = "/redfish/v1/Systems/System.Embedded.1"
@@ -35,6 +37,27 @@ def test_query_idrac_returns_requested_resource(redfish_api):
         ApiRequestType.QueryIdrac,
         "query_idrac",
         resource=SYSTEM_RESOURCE,
+    )
+
+    _assert_system_resource(result)
+
+
+def test_get_command_is_registered_with_positional_uri():
+    """get registers as an operator-friendly alias for raw URI reads."""
+    parser = argparse.ArgumentParser()
+    commands = create_cmd_tree(parser)
+
+    assert "get" in commands
+    parsed = parser.parse_args(["get", SYSTEM_RESOURCE])
+    assert parsed.uri == SYSTEM_RESOURCE
+
+
+def test_raw_get_returns_requested_resource(redfish_api):
+    """raw_get GETs the caller-provided Redfish resource."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.RawGet,
+        "raw_get",
+        uri=SYSTEM_RESOURCE,
     )
 
     _assert_system_resource(result)


### PR DESCRIPTION
## Summary
- Add a read-only `get <uri>` command for arbitrary Redfish resource paths.
- Register the command through the existing command registry and request type enum.
- Document the command and mark the live-sanity read gap as covered.

## Validation
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python3 -m pytest -q tests/test_query_idrac_dualmode.py`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check redfish_ctl/cmd_get.py redfish_ctl/idrac_shared.py redfish_ctl/__init__.py tests/test_query_idrac_dualmode.py`
- `git diff --check`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python3 -B -m redfish_ctl get --help`
- `/Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python3 -m pytest -q -o cache_dir=/private/tmp/idrac-codex-worker-pytest-cache`