### PR TITLE
Add full training-corpus producer, contract test, and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ bios_firmware/
 # live-sanity-check raw capture traces — local until sanitized (see RF-CORPUS pipeline)
 scripts/live_sanity_check/captures/**
 !scripts/live_sanity_check/captures/.gitkeep
+
+# Full (unfiltered) training corpora — carry internal IPs/serials, stay PRIVATE (repo is public)
+/full_corpus/

--- a/docs/full-corpus-contract.md
+++ b/docs/full-corpus-contract.md
@@ -1,0 +1,57 @@
+# Full (training) corpus contract
+
+Two kinds of corpus artifact exist in this project, and they are **separate**:
+
+| kind | purpose | producer | location | `artifact_type` |
+| --- | --- | --- | --- | --- |
+| **compact mock** | fast offline tests + the mock BMC | `tools/pack_corpus.py` (filters) | `tests/*_corpus.tar.gz` (public, LFS) | `compact_mock` |
+| **full training** | complete capture for training/analysis | `tools/pack_full_corpus.py` (no filter) | private / gitignored (see below) | `full_training` |
+
+A compact mock **must not** overwrite, replace, or be mistaken for a full training
+corpus. The mock may drop schemas/registries/log entries; the full corpus **may not**.
+
+## Binding rule — full corpora are complete
+A full training corpus keeps **everything** `redfish_ctl discovery` produced — every
+JSON resource, all `Actions`/`@Redfish.AllowableValues`/`@Redfish.Settings`, all
+attribute/BIOS/network/OEM registries, all `JsonSchemas`, all OEM resources — plus the
+**exact** `rest_api_map.npy` from the same run and a `corpus_manifest.json`. Do not
+filter, do not regenerate the map from filenames, do not downgrade a writable method.
+
+## Producer
+```bash
+redfish_ctl discovery                                  # -> ~/.json_responses/<host-id>/{*.json, rest_api_map.npy}
+python tools/pack_full_corpus.py ~/.json_responses/<host-id> \
+    full_corpus/<vendor>_<model>_full_corpus.tar.gz --vendor <v> --model <m>
+```
+The archive unpacks to exactly one `<host-id>/` directory containing all JSON, the
+same-run `rest_api_map.npy`, and `corpus_manifest.json`.
+
+## Redaction — credentials + usernames ONLY
+`pack_full_corpus.py` scrubs only credential/secret values (Password, SHA256Password,
+IPMIKey, MD5v3Key, community strings, tokens, private keys, …) and account **usernames**.
+**Everything else is left original** — serials, MACs, IPs, hostnames, schemas, registries.
+Because it still carries internal identifiers, a full corpus is **INTERNAL/PRIVATE**:
+
+- **This repository is PUBLIC**, so full corpora are **NOT committed to `tests/`**. They
+  are written under a gitignored location (`full_corpus/`) or a private store. Only the
+  sanitized compact mock is public. A public full corpus would require further
+  sanitization of IPs/serials/hostnames (a separate `redaction_status`).
+
+## `rest_api_map.npy` contract
+Loads with `np.load(path, allow_pickle=True).item()` and has exactly two required
+top-level keys:
+- `url_file_mapping`: `{ "/redfish/v1/…": "_redfish_v1_….json" }` — every value is a file
+  present in the same host dir; every resource JSON has a URL entry.
+- `allowed_methods_mapping`: `{ "/redfish/v1/…": ["GET","HEAD","PATCH", …] }` — the real
+  discovered HTTP methods, preserved exactly; a writable endpoint is **never** collapsed
+  to `GET`/`HEAD`. Every URL here exists in `url_file_mapping`.
+
+## Validation gate (fail closed)
+`pack_full_corpus.py` refuses to write unless: all JSON parse; the map loads and has both
+mappings; `json_file_count == len(url_file_mapping) == len(allowed_methods_mapping)`;
+every mapped file exists; no resource JSON is unmapped; every methods-URL is in
+`url_file_mapping`. `tests/test_full_corpus_contract.py` pins all of this.
+
+`corpus_manifest.json` records `schema_version`, `artifact_type`, vendor/model/host_id,
+`redfish_version`, the three counts, per-method `method_counts`, `redaction_status`, and
+`artifact_checksum`.

--- a/tests/test_full_corpus_contract.py
+++ b/tests/test_full_corpus_contract.py
@@ -1,0 +1,137 @@
+"""Rock-solid contract tests for the full training corpus + rest_api_map.npy.
+
+Pins the ``tools/pack_full_corpus`` producer and the ``rest_api_map.npy`` contract
+so a full corpus can never silently drop resources, mismatch its map, downgrade a
+writable method to read-only, or over-redact. See docs/full-corpus-contract.md.
+
+The map contract (per the handoff spec):
+- loads with ``np.load(path, allow_pickle=True).item()``;
+- has top-level ``url_file_mapping`` and ``allowed_methods_mapping``;
+- every mapped file exists; every resource JSON is mapped; every methods-url is in url_file_mapping;
+- writable methods (POST/PATCH/PUT/DELETE) are preserved, never collapsed to GET/HEAD.
+"""
+from __future__ import annotations
+
+import json
+import tarfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tools import pack_full_corpus
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_host_dir(root: Path, resources: dict, methods: dict) -> Path:
+    """Create a synthetic discovery host dir + a same-shape rest_api_map.npy."""
+    host = root / "10.0.0.9"
+    host.mkdir()
+    url_file = {}
+    for url, (fname, body) in resources.items():
+        (host / fname).write_text(json.dumps(body, indent=4))
+        url_file[url] = fname
+    np.save(host / "rest_api_map.npy",
+            {"url_file_mapping": url_file, "allowed_methods_mapping": methods})
+    return host
+
+
+@pytest.fixture
+def good_host(tmp_path):
+    """A minimal but valid full-corpus host dir (a read, a PATCH, and a POST target)."""
+    resources = {
+        "/redfish/v1/": ("_redfish_v1.json", {"RedfishVersion": "1.17.0", "@odata.id": "/redfish/v1/"}),
+        "/redfish/v1/Systems/1/Bios/Settings": (
+            "_redfish_v1_Systems_1_Bios_Settings.json",
+            {"@odata.id": "/redfish/v1/Systems/1/Bios/Settings", "Attributes": {"AdminName": "op"}}),
+        "/redfish/v1/Managers/1/Accounts": (
+            "_redfish_v1_Managers_1_Accounts.json",
+            {"@odata.id": "/redfish/v1/Managers/1/Accounts",
+             "Members": [{"UserName": "root", "Password": "s3cr3t-hash", "SerialNumber": "ABC123"}]}),
+    }
+    methods = {
+        "/redfish/v1/": ["GET", "HEAD"],
+        "/redfish/v1/Systems/1/Bios/Settings": ["GET", "HEAD", "PATCH"],
+        "/redfish/v1/Managers/1/Accounts": ["GET", "HEAD", "POST"],
+    }
+    return _write_host_dir(tmp_path, resources, methods)
+
+
+def test_map_loads_and_has_required_keys(good_host):
+    """rest_api_map.npy loads with allow_pickle and carries both required mappings."""
+    api = pack_full_corpus.load_api_map(good_host)
+    assert set(api) >= {"url_file_mapping", "allowed_methods_mapping"}
+    api2 = np.load(good_host / "rest_api_map.npy", allow_pickle=True).item()
+    assert api2 == api
+
+
+def test_valid_corpus_passes_gate(good_host):
+    """A complete, consistent host dir produces zero validation problems."""
+    api = pack_full_corpus.load_api_map(good_host)
+    files = sorted(good_host.glob("*.json"))
+    assert pack_full_corpus.validate(good_host, api, files) == []
+
+
+def test_writable_methods_preserved_in_manifest(good_host):
+    """PATCH/POST are counted, never downgraded to GET/HEAD."""
+    api = pack_full_corpus.load_api_map(good_host)
+    files = sorted(good_host.glob("*.json"))
+    m = pack_full_corpus.build_manifest(good_host, api, "acme", "x", files, "x")
+    assert m["method_counts"]["PATCH"] == 1
+    assert m["method_counts"]["POST"] == 1
+    assert m["artifact_type"] == "full_training"
+    assert m["json_file_count"] == m["url_file_mapping_count"] == len(files)
+
+
+def test_gate_fails_on_unmapped_resource(good_host):
+    """A resource JSON with no url_file_mapping entry is a fail-closed violation."""
+    (good_host / "_redfish_v1_Chassis_1.json").write_text('{"@odata.id":"/redfish/v1/Chassis/1"}')
+    api = pack_full_corpus.load_api_map(good_host)
+    files = sorted(good_host.glob("*.json"))
+    problems = pack_full_corpus.validate(good_host, api, files)
+    assert any("not in url_file_mapping" in p for p in problems)
+
+
+def test_gate_fails_on_missing_mapped_file(good_host):
+    """A url_file_mapping pointing at a nonexistent file fails the gate."""
+    api = pack_full_corpus.load_api_map(good_host)
+    api["url_file_mapping"]["/redfish/v1/Ghost"] = "_redfish_v1_Ghost.json"
+    np.save(good_host / "rest_api_map.npy", api)
+    api = pack_full_corpus.load_api_map(good_host)
+    files = sorted(good_host.glob("*.json"))
+    problems = pack_full_corpus.validate(good_host, api, files)
+    assert any("mapped file missing" in p for p in problems)
+
+
+def test_redaction_only_touches_credentials_and_username(good_host):
+    """Redaction scrubs Password + UserName; leaves SerialNumber (and all else) original."""
+    body = json.loads((good_host / "_redfish_v1_Managers_1_Accounts.json").read_text())
+    cleaned = pack_full_corpus._redact_credentials(body)
+    member = cleaned["Members"][0]
+    assert member["Password"] == "REDACTED"
+    assert member["UserName"] == "REDACTED"
+    assert member["SerialNumber"] == "ABC123"  # NOT redacted — full corpus keeps identifiers
+
+
+def test_full_pack_roundtrips_and_revalidates(good_host, tmp_path):
+    """Packing produces a tarball that unpacks to one host dir with map+manifest and re-validates."""
+    out = tmp_path / "acme_x_full_corpus.tar.gz"
+    rc = pack_full_corpus.pack(good_host, out, "acme", "x", redact=True)
+    assert rc == 0 and out.exists()
+    unpack = tmp_path / "unpack"
+    with tarfile.open(out) as tar:
+        tar.extractall(unpack)
+    root = unpack / good_host.name
+    assert (root / "rest_api_map.npy").exists()
+    manifest = json.loads((root / "corpus_manifest.json").read_text())
+    assert manifest["artifact_type"] == "full_training"
+    assert manifest["redaction_status"] == "credentials_username_redacted"
+    # re-validate the unpacked corpus
+    api = pack_full_corpus.load_api_map(root)
+    files = sorted(p for p in root.glob("*.json") if p.name != "corpus_manifest.json")
+    assert pack_full_corpus.validate(root, api, files) == []
+    # credential redaction survived the pack
+    acct = json.loads((root / "_redfish_v1_Managers_1_Accounts.json").read_text())
+    assert acct["Members"][0]["Password"] == "REDACTED"
+    assert acct["Members"][0]["SerialNumber"] == "ABC123"

--- a/tools/pack_full_corpus.py
+++ b/tools/pack_full_corpus.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Produce a COMPLETE (unfiltered) Redfish training corpus from a discovery run.
+
+Unlike ``tools/pack_corpus.py`` (which filters to a compact device+telemetry MOCK
+corpus by dropping JsonSchemas/Registries/Entries), this keeps EVERYTHING a
+``redfish_ctl discovery`` run produced — every JSON resource, all registries,
+schemas, actions, settings, and OEM resources — plus the exact ``rest_api_map.npy``
+from the same run and a ``corpus_manifest.json``. It is the ``full_training``
+artifact. See ``docs/full-corpus-contract.md``.
+
+Redaction: ONLY credential/secret values and account usernames are scrubbed
+(reusing ``tools/redact_corpus.SECRET_SUFFIXES`` plus ``username``); every other
+value — serials, MACs, IPs, hostnames, schema/registry bodies — is left ORIGINAL.
+A full corpus that still carries internal identifiers is INTERNAL/PRIVATE and must
+not be committed to a public repo (write it under a gitignored location).
+
+Usage:
+    python tools/pack_full_corpus.py ~/.json_responses/<host-id> \\
+        full_corpus/<vendor>_<model>_full_corpus.tar.gz \\
+        --vendor supermicro --model gb300
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+_METHODS = ("GET", "HEAD", "OPTIONS", "POST", "PATCH", "PUT", "DELETE")
+# Credential/secret + account-identity keys to scrub (matched on the last dotted
+# segment, case-insensitive). Everything NOT in this set is left ORIGINAL — a full
+# corpus keeps serials, MACs, IPs, hostnames, schemas, registries as captured.
+_REDACT_SUFFIXES = {
+    "password", "sha256password", "sha256passwordsalt", "ipmikey", "md5v3key",
+    "shav3key", "communityname", "agentcommunity", "snmpv3passphrase", "passphrase",
+    "token", "authtoken", "privatekey", "sharedsecret", "presharedkey",
+    "chapsecret", "chapsecretreverse", "username", "usernames",
+}
+
+
+def _redact_credentials(obj):
+    """Scrub ONLY credential + username values; leave every other value original."""
+    if isinstance(obj, dict):
+        out = {}
+        for k, v in obj.items():
+            last = k.lower().rsplit(".", 1)[-1]
+            if last in _REDACT_SUFFIXES and isinstance(v, str) and v.strip() and v.lower() != "null":
+                out[k] = "REDACTED"
+            elif last in _REDACT_SUFFIXES and isinstance(v, list) and all(isinstance(x, str) for x in v):
+                out[k] = ["REDACTED" for _ in v]
+            else:
+                out[k] = _redact_credentials(v)
+        return out
+    if isinstance(obj, list):
+        return [_redact_credentials(x) for x in obj]
+    return obj
+
+
+def load_api_map(host_dir: Path) -> dict:
+    """Load rest_api_map.npy (allow_pickle) and return its dict; raise on problems."""
+    import numpy as np
+    p = host_dir / "rest_api_map.npy"
+    if not p.exists():
+        raise FileNotFoundError(f"no rest_api_map.npy in {host_dir} — run `redfish_ctl discovery` first")
+    api_map = np.load(p, allow_pickle=True).item()
+    for key in ("url_file_mapping", "allowed_methods_mapping"):
+        if key not in api_map:
+            raise ValueError(f"rest_api_map.npy missing required top-level key '{key}'")
+    return api_map
+
+
+def build_manifest(host_dir: Path, api_map: dict, vendor: str, model: str,
+                   json_files: list[Path], redaction_status: str) -> dict:
+    """Assemble corpus_manifest.json (counts derived from the map + files)."""
+    ufm = api_map["url_file_mapping"]
+    amm = api_map["allowed_methods_mapping"]
+    method_counts = {m: 0 for m in _METHODS}
+    for methods in amm.values():
+        for m in methods:
+            if m in method_counts:
+                method_counts[m] += 1
+    redfish_version = ""
+    sr = host_dir / "_redfish_v1.json"
+    if sr.exists():
+        try:
+            redfish_version = json.loads(sr.read_text()).get("RedfishVersion", "")
+        except (ValueError, OSError):
+            pass
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], cwd=Path(__file__).resolve().parent.parent,
+            text=True, stderr=subprocess.DEVNULL).strip()
+    except (OSError, subprocess.CalledProcessError):
+        commit = ""
+    return {
+        "schema_version": 1,
+        "artifact_type": "full_training",
+        "vendor": vendor,
+        "model": model,
+        "host_id": host_dir.name,
+        "redfish_version": redfish_version,
+        "bmc_firmware_version": "",
+        "discovery_timestamp": "",
+        "redfish_ctl_commit": commit,
+        "json_file_count": len(json_files),
+        "url_file_mapping_count": len(ufm),
+        "allowed_methods_mapping_count": len(amm),
+        "method_counts": method_counts,
+        "redaction_status": redaction_status,
+        "artifact_checksum": "",
+    }
+
+
+def validate(host_dir: Path, api_map: dict, json_files: list[Path]) -> list[str]:
+    """Return a list of contract violations (empty = valid). Fail closed on any."""
+    problems: list[str] = []
+    ufm = api_map["url_file_mapping"]
+    amm = api_map["allowed_methods_mapping"]
+    names = {p.name for p in json_files}
+    for p in json_files:
+        try:
+            json.loads(p.read_text())
+        except (ValueError, OSError) as e:
+            problems.append(f"unparseable JSON {p.name}: {e}")
+    if len(ufm) != len(json_files):
+        problems.append(f"json_file_count {len(json_files)} != url_file_mapping {len(ufm)}")
+    if len(amm) != len(ufm):
+        problems.append(f"allowed_methods_mapping {len(amm)} != url_file_mapping {len(ufm)}")
+    for url, fname in ufm.items():
+        if Path(fname).name not in names:
+            problems.append(f"mapped file missing from corpus: {url} -> {fname}")
+    mapped = {Path(f).name for f in ufm.values()}
+    for p in json_files:
+        if p.name == "rest_api_map.npy" or p.name == "corpus_manifest.json":
+            continue
+        if p.name not in mapped:
+            problems.append(f"resource JSON not in url_file_mapping: {p.name}")
+    for url in amm:
+        if url not in ufm:
+            problems.append(f"url in allowed_methods_mapping but not url_file_mapping: {url}")
+    return problems
+
+
+def pack(host_dir: Path, output: Path, vendor: str, model: str,
+         redact: bool = True, dry_run: bool = False) -> int:
+    """Validate + (optionally redact) + pack a full corpus. Fail closed."""
+    host_dir = host_dir.resolve()
+    json_files = sorted(p for p in host_dir.glob("*.json"))
+    if not json_files:
+        print(f"no *.json in {host_dir}", file=sys.stderr)
+        return 2
+    api_map = load_api_map(host_dir)
+    problems = validate(host_dir, api_map, json_files)
+    if problems:
+        print("BLOCKER: full-corpus validation failed (fail closed):", file=sys.stderr)
+        for p in problems[:20]:
+            print(f"  - {p}", file=sys.stderr)
+        return 3
+    redaction_status = "original_internal" if not redact else "credentials_username_redacted"
+    manifest = build_manifest(host_dir, api_map, vendor, model, json_files, redaction_status)
+    print(f"{host_dir.name}: {len(json_files)} json, map {manifest['url_file_mapping_count']} urls, "
+          f"methods {manifest['method_counts']}, redact={redact}")
+    if dry_run:
+        return 0
+
+    staging = Path(tempfile.mkdtemp(prefix="full_corpus_"))
+    dest = staging / host_dir.name
+    dest.mkdir(parents=True)
+    for p in json_files:
+        data = json.loads(p.read_text())
+        if redact:
+            data = _redact_credentials(data)
+        (dest / p.name).write_text(json.dumps(data, indent=4))
+    # copy the EXACT rest_api_map.npy (same-run; no credentials in URLs/methods)
+    (dest / "rest_api_map.npy").write_bytes((host_dir / "rest_api_map.npy").read_bytes())
+    (dest / "corpus_manifest.json").write_text(json.dumps(manifest, indent=2))
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tarfile.open(output, "w:gz") as tar:
+        tar.add(dest, arcname=host_dir.name)
+    manifest["artifact_checksum"] = "sha256:" + hashlib.sha256(output.read_bytes()).hexdigest()
+    (dest / "corpus_manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"wrote {output} (full_training, {len(json_files)} json + map + manifest)")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("host_dir", type=Path, help="discovery host dir (~/.json_responses/<host-id>)")
+    parser.add_argument("output", type=Path, help="output full-corpus .tar.gz (gitignored/private location)")
+    parser.add_argument("--vendor", required=True)
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--no-redact", action="store_true",
+                        help="keep the ORIGINAL tree with no redaction (internal-only artifact)")
+    parser.add_argument("--dry-run", action="store_true", help="validate + report, do not write")
+    args = parser.parse_args(argv)
+    return pack(args.host_dir, args.output, args.vendor, args.model,
+                redact=not args.no_redact, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds `tools/pack_full_corpus.py` (complete/unfiltered corpus producer — all JSON + same-run `rest_api_map.npy` + `corpus_manifest.json`), `tests/test_full_corpus_contract.py` (rock-solid map + validation-gate tests, fail-closed), and `docs/full-corpus-contract.md`. Full corpora are kept **private** (gitignored `full_corpus/`) because they retain internal IPs/serials — only the sanitized compact mock is public. Redaction touches **only** credentials + usernames; everything else stays original. Distinct from the compact mock (`tools/pack_corpus.py`, `tests/*_corpus.tar.gz`).