### PR TITLE
Record full corpus payload checksums

### DIFF
--- a/docs/full-corpus-contract.md
+++ b/docs/full-corpus-contract.md
@@ -90,4 +90,7 @@ still validate.
 `corpus_manifest.json` records `schema_version`, `artifact_type`, vendor/model/host_id,
 `redfish_version`, the counts (`json_file_count`, `url_file_mapping_count`,
 `error_file_mapping_count`, `allowed_methods_mapping_count`), per-method `method_counts`,
-`http_status_counts`, `redaction_status`, and `artifact_checksum`.
+`http_status_counts`, `redaction_status`, and `artifact_checksum`. The `artifact_checksum`
+field is a deterministic `sha256:` digest over the
+staged payload files, excluding `corpus_manifest.json` so the checksum can be stored inside the
+manifest without a self-reference cycle.

--- a/tests/test_full_corpus_contract.py
+++ b/tests/test_full_corpus_contract.py
@@ -210,6 +210,9 @@ def test_full_pack_roundtrips_and_revalidates(good_host, tmp_path):
     manifest = json.loads((root / "corpus_manifest.json").read_text())
     assert manifest["artifact_type"] == "full_training"
     assert manifest["redaction_status"] == "credentials_username_redacted"
+    assert manifest["artifact_checksum"].startswith("sha256:")
+    assert len(manifest["artifact_checksum"]) == len("sha256:") + 64
+    assert manifest["artifact_checksum"] == pack_full_corpus.artifact_payload_checksum(root)
     # re-validate the unpacked corpus
     api = pack_full_corpus.load_api_map(root)
     files = sorted(p for p in root.glob("*.json") if p.name != "corpus_manifest.json")

--- a/tools/pack_full_corpus.py
+++ b/tools/pack_full_corpus.py
@@ -141,6 +141,18 @@ def build_manifest(host_dir: Path, api_map: dict, vendor: str, model: str,
     }
 
 
+def artifact_payload_checksum(root: Path) -> str:
+    """Return a deterministic checksum for payload files, excluding the manifest."""
+    digest = hashlib.sha256()
+    for path in sorted(p for p in root.rglob("*") if p.is_file() and p.name != "corpus_manifest.json"):
+        rel = path.relative_to(root).as_posix().encode("utf-8")
+        digest.update(rel)
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return "sha256:" + digest.hexdigest()
+
+
 def validate(host_dir: Path, api_map: dict, json_files: list[Path]) -> list[str]:
     """Return a list of contract violations (empty = valid). Fail closed on any.
 
@@ -230,13 +242,12 @@ def pack(host_dir: Path, output: Path, vendor: str, model: str,
         (dest / p.name).write_text(json.dumps(data, indent=4))
     # copy the EXACT rest_api_map.npy (same-run; no credentials in URLs/methods)
     (dest / "rest_api_map.npy").write_bytes((host_dir / "rest_api_map.npy").read_bytes())
+    manifest["artifact_checksum"] = artifact_payload_checksum(dest)
     (dest / "corpus_manifest.json").write_text(json.dumps(manifest, indent=2))
 
     output.parent.mkdir(parents=True, exist_ok=True)
     with tarfile.open(output, "w:gz") as tar:
         tar.add(dest, arcname=host_dir.name)
-    manifest["artifact_checksum"] = "sha256:" + hashlib.sha256(output.read_bytes()).hexdigest()
-    (dest / "corpus_manifest.json").write_text(json.dumps(manifest, indent=2))
     print(f"wrote {output} (full_training, {len(json_files)} json + map + manifest)")
     return 0
 


### PR DESCRIPTION
## Summary
- compute `artifact_checksum` from staged full-corpus payload files before writing the manifest
- exclude `corpus_manifest.json` from the digest so the checksum can be stored in the manifest
- document the checksum contract and assert it in the round-trip corpus test

## Tests
- `conda run -n idrac_ctl python3 -m pytest -q tests/test_full_corpus_contract.py`
- `conda run -n idrac_ctl ruff check tools/pack_full_corpus.py tests/test_full_corpus_contract.py`
- `conda run -n idrac_ctl python3 -m pytest -q`