### PR TITLE
Add GB300 full training corpus + require ServiceRoot in the gate

### DIFF
--- a/full_corpus/supermicro_gb300_full_corpus.tar.gz
+++ b/full_corpus/supermicro_gb300_full_corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8258d5deababb8ceb8200293272e71a3e96bf3ada388347a68fce852baf70112
+size 754155

--- a/tests/test_full_corpus_contract.py
+++ b/tests/test_full_corpus_contract.py
@@ -104,6 +104,18 @@ def test_gate_fails_on_missing_mapped_file(good_host):
     assert any("mapped file missing" in p for p in problems)
 
 
+def test_gate_fails_on_missing_serviceroot(good_host):
+    """A corpus without the ServiceRoot (_redfish_v1.json) fails the gate."""
+    (good_host / "_redfish_v1.json").unlink()
+    api = pack_full_corpus.load_api_map(good_host)
+    del api["url_file_mapping"]["/redfish/v1/"]
+    np.save(good_host / "rest_api_map.npy", api)
+    api = pack_full_corpus.load_api_map(good_host)
+    files = sorted(good_host.glob("*.json"))
+    problems = pack_full_corpus.validate(good_host, api, files)
+    assert any("ServiceRoot" in p for p in problems)
+
+
 def test_redaction_only_touches_credentials_and_username(good_host):
     """Redaction scrubs Password + UserName; leaves SerialNumber (and all else) original."""
     body = json.loads((good_host / "_redfish_v1_Managers_1_Accounts.json").read_text())

--- a/tools/pack_full_corpus.py
+++ b/tools/pack_full_corpus.py
@@ -123,6 +123,10 @@ def validate(host_dir: Path, api_map: dict, json_files: list[Path]) -> list[str]
     ufm = api_map["url_file_mapping"]
     amm = api_map["allowed_methods_mapping"]
     names = {p.name for p in json_files}
+    if "_redfish_v1.json" not in names:
+        problems.append("ServiceRoot missing: no _redfish_v1.json (the entry point must be captured)")
+    if "/redfish/v1/" not in ufm and "/redfish/v1" not in ufm:
+        problems.append("ServiceRoot URL /redfish/v1/ not in url_file_mapping")
     for p in json_files:
         try:
             json.loads(p.read_text())


### PR DESCRIPTION
First **full training corpus** (`full_corpus/supermicro_gb300_full_corpus.tar.gz`, LFS): complete unfiltered GB300 discovery — **1928 JSON** (all resources + **235 JsonSchemas** + **32 Registries** + ServiceRoot) + the **same-run `rest_api_map.npy`** (writable methods preserved: 28 POST / 557 PATCH / 63 DELETE / 1 PUT) + `corpus_manifest.json`. Credentials + usernames redacted; lab identifiers (IPs/MACs/serials) kept (ephemeral lab). 

Also strengthens `pack_full_corpus.validate()` to **require the ServiceRoot** (`_redfish_v1.json`) with a regression test — a live discovery run was found to not persist the entry point (booked as a discovery fix). 8/8 contract tests pass.