### PR TITLE
Add Dell XR8620t full training corpus (map-backed, full-training path)

### DIFF
--- a/full_corpus/dell_xr8620t_full_corpus.tar.gz
+++ b/full_corpus/dell_xr8620t_full_corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c4796093bb02d87fb79a91e0a21fba968db693954bf3caac2ac77b5d115c28ac
+size 1486348


### PR DESCRIPTION
Recovers the map-backed Dell full object from the earlier corpora branch and lands it under `full_corpus/` (full-training), separate from the compact `tests/` mock. 2466 JSON (all resources + schemas + registries + ServiceRoot) + same-run `rest_api_map.npy` (writable methods preserved) + `corpus_manifest.json`; credentials+usernames redacted, lab identifiers kept. Passes the full-corpus contract gate.