### PR TITLE
Add Supermicro X10SDV full training corpus

### DIFF
--- a/full_corpus/supermicro_x10_full_corpus.tar.gz
+++ b/full_corpus/supermicro_x10_full_corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7a9d9b7e90de09653c01a7698616dcc7cdc7f47a0f44d856c359c22adb30e663
+size 12179


### PR DESCRIPTION
Third full training corpus for the library (after GB300 and Dell), unblocking IGC's cross-vendor training set.

- **What:** complete unfiltered Redfish crawl of a live Supermicro X10SDV BMC — 64 resources, **Redfish 1.0.1**, map-backed with the same-run `rest_api_map.npy` + `corpus_manifest.json` (`artifact_type: full_training`).
- **Redaction:** only credentials + account usernames scrubbed; serials/MACs/IPs kept as captured (disposable lab hardware). Zero credential leaks verified.
- **Distinct data point:** this older AMI/Supermicro BMC advertises **no `Allow` header**, so `allowed_methods_mapping` is empty by BMC behavior (verified live), not by filtering — a different firmware generation vs GB300 (OpenBMC) and Dell (iDRAC).
- **Contract:** passes `tools/pack_full_corpus.validate` (ServiceRoot present, map/file counts consistent) and the `tests/test_full_corpus_contract.py` gate.

Path: `full_corpus/supermicro_x10_full_corpus.tar.gz` (Git-LFS).