### PR TITLE
Add HPE iLO5 (DL360) full training corpus

### DIFF
--- a/full_corpus/hpe_dl360_full_corpus.tar.gz
+++ b/full_corpus/hpe_dl360_full_corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b57f2e3fb1e408aa878a1d2f616650551adff2166bb8df36c245c0796ddce18
+size 689556


### PR DESCRIPTION
Fourth vendor generation in the full-corpus library (after GB300, Dell, X10SDV) — completes the cross-vendor training set for IGC.

- **What:** complete unfiltered Redfish crawl of a live HPE ProLiant DL360 iLO5 BMC — 986 resources, **Redfish 1.6.0**, map-backed with the same-run `rest_api_map.npy` + `corpus_manifest.json` (`artifact_type: full_training`).
- **Rich writable methods:** iLO5 fully advertises `Allow`, so `allowed_methods_mapping` carries real mutation ground truth — **POST 24, PATCH 204, PUT 10, DELETE 24**. Strong contrast with the X10SDV corpus (empty by BMC behavior).
- **Redaction:** only credentials + account usernames scrubbed; serials/MACs/IPs kept as captured (lab hardware). Zero credential leaks verified.
- **Faithful capture:** 12 resources that errored during the crawl (HPE OEM `hpsut`, deprecated `NetworkPorts`) were never written and are excluded — the map references exactly the 986 files on disk.
- **Contract:** passes `tools/pack_full_corpus.validate` and the `tests/test_full_corpus_contract.py` gate.

Path: `full_corpus/hpe_dl360_full_corpus.tar.gz` (Git-LFS).