### PR TITLE
Fix SNMPv3 key leak in full corpora; refresh iLO capture

### DIFF
--- a/full_corpus/dell_xr8620t_full_corpus.tar.gz
+++ b/full_corpus/dell_xr8620t_full_corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c4796093bb02d87fb79a91e0a21fba968db693954bf3caac2ac77b5d115c28ac
-size 1486348
+oid sha256:eeb43b32fb714b9b513c4574f18edf51395d3b84a4afeadea6492803ff2ba2e6
+size 1486322

--- a/full_corpus/hpe_dl360_full_corpus.tar.gz
+++ b/full_corpus/hpe_dl360_full_corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0b57f2e3fb1e408aa878a1d2f616650551adff2166bb8df36c245c0796ddce18
-size 689556
+oid sha256:016567107331f5e2d83d8cc4aabca38861d9da3ca04ece37576fa474a94c7abe
+size 689520

--- a/full_corpus/supermicro_gb300_full_corpus.tar.gz
+++ b/full_corpus/supermicro_gb300_full_corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8258d5deababb8ceb8200293272e71a3e96bf3ada388347a68fce852baf70112
-size 754155
+oid sha256:1f1b8538541809ef81339257105d74de0506f47307ee8d550e2f2f2d879744ac
+size 754165

--- a/full_corpus/supermicro_x10_full_corpus.tar.gz
+++ b/full_corpus/supermicro_x10_full_corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7a9d9b7e90de09653c01a7698616dcc7cdc7f47a0f44d856c359c22adb30e663
-size 12179
+oid sha256:91d35c07fe5d6fada3b08addcd48846e8f197902b601bece53b6977010cc532a
+size 12149

--- a/tests/test_full_corpus_contract.py
+++ b/tests/test_full_corpus_contract.py
@@ -126,6 +126,77 @@ def test_redaction_only_touches_credentials_and_username(good_host):
     assert member["SerialNumber"] == "ABC123"  # NOT redacted — full corpus keeps identifiers
 
 
+def test_snmpv3_key_family_is_redacted():
+    """Regression: EVERY SNMPv3 localized key variant is scrubbed, not just the ones
+    spelled out in the set. A Dell ``SHA1v3Key`` once leaked because the exact-match
+    set held ``shav3key`` (no such Dell key) while the real ``SHA1v3Key`` lowercases
+    to ``sha1v3key``; its siblings ``MD5v3Key``/``SHA256Password`` were scrubbed, so
+    the corpus shipped 3 live SNMPv3 auth keys. The ``*v3key`` suffix pattern closes
+    this whole class."""
+    body = {
+        "Attributes": {
+            "Users.2.SHA1v3Key": "0123456789abcdef0123456789abcdef01234567",
+            "Users.3.SHA256v3Key": "deadbeef" * 8,
+            "Users.4.MD5v3Key": "cafebabecafebabecafebabecafebabe",
+            "Users.5.ShaV3Key": "feedface" * 5,
+        }
+    }
+    cleaned = pack_full_corpus._redact_credentials(body)["Attributes"]
+    for k in body["Attributes"]:
+        assert cleaned[k] == "REDACTED", f"{k} survived redaction"
+
+
+def test_community_and_extra_secret_key_classes_redacted():
+    """Community strings and the newly-covered key classes are scrubbed. ``*community``
+    catches RO/RW/Agent community; ``EncryptionKey`` (IPMI) and ``BindPassword`` (LDAP)
+    are added exact keys — all secret material a full corpus must not ship."""
+    body = {
+        "ROCommunity": "not-public-secret",
+        "RWCommunity": "not-private-secret",
+        "SNMPAlert.1.SNMPv3Community": "custom-community",
+        "IPMILan.1.EncryptionKey": "1122334455667788990011223344556677889900",
+        "LDAP.1.BindPassword": "s3cr3t-bind",
+    }
+    cleaned = pack_full_corpus._redact_credentials(body)
+    for k in body:
+        assert cleaned[k] == "REDACTED", f"{k} survived redaction"
+
+
+def test_non_secret_config_keys_are_not_over_redacted():
+    """The redactor must NOT collapse non-secret config that merely resembles a secret
+    key. Password-*policy* fields, protocol names, and numeric values stay ORIGINAL so
+    the corpus keeps its device configuration faithful."""
+    body = {
+        "PasswordExpiration": "90",          # policy value, last segment != 'password'
+        "MinimumPasswordLength": 8,           # non-string, untouched
+        "SNMPProtocol": "SNMPv3",             # protocol name, not a key
+        "CommunityNameEnabled": "true",       # boolean-ish flag, last segment not matched
+        "SerialNumber": "CN7016327K0033",     # identifier, kept by policy
+    }
+    cleaned = pack_full_corpus._redact_credentials(body)
+    assert cleaned == body, "a non-secret config value was over-redacted"
+
+
+def test_dell_dellattributes_shape_redaction():
+    """On the real Dell DellAttributes shape (dotted composite keys under Attributes),
+    only the SNMPv3 key + account username are scrubbed; the alert destination and
+    other attributes stay original."""
+    body = {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellAttributes/iDRAC.Embedded.1",
+        "Attributes": {
+            "Users.2.SHA1v3Key": "0123456789abcdef0123456789abcdef01234567",
+            "Users.2.UserName": "root",
+            "SNMPAlert.1.Destination": "10.0.0.5",
+            "Time.1.Timezone": "US/Central",
+        },
+    }
+    attrs = pack_full_corpus._redact_credentials(body)["Attributes"]
+    assert attrs["Users.2.SHA1v3Key"] == "REDACTED"
+    assert attrs["Users.2.UserName"] == "REDACTED"
+    assert attrs["SNMPAlert.1.Destination"] == "10.0.0.5"   # not a secret — kept
+    assert attrs["Time.1.Timezone"] == "US/Central"
+
+
 def test_full_pack_roundtrips_and_revalidates(good_host, tmp_path):
     """Packing produces a tarball that unpacks to one host dir with map+manifest and re-validates."""
     out = tmp_path / "acme_x_full_corpus.tar.gz"

--- a/tools/pack_full_corpus.py
+++ b/tools/pack_full_corpus.py
@@ -34,14 +34,30 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 _METHODS = ("GET", "HEAD", "OPTIONS", "POST", "PATCH", "PUT", "DELETE")
 # Credential/secret + account-identity keys to scrub (matched on the last dotted
-# segment, case-insensitive). Everything NOT in this set is left ORIGINAL — a full
+# segment, case-insensitive). Everything NOT matched is left ORIGINAL — a full
 # corpus keeps serials, MACs, IPs, hostnames, schemas, registries as captured.
 _REDACT_SUFFIXES = {
     "password", "sha256password", "sha256passwordsalt", "ipmikey", "md5v3key",
-    "shav3key", "communityname", "agentcommunity", "snmpv3passphrase", "passphrase",
-    "token", "authtoken", "privatekey", "sharedsecret", "presharedkey",
-    "chapsecret", "chapsecretreverse", "username", "usernames",
+    "shav3key", "sha1v3key", "sha256v3key", "communityname", "agentcommunity",
+    "snmpv3passphrase", "passphrase", "token", "authtoken", "privatekey",
+    "sharedsecret", "presharedkey", "chapsecret", "chapsecretreverse",
+    "encryptionkey", "bindpassword", "username", "usernames",
 }
+# Suffix PATTERNS so a new vendor variant of a known secret class can't slip
+# through an exact-match gap (the reason a Dell `SHA1v3Key` once leaked while its
+# siblings `MD5v3Key`/`SHA256Password` were scrubbed). A last dotted segment that
+# ENDS WITH any of these is treated as the same secret class:
+#   *v3key      -> all SNMPv3 localized key material (md5/sha/sha1/sha256 v3key)
+#   *community  -> ro/rw/agent/snmp community strings (bare `communityname` in the set)
+_REDACT_SUFFIX_PATTERNS = ("v3key", "community")
+
+
+def _is_secret_key(key: str) -> bool:
+    """True if this key's last dotted segment names a credential/secret to scrub."""
+    last = key.lower().rsplit(".", 1)[-1]
+    if last in _REDACT_SUFFIXES:
+        return True
+    return any(last.endswith(pat) for pat in _REDACT_SUFFIX_PATTERNS)
 
 
 def _redact_credentials(obj):
@@ -49,10 +65,9 @@ def _redact_credentials(obj):
     if isinstance(obj, dict):
         out = {}
         for k, v in obj.items():
-            last = k.lower().rsplit(".", 1)[-1]
-            if last in _REDACT_SUFFIXES and isinstance(v, str) and v.strip() and v.lower() != "null":
+            if _is_secret_key(k) and isinstance(v, str) and v.strip() and v.lower() != "null":
                 out[k] = "REDACTED"
-            elif last in _REDACT_SUFFIXES and isinstance(v, list) and all(isinstance(x, str) for x in v):
+            elif _is_secret_key(k) and isinstance(v, list) and all(isinstance(x, str) for x in v):
                 out[k] = ["REDACTED" for _ in v]
             else:
                 out[k] = _redact_credentials(v)


### PR DESCRIPTION
## Security fix (found by adversarial redaction verification)

The full-corpus redactor (`tools/pack_full_corpus.py`) matched secret keys by **exact** last dotted segment. The set listed `shav3key`, but Dell's real attribute is `SHA1v3Key` (segment `sha1v3key`), so the match never fired — and **three SNMPv3 SHA-1 localized auth keys shipped in the published Dell corpus** (`Users.{2,3,16}.SHA1v3Key`), even though the sibling secrets in the same account objects (`MD5v3Key`, `IPMIKey`, `SHA256Password`) were correctly `REDACTED`.

### What changed
- **Redactor matches the whole secret *class* by suffix pattern**, not fragile exact strings: any `*v3key` (all SNMPv3 localized key material — md5/sha/sha1/sha256) and any `*community` string, plus added `EncryptionKey` (IPMI) and `BindPassword` (LDAP). This closes the gap that let `SHA1v3Key` through.
- **Regression tests** (`tests/test_full_corpus_contract.py`, now 12): the SNMPv3 key family, community/IPMI/LDAP secret keys, and a guard that non-secret config (password-*policy* fields, protocol names, numbers) is **not** over-redacted.
- **Re-packed all four corpora** with the fixed redactor and independently re-scanned — **zero surviving secret values**. Dell `SHA1v3Key` now reads `REDACTED`×3. Composition preserved (Dell 2466, GB300 1928, X10 64).

### Also: HPE iLO5 corpus refreshed ("full iLO")
Re-crawled the iLO5 completely and rebuilt `hpe_dl360_full_corpus.tar.gz` (985 resources): recovered `Systems/1/Storage` (transient 400→200), dropped non-reproducible ephemeral session objects, ServiceRoot injected, map fully consistent (PATCH 204 / POST 24 / PUT 10 / DELETE 23). Verified by a 4-lens adversarial workflow (redaction · map-contract · completeness · manifest).

### Note on history
The pre-fix Dell LFS object retains the leaked keys in history. The hardware is decommissioned/disposable lab gear, but the three SNMPv3 keys should be treated as exposed. History rewrite (BFG/`git lfs migrate`) is destructive and left to the maintainer's call.