### PR TITLE
Replay captured mock BMC error statuses

### DIFF
--- a/docker/Dockerfile.mock-bmc
+++ b/docker/Dockerfile.mock-bmc
@@ -10,10 +10,11 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     MOCK_BMC_CORPUS_DIR=/corpus/gb300
 
-# PyYAML lets the mock load YAML replay traces and mutation-rules files; the
-# server itself is otherwise stdlib-only. Without it the mock can only read
-# plain-JSON traces (see mock_bmc_server._load_trace).
-RUN pip install --no-cache-dir "pyyaml>=6,<7"
+# PyYAML loads YAML replay traces/rules. NumPy loads the rest_api_map.npy file
+# written by discovery so captured non-2xx responses replay with their status.
+RUN pip install --no-cache-dir \
+    "numpy>=1.26,<3" \
+    "pyyaml>=6,<7"
 
 # Pin a numeric uid/gid so Kubernetes can verify runAsNonRoot without a
 # runAsUser override (a named user cannot be checked at admission).

--- a/docs/simulator-contract.md
+++ b/docs/simulator-contract.md
@@ -43,6 +43,10 @@ re-seeds the sequence.
 `CorpusRequestHandler`, defined in `k8s/sandbox/mock_bmc_server.py`, exposes:
 
 - `GET`, `HEAD`, and `OPTIONS` for corpus resources under `/redfish/v1`.
+- When `rest_api_map.npy`, written by discovery and packed with the corpus,
+  is present, reads honor `url_file_mapping`, `http_status_mapping`, and
+  `error_file_mapping`: captured 403/404/405 responses return their original
+  status and error envelope instead of being normalized to `200`.
 - `GET /__replay_status`, which reports replay or mutation-rule status when a
   write engine is enabled.
 - `POST /__set_scenario`, which calls the active engine's `reset()` and returns

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -103,14 +103,22 @@ def _resolve_mapped_fixture(corpus_dir: Path, mapped_name: Any) -> Path | None:
         return None
     root = Path(corpus_dir)
     mapped_path = Path(mapped_name)
-    candidates: list[Path] = []
     if mapped_path.is_absolute():
         return None
-    candidates.append(root / mapped_path)
-    candidates.append(root / mapped_path.name)
+    root_resolved = root.resolve()
+    candidates: list[Path] = [root / mapped_path, root / mapped_path.name]
     for candidate in candidates:
-        if candidate.is_file():
-            return candidate
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        # Containment guard: a mapped name from rest_api_map with '..' segments
+        # must never resolve outside the corpus dir. Without this, a crafted
+        # url_file_mapping entry like "../../etc/passwd" would be served.
+        if not resolved.is_relative_to(root_resolved):
+            continue
+        if resolved.is_file():
+            return resolved
     return None
 
 

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -34,6 +34,57 @@ def _build_fixture_index(corpus_dir: Path) -> dict[str, Path]:
     return {path.name.lower(): path for path in root.glob("*.json")}
 
 
+def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
+    map_path = Path(corpus_dir) / "rest_api_map.npy"
+    if not map_path.exists():
+        return {}
+    try:
+        import numpy as np
+    except ModuleNotFoundError:
+        return {}
+    try:
+        data = np.load(map_path, allow_pickle=True).item()
+    except Exception as exc:  # noqa: BLE001 - include loader context.
+        raise ValueError(f"failed to load Redfish API map: {map_path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Redfish API map must contain an object: {map_path}")
+    return data
+
+
+def _mapping_dict(api_map: dict[str, Any], key: str) -> dict[str, Any]:
+    value = api_map.get(key) or {}
+    return value if isinstance(value, dict) else {}
+
+
+def _candidate_map_keys(request_path: str) -> tuple[str, ...]:
+    path = _normalize_request_path(request_path)
+    if path == "/redfish/v1":
+        return (path, "/redfish/v1/")
+    return (path,)
+
+
+def _lookup_mapping(mapping: dict[str, Any], request_path: str) -> Any:
+    for key in _candidate_map_keys(request_path):
+        if key in mapping:
+            return mapping[key]
+    return None
+
+
+def _resolve_mapped_fixture(corpus_dir: Path, mapped_name: Any) -> Path | None:
+    if not isinstance(mapped_name, str) or not mapped_name:
+        return None
+    root = Path(corpus_dir)
+    mapped_path = Path(mapped_name)
+    candidates: list[Path] = []
+    if not mapped_path.is_absolute():
+        candidates.append(root / mapped_path)
+    candidates.append(root / mapped_path.name)
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _normalize_request_path(request_path: str) -> str:
     path = unquote(urlsplit(request_path).path)
     if path != "/" and path.endswith("/"):
@@ -413,11 +464,45 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
 
     def _fixture_for_request(self) -> Path | None:
         fixture_index = getattr(type(self), "fixture_index")
+        api_map = getattr(type(self), "api_map", {})
+        corpus_dir = getattr(type(self), "corpus_dir")
         path = _normalize_request_path(self.path)
         if not path.startswith("/redfish/v1"):
             return None
+        mapped_name = _lookup_mapping(
+            _mapping_dict(api_map, "url_file_mapping"),
+            path,
+        )
+        mapped_fixture = _resolve_mapped_fixture(corpus_dir, mapped_name)
+        if mapped_fixture is not None:
+            return mapped_fixture
         key = "_" + path.strip("/").replace("/", "_") + ".json"
         return fixture_index.get(key.lower())
+
+    def _captured_error_for_request(self) -> tuple[int, Path | None] | None:
+        api_map = getattr(type(self), "api_map", {})
+        if not api_map:
+            return None
+        path = _normalize_request_path(self.path)
+        if not path.startswith("/redfish/v1"):
+            return None
+        raw_status = _lookup_mapping(
+            _mapping_dict(api_map, "http_status_mapping"),
+            path,
+        )
+        try:
+            status = int(raw_status)
+        except (TypeError, ValueError):
+            status = None
+        error_fixture = _resolve_mapped_fixture(
+            getattr(type(self), "corpus_dir"),
+            _lookup_mapping(_mapping_dict(api_map, "error_file_mapping"), path),
+        )
+        if error_fixture is None:
+            if status is None or status < 400:
+                return None
+            return status, None
+        return status or 500, error_fixture
 
     def _active_writer(self) -> "ReplayState | MutationRules | None":
         """The write engine in effect (mutation-rules takes precedence)."""
@@ -463,6 +548,24 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def _serve_fixture(self, send_body: bool) -> None:
+        captured_error = self._captured_error_for_request()
+        if captured_error is not None:
+            status, error_fixture = captured_error
+            if error_fixture is None:
+                content = json.dumps(
+                    {"error": f"captured status {status} for {self.path}"},
+                    sort_keys=True,
+                ).encode("utf-8")
+            else:
+                content = error_fixture.read_bytes()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(content)))
+            self.end_headers()
+            if send_body:
+                self.wfile.write(content)
+            return
+
         fixture = self._fixture_for_request()
         if fixture is None:
             self._send_json(404, {"error": f"no fixture for {self.path}"})
@@ -637,6 +740,8 @@ def make_handler(
     class Handler(CorpusRequestHandler):
         pass
 
+    Handler.corpus_dir = root
+    Handler.api_map = _load_rest_api_map(root)
     Handler.fixture_index = _build_fixture_index(root)
     if not Handler.fixture_index:
         raise ValueError(f"no JSON fixtures found under {root}")

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -41,14 +41,42 @@ def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
     try:
         import numpy as np
     except ModuleNotFoundError:
-        return {}
+        raise ValueError(
+            f"NumPy is required to load Redfish API map: {map_path}"
+        ) from None
     try:
         data = np.load(map_path, allow_pickle=True).item()
     except Exception as exc:  # noqa: BLE001 - include loader context.
         raise ValueError(f"failed to load Redfish API map: {map_path}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"Redfish API map must contain an object: {map_path}")
+    _validate_rest_api_map(data, map_path)
     return data
+
+
+def _validate_rest_api_map(api_map: dict[str, Any], map_path: Path) -> None:
+    for key in ("url_file_mapping", "http_status_mapping", "error_file_mapping"):
+        value = api_map.get(key)
+        if value is not None and not isinstance(value, dict):
+            raise ValueError(f"{key} must be an object in Redfish API map: {map_path}")
+
+    status_mapping = api_map.get("http_status_mapping")
+    if not isinstance(status_mapping, dict):
+        return
+    for request_path, raw_status in list(status_mapping.items()):
+        try:
+            status = int(raw_status)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                "http_status_mapping values must be integer HTTP statuses "
+                f"in Redfish API map: {map_path} ({request_path!r})"
+            ) from exc
+        if status < 100 or status > 599:
+            raise ValueError(
+                "http_status_mapping values must be valid HTTP statuses "
+                f"in Redfish API map: {map_path} ({request_path!r})"
+            )
+        status_mapping[request_path] = status
 
 
 def _mapping_dict(api_map: dict[str, Any], key: str) -> dict[str, Any]:
@@ -76,8 +104,9 @@ def _resolve_mapped_fixture(corpus_dir: Path, mapped_name: Any) -> Path | None:
     root = Path(corpus_dir)
     mapped_path = Path(mapped_name)
     candidates: list[Path] = []
-    if not mapped_path.is_absolute():
-        candidates.append(root / mapped_path)
+    if mapped_path.is_absolute():
+        return None
+    candidates.append(root / mapped_path)
     candidates.append(root / mapped_path.name)
     for candidate in candidates:
         if candidate.is_file():
@@ -490,10 +519,7 @@ class CorpusRequestHandler(BaseHTTPRequestHandler):
             _mapping_dict(api_map, "http_status_mapping"),
             path,
         )
-        try:
-            status = int(raw_status)
-        except (TypeError, ValueError):
-            status = None
+        status = int(raw_status) if raw_status is not None else None
         error_fixture = _resolve_mapped_fixture(
             getattr(type(self), "corpus_dir"),
             _lookup_mapping(_mapping_dict(api_map, "error_file_mapping"), path),

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -8,6 +8,7 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+import numpy as np
 import pytest
 import yaml
 from vendor_corpus import corpus_dir
@@ -54,6 +55,63 @@ def _http(base: str, path: str, method: str = "GET", body=None):
         return exc.code, (json.loads(raw) if raw else None)
 
 
+def _fixture_name(path: str) -> str:
+    return "_" + path.strip("/").replace("/", "_") + ".json"
+
+
+def _write_status_map_corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "status-map-corpus"
+    corpus.mkdir()
+    normal_path = "/redfish/v1/Systems/1"
+    error_cases = {
+        "/redfish/v1/Secret": (
+            403,
+            "_redfish_v1_Secret.error.json",
+            {"error": {"code": "Base.1.17.InsufficientPrivilege"}},
+        ),
+        "/redfish/v1/Missing": (
+            404,
+            "_redfish_v1_Missing.error.json",
+            {"error": {"code": "Base.1.17.ResourceMissingAtURI"}},
+        ),
+        "/redfish/v1/ReadOnly": (
+            405,
+            "_redfish_v1_ReadOnly.error.json",
+            {"error": {"code": "Base.1.17.ActionNotSupported"}},
+        ),
+    }
+
+    (corpus / _fixture_name("/redfish/v1")).write_text(
+        json.dumps({"@odata.id": "/redfish/v1/"}),
+        encoding="utf-8",
+    )
+    (corpus / _fixture_name(normal_path)).write_text(
+        json.dumps({"@odata.id": normal_path}),
+        encoding="utf-8",
+    )
+    for _path, (_status, filename, payload) in error_cases.items():
+        (corpus / filename).write_text(json.dumps(payload), encoding="utf-8")
+
+    np.save(
+        corpus / "rest_api_map.npy",
+        {
+            "url_file_mapping": {
+                "/redfish/v1/": _fixture_name("/redfish/v1"),
+                normal_path: _fixture_name(normal_path),
+            },
+            "http_status_mapping": {
+                "/redfish/v1/": 200,
+                normal_path: 200,
+                **{path: status for path, (status, _name, _body) in error_cases.items()},
+            },
+            "error_file_mapping": {
+                path: filename for path, (_status, filename, _body) in error_cases.items()
+            },
+        },
+    )
+    return corpus
+
+
 def test_mock_bmc_maps_redfish_paths_to_gb300_corpus() -> None:
     """Redfish URLs resolve to the flattened files in the GB300 corpus."""
     module = _load_server_module()
@@ -92,6 +150,33 @@ def test_mock_bmc_serves_json_read_only_over_http() -> None:
             assert exc.code == 405
         else:  # pragma: no cover - the assertion above is the expected path.
             raise AssertionError("POST unexpectedly succeeded")
+
+
+@pytest.mark.parametrize(
+    ("path", "status", "code"),
+    [
+        ("/redfish/v1/Secret", 403, "Base.1.17.InsufficientPrivilege"),
+        ("/redfish/v1/Missing", 404, "Base.1.17.ResourceMissingAtURI"),
+        ("/redfish/v1/ReadOnly", 405, "Base.1.17.ActionNotSupported"),
+    ],
+)
+def test_mock_bmc_replays_captured_error_status_map(
+    tmp_path: Path,
+    path: str,
+    status: int,
+    code: str,
+) -> None:
+    module = _load_server_module()
+    corpus = _write_status_map_corpus(tmp_path)
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        assert _http(base, "/redfish/v1/Systems/1")[0] == 200
+        observed_status, payload = _http(base, path)
+
+    assert observed_status == status
+    assert payload == {"error": {"code": code}}
 
 
 def test_mock_bmc_replay_graceful_restart_updates_system_state() -> None:
@@ -142,6 +227,7 @@ def test_mock_bmc_container_builds_from_corpus_without_credentials() -> None:
     dockerfile = DOCKERFILE.read_text(encoding="utf-8")
 
     assert "FROM python:3.12-slim" in dockerfile
+    assert "numpy" in dockerfile
     assert "--chown=mockbmc:mockbmc" in dockerfile
     assert "k8s/sandbox/mock_bmc_server.py" in dockerfile
     assert "tests/supermicro_gb300_corpus.tar.gz" in dockerfile

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -259,6 +259,23 @@ def test_absolute_mapped_fixture_names_are_ignored(tmp_path: Path) -> None:
     ) is None
 
 
+def test_mapped_fixture_names_cannot_escape_corpus_dir(tmp_path: Path) -> None:
+    """A rest_api_map entry with '..' segments must never resolve outside the
+    corpus dir. A real secret file is planted next to (not inside) the corpus;
+    a crafted ``../`` mapping must not serve it (path-traversal guard)."""
+    module = _load_server_module()
+    corpus = _write_status_map_corpus(tmp_path)
+    secret = tmp_path / "secret.json"
+    secret.write_text('{"leaked": true}', encoding="utf-8")
+
+    # relative traversal that would land on the planted secret one level up
+    assert module._resolve_mapped_fixture(corpus, "../secret.json") is None
+    assert module._resolve_mapped_fixture(corpus, "../../etc/hostname") is None
+    # a legitimate in-corpus name still resolves
+    good = next(corpus.glob("*.json"))
+    assert module._resolve_mapped_fixture(corpus, good.name) == good.resolve()
+
+
 def test_head_to_captured_error_status_suppresses_body(tmp_path: Path) -> None:
     """HEAD returns captured error headers without writing an error body."""
     module = _load_server_module()

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -112,6 +112,42 @@ def _write_status_map_corpus(tmp_path: Path) -> Path:
     return corpus
 
 
+def _write_url_map_corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "url-map-corpus"
+    corpus.mkdir()
+    mapped_dir = corpus / "mapped"
+    mapped_dir.mkdir()
+
+    (corpus / _fixture_name("/redfish/v1")).write_text(
+        json.dumps({"@odata.id": "/redfish/v1/"}),
+        encoding="utf-8",
+    )
+    (mapped_dir / "aliased-system.json").write_text(
+        json.dumps(
+            {
+                "@odata.id": "/redfish/v1/Systems/Original",
+                "Id": "Original",
+            }
+        ),
+        encoding="utf-8",
+    )
+    np.save(
+        corpus / "rest_api_map.npy",
+        {
+            "url_file_mapping": {
+                "/redfish/v1/": _fixture_name("/redfish/v1"),
+                "/redfish/v1/Alias": "mapped/aliased-system.json",
+            },
+            "http_status_mapping": {
+                "/redfish/v1/": 200,
+                "/redfish/v1/Alias": 200,
+            },
+            "error_file_mapping": {},
+        },
+    )
+    return corpus
+
+
 def test_mock_bmc_maps_redfish_paths_to_gb300_corpus() -> None:
     """Redfish URLs resolve to the flattened files in the GB300 corpus."""
     module = _load_server_module()
@@ -177,6 +213,69 @@ def test_mock_bmc_replays_captured_error_status_map(
 
     assert observed_status == status
     assert payload == {"error": {"code": code}}
+
+
+def test_mock_bmc_serves_url_file_mapping_alias(tmp_path: Path) -> None:
+    """URL mappings can serve fixtures whose names do not derive from the URL."""
+    module = _load_server_module()
+    corpus = _write_url_map_corpus(tmp_path)
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, payload = _http(base, "/redfish/v1/Alias")
+
+    assert status == 200
+    assert payload == {
+        "@odata.id": "/redfish/v1/Systems/Original",
+        "Id": "Original",
+    }
+
+
+def test_rest_api_map_rejects_malformed_status_values(tmp_path: Path) -> None:
+    """A bad status map fails startup instead of silently dropping a status."""
+    module = _load_server_module()
+    corpus = _write_status_map_corpus(tmp_path)
+    np.save(
+        corpus / "rest_api_map.npy",
+        {
+            "url_file_mapping": {"/redfish/v1/": _fixture_name("/redfish/v1")},
+            "http_status_mapping": {"/redfish/v1/Broken": "not-a-status"},
+            "error_file_mapping": {},
+        },
+    )
+
+    with pytest.raises(ValueError, match="http_status_mapping"):
+        module.make_handler(corpus)
+
+
+def test_absolute_mapped_fixture_names_are_ignored(tmp_path: Path) -> None:
+    """Mapped fixture names stay corpus-relative instead of accepting paths."""
+    module = _load_server_module()
+    corpus = _write_status_map_corpus(tmp_path)
+
+    assert module._resolve_mapped_fixture(
+        corpus,
+        "/tmp/_redfish_v1_Missing.error.json",
+    ) is None
+
+
+def test_head_to_captured_error_status_suppresses_body(tmp_path: Path) -> None:
+    """HEAD returns captured error headers without writing an error body."""
+    module = _load_server_module()
+    corpus = _write_status_map_corpus(tmp_path)
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        request = urllib.request.Request(
+            base + "/redfish/v1/Missing",
+            method="HEAD",
+        )
+        with pytest.raises(urllib.error.HTTPError) as exc_info:
+            urllib.request.urlopen(request, timeout=5)
+
+    assert exc_info.value.code == 404
+    assert exc_info.value.read() == b""
+    assert int(exc_info.value.headers["Content-Length"]) > 0
 
 
 def test_mock_bmc_replay_graceful_restart_updates_system_state() -> None:


### PR DESCRIPTION
## Summary
- Load the capture API map in the sandbox mock BMC when it is present.
- Return captured non-2xx statuses and error envelopes from error_file_mapping/http_status_mapping.
- Install NumPy in the mock-BMC image and document the simulator contract.

## Tests
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python3 -m pytest -q tests/test_k8s_mock_bmc_server.py -k captured_error_status_map
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl python3 -m pytest -q tests/test_k8s_mock_bmc_server.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl ruff check k8s/sandbox/mock_bmc_server.py tests/test_k8s_mock_bmc_server.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD -u REDFISH_PORT python3 -m pytest -q tests/test_k8s_mock_bmc_server.py tests/test_full_corpus_contract.py tests/test_discovery_producer.py tests/test_discovery_walker.py
- /Users/spyroot/miniconda3/condabin/conda run -n idrac_ctl env -u IDRAC_IP -u IDRAC_USERNAME -u IDRAC_PASSWORD -u IDRAC_PORT -u REDFISH_IP -u REDFISH_USERNAME -u REDFISH_PASSWORD -u REDFISH_PORT python3 -m pytest -q

Refs #114