### PR TITLE
Clarify live action docs safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,41 +7,10 @@
 
 `redfish_ctl` is a standalone command-line tool for driving server BMCs entirely through the
 Redfish REST API — no web UI, no vendor GUI. It wraps 100+ subcommands behind one consistent CLI
-with JSON or YAML output (`--yaml`, and save-to-file), both synchronous and asynchronous calls,
-optional server-side `$expand` on large collection reads, and a read-first, guarded-write model
-(mutating commands preview with `--dry_run` and require `--confirm`). It is vendor-neutral by design — Dell iDRAC,
-Supermicro (including GB300 / Grace-Blackwell and X10), HPE iLO, and generic DMTF Redfish — built on
-a product-neutral Redfish client with the Dell/iDRAC specifics layered on top.
-
-What it does across the whole server lifecycle:
-
-- **Inventory & health** — system, chassis, manager, processors, memory, PCI, storage, drives,
-  network adapters/ports, NVLink ports, ethernet interfaces, and firmware inventory.
-- **BIOS** — read and stage attributes, pending management, the attribute registry, transactional
-  snapshots/restore points for rollback, and curated tuning profiles (low-latency, Dell
-  System/Workload, Intel, AMD).
-- **Boot** — boot order, one-time boot (UEFI or Legacy), boot sources, and next-boot inference.
-- **Power & reset** — vendor-neutral host reset / power-cycle (discovers `ComputerSystem.Reset`),
-  chassis reset, manager reboot, and a guarded `system-reset`.
-- **Storage & RAID** — controllers, drives, volumes, the RAID service, RAID/non-RAID conversion,
-  and volume initialize.
-- **Virtual media & OS provisioning** — mount/eject ISOs, one-shot ISO boot, Supermicro OEM
-  virtual media (CfgCD), and Dell OEM network-ISO boot.
-- **Serial console & SOL** — report and enable host BIOS serial redirection together with the BMC
-  Serial-over-LAN service, in one step, vendor-neutrally.
-- **Sensors & telemetry** — read every chassis sensor and TelemetryService report/definition, plus
-  an out-of-band exporter that streams BMC metrics — including GB300 GPU, NVLink, thermal, and power
-  — to Prometheus, SignalFx, and Splunk Observability. The
-  [telemetry exporter guide](docs/telemetry-exporter.md) covers the one-exporter-per-BMC deployment
-  model and the supported consumer modes.
-- **Firmware** — inventory and guarded `UpdateService` SimpleUpdate.
-- **Accounts & security** — create/update/delete accounts, SSH-key import, the account and privilege
-  services, Secure Boot, and SPDM component-integrity attestation.
-- **Jobs & tasks** — Dell Lifecycle Controller jobs and the standard Redfish Job/Task services,
-  with watch/apply/delete.
-- **Config, logs & events** — system config export/import, system and manager logs (SEL), test
-  events, the BMC clock, and a `wait` that blocks until the BMC answers after a reboot.
-- **Discovery** — scan a subnet for BMCs, classify their vendor, and crawl a Redfish tree.
+with JSON or YAML output (`--yaml`, and save-to-file), synchronous and asynchronous calls, and
+optional server-side `$expand` on large collection reads. It is vendor-neutral by design — Dell
+iDRAC, Supermicro (including GB300 / Grace-Blackwell and X10), HPE iLO, and generic DMTF Redfish —
+built on a product-neutral Redfish client with the Dell/iDRAC specifics layered on top.
 
 > The tool was renamed from `idrac_ctl` to `redfish_ctl`. `idrac_ctl` still works as a
 > backward-compatible alias — the `idrac_ctl` command, `import idrac_ctl`, and the legacy
@@ -69,12 +38,45 @@ redfish_ctl --help             # every subcommand
 ```
 
 Reads are safe. Commands that change hardware (power, BIOS, boot, storage, virtual media, firmware)
-follow a read-first, guarded-write model — they preview with `--dry_run` and only act with
-`--confirm`. See [Mutating Commands](#mutating-commands) below.
+vary by safety label: **Guarded** commands require an intent flag such as `--confirm`, while
+**Write** commands may mutate as soon as they are invoked. Check the
+[Command reference](docs/commands.md) before changing hardware.
 
 > **Upgrading from `idrac_ctl`?** Install `redfish_ctl` — the `idrac_ctl` command, `import idrac_ctl`,
 > and the legacy `IDRAC_*` env vars all keep working as a backward-compatible alias. The old
 > `idrac_ctl` PyPI package (≤ 1.0.13) is the pre-rename tool; new work should `pip install redfish_ctl`.
+
+## Capabilities
+
+What it does across the whole server lifecycle:
+
+- **Inventory & health** — system, chassis, manager, processors, memory, PCI, storage, drives,
+  network adapters/ports, NVLink ports, ethernet interfaces, and firmware inventory.
+- **BIOS** — read and stage attributes, pending management, the attribute registry, transactional
+  snapshots/restore points for rollback, and curated tuning profiles (low-latency, Dell
+  System/Workload, Intel, AMD).
+- **Boot** — boot order, one-time boot (UEFI or Legacy), boot sources, and next-boot inference.
+- **Power & reset** — discover host reset / power-cycle actions, chassis reset, manager reboot, and
+  the guarded `system-reset` command. These are live hardware actions, not quickstart commands.
+- **Storage & RAID** — controllers, drives, volumes, the RAID service, RAID/non-RAID conversion,
+  and volume initialize.
+- **Virtual media & OS provisioning** — mount/eject ISOs, one-shot ISO boot, Supermicro OEM
+  virtual media (CfgCD), and Dell OEM network-ISO boot.
+- **Serial console & SOL** — report and enable host BIOS serial redirection together with the BMC
+  Serial-over-LAN service, in one step, vendor-neutrally.
+- **Sensors & telemetry** — read every chassis sensor and TelemetryService report/definition, plus
+  an out-of-band exporter that streams BMC metrics — including GB300 GPU, NVLink, thermal, and power
+  — to Prometheus, SignalFx, and Splunk Observability. The
+  [telemetry exporter guide](docs/telemetry-exporter.md) covers the one-exporter-per-BMC deployment
+  model and the supported consumer modes.
+- **Firmware** — inventory and guarded `UpdateService` SimpleUpdate.
+- **Accounts & security** — create/update/delete accounts, SSH-key import, the account and privilege
+  services, Secure Boot, and SPDM component-integrity attestation.
+- **Jobs & tasks** — Dell Lifecycle Controller jobs and the standard Redfish Job/Task services,
+  with watch/apply/delete.
+- **Config, logs & events** — system config export/import, system and manager logs (SEL), test
+  events, the BMC clock, and a `wait` that blocks until the BMC answers after a reboot.
+- **Discovery** — scan a subnet for BMCs, classify their vendor, and crawl a Redfish tree.
 
 ## Install
 
@@ -232,7 +234,8 @@ opt-in emulator canary in `examples/hpe_ilo_canary.sh`. See [Vendors](docs/vendo
 
 Some commands change real hardware: power, BIOS, boot order, storage conversion, virtual media,
 firmware update, and manager reset. Read current state first, preview when the command has
-`--show` or `--dry_run`, then verify after the job or task completes.
+`--show` or `--dry_run`, run live apply commands only on an approved target, then verify after the
+job or task completes.
 
 ```bash
 redfish_ctl system-reset --reset_type GracefulRestart --dry_run
@@ -240,8 +243,9 @@ redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset --show
 redfish_ctl firmware-update --image_uri https://example.invalid/firmware.exe --dry_run
 ```
 
-Use `--confirm` only when you mean to perform a guarded action such as `system-reset` or
-`firmware-update`.
+Use `--confirm`, `--commit`, or reset/apply flags only when you mean to perform the approved live
+action. See the [Command reference](docs/commands.md) for the **Read**, **Guarded**, and **Write**
+safety labels.
 
 ## Observability with Splunk
 
@@ -289,8 +293,9 @@ First-run problems are almost always the connection, not the command:
   default, so this usually means you passed `--verify-ssl` against a BMC without a trusted chain;
   drop the flag, or point it at a BMC whose certificate you trust.
 - **Connection timeout / refused / no route** — the BMC IP is unreachable, on a different network,
-  or Redfish is on a non-default port. Confirm reachability (`ping`, `curl -k https://$REDFISH_IP/redfish/v1`)
-  and set `REDFISH_PORT` if it isn't 443. After a reboot, `redfish_ctl wait` blocks until the BMC answers again.
+  or Redfish is on a non-default port. Confirm basic network reachability if your environment allows
+  it, then run `redfish_ctl --debug system` and set `REDFISH_PORT` if it is not 443. After a reboot,
+  `redfish_ctl wait` blocks until the BMC answers again.
 - **A command exists but returns little on your hardware** — Redfish trees differ by vendor and
   model. Use `redfish_ctl discovery` to see what your BMC actually exposes.
 - **More detail** — add `--debug` (or `--verbose`) to any command to see the Redfish requests and
@@ -312,7 +317,6 @@ First-run problems are almost always the connection, not the command:
 - [Fixture capture](docs/fixture-capture.md) - crawl a BMC with `discovery`, sanitize it, and contribute it as a vendor corpus.
 - [CI/CD](docs/ci.md) - the GitHub Actions test + release pipeline, the runner, and the Node.js runtime.
 - [Architecture](docs/architecture.md) - Redfish core, iDRAC layer, command registration, and known debt.
-- [Corpus Library](docs/corpus-library.md) - committed Redfish corpora and extraction workflow.
 - [Telemetry metrics](docs/telemetry-metrics.md) - GB300 MetricReport/MetricReportDefinition reference catalog.
 - [Changelog](CHANGELOG.md) - what each release adds, changes, and fixes; watch **Unreleased** for what the next tag will contain.
 - [Releasing](docs/releasing.md) - local verification, package build, PyPI upload, and tagging.

--- a/docs/bios-profiles.md
+++ b/docs/bios-profiles.md
@@ -4,25 +4,32 @@ Author: Mus <spyroot@gmail.com>
 
 BIOS profiles make host tuning repeatable and reviewable: each profile is a named set of BIOS
 attributes that can be inspected, previewed, staged, and verified as one unit instead of as ad-hoc
-edits. The working pattern is always the same: inspect the registry, preview the change, stage it,
-then verify after the reset.
+edits. The working pattern is always the same: inspect the registry, preview the change, stage it
+only after approval, then verify after the approved maintenance reset.
 
 The spec files used below are indexed with vendor and safety labels in [Specs](../specs/README.md).
 
-## The Safe Pattern
+## Read, Preview, Stage, Verify
 
 ```bash
 redfish_ctl bios-registry --attr_name SysProfile
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset --show
-redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset --commit
-redfish_ctl jobs
-redfish_ctl bios --filter SysProfile,ProcCStates,MemFrequency
 ```
 
-Use `-r` only when you are ready for the host reset:
+After approval, stage the pending BIOS change and verify the pending state:
+
+```bash
+redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset --commit
+redfish_ctl bios-pending
+redfish_ctl jobs
+```
+
+Use `-r` only during an approved maintenance window, then verify after the host returns:
 
 ```bash
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset -r
+redfish_ctl jobs
+redfish_ctl bios --filter SysProfile,ProcCStates,MemFrequency
 ```
 
 `bios-change`, defined in `redfish_ctl/bios/cmd_change_bios.py`, requires an apply mode:
@@ -44,11 +51,11 @@ redfish_ctl bios-profile show gb300-power-capped
 
 Use the catalog by operator purpose first, then inspect the exact attributes before staging anything:
 
-| Profile | Target | Operator purpose | Key attribute |
-|---|---|---|---|
-| `gb300-power-capped` | Supermicro GB300 | Smooth rack-level power draw by using a 1 s input-power capping timescale. | `ServerPowerControl=InputPowerCappingUsing1sTimescale` |
-| `gb300-extended-gpu-memory` | Supermicro GB300 | Enable Extended GPU Memory so Grace CPU memory can expand the usable memory pool for large model runs. | `EGM=true` |
-| `dell-cstates-off` | Dell PowerEdge | Reduce wakeup jitter for latency-sensitive workloads that can trade away idle power savings. | `ProcCStates=Disabled` |
+| Profile | Platform/vendor | Safety | Verify with | Key attribute |
+|---|---|---|---|---|
+| `gb300-power-capped` | Supermicro/GB300 | Guarded | `bios-pending`, `bios --filter ServerPowerControl` | `ServerPowerControl=InputPowerCappingUsing1sTimescale` |
+| `gb300-extended-gpu-memory` | Supermicro/GB300 | Guarded | `bios-pending`, `bios --filter EGM` | `EGM=true` |
+| `dell-cstates-off` | Dell/iDRAC, CPU/platform | Guarded | `bios-pending`, `bios --filter ProcCStates` | `ProcCStates=Disabled` |
 
 The intended named-profile workflow is read, compare, then stage:
 
@@ -57,7 +64,6 @@ redfish_ctl bios-profile list
 redfish_ctl bios-profile show gb300-power-capped
 redfish_ctl bios-profile diff gb300-power-capped
 redfish_ctl bios-profile apply gb300-power-capped --dry_run
-redfish_ctl bios-profile apply gb300-power-capped --confirm
 ```
 
 The catalog command ships all four actions: `list` and `show` read only the local catalog, `diff`
@@ -65,6 +71,11 @@ compares a profile against the current BIOS attributes over a read-only BMC quer
 `apply` previews by default and stages only with `--confirm`, capturing a rollback snapshot first.
 Applying a profile stages BIOS settings and can require a host reset; only run the apply step during
 an approved maintenance window.
+
+```bash
+redfish_ctl bios-profile apply gb300-power-capped --confirm
+redfish_ctl bios-pending
+```
 
 ## Included Examples
 
@@ -84,6 +95,11 @@ tests, then enables high-performance memory and SR-IOV knobs where the platform 
 
 ```bash
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset --show
+```
+
+After approval:
+
+```bash
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset -r
 ```
 
@@ -97,6 +113,11 @@ Dell PowerEdge systems often expose one high-level `SysProfile` attribute:
 ```bash
 redfish_ctl bios-registry --attr_name SysProfile
 redfish_ctl bios-change --attr_name SysProfile --attr_value PerfOptimized on-reset --show
+```
+
+After approval:
+
+```bash
 redfish_ctl bios-change --attr_name SysProfile --attr_value PerfOptimized on-reset -r
 ```
 
@@ -116,10 +137,15 @@ A custom profile is just a JSON spec with an `Attributes` object:
 }
 ```
 
-Save it, preview it, then apply it:
+Save it and preview it:
 
 ```bash
 redfish_ctl bios-change --from_spec /tmp/my_profile.spec.json on-reset --show
+```
+
+After approval:
+
+```bash
 redfish_ctl bios-change --from_spec /tmp/my_profile.spec.json on-reset -r
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Author: Mus <spyroot@gmail.com>
 When connecting to a new BMC, run `redfish_ctl system` first. It proves the endpoint, credentials, and
 basic Redfish path before deeper inventory or any staged change.
 
-The table below follows the 122 command names imported by `redfish_ctl/__init__.py`. Run
+The table below follows the command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
 backward-compatible alias for the `redfish_ctl` command, and `IDRAC_*` env vars are still read.)
 
@@ -236,15 +236,22 @@ Before running either kind of write, use the same four phases:
 ```bash
 redfish_ctl bios --filter ProcCStates,SysProfile,WorkloadProfile
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset --show
+```
+
+After target approval, staging and reset commands stay separate from read/preview commands:
+
+```bash
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset --commit
+redfish_ctl bios-pending
 redfish_ctl jobs
 ```
 
-Many BIOS changes remain pending until an apply job and host reset. Add `-r` only when you are ready
-for the host reset:
+Many BIOS changes remain pending until an apply job and host reset. Use `-r` only during an approved
+maintenance window:
 
 ```bash
 redfish_ctl bios-change --from_spec specs/realtime.opt.spec.json on-reset -r
+redfish_ctl jobs
 ```
 
 Named profiles under `specs/profiles/` use the same staging path but add an automatic rollback
@@ -254,12 +261,16 @@ snapshot before the profile is previewed or staged:
 redfish_ctl bios-profile list
 redfish_ctl bios-profile show dell-cstates-off
 redfish_ctl bios-profile apply dell-cstates-off
-redfish_ctl bios-profile apply dell-cstates-off --confirm
 ```
 
 `bios-profile apply` is a dry-run by default. It reads the current BIOS values for the named
 attributes, returns a rollback spec, and only stages the profile through `bios-change` when
-`--confirm` is present.
+`--confirm` is present:
+
+```bash
+redfish_ctl bios-profile apply dell-cstates-off --confirm
+redfish_ctl bios-pending
+```
 
 ### Secure Boot
 
@@ -267,6 +278,11 @@ attributes, returns a rollback spec, and only stages the profile through `bios-c
 redfish_ctl secure-boot
 redfish_ctl bios-registry --attr_name SecureBoot
 redfish_ctl bios-change --attr_name SecureBoot --attr_value Enabled on-reset --show
+```
+
+After approval for a host reset:
+
+```bash
 redfish_ctl bios-change --attr_name SecureBoot --attr_value Enabled on-reset -r
 redfish_ctl secure-boot
 ```
@@ -275,12 +291,17 @@ redfish_ctl secure-boot
 
 ```bash
 redfish_ctl get_vm
-redfish_ctl eject_vm --device_id 1
-redfish_ctl insert_vm --uri_path http://10.0.0.10/ubuntu.iso --device_id 1
-redfish_ctl get_vm
 redfish_ctl boot-one-shot --device Cd --dry_run
+```
+
+After approval for live media and next-boot changes:
+
+```bash
+redfish_ctl eject_vm --device_id 1
+redfish_ctl insert_vm --uri_path http://192.0.2.10/ubuntu.iso --device_id 1
+redfish_ctl get_vm
 redfish_ctl boot-one-shot --device Cd -r
-redfish_ctl current_boot
+redfish_ctl boot-state
 ```
 
 ### Power Reset
@@ -288,6 +309,11 @@ redfish_ctl current_boot
 ```bash
 redfish_ctl system
 redfish_ctl system-reset --reset_type GracefulRestart --dry_run
+```
+
+After approval for a live host reset:
+
+```bash
 redfish_ctl system-reset --reset_type GracefulRestart --confirm
 redfish_ctl system
 ```
@@ -301,8 +327,13 @@ unless `--dry_run` is supplied; `--wait` only waits after a real reset.
 ```bash
 redfish_ctl firmware_inventory
 redfish_ctl firmware-update --image_uri https://example.invalid/firmware.exe --dry_run
-redfish_ctl firmware-update --image_uri https://example.invalid/firmware.exe --confirm
 redfish_ctl firmware-update --image_file ./firmware.bin --dry_run
+```
+
+After approval for a live firmware update:
+
+```bash
+redfish_ctl firmware-update --image_uri https://example.invalid/firmware.exe --confirm
 redfish_ctl firmware-update --image_file ./firmware.bin --confirm
 redfish_ctl tasks
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,7 +30,9 @@ Platform/vendor labels:
 
 ## Index
 
-Run examples from the repository root with `bash examples/<script>`.
+Run **Read** examples from the repository root with `bash examples/<script>`. For **Guarded** and
+**Write** examples, inspect the script first, confirm each live step, and run only on an approved
+target.
 
 | Example | Platform/vendor | Safety | Purpose |
 |---|---|---|---|


### PR DESCRIPTION
## Summary
- correct the README safety contract so Guarded and Write commands are distinguished
- split read/preview snippets from approved live apply snippets in command and BIOS-profile workflows
- tighten the examples index run guidance for Write and Guarded scripts

## Tests
- git diff --check
- git diff --cached --check
- changed-doc local link check
- command registry/docs parity: registry=123 docs=123 missing=0 extra=0
- help checks: bios-change, bios-profile, boot-one-shot, system-reset, firmware-update, secure-boot
- pytest -q with live Redfish env vars unset: 1068 passed, 58 skipped
