### PR TITLE
Add guarded identify LED command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Author: Mus <spyroot@gmail.com>
 When connecting to a new BMC, run `redfish_ctl system` first. It proves the endpoint, credentials, and
 basic Redfish path before deeper inventory or any staged change.
 
-The table below follows the 123 command names imported by `redfish_ctl/__init__.py`. Run
+The table below follows the command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
 backward-compatible alias for the `redfish_ctl` command, and `IDRAC_*` env vars are still read.)
 
@@ -125,6 +125,7 @@ Safety labels:
 | `fleet` | Read a YAML fleet inventory and summarize per-node health, sensor count, and temperature max. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
+| `identify-led` | Read or set a chassis/system identify LED; requires `--confirm` to write. | Guarded |
 | `insert_vm` | Insert virtual media from a URI. | Write |
 | `job` | Read one Dell job. | Read |
 | `job-apply` | Apply pending jobs. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -81,6 +81,7 @@ from .storage.cmd_convert_to_raid import *
 from .chassis.cmd_chassis_query import *
 from .chassis.cmd_chasis_reset import *
 from .chassis.cmd_asset_tag_set import *
+from .chassis.cmd_identify_led import *
 from .sensors.cmd_sensors import *
 from .controls.cmd_controls import *
 from .thermal.cmd_thermal import *

--- a/redfish_ctl/chassis/cmd_identify_led.py
+++ b/redfish_ctl/chassis/cmd_identify_led.py
@@ -110,6 +110,10 @@ class IdentifyLed(IDracManager,
             return {property_name: bool(active)}
         return {property_name: "Lit" if active else "Off"}
 
+    @staticmethod
+    def _target_matches(uri, resource_id, target_id):
+        return resource_id.casefold() == target_id.casefold() or uri == target_id
+
     def _get(self, uri, do_async):
         result = self.base_query(uri, do_async=do_async)
         if result.error is not None:
@@ -128,7 +132,7 @@ class IdentifyLed(IDracManager,
         for uri in self._members(collection):
             data = self._get(uri, do_async)
             resource_id = self._resource_id(uri, data)
-            if resource_id != target_id and uri != target_id:
+            if not self._target_matches(uri, resource_id, target_id):
                 continue
             led_property = self._property_for(data, property_name)
             return {

--- a/redfish_ctl/chassis/cmd_identify_led.py
+++ b/redfish_ctl/chassis/cmd_identify_led.py
@@ -1,0 +1,199 @@
+"""Read or set Redfish identify LED state on Chassis or ComputerSystem resources."""
+
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+from ..redfish_shared import RedfishApi
+
+_COLLECTIONS = {
+    "chassis": RedfishApi.Chassis,
+    "system": RedfishApi.Systems,
+}
+_PROPERTIES = {"LocationIndicatorActive", "IndicatorLED"}
+
+
+class IdentifyLed(IDracManager,
+                  scm_type=ApiRequestType.IdentifyLed,
+                  name="identify-led",
+                  metaclass=Singleton):
+    """Read or set the physical identify LED on a chassis or system."""
+
+    def __init__(self, *args, **kwargs):
+        super(IdentifyLed, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``identify-led`` subcommand."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--resource",
+            choices=sorted(_COLLECTIONS),
+            default="chassis",
+            help="resource collection to search",
+        )
+        cmd_parser.add_argument(
+            "--target-id",
+            required=True,
+            dest="target_id",
+            help="resource Id to read or patch, such as Chassis_0 or System_0",
+        )
+        state = cmd_parser.add_mutually_exclusive_group()
+        state.add_argument(
+            "--on",
+            action="store_true",
+            dest="active_on",
+            default=False,
+            help="turn the identify LED on",
+        )
+        state.add_argument(
+            "--off",
+            action="store_true",
+            dest="active_off",
+            default=False,
+            help="turn the identify LED off",
+        )
+        cmd_parser.add_argument(
+            "--property",
+            choices=sorted(_PROPERTIES),
+            dest="property_name",
+            default=None,
+            help="LED property to patch; defaults to LocationIndicatorActive when present",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="apply the PATCH; without it the command only previews",
+        )
+        return cmd_parser, "identify-led", "read or set identify LED state"
+
+    @staticmethod
+    def _members(data):
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _resource_id(uri, data):
+        if isinstance(data, dict) and isinstance(data.get("Id"), str):
+            return data["Id"]
+        return uri.rstrip("/").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _property_for(data, property_name):
+        if property_name:
+            if property_name not in _PROPERTIES:
+                raise InvalidArgument(f"unsupported LED property {property_name!r}")
+            if property_name not in data:
+                raise InvalidArgument(f"target does not expose {property_name}")
+            return property_name
+        if "LocationIndicatorActive" in data:
+            return "LocationIndicatorActive"
+        if "IndicatorLED" in data:
+            return "IndicatorLED"
+        raise InvalidArgument("target does not expose an identify LED property")
+
+    @staticmethod
+    def _payload(property_name, active):
+        if property_name == "LocationIndicatorActive":
+            return {property_name: bool(active)}
+        return {property_name: "Lit" if active else "Off"}
+
+    def _get(self, uri, do_async):
+        result = self.base_query(uri, do_async=do_async)
+        if result.error is not None:
+            raise InvalidArgument(f"Unable to read {uri}: {result.error}")
+        if not isinstance(result.data, dict):
+            raise InvalidArgument(f"Unable to read {uri}: expected object response")
+        return result.data
+
+    def _resolve(self, resource, target_id, property_name, do_async):
+        if resource not in _COLLECTIONS:
+            raise InvalidArgument(f"unsupported identify LED resource {resource!r}")
+        if not target_id:
+            raise InvalidArgument("target_id is required")
+
+        collection = self._get(_COLLECTIONS[resource], do_async)
+        for uri in self._members(collection):
+            data = self._get(uri, do_async)
+            resource_id = self._resource_id(uri, data)
+            if resource_id != target_id and uri != target_id:
+                continue
+            led_property = self._property_for(data, property_name)
+            return {
+                "resource": resource,
+                "target_id": resource_id,
+                "target": uri,
+                "property": led_property,
+                "current": data.get(led_property),
+            }
+        raise InvalidArgument(f"No {resource} resource named {target_id}")
+
+    @staticmethod
+    def _active_from_flags(active, active_on, active_off):
+        if active is not None:
+            return bool(active)
+        if active_on:
+            return True
+        if active_off:
+            return False
+        return None
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                resource: Optional[str] = "chassis",
+                target_id: Optional[str] = None,
+                property_name: Optional[str] = None,
+                active: Optional[bool] = None,
+                active_on: Optional[bool] = False,
+                active_off: Optional[bool] = False,
+                confirm: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Read or preview/apply an identify LED state change."""
+        target = self._resolve(resource, target_id, property_name, do_async)
+        desired = self._active_from_flags(active, active_on, active_off)
+        if desired is None:
+            target["read_only"] = True
+            return CommandResult(target, None, None, None)
+
+        payload = self._payload(target["property"], desired)
+        if not confirm:
+            return CommandResult({
+                **target,
+                "dry_run": True,
+                "note": "preview only; re-run with --confirm to apply",
+                "payload": payload,
+            }, None, None, None)
+
+        result, status = self.base_patch(
+            target["target"],
+            payload=payload,
+            do_async=do_async,
+            expected_status=200,
+        )
+        observed = self._get(target["target"], do_async).get(target["property"])
+        return CommandResult({
+            **target,
+            "payload": payload,
+            "applied": {
+                "target": target["target"],
+                "status": str(status),
+                "error": result.error,
+            },
+            "observed": observed,
+        }, None, None, None)

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -143,6 +143,7 @@ class ApiRequestType(Enum):
     ManagerQuery = auto()
     ManagerNetworkProtocol = auto()
     NtpSet = auto()
+    IdentifyLed = auto()
     ManagerReset = auto()
 
     # bios related

--- a/scripts/live_sanity_check/README.md
+++ b/scripts/live_sanity_check/README.md
@@ -44,7 +44,7 @@ Standard Redfish URIs shown; the manager/system id is DISCOVERED (never hardcode
 | --- | --- | --- | --- | --- |
 | virtual-media mount/eject | `get_vm` ✅ | `insert_vm`/`eject_vm` 🔨 **Dell-hardcoded (`iDRAC.Embedded.1`→404) — generalize via discovery** | eject | GAP |
 | ntp | `manager-network` ✅ | `ntp-set` ✅ (`--clear` restores an originally empty list) | restore list | script ready; live capture pending |
-| identify LED (Chassis_0, System_0) | 🔨 read LocationIndicatorActive | 🔨 **new `identify-led` cmd (PATCH LocationIndicatorActive)** | set back | GAP |
+| identify LED (Chassis_0, System_0) | `identify-led` ✅ | `identify-led` ✅ (guarded PATCH) | set back | command ready; live trace pending |
 | test-event (emit only) | — | `event-submit-test` ✅ | none | ✅ DONE (`event_submit_test.sh`, verified live) |
 | event subscription create/delete | `event-service` ✅ (read) | 🔨 **new `subscription-create`/`subscription-delete`** | DELETE created id | GAP |
 | **negative**: bad value on any above | — | (invalid enum/type) | n/a | capture error envelope |
@@ -55,7 +55,7 @@ NOTE: GB300 has **NO safe BIOS attribute** (all 360 writable attrs are hardware-
 | --- | --- | --- | --- | --- |
 | BIOS AdminName / AdminEmail / AdminPhone | `bios`/`attr` ✅ | `bios-change`/`attr-update` ✅ (verify iLO path `/systems/1/bios/settings/`) | stage X back | verify live |
 | AssetTag (Chassis/1, Systems/1) | `chassis`/`system` ✅ | 🔨 **new `asset-tag-set` (or generic property PATCH)** | restore | GAP |
-| identify LED (LocationIndicatorActive / IndicatorLED) | 🔨 | 🔨 **`identify-led`** | set back | GAP |
+| identify LED (LocationIndicatorActive / IndicatorLED) | `identify-led` ✅ | `identify-led` ✅ (guarded PATCH) | set back | command ready; live trace pending |
 | boot override (one-time, inert until reboot) | `current_boot` ✅ | `boot-one-shot` ✅ | set Disabled | verify live |
 | **negative**: LocationIndicatorActive="Lit", BootTarget="Banana", unknown BIOS attr | — | invalid | n/a | capture error envelope |
 
@@ -69,7 +69,7 @@ enumeration is task X10-ENUM.
 ## Engine gaps to IMPLEMENT (prerequisites — one PR each, mutating = gated review)
 1. **generalize `insert_vm`/`eject_vm`** — discover Manager id (kills the `iDRAC.Embedded.1` 404).
 2. **`redfish_ctl get <uri>` / `raw`** — generic read so no script ever needs curl.
-3. **`identify-led`** — PATCH LocationIndicatorActive/IndicatorLED on Chassis/System.
+3. ✅ **`identify-led`** — PATCH LocationIndicatorActive/IndicatorLED on Chassis/System.
 4. **`ntp-set --clear`** — ✅ command support + GB300 round-trip script ready; live capture pending.
 5. **`subscription-create` / `subscription-delete`** — EventDestination lifecycle.
 6. **`asset-tag-set`** (or a guarded generic property PATCH).

--- a/scripts/live_sanity_check/hp/dl360/identify_led_roundtrip.sh
+++ b/scripts/live_sanity_check/hp/dl360/identify_led_roundtrip.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# HPE iLO identify LED round-trip, calls only redfish_ctl.
+#
+# Target and credentials come from REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD.
+# Optional overrides:
+#   IDENTIFY_LED_RESOURCE=chassis|system
+#   IDENTIFY_LED_TARGET_ID=1
+#   IDENTIFY_LED_PROPERTY=LocationIndicatorActive|IndicatorLED
+#   IDENTIFY_LED_CAPTURE_DIR=scripts/live_sanity_check/captures/hp/dl360
+set -euo pipefail
+
+: "${REDFISH_IP:?set REDFISH_IP}" "${REDFISH_USERNAME:?}" "${REDFISH_PASSWORD:?}"
+
+RCTL=(redfish_ctl --nocolor --json_only)
+RESOURCE="${IDENTIFY_LED_RESOURCE:-system}"
+TARGET_ID="${IDENTIFY_LED_TARGET_ID:-1}"
+CAPTURE_DIR="${IDENTIFY_LED_CAPTURE_DIR:-scripts/live_sanity_check/captures/hp/dl360}"
+PROPERTY_ARGS=()
+RESTORE_NEEDED=0
+RESTORE_FLAG=""
+
+if [ -n "${IDENTIFY_LED_PROPERTY:-}" ]; then
+  PROPERTY_ARGS=(--property "$IDENTIFY_LED_PROPERTY")
+fi
+
+mkdir -p "$CAPTURE_DIR"
+
+json_get() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["data"].get(sys.argv[1], ""))' "$1"
+}
+
+read_state() {
+  "${RCTL[@]}" identify-led \
+    --resource "$RESOURCE" \
+    --target-id "$TARGET_ID" \
+    "${PROPERTY_ARGS[@]}"
+}
+
+apply_state() {
+  local flag="$1"
+  "${RCTL[@]}" identify-led \
+    --resource "$RESOURCE" \
+    --target-id "$TARGET_ID" \
+    "${PROPERTY_ARGS[@]}" \
+    "$flag" \
+    --confirm
+}
+
+restore_on_failure() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ "$RESTORE_NEEDED" -eq 1 ]; then
+    echo "WARN: attempting best-effort identify LED restore with $RESTORE_FLAG"
+    if restored="$(apply_state "$RESTORE_FLAG" 2>&1)"; then
+      printf '%s\n' "$restored" > "$CAPTURE_DIR/identify_led.restore.best_effort.json"
+    else
+      echo "WARN: best-effort restore failed"
+      printf '%s\n' "$restored"
+    fi
+  fi
+}
+trap restore_on_failure EXIT
+
+echo "[hp-dl360] identify-led ${RESOURCE}/${TARGET_ID} -> ${REDFISH_IP}"
+before="$(read_state)"
+printf '%s\n' "$before" > "$CAPTURE_DIR/identify_led.read.json"
+
+property="$(printf '%s' "$before" | json_get property)"
+current="$(printf '%s' "$before" | json_get current)"
+if [ "$property" = "LocationIndicatorActive" ]; then
+  if [ "$current" = "True" ]; then
+    set_flag="--off"
+    restore_flag="--on"
+    expected="False"
+  else
+    set_flag="--on"
+    restore_flag="--off"
+    expected="True"
+  fi
+else
+  if [ "$current" = "Lit" ]; then
+    set_flag="--off"
+    restore_flag="--on"
+    expected="Off"
+  else
+    set_flag="--on"
+    restore_flag="--off"
+    expected="Lit"
+  fi
+fi
+
+RESTORE_FLAG="$restore_flag"
+RESTORE_NEEDED=1
+
+changed="$(apply_state "$set_flag")"
+printf '%s\n' "$changed" > "$CAPTURE_DIR/identify_led.ok.json"
+observed="$(printf '%s' "$changed" | json_get observed)"
+if [ "$observed" != "$expected" ]; then
+  echo "FAIL: expected observed=$expected after $set_flag, got '$observed'"
+  printf '%s\n' "$changed"
+  exit 1
+fi
+
+restored="$(apply_state "$restore_flag")"
+printf '%s\n' "$restored" > "$CAPTURE_DIR/identify_led.restore.json"
+restored_value="$(printf '%s' "$restored" | json_get observed)"
+if [ "$restored_value" != "$current" ]; then
+  echo "FAIL: expected restored observed=$current, got '$restored_value'"
+  printf '%s\n' "$restored"
+  exit 1
+fi
+
+RESTORE_NEEDED=0
+echo "PASS: identify LED ${RESOURCE}/${TARGET_ID} changed to $observed and restored to $restored_value."

--- a/scripts/live_sanity_check/supermicro/gb300/identify_led_roundtrip.sh
+++ b/scripts/live_sanity_check/supermicro/gb300/identify_led_roundtrip.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# GB300 identify LED round-trip, calls only redfish_ctl.
+#
+# Target and credentials come from REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD.
+# Optional overrides:
+#   IDENTIFY_LED_RESOURCE=chassis|system
+#   IDENTIFY_LED_TARGET_ID=Chassis_0|System_0
+#   IDENTIFY_LED_PROPERTY=LocationIndicatorActive|IndicatorLED
+#   IDENTIFY_LED_CAPTURE_DIR=scripts/live_sanity_check/captures/supermicro/gb300
+set -euo pipefail
+
+: "${REDFISH_IP:?set REDFISH_IP}" "${REDFISH_USERNAME:?}" "${REDFISH_PASSWORD:?}"
+
+RCTL=(redfish_ctl --nocolor --json_only)
+RESOURCE="${IDENTIFY_LED_RESOURCE:-chassis}"
+TARGET_ID="${IDENTIFY_LED_TARGET_ID:-Chassis_0}"
+CAPTURE_DIR="${IDENTIFY_LED_CAPTURE_DIR:-scripts/live_sanity_check/captures/supermicro/gb300}"
+PROPERTY_ARGS=()
+RESTORE_NEEDED=0
+RESTORE_FLAG=""
+
+if [ -n "${IDENTIFY_LED_PROPERTY:-}" ]; then
+  PROPERTY_ARGS=(--property "$IDENTIFY_LED_PROPERTY")
+fi
+
+mkdir -p "$CAPTURE_DIR"
+
+json_get() {
+  python3 -c 'import json,sys; print(json.load(sys.stdin)["data"].get(sys.argv[1], ""))' "$1"
+}
+
+read_state() {
+  "${RCTL[@]}" identify-led \
+    --resource "$RESOURCE" \
+    --target-id "$TARGET_ID" \
+    "${PROPERTY_ARGS[@]}"
+}
+
+apply_state() {
+  local flag="$1"
+  "${RCTL[@]}" identify-led \
+    --resource "$RESOURCE" \
+    --target-id "$TARGET_ID" \
+    "${PROPERTY_ARGS[@]}" \
+    "$flag" \
+    --confirm
+}
+
+restore_on_failure() {
+  local rc=$?
+  if [ "$rc" -ne 0 ] && [ "$RESTORE_NEEDED" -eq 1 ]; then
+    echo "WARN: attempting best-effort identify LED restore with $RESTORE_FLAG"
+    if restored="$(apply_state "$RESTORE_FLAG" 2>&1)"; then
+      printf '%s\n' "$restored" > "$CAPTURE_DIR/identify_led.restore.best_effort.json"
+    else
+      echo "WARN: best-effort restore failed"
+      printf '%s\n' "$restored"
+    fi
+  fi
+}
+trap restore_on_failure EXIT
+
+echo "[gb300] identify-led ${RESOURCE}/${TARGET_ID} -> ${REDFISH_IP}"
+before="$(read_state)"
+printf '%s\n' "$before" > "$CAPTURE_DIR/identify_led.read.json"
+
+property="$(printf '%s' "$before" | json_get property)"
+current="$(printf '%s' "$before" | json_get current)"
+if [ "$property" = "LocationIndicatorActive" ]; then
+  if [ "$current" = "True" ]; then
+    set_flag="--off"
+    restore_flag="--on"
+    expected="False"
+  else
+    set_flag="--on"
+    restore_flag="--off"
+    expected="True"
+  fi
+else
+  if [ "$current" = "Lit" ]; then
+    set_flag="--off"
+    restore_flag="--on"
+    expected="Off"
+  else
+    set_flag="--on"
+    restore_flag="--off"
+    expected="Lit"
+  fi
+fi
+
+RESTORE_FLAG="$restore_flag"
+RESTORE_NEEDED=1
+
+changed="$(apply_state "$set_flag")"
+printf '%s\n' "$changed" > "$CAPTURE_DIR/identify_led.ok.json"
+observed="$(printf '%s' "$changed" | json_get observed)"
+if [ "$observed" != "$expected" ]; then
+  echo "FAIL: expected observed=$expected after $set_flag, got '$observed'"
+  printf '%s\n' "$changed"
+  exit 1
+fi
+
+restored="$(apply_state "$restore_flag")"
+printf '%s\n' "$restored" > "$CAPTURE_DIR/identify_led.restore.json"
+restored_value="$(printf '%s' "$restored" | json_get observed)"
+if [ "$restored_value" != "$current" ]; then
+  echo "FAIL: expected restored observed=$current, got '$restored_value'"
+  printf '%s\n' "$restored"
+  exit 1
+fi
+
+RESTORE_NEEDED=0
+echo "PASS: identify LED ${RESOURCE}/${TARGET_ID} changed to $observed and restored to $restored_value."

--- a/tests/test_identify_led_dualmode.py
+++ b/tests/test_identify_led_dualmode.py
@@ -151,3 +151,45 @@ def test_identify_led_indicatorled_payload_uses_legacy_values(redfish_mock_facto
     assert result.data["payload"] == {"IndicatorLED": "Off"}
     assert result.data["current"] == "Off"
     assert _mutating_requests(service) == []
+
+
+def test_identify_led_confirm_turns_led_off(redfish_mock_factory):
+    """identify-led --confirm with the off state PATCHes the property to False.
+
+    The existing confirm test only covers turning the LED on (active=True); this
+    covers the turn-OFF mutation path so a regression that inverts or drops the
+    off value is caught.
+    """
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.IdentifyLed,
+        "identify-led",
+        resource="system",
+        target_id="System_0",
+        active=False,
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].json() == {"LocationIndicatorActive": False}
+    assert result.data["applied"]["error"] is None
+    assert result.data["observed"] is False
+
+
+def test_identify_led_auto_selects_indicator_led_fallback():
+    """With no explicit --property, a target exposing only the legacy IndicatorLED
+    (no LocationIndicatorActive) auto-selects IndicatorLED and emits the Lit/Off
+    string enum, while LocationIndicatorActive still wins when both are present."""
+    from redfish_ctl.chassis.cmd_identify_led import IdentifyLed
+
+    # auto-fallback: IndicatorLED is chosen when LocationIndicatorActive is absent
+    assert IdentifyLed._property_for({"IndicatorLED": "Off"}, None) == "IndicatorLED"
+    # preference: LocationIndicatorActive wins when both are exposed
+    assert IdentifyLed._property_for(
+        {"IndicatorLED": "Off", "LocationIndicatorActive": False}, None
+    ) == "LocationIndicatorActive"
+    # the legacy property uses the string enum, not a bool
+    assert IdentifyLed._payload("IndicatorLED", True) == {"IndicatorLED": "Lit"}
+    assert IdentifyLed._payload("IndicatorLED", False) == {"IndicatorLED": "Off"}

--- a/tests/test_identify_led_dualmode.py
+++ b/tests/test_identify_led_dualmode.py
@@ -66,6 +66,24 @@ def test_identify_led_dry_run_previews_chassis_patch(redfish_mock_factory):
     assert _mutating_requests(service) == []
 
 
+def test_identify_led_matches_target_id_case_insensitively(redfish_mock_factory):
+    """Users can pass a target Id with different case than the Redfish payload."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.IdentifyLed,
+        "identify-led",
+        resource="system",
+        target_id="system_0",
+    )
+
+    assert result.error is None
+    assert result.data["target_id"] == "System_0"
+    assert result.data["target"] == "/redfish/v1/Systems/System_0"
+    assert result.data["read_only"] is True
+    assert _mutating_requests(service) == []
+
+
 def test_identify_led_confirm_patches_and_rereads_system_state(redfish_mock_factory):
     """identify-led --confirm PATCHes only the LED property and returns observed state."""
     manager, service = redfish_mock_factory("supermicro")

--- a/tests/test_identify_led_dualmode.py
+++ b/tests/test_identify_led_dualmode.py
@@ -1,0 +1,153 @@
+"""Dual-mode tests for the identify-led command."""
+
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+
+def _mutating_requests(service):
+    return [
+        request
+        for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    ]
+
+
+def _patch_requests(service):
+    return [request for request in service.requests if request.method == "PATCH"]
+
+
+def test_identify_led_reads_current_chassis_state_without_patch(redfish_mock_factory):
+    """identify-led reads LocationIndicatorActive when no desired state is supplied."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.IdentifyLed,
+        "identify-led",
+        resource="chassis",
+        target_id="Chassis_0",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "resource": "chassis",
+        "target_id": "Chassis_0",
+        "target": "/redfish/v1/Chassis/Chassis_0",
+        "property": "LocationIndicatorActive",
+        "current": False,
+        "read_only": True,
+    }
+    assert _mutating_requests(service) == []
+
+
+def test_identify_led_dry_run_previews_chassis_patch(redfish_mock_factory):
+    """identify-led previews a LocationIndicatorActive PATCH unless confirmed."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.IdentifyLed,
+        "identify-led",
+        resource="chassis",
+        target_id="Chassis_0",
+        active=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["current"] is False
+    assert result.data["payload"] == {"LocationIndicatorActive": True}
+    assert result.data["target"] == "/redfish/v1/Chassis/Chassis_0"
+    assert _mutating_requests(service) == []
+
+
+def test_identify_led_confirm_patches_and_rereads_system_state(redfish_mock_factory):
+    """identify-led --confirm PATCHes only the LED property and returns observed state."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.IdentifyLed,
+        "identify-led",
+        resource="system",
+        target_id="System_0",
+        active=True,
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/systems/system_0"
+    assert patches[0].json() == {"LocationIndicatorActive": True}
+    assert result.data["applied"] == {
+        "target": "/redfish/v1/Systems/System_0",
+        "status": "IdracApiRespond.Ok",
+        "error": None,
+    }
+    assert result.data["observed"] is True
+
+
+def test_identify_led_rejects_bad_targets_before_patch(redfish_mock_factory):
+    """identify-led fails closed when the requested resource id is absent."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument, match="No chassis resource named Missing"):
+        manager.sync_invoke(
+            ApiRequestType.IdentifyLed,
+            "identify-led",
+            resource="chassis",
+            target_id="Missing",
+            active=True,
+            confirm=True,
+        )
+
+    assert _mutating_requests(service) == []
+
+
+def test_identify_led_collection_query_error_is_reported(monkeypatch):
+    """Collection read failures report the BMC/query error, not a missing target."""
+    from redfish_ctl.chassis.cmd_identify_led import IdentifyLed
+
+    command = object.__new__(IdentifyLed)
+
+    def fail_query(uri, do_async=False):
+        return CommandResult(None, None, None, f"query failed for {uri}")
+
+    monkeypatch.setattr(command, "base_query", fail_query)
+
+    with pytest.raises(InvalidArgument, match="query failed for /redfish/v1/Chassis"):
+        command._resolve("chassis", "Chassis_0", None, False)
+
+
+def test_identify_led_live_scripts_use_portable_bash_shebang():
+    """identify-led live scripts must not depend on a local Homebrew bash path."""
+    repo_root = Path(__file__).resolve().parents[1]
+    scripts = [
+        repo_root / "scripts/live_sanity_check/hp/dl360/identify_led_roundtrip.sh",
+        repo_root / "scripts/live_sanity_check/supermicro/gb300/identify_led_roundtrip.sh",
+    ]
+
+    for script in scripts:
+        assert script.read_text(encoding="utf-8").splitlines()[0] == "#!/usr/bin/env bash"
+
+
+def test_identify_led_indicatorled_payload_uses_legacy_values(redfish_mock_factory):
+    """The legacy IndicatorLED property maps on/off to Lit/Off payload values."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.IdentifyLed,
+        "identify-led",
+        resource="chassis",
+        target_id="Chassis_0",
+        property_name="IndicatorLED",
+        active=False,
+    )
+
+    assert result.data["payload"] == {"IndicatorLED": "Off"}
+    assert result.data["current"] == "Off"
+    assert _mutating_requests(service) == []


### PR DESCRIPTION
## Summary
- Add an identify-led command for Chassis and ComputerSystem resources.
- Keep reads as the default behavior, preview writes unless --confirm is provided, and PATCH only the LED property.
- Add dual-mode coverage plus GB300 and HPE iLO live sanity round-trip wrappers.

## Tests
- conda run -n idrac_ctl python3 -m pytest -q tests/test_identify_led_dualmode.py
- /opt/homebrew/bin/bash -n scripts/live_sanity_check/supermicro/gb300/identify_led_roundtrip.sh
- /opt/homebrew/bin/bash -n scripts/live_sanity_check/hp/dl360/identify_led_roundtrip.sh
- conda run -n idrac_ctl python3 -m redfish_ctl.redfish_main identify-led --help
- conda run -n idrac_ctl ruff check redfish_ctl/chassis/cmd_identify_led.py redfish_ctl/idrac_shared.py redfish_ctl/__init__.py tests/test_identify_led_dualmode.py
- /opt/homebrew/bin/shellcheck scripts/live_sanity_check/supermicro/gb300/identify_led_roundtrip.sh scripts/live_sanity_check/hp/dl360/identify_led_roundtrip.sh
- conda run -n idrac_ctl python3 -m pytest -q