### PR TITLE
Add ntp-set empty-list restore

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -144,7 +144,7 @@ Safety labels:
 | `metric-reports` | Read TelemetryService metric reports; `--report` filters by id substring. | Read |
 | `network-adapters` | Read chassis NetworkAdapters such as NICs and DPUs. | Read |
 | `network-ports` | Read NetworkAdapter port link state and speed. | Read |
-| `ntp-set` | Set ManagerNetworkProtocol NTP servers; dry-run by default and `--confirm` applies an NTP-only PATCH. | Guarded |
+| `ntp-set` | Set or clear ManagerNetworkProtocol NTP servers; dry-run by default and `--confirm` applies an NTP-only PATCH. | Guarded |
 | `nvlink-ports` | Read GPU NVLink port resources where the BMC exposes them. | Read |
 | `oem-actions` | Read supported Dell OEM OS deployment actions. | Read |
 | `oem-attach` | Attach a network ISO through a Dell OEM action. | Write |

--- a/redfish_ctl/manager/cmd_ntp_set.py
+++ b/redfish_ctl/manager/cmd_ntp_set.py
@@ -14,7 +14,11 @@ _MAX_NTP_SERVERS = 4
 _HOST_LABEL = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
 
 
-def _normalize_ntp_servers(servers) -> list[str]:
+def _normalize_ntp_servers(servers, clear: bool = False) -> list[str]:
+    if clear:
+        if servers:
+            raise InvalidArgument("--clear cannot be used with --server")
+        return []
     if servers is None:
         raise InvalidArgument("at least one NTP server is required")
     if isinstance(servers, str):
@@ -73,7 +77,10 @@ class NtpSet(IDracManager,
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--server', action='append', dest='servers', metavar='HOST',
-            required=True, help="NTP hostname or IP; repeat for up to 4 servers")
+            help="NTP hostname or IP; repeat for up to 4 servers")
+        cmd_parser.add_argument(
+            '--clear', action='store_true', dest='clear', default=False,
+            help="restore an empty NTP server list")
         cmd_parser.add_argument(
             '--manager', type=str, dest='manager_id', default=None, metavar='ID',
             help="optional Manager id to patch; default patches NTP-capable managers")
@@ -95,7 +102,10 @@ class NtpSet(IDracManager,
             return {}
 
     def _ntp_plan(self, servers, manager_id, do_async):
-        payload = {"NTP": {"NTPServers": servers, "ProtocolEnabled": True}}
+        ntp_payload = {"NTPServers": servers}
+        if servers:
+            ntp_payload["ProtocolEnabled"] = True
+        payload = {"NTP": ntp_payload}
         plan = []
         skipped = []
 
@@ -140,10 +150,11 @@ class NtpSet(IDracManager,
                 do_expanded: Optional[bool] = False,
                 servers=None,
                 manager_id: Optional[str] = None,
+                clear: Optional[bool] = False,
                 confirm: Optional[bool] = False,
                 **kwargs) -> CommandResult:
         """Preview or apply NTP servers on ManagerNetworkProtocol resources."""
-        normalized_servers = _normalize_ntp_servers(servers)
+        normalized_servers = _normalize_ntp_servers(servers, bool(clear))
         plan, skipped = self._ntp_plan(normalized_servers, manager_id, do_async)
 
         if not confirm:

--- a/scripts/live_sanity_check/README.md
+++ b/scripts/live_sanity_check/README.md
@@ -4,7 +4,7 @@ These scripts drive **real BMCs** to capture how each vendor responds to writes 
 bad-patch), so the simulator is grounded in captured behavior — the golden workflows are *generated tests*,
 never hand-coded simulator logic.
 
-## 🚨 HARD SAFETY BLOCKER (applies to every human + agent — no exceptions)
+## 🚨 HARD SAFETY BLOCKER (applies to every operator and tool run — no exceptions)
 **NEVER reboot, power-cycle, reset, factory-reset, flash firmware, delete a volume, erase a drive, or run ANY
 host- or BMC-disrupting operation on a LIVE system without the operator's explicit per-target approval.**
 These scripts are **read + reversible-config only**. Destructive actions are enumerated and NEVER invoked:
@@ -43,7 +43,7 @@ Standard Redfish URIs shown; the manager/system id is DISCOVERED (never hardcode
 | op | read | mutate | revert | status |
 | --- | --- | --- | --- | --- |
 | virtual-media mount/eject | `get_vm` ✅ | `insert_vm`/`eject_vm` 🔨 **Dell-hardcoded (`iDRAC.Embedded.1`→404) — generalize via discovery** | eject | GAP |
-| ntp | read NetworkProtocol 🔨 (need a `network-protocol` read) | `ntp-set` ✅ (vendor-neutral) 🔨 **add `--clear`/empty to restore empty original** | restore list | GAP |
+| ntp | `manager-network` ✅ | `ntp-set` ✅ (`--clear` restores an originally empty list) | restore list | script ready; live capture pending |
 | identify LED (Chassis_0, System_0) | 🔨 read LocationIndicatorActive | 🔨 **new `identify-led` cmd (PATCH LocationIndicatorActive)** | set back | GAP |
 | test-event (emit only) | — | `event-submit-test` ✅ | none | ✅ DONE (`event_submit_test.sh`, verified live) |
 | event subscription create/delete | `event-service` ✅ (read) | 🔨 **new `subscription-create`/`subscription-delete`** | DELETE created id | GAP |
@@ -66,11 +66,11 @@ enumeration is task X10-ENUM.
 ### Dell (dell/xr8620t) — box DECOMMISSIONED/offline → scripts validate against the committed corpus + mark
 `SKIP: no live Dell target`. Safe ops mirror iLO (AssetTag, LED, NTP, BIOS Admin*).
 
-## Engine gaps to IMPLEMENT (prerequisites — one PR each, mutating = Claude-gated)
+## Engine gaps to IMPLEMENT (prerequisites — one PR each, mutating = gated review)
 1. **generalize `insert_vm`/`eject_vm`** — discover Manager id (kills the `iDRAC.Embedded.1` 404).
 2. **`redfish_ctl get <uri>` / `raw`** — generic read so no script ever needs curl.
 3. **`identify-led`** — PATCH LocationIndicatorActive/IndicatorLED on Chassis/System.
-4. **`ntp-set --clear`** — restore an empty NTP list.
+4. **`ntp-set --clear`** — ✅ command support + GB300 round-trip script ready; live capture pending.
 5. **`subscription-create` / `subscription-delete`** — EventDestination lifecycle.
 6. **`asset-tag-set`** (or a guarded generic property PATCH).
 7. **trace capture** — a `--capture-trace <dir>` flag (or wrapper) that saves request+response per call → sim.

--- a/scripts/live_sanity_check/supermicro/gb300/ntp_roundtrip.sh
+++ b/scripts/live_sanity_check/supermicro/gb300/ntp_roundtrip.sh
@@ -1,0 +1,123 @@
+#!/opt/homebrew/bin/bash
+# GB300 (NVIDIA HGX / OpenBMC) - ManagerNetworkProtocol NTP round-trip.
+#
+# Target/creds come from REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD env only.
+# This script never touches the BMC except through `redfish_ctl`.
+set -euo pipefail
+
+: "${REDFISH_IP:?set REDFISH_IP}" "${REDFISH_USERNAME:?}" "${REDFISH_PASSWORD:?}"
+
+RCTL=(redfish_ctl --nocolor --json_only)
+CAPTURE_DIR="${TRACE_DIR:-scripts/live_sanity_check/captures/supermicro/gb300}"
+TEST_SERVER="${1:-0.pool.ntp.org}"
+
+mkdir -p "$CAPTURE_DIR"
+
+select_ntp_state() {
+  python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+for row in payload.get("data", []):
+    ntp = row.get("NTP") or {}
+    servers = ntp.get("NTPServers") or []
+    if ntp.get("ProtocolEnabled") is not None or servers:
+        print("{}\t{}".format(row.get("Manager", ""), json.dumps(servers)))
+        break
+else:
+    raise SystemExit("FAIL: no NTP-capable manager found")
+'
+}
+
+servers_for_manager() {
+  local manager_id="$1"
+  python3 -c '
+import json
+import sys
+
+manager_id = sys.argv[1]
+payload = json.load(sys.stdin)
+for row in payload.get("data", []):
+    if row.get("Manager") == manager_id:
+        print(json.dumps((row.get("NTP") or {}).get("NTPServers") or []))
+        break
+else:
+    raise SystemExit(f"FAIL: manager {manager_id!r} not found")
+' "$manager_id"
+}
+
+json_array_from_args() {
+  python3 -c 'import json, sys; print(json.dumps(sys.argv[1:]))' "$@"
+}
+
+assert_servers() {
+  local manager_id="$1"
+  local expected_json="$2"
+  local label="$3"
+  local current_json
+
+  "${RCTL[@]}" manager-network > "$CAPTURE_DIR/ntp.${label}.read.json"
+  current_json="$(
+    servers_for_manager "$manager_id" < "$CAPTURE_DIR/ntp.${label}.read.json"
+  )"
+  if [ "$current_json" != "$expected_json" ]; then
+    echo "FAIL: expected $expected_json after $label, got $current_json"
+    exit 1
+  fi
+}
+
+echo "[gb300] NTP round-trip on $REDFISH_IP"
+"${RCTL[@]}" manager-network > "$CAPTURE_DIR/ntp.before.json"
+
+state="$(select_ntp_state < "$CAPTURE_DIR/ntp.before.json")"
+IFS=$'\t' read -r manager_id original_servers_json <<< "$state"
+
+mapfile -t original_servers < <(
+  python3 -c '
+import json
+import sys
+for server in json.loads(sys.argv[1]):
+    print(server)
+' "$original_servers_json"
+)
+
+set_servers=("$TEST_SERVER")
+if [ "$original_servers_json" = "$(json_array_from_args "$TEST_SERVER")" ]; then
+  set_servers=("1.pool.ntp.org")
+fi
+set_servers_json="$(json_array_from_args "${set_servers[@]}")"
+
+"${RCTL[@]}" ntp-set \
+  --manager "$manager_id" \
+  --server "${set_servers[0]}" \
+  --confirm > "$CAPTURE_DIR/ntp.set.ok.json"
+assert_servers "$manager_id" "$set_servers_json" "set"
+
+if [ "${#original_servers[@]}" -eq 0 ]; then
+  "${RCTL[@]}" ntp-set \
+    --manager "$manager_id" \
+    --clear \
+    --confirm > "$CAPTURE_DIR/ntp.restore.ok.json"
+else
+  restore_args=()
+  for server in "${original_servers[@]}"; do
+    restore_args+=(--server "$server")
+  done
+  "${RCTL[@]}" ntp-set \
+    --manager "$manager_id" \
+    "${restore_args[@]}" \
+    --confirm > "$CAPTURE_DIR/ntp.restore.ok.json"
+fi
+assert_servers "$manager_id" "$original_servers_json" "restore"
+
+if "${RCTL[@]}" ntp-set \
+    --manager "$manager_id" \
+    --clear \
+    --server "$TEST_SERVER" \
+    --confirm > "$CAPTURE_DIR/ntp.err.json" 2>&1; then
+  echo "FAIL: --clear with --server unexpectedly succeeded"
+  exit 1
+fi
+
+echo "PASS: NTP servers round-tripped and restored for manager $manager_id"

--- a/tests/test_ntp_set_dualmode.py
+++ b/tests/test_ntp_set_dualmode.py
@@ -76,6 +76,46 @@ def test_ntp_set_confirm_patches_only_the_ntp_block(redfish_mock_factory):
     }]
 
 
+def test_ntp_set_clear_patches_empty_server_list_only(redfish_mock_factory):
+    """ntp-set --clear restores an empty NTP server list without toggling NTP."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        clear=True,
+        confirm=True,
+    )
+
+    patches = [request for request in service.requests if request.method == "PATCH"]
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/bmc_0/networkprotocol"
+    assert patches[0].json() == {"NTP": {"NTPServers": []}}
+    assert result.data["servers"] == []
+    assert result.data["applied"] == [{
+        "Manager": "BMC_0",
+        "target": "/redfish/v1/Managers/BMC_0/NetworkProtocol",
+        "status": "IdracApiRespond.Ok",
+        "error": None,
+    }]
+
+
+def test_ntp_set_clear_rejects_explicit_servers(redfish_mock_factory):
+    """ntp-set --clear is mutually exclusive with explicit server values."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument):
+        manager.sync_invoke(
+            ApiRequestType.NtpSet,
+            "ntp-set",
+            servers=["0.pool.ntp.org"],
+            clear=True,
+            confirm=True,
+        )
+
+    assert _mutating_requests(service) == []
+
+
 @pytest.mark.parametrize(
     "servers",
     [


### PR DESCRIPTION
## Summary
- Add `ntp-set --clear` to restore an empty ManagerNetworkProtocol NTP server list.
- Keep server-setting behavior unchanged and avoid toggling `ProtocolEnabled` when clearing.
- Add a GB300 NTP round-trip live-sanity wrapper and update command documentation.

## Tests
- `conda run -n idrac_ctl python3 -m pytest -q tests/test_ntp_set_dualmode.py`
- `conda run -n idrac_ctl python3 -m redfish_ctl.redfish_main ntp-set --help`
- `conda run -n idrac_ctl ruff check redfish_ctl/manager/cmd_ntp_set.py tests/test_ntp_set_dualmode.py`
- `bash -n scripts/live_sanity_check/supermicro/gb300/ntp_roundtrip.sh`
- `shellcheck scripts/live_sanity_check/supermicro/gb300/ntp_roundtrip.sh`
- offline mocked script smoke
- `git diff --check`
- `conda run -n idrac_ctl python3 -m pytest -q`