### PR TITLE
Add EventDestination subscription lifecycle commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -175,6 +175,8 @@ Safety labels:
 | `storage-drives` | Read storage drive members. | Read |
 | `storage-get` | Read one storage controller with optional `--filter Drives,Volumes`. | Read |
 | `storage-list` | List storage devices. | Read |
+| `subscription-create` | Create an EventDestination subscription; dry-run by default and `--confirm` POSTs. | Guarded |
+| `subscription-delete` | Delete an EventDestination subscription by id or URI; dry-run by default and `--confirm` DELETEs. | Guarded |
 | `system` | Read ComputerSystem data. | Read |
 | `system-export` | Export system configuration. | Read |
 | `system-import` | Import system configuration; may reboot depending on options. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -101,6 +101,7 @@ from .ports.cmd_nvlink_ports import *
 from .actions.cmd_action_list import *
 from .events.cmd_event_service import *
 from .events.cmd_event_submit_test import *
+from .events.cmd_subscription_lifecycle import *
 from .compute.cmd_system_reset import *
 from .logs.cmd_logs import *
 from .network.cmd_ethernet_interfaces import *

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -1,0 +1,270 @@
+"""Create and delete Redfish EventDestination subscriptions."""
+
+import json
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..idrac_manager import IDracManager
+from ..idrac_shared import IDRAC_API, ApiRequestType, RedfishJsonSpec, Singleton
+from ..redfish_manager import CommandResult
+
+
+def _as_list(values) -> list[str]:
+    if values is None:
+        return []
+    raw_values = [values] if isinstance(values, str) else list(values)
+    normalized = []
+    for raw in raw_values:
+        for value in str(raw).split(","):
+            item = value.strip()
+            if item:
+                normalized.append(item)
+    return normalized
+
+
+class _SubscriptionBase(IDracManager):
+    """Shared EventService subscription helpers."""
+
+    @staticmethod
+    def _link(data, key):
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _subscription_collection_uri(self, do_async):
+        service = self.base_query(
+            IDRAC_API.EventServiceQuery,
+            do_async=do_async,
+        ).data or {}
+        subscriptions_uri = self._link(service, "Subscriptions")
+        if not subscriptions_uri:
+            raise InvalidArgument("EventService Subscriptions link is not available")
+        return subscriptions_uri
+
+    def _subscription_members(self, subscriptions_uri, do_async):
+        collection = self.base_query(subscriptions_uri, do_async=do_async).data or {}
+        members = collection.get("Members")
+        if not isinstance(members, list):
+            members = []
+        return [
+            member.get("@odata.id")
+            for member in members
+            if isinstance(member, dict) and member.get("@odata.id")
+        ]
+
+    def _resolve_subscription_uri(self, subscription, subscriptions_uri, do_async):
+        if not subscription or not str(subscription).strip():
+            raise InvalidArgument("subscription id or URI is required")
+        value = str(subscription).strip()
+        if value.startswith("/redfish/"):
+            prefix = subscriptions_uri.rstrip("/") + "/"
+            if value != subscriptions_uri and not value.startswith(prefix):
+                raise InvalidArgument(
+                    f"subscription URI must be under {subscriptions_uri}"
+                )
+            return value
+
+        for member_uri in self._subscription_members(subscriptions_uri, do_async):
+            if member_uri.rsplit("/", 1)[-1] == value or member_uri == value:
+                return member_uri
+        raise InvalidArgument(f"subscription {value!r} was not found")
+
+
+class SubscriptionCreate(_SubscriptionBase,
+                         scm_type=ApiRequestType.SubscriptionCreate,
+                         name='subscription-create',
+                         metaclass=Singleton):
+    """Create an EventDestination subscription after dry-run preview."""
+
+    def __init__(self, *args, **kwargs):
+        super(SubscriptionCreate, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded subscription-create subcommand."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--destination", required=True, dest="destination", metavar="URI",
+            help="EventDestination listener URI")
+        cmd_parser.add_argument(
+            "--protocol", default="Redfish", dest="protocol",
+            help="EventDestination protocol; default is Redfish")
+        cmd_parser.add_argument(
+            "--event-format-type", default=None, dest="event_format_type",
+            help="optional EventFormatType such as Event or MetricReport")
+        cmd_parser.add_argument(
+            "--event-type", action="append", dest="event_types", default=None,
+            metavar="TYPE", help="optional EventTypes value; repeat or comma-separate")
+        cmd_parser.add_argument(
+            "--registry-prefix", action="append", dest="registry_prefixes",
+            default=None, metavar="PREFIX",
+            help="optional RegistryPrefixes value; repeat or comma-separate")
+        cmd_parser.add_argument(
+            "--resource-type", action="append", dest="resource_types",
+            default=None, metavar="TYPE",
+            help="optional ResourceTypes value; repeat or comma-separate")
+        cmd_parser.add_argument(
+            "--context", default=None, dest="context",
+            help="optional EventDestination Context string")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="create the subscription; without it the command only previews")
+        help_text = "create an EventService EventDestination subscription"
+        return cmd_parser, "subscription-create", help_text
+
+    @staticmethod
+    def _payload(destination, protocol, event_format_type, event_types,
+                 registry_prefixes, resource_types, context):
+        if not destination or not str(destination).strip():
+            raise InvalidArgument("destination URI is required")
+        if not protocol or not str(protocol).strip():
+            raise InvalidArgument("subscription protocol is required")
+
+        payload = {
+            "Destination": str(destination).strip(),
+            "Protocol": str(protocol).strip(),
+        }
+        if event_format_type:
+            payload["EventFormatType"] = str(event_format_type).strip()
+        normalized_event_types = _as_list(event_types)
+        if normalized_event_types:
+            payload["EventTypes"] = normalized_event_types
+        normalized_registry_prefixes = _as_list(registry_prefixes)
+        if normalized_registry_prefixes:
+            payload["RegistryPrefixes"] = normalized_registry_prefixes
+        normalized_resource_types = _as_list(resource_types)
+        if normalized_resource_types:
+            payload["ResourceTypes"] = normalized_resource_types
+        if context:
+            payload["Context"] = str(context)
+        return payload
+
+    def _post_subscription(self, target, payload):
+        headers = {}
+        headers.update(self.json_content_type)
+        response = self.api_post_call(
+            f"{self._default_method}{self.redfish_ip}{target}",
+            json.dumps(payload),
+            headers,
+        )
+        status = self.default_post_success(response, expected=201)
+        location = response.headers.get(RedfishJsonSpec.Location)
+        return status, location
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                destination: Optional[str] = None,
+                protocol: Optional[str] = "Redfish",
+                event_format_type: Optional[str] = None,
+                event_types=None,
+                registry_prefixes=None,
+                resource_types=None,
+                context: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or create an EventDestination subscription."""
+        target = self._subscription_collection_uri(do_async)
+        payload = self._payload(
+            destination,
+            protocol,
+            event_format_type,
+            event_types,
+            registry_prefixes,
+            resource_types,
+            context,
+        )
+        if not confirm:
+            return CommandResult({
+                "dry_run": True,
+                "action": "create",
+                "target": target,
+                "payload": payload,
+                "note": "preview only; re-run with --confirm to create subscription",
+            }, None, None, None)
+
+        if do_async:
+            result, status = self.base_post(
+                target,
+                payload=payload,
+                do_async=do_async,
+                expected_status=201,
+            )
+            location = None
+            error = result.error
+        else:
+            status, location = self._post_subscription(target, payload)
+            error = None
+        data = {
+            "action": "create",
+            "target": target,
+            "status": str(status),
+            "location": location,
+            "error": error,
+        }
+        return CommandResult(data, None, None, error)
+
+
+class SubscriptionDelete(_SubscriptionBase,
+                         scm_type=ApiRequestType.SubscriptionDelete,
+                         name='subscription-delete',
+                         metaclass=Singleton):
+    """Delete an EventDestination subscription after dry-run preview."""
+
+    def __init__(self, *args, **kwargs):
+        super(SubscriptionDelete, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded subscription-delete subcommand."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--subscription", required=True, dest="subscription", metavar="ID_OR_URI",
+            help="subscription member id or /redfish/v1/EventService/Subscriptions URI")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="delete the subscription; without it the command only previews")
+        help_text = "delete an EventService EventDestination subscription"
+        return cmd_parser, "subscription-delete", help_text
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                subscription: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or delete an EventDestination subscription."""
+        subscriptions_uri = self._subscription_collection_uri(do_async)
+        target = self._resolve_subscription_uri(
+            subscription,
+            subscriptions_uri,
+            do_async,
+        )
+        if not confirm:
+            return CommandResult({
+                "dry_run": True,
+                "action": "delete",
+                "target": target,
+                "note": "preview only; re-run with --confirm to delete subscription",
+            }, None, None, None)
+
+        result, status = self.base_delete(
+            target,
+            do_async=do_async,
+            expected_status=200,
+        )
+        data = {
+            "action": "delete",
+            "target": target,
+            "status": str(status),
+            "error": result.error,
+        }
+        return CommandResult(data, None, None, result.error)

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -1,12 +1,10 @@
 """Create and delete Redfish EventDestination subscriptions."""
 
-import json
-from abc import abstractmethod
 from typing import Optional
 
 from ..cmd_exceptions import InvalidArgument
 from ..idrac_manager import IDracManager
-from ..idrac_shared import IDRAC_API, ApiRequestType, RedfishJsonSpec, Singleton
+from ..idrac_shared import IDRAC_API, ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
 
 
@@ -57,8 +55,12 @@ class _SubscriptionBase(IDracManager):
             raise InvalidArgument("subscription id or URI is required")
         value = str(subscription).strip()
         if value.startswith("/redfish/"):
+            if value.rstrip("/") == subscriptions_uri.rstrip("/"):
+                raise InvalidArgument(
+                    f"subscription member URI under {subscriptions_uri} is required"
+                )
             prefix = subscriptions_uri.rstrip("/") + "/"
-            if value != subscriptions_uri and not value.startswith(prefix):
+            if not value.startswith(prefix):
                 raise InvalidArgument(
                     f"subscription URI must be under {subscriptions_uri}"
                 )
@@ -80,7 +82,6 @@ class SubscriptionCreate(_SubscriptionBase,
         super(SubscriptionCreate, self).__init__(*args, **kwargs)
 
     @staticmethod
-    @abstractmethod
     def register_subcommand(cls):
         """Register the guarded subscription-create subcommand."""
         cmd_parser = cls.base_parser()
@@ -140,18 +141,6 @@ class SubscriptionCreate(_SubscriptionBase,
             payload["Context"] = str(context)
         return payload
 
-    def _post_subscription(self, target, payload):
-        headers = {}
-        headers.update(self.json_content_type)
-        response = self.api_post_call(
-            f"{self._default_method}{self.redfish_ip}{target}",
-            json.dumps(payload),
-            headers,
-        )
-        status = self.default_post_success(response, expected=201)
-        location = response.headers.get(RedfishJsonSpec.Location)
-        return status, location
-
     def execute(self,
                 filename: Optional[str] = None,
                 data_type: Optional[str] = "json",
@@ -187,26 +176,20 @@ class SubscriptionCreate(_SubscriptionBase,
                 "note": "preview only; re-run with --confirm to create subscription",
             }, None, None, None)
 
-        if do_async:
-            result, status = self.base_post(
-                target,
-                payload=payload,
-                do_async=do_async,
-                expected_status=201,
-            )
-            location = None
-            error = result.error
-        else:
-            status, location = self._post_subscription(target, payload)
-            error = None
+        result, status = self.base_post(
+            target,
+            payload=payload,
+            do_async=do_async,
+            expected_status=201,
+        )
         data = {
             "action": "create",
             "target": target,
             "status": str(status),
-            "location": location,
-            "error": error,
+            "location": None,
+            "error": result.error,
         }
-        return CommandResult(data, None, None, error)
+        return CommandResult(data, None, None, result.error)
 
 
 class SubscriptionDelete(_SubscriptionBase,
@@ -219,13 +202,12 @@ class SubscriptionDelete(_SubscriptionBase,
         super(SubscriptionDelete, self).__init__(*args, **kwargs)
 
     @staticmethod
-    @abstractmethod
     def register_subcommand(cls):
         """Register the guarded subscription-delete subcommand."""
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             "--subscription", required=True, dest="subscription", metavar="ID_OR_URI",
-            help="subscription member id or /redfish/v1/EventService/Subscriptions URI")
+            help="subscription member id or member URI")
         cmd_parser.add_argument(
             "--confirm", action="store_true", dest="confirm", default=False,
             help="delete the subscription; without it the command only previews")
@@ -259,7 +241,7 @@ class SubscriptionDelete(_SubscriptionBase,
         result, status = self.base_delete(
             target,
             do_async=do_async,
-            expected_status=200,
+            expected_status=204,
         )
         data = {
             "action": "delete",

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -105,6 +105,8 @@ class ApiRequestType(Enum):
     ActionList = auto()
     EventSubmitTest = auto()
     EventServiceQuery = auto()
+    SubscriptionCreate = auto()
+    SubscriptionDelete = auto()
     SystemReset = auto()
     Logs = auto()
     EthernetInterfaces = auto()

--- a/scripts/live_sanity_check/supermicro/gb300/subscription_roundtrip.sh
+++ b/scripts/live_sanity_check/supermicro/gb300/subscription_roundtrip.sh
@@ -1,0 +1,126 @@
+#!/opt/homebrew/bin/bash
+# GB300 (NVIDIA HGX / OpenBMC) - EventDestination subscription round-trip.
+#
+# Target/creds come from REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD env only.
+# SUBSCRIPTION_DESTINATION must point at an operator-approved listener.
+# This script never touches the BMC except through `redfish_ctl`.
+set -euo pipefail
+
+: "${REDFISH_IP:?set REDFISH_IP}" "${REDFISH_USERNAME:?}" "${REDFISH_PASSWORD:?}"
+: "${SUBSCRIPTION_DESTINATION:?set SUBSCRIPTION_DESTINATION}"
+
+RCTL=(redfish_ctl --nocolor --json_only)
+CAPTURE_DIR="${TRACE_DIR:-scripts/live_sanity_check/captures/supermicro/gb300}"
+CONTEXT="${SUBSCRIPTION_CONTEXT:-gb300-subscription-roundtrip}"
+
+mkdir -p "$CAPTURE_DIR"
+
+members_json() {
+  python3 -c '
+import json
+import sys
+
+payload = json.load(sys.stdin)
+members = payload.get("data", {}).get("Subscriptions", {}).get("members") or []
+print(json.dumps(members, sort_keys=True))
+'
+}
+
+created_location() {
+  python3 -c '
+import json
+import sys
+from urllib.parse import urlparse
+
+payload = json.load(sys.stdin)
+location = payload.get("data", {}).get("location") or ""
+if location.startswith("http://") or location.startswith("https://"):
+    location = urlparse(location).path
+print(location)
+'
+}
+
+new_member() {
+  python3 -c '
+import json
+import sys
+
+before = set(json.loads(sys.argv[1]))
+after = json.loads(sys.argv[2])
+preferred = sys.argv[3]
+
+if preferred and preferred in after:
+    print(preferred)
+    raise SystemExit(0)
+
+created = [member for member in after if member not in before]
+if created:
+    print(created[-1])
+    raise SystemExit(0)
+
+raise SystemExit("FAIL: subscription member was not created")
+' "$1" "$2" "$3"
+}
+
+contains_member() {
+  python3 -c '
+import json
+import sys
+
+members = set(json.loads(sys.argv[1]))
+raise SystemExit(0 if sys.argv[2] in members else 1)
+' "$1" "$2"
+}
+
+echo "[gb300] Event subscription round-trip on $REDFISH_IP"
+"${RCTL[@]}" event-service > "$CAPTURE_DIR/subscription.before.json"
+before_members="$(members_json < "$CAPTURE_DIR/subscription.before.json")"
+
+"${RCTL[@]}" subscription-create \
+  --destination "$SUBSCRIPTION_DESTINATION" \
+  --event-format-type Event \
+  --context "$CONTEXT" \
+  --confirm > "$CAPTURE_DIR/subscription.create.ok.json"
+location="$(created_location < "$CAPTURE_DIR/subscription.create.ok.json")"
+
+created_member=""
+for _ in 1 2 3 4 5; do
+  "${RCTL[@]}" event-service > "$CAPTURE_DIR/subscription.after-create.json"
+  after_members="$(members_json < "$CAPTURE_DIR/subscription.after-create.json")"
+  if created_member="$(new_member "$before_members" "$after_members" "$location" 2>/dev/null)"; then
+    break
+  fi
+  sleep 2
+done
+
+if [ -z "$created_member" ]; then
+  echo "FAIL: subscription member was not created"
+  exit 1
+fi
+
+"${RCTL[@]}" subscription-delete \
+  --subscription "$created_member" \
+  --confirm > "$CAPTURE_DIR/subscription.delete.ok.json"
+
+for _ in 1 2 3 4 5; do
+  "${RCTL[@]}" event-service > "$CAPTURE_DIR/subscription.after-delete.json"
+  after_delete_members="$(members_json < "$CAPTURE_DIR/subscription.after-delete.json")"
+  if ! contains_member "$after_delete_members" "$created_member"; then
+    break
+  fi
+  sleep 2
+done
+
+if contains_member "$after_delete_members" "$created_member"; then
+  echo "FAIL: subscription member still present after delete: $created_member"
+  exit 1
+fi
+
+if "${RCTL[@]}" subscription-delete \
+    --subscription "$created_member" \
+    --confirm > "$CAPTURE_DIR/subscription.err.json" 2>&1; then
+  echo "FAIL: deleting an already-deleted subscription unexpectedly succeeded"
+  exit 1
+fi
+
+echo "PASS: subscription created and deleted: $created_member"

--- a/scripts/live_sanity_check/supermicro/gb300/subscription_roundtrip.sh
+++ b/scripts/live_sanity_check/supermicro/gb300/subscription_roundtrip.sh
@@ -21,7 +21,12 @@ import json
 import sys
 
 payload = json.load(sys.stdin)
-members = payload.get("data", {}).get("Subscriptions", {}).get("members") or []
+subscriptions = payload.get("data", {}).get("Subscriptions", {}) or {}
+members = [
+    member.get("@odata.id")
+    for member in subscriptions.get("Members", [])
+    if isinstance(member, dict) and member.get("@odata.id")
+]
 print(json.dumps(members, sort_keys=True))
 '
 }

--- a/tests/test_subscription_lifecycle_dualmode.py
+++ b/tests/test_subscription_lifecycle_dualmode.py
@@ -1,5 +1,11 @@
 """Dual-mode tests for EventDestination subscription lifecycle commands."""
 
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
 import pytest
 
 from redfish_ctl.cmd_exceptions import InvalidArgument
@@ -105,6 +111,33 @@ def test_subscription_create_confirm_posts_event_destination_payload(
     }
 
 
+def test_subscription_create_splits_comma_separated_filters(
+    redfish_mock_factory,
+):
+    """subscription-create accepts repeated or comma-separated filter values."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionCreate"),
+        "subscription-create",
+        destination=DESTINATION,
+        event_types=["Alert,StatusChange", "ResourceUpdated"],
+        registry_prefixes="Base, TaskEvent",
+        resource_types=["Task, MetricReport"],
+        confirm=False,
+    )
+
+    assert result.error is None
+    assert _mutating_requests(service) == []
+    assert result.data["payload"]["EventTypes"] == [
+        "Alert",
+        "StatusChange",
+        "ResourceUpdated",
+    ]
+    assert result.data["payload"]["RegistryPrefixes"] == ["Base", "TaskEvent"]
+    assert result.data["payload"]["ResourceTypes"] == ["Task", "MetricReport"]
+
+
 def test_subscription_delete_dry_run_resolves_member_without_delete(
     redfish_mock_factory,
 ):
@@ -152,6 +185,42 @@ def test_subscription_delete_confirm_deletes_resolved_member(
     assert result.data["status"] == "IdracApiRespond.Ok"
     assert len(deletes) == 1
     assert deletes[0].path.lower() == SUBSCRIPTION_ONE_PATH.lower()
+
+
+def test_subscription_delete_rejects_collection_uri_without_delete(
+    redfish_mock_factory,
+):
+    """subscription-delete never accepts the collection URI as a delete target."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_subscription(service)
+
+    with pytest.raises(InvalidArgument, match="subscription member URI"):
+        manager.sync_invoke(
+            _request_type("SubscriptionDelete"),
+            "subscription-delete",
+            subscription=SUBSCRIPTIONS_PATH,
+            confirm=True,
+        )
+
+    assert all(request.method != "DELETE" for request in service.requests)
+
+
+def test_subscription_delete_rejects_other_collection_uri_without_delete(
+    redfish_mock_factory,
+):
+    """subscription-delete rejects URIs outside the EventDestination collection."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_subscription(service)
+
+    with pytest.raises(InvalidArgument, match="must be under"):
+        manager.sync_invoke(
+            _request_type("SubscriptionDelete"),
+            "subscription-delete",
+            subscription="/redfish/v1/EventService/Other/1",
+            confirm=True,
+        )
+
+    assert all(request.method != "DELETE" for request in service.requests)
 
 
 def test_subscription_commands_fail_closed_without_subscription_collection(
@@ -203,3 +272,92 @@ def test_subscription_commands_expose_cli_entrypoints():
     assert delete_name == "subscription-delete"
     assert "subscription" in create_help.lower()
     assert "subscription" in delete_help.lower()
+    assert "collection URI" not in delete_parser.format_help()
+
+
+def test_gb300_subscription_roundtrip_script_tracks_created_member(tmp_path):
+    """The GB300 live script parses Redfish Members keys during the round-trip."""
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is not available")
+
+    bin_dir = tmp_path / "bin"
+    capture_dir = tmp_path / "captures"
+    state_file = tmp_path / "state"
+    bin_dir.mkdir()
+    state_file.write_text("initial\n")
+
+    fake_redfish_ctl = bin_dir / "redfish_ctl"
+    fake_redfish_ctl.write_text(
+        textwrap.dedent(
+            f"""\
+            #!{bash}
+            set -euo pipefail
+
+            while [[ "$#" -gt 0 && "$1" == --* ]]; do
+              shift
+            done
+
+            command="${{1:-}}"
+            shift || true
+            state="$(cat "{state_file}")"
+
+            case "$command" in
+              event-service)
+                if [[ "$state" == created ]]; then
+                  printf '%s\\n' '{{"data":{{"Subscriptions":{{"Members":[{{"@odata.id":"{SUBSCRIPTION_ONE_PATH}"}},{{"@odata.id":"{SUBSCRIPTIONS_PATH}/new"}}]}}}}}}'
+                else
+                  printf '%s\\n' '{{"data":{{"Subscriptions":{{"Members":[{{"@odata.id":"{SUBSCRIPTION_ONE_PATH}"}}]}}}}}}'
+                fi
+                ;;
+              subscription-create)
+                printf '%s\\n' created > "{state_file}"
+                printf '%s\\n' '{{"data":{{"location":"{SUBSCRIPTIONS_PATH}/new"}}}}'
+                ;;
+              subscription-delete)
+                if [[ "$state" == deleted ]]; then
+                  printf '%s\\n' '{{"error":"not found"}}'
+                  exit 1
+                fi
+                printf '%s\\n' deleted > "{state_file}"
+                printf '%s\\n' '{{"data":{{"status":"deleted"}}}}'
+                ;;
+              *)
+                echo "unexpected command: $command" >&2
+                exit 2
+                ;;
+            esac
+            """
+        )
+    )
+    fake_redfish_ctl.chmod(0o755)
+
+    fake_sleep = bin_dir / "sleep"
+    fake_sleep.write_text(f"#!{bash}\nexit 0\n")
+    fake_sleep.chmod(0o755)
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+        "REDFISH_IP": "192.0.2.10",
+        "REDFISH_USERNAME": "root",
+        "REDFISH_PASSWORD": "secret",
+        "SUBSCRIPTION_DESTINATION": DESTINATION,
+        "TRACE_DIR": str(capture_dir),
+    }
+    script = (
+        "scripts/live_sanity_check/supermicro/gb300/"
+        "subscription_roundtrip.sh"
+    )
+
+    result = subprocess.run(
+        [bash, script],
+        cwd=Path(__file__).resolve().parents[1],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr + result.stdout
+    assert "PASS: subscription created and deleted" in result.stdout

--- a/tests/test_subscription_lifecycle_dualmode.py
+++ b/tests/test_subscription_lifecycle_dualmode.py
@@ -1,0 +1,205 @@
+"""Dual-mode tests for EventDestination subscription lifecycle commands."""
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+SUBSCRIPTIONS_PATH = "/redfish/v1/EventService/Subscriptions"
+SUBSCRIPTION_ONE_PATH = f"{SUBSCRIPTIONS_PATH}/1"
+DESTINATION = "https://listener.example.com/redfish/events"
+
+
+def _request_type(name):
+    request_type = getattr(ApiRequestType, name, None)
+    assert request_type is not None, f"missing ApiRequestType.{name}"
+    return request_type
+
+
+def _mutating_requests(service):
+    return [
+        request for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    ]
+
+
+def _seed_subscription(service):
+    service._overlay[SUBSCRIPTIONS_PATH.lower()] = {
+        "@odata.id": SUBSCRIPTIONS_PATH,
+        "Members": [{"@odata.id": SUBSCRIPTION_ONE_PATH}],
+        "Members@odata.count": 1,
+    }
+    service._overlay[SUBSCRIPTION_ONE_PATH.lower()] = {
+        "@odata.id": SUBSCRIPTION_ONE_PATH,
+        "Id": "1",
+        "Name": "Test Event Destination",
+        "Destination": DESTINATION,
+        "Protocol": "Redfish",
+    }
+
+
+def test_subscription_create_dry_run_builds_payload_without_post(
+    redfish_mock_factory,
+):
+    """subscription-create previews the EventDestination payload by default."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionCreate"),
+        "subscription-create",
+        destination=DESTINATION,
+        event_format_type="Event",
+        event_types=["Alert"],
+        context="gb300-smoke",
+        confirm=False,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "create",
+        "target": SUBSCRIPTIONS_PATH,
+        "payload": {
+            "Destination": DESTINATION,
+            "Protocol": "Redfish",
+            "EventFormatType": "Event",
+            "EventTypes": ["Alert"],
+            "Context": "gb300-smoke",
+        },
+        "note": "preview only; re-run with --confirm to create subscription",
+    }
+    assert _mutating_requests(service) == []
+
+
+def test_subscription_create_confirm_posts_event_destination_payload(
+    redfish_mock_factory,
+):
+    """subscription-create --confirm POSTs only the EventDestination body."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionCreate"),
+        "subscription-create",
+        destination=DESTINATION,
+        registry_prefixes=["Base", "TaskEvent"],
+        resource_types=["Task"],
+        confirm=True,
+    )
+
+    posts = [request for request in service.requests if request.method == "POST"]
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["action"] == "create"
+    assert result.data["target"] == SUBSCRIPTIONS_PATH
+    assert result.data["status"] == "IdracApiRespond.Success"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SUBSCRIPTIONS_PATH.lower()
+    assert posts[0].json() == {
+        "Destination": DESTINATION,
+        "Protocol": "Redfish",
+        "RegistryPrefixes": ["Base", "TaskEvent"],
+        "ResourceTypes": ["Task"],
+    }
+
+
+def test_subscription_delete_dry_run_resolves_member_without_delete(
+    redfish_mock_factory,
+):
+    """subscription-delete previews the resolved member URI until confirmed."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_subscription(service)
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionDelete"),
+        "subscription-delete",
+        subscription="1",
+        confirm=False,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "delete",
+        "target": SUBSCRIPTION_ONE_PATH,
+        "note": "preview only; re-run with --confirm to delete subscription",
+    }
+    assert all(request.method != "DELETE" for request in service.requests)
+
+
+def test_subscription_delete_confirm_deletes_resolved_member(
+    redfish_mock_factory,
+):
+    """subscription-delete --confirm DELETEs only the resolved member URI."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_subscription(service)
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionDelete"),
+        "subscription-delete",
+        subscription=SUBSCRIPTION_ONE_PATH,
+        confirm=True,
+    )
+
+    deletes = [request for request in service.requests if request.method == "DELETE"]
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["action"] == "delete"
+    assert result.data["target"] == SUBSCRIPTION_ONE_PATH
+    assert result.data["status"] == "IdracApiRespond.Ok"
+    assert len(deletes) == 1
+    assert deletes[0].path.lower() == SUBSCRIPTION_ONE_PATH.lower()
+
+
+def test_subscription_commands_fail_closed_without_subscription_collection(
+    redfish_mock_factory,
+):
+    """Subscription writes fail before mutation if EventService has no collection."""
+    manager, service = redfish_mock_factory("supermicro")
+    event_service = dict(service._state("/redfish/v1/EventService"))
+    event_service.pop("Subscriptions", None)
+    service._overlay["/redfish/v1/eventservice"] = event_service
+
+    with pytest.raises(InvalidArgument, match="Subscriptions link is not available"):
+        manager.sync_invoke(
+            _request_type("SubscriptionCreate"),
+            "subscription-create",
+            destination=DESTINATION,
+            confirm=True,
+        )
+    with pytest.raises(InvalidArgument, match="Subscriptions link is not available"):
+        manager.sync_invoke(
+            _request_type("SubscriptionDelete"),
+            "subscription-delete",
+            subscription="1",
+            confirm=True,
+        )
+
+    assert _mutating_requests(service) == []
+
+
+def test_subscription_commands_expose_cli_entrypoints():
+    """The subscription lifecycle commands are wired into the package registry."""
+    registry = IDracManager().get_registry()
+
+    create_type = _request_type("SubscriptionCreate")
+    delete_type = _request_type("SubscriptionDelete")
+    assert "subscription-create" in registry[create_type]
+    assert "subscription-delete" in registry[delete_type]
+
+    create_parser, create_name, create_help = registry[create_type][
+        "subscription-create"
+    ].register_subcommand(registry[create_type]["subscription-create"])
+    delete_parser, delete_name, delete_help = registry[delete_type][
+        "subscription-delete"
+    ].register_subcommand(registry[delete_type]["subscription-delete"])
+
+    assert create_parser.format_help()
+    assert delete_parser.format_help()
+    assert create_name == "subscription-create"
+    assert delete_name == "subscription-delete"
+    assert "subscription" in create_help.lower()
+    assert "subscription" in delete_help.lower()


### PR DESCRIPTION
## Summary
- add guarded EventDestination subscription create/delete commands
- add offline dual-mode coverage for dry-run, confirmed POST/DELETE, and fail-closed discovery
- add a GB300 live-sanity wrapper for create/assert/delete capture flow

## Validation
- conda run -n idrac_ctl python3 -m pytest -q tests/test_subscription_lifecycle_dualmode.py
- conda run -n idrac_ctl python3 -m pytest -q tests/test_subscription_lifecycle_dualmode.py tests/test_event_service_dualmode.py tests/test_event_submit_dualmode.py tests/test_action_commands_dualmode.py
- conda run -n idrac_ctl ruff check redfish_ctl/events/cmd_subscription_lifecycle.py redfish_ctl/__init__.py redfish_ctl/idrac_shared.py tests/test_subscription_lifecycle_dualmode.py
- bash -n scripts/live_sanity_check/supermicro/gb300/subscription_roundtrip.sh
- shellcheck scripts/live_sanity_check/supermicro/gb300/subscription_roundtrip.sh
- PYTHONPATH=. conda run -n idrac_ctl python3 -m redfish_ctl.redfish_main subscription-create --help
- PYTHONPATH=. conda run -n idrac_ctl python3 -m redfish_ctl.redfish_main subscription-delete --help
- conda run -n idrac_ctl python3 -m pytest -q

Part of #114.