### PR TITLE
Clarify docs safety indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 `redfish_ctl` is a standalone command-line tool for driving server BMCs entirely through the
 Redfish REST API — no web UI, no vendor GUI. It wraps 100+ subcommands behind one consistent CLI
 with JSON or YAML output (`--yaml`, and save-to-file), both synchronous and asynchronous calls,
-optional server-side `$expand` on large collection reads, and a read-first, guarded-write model
-(mutating commands preview with `--dry_run` and require `--confirm`). It is vendor-neutral by design — Dell iDRAC,
-Supermicro (including GB300 / Grace-Blackwell and X10), HPE iLO, and generic DMTF Redfish — built on
-a product-neutral Redfish client with the Dell/iDRAC specifics layered on top.
+optional server-side `$expand` on large collection reads, and safety labels that separate read-only,
+guarded, and immediate-write operations. It is vendor-neutral by design — Dell iDRAC, Supermicro
+(including GB300 / Grace-Blackwell and X10), HPE iLO, and generic DMTF Redfish — built on a
+product-neutral Redfish client with the Dell/iDRAC specifics layered on top.
 
 What it does across the whole server lifecycle:
 
@@ -68,9 +68,11 @@ redfish_ctl system --yaml      # same data as YAML instead of JSON
 redfish_ctl --help             # every subcommand
 ```
 
-Reads are safe. Commands that change hardware (power, BIOS, boot, storage, virtual media, firmware)
-follow a read-first, guarded-write model — they preview with `--dry_run` and only act with
-`--confirm`. See [Mutating Commands](#mutating-commands) below.
+Reads are safe. Commands that change hardware are labeled **Guarded** or **Write** in the
+[command reference](docs/commands.md#registered-commands): Guarded commands require an explicit
+intent flag such as `--confirm`, while Write commands may mutate immediately. Preview with
+`--show` or `--dry_run` when the command supports it, then see [Mutating Commands](#mutating-commands)
+below before applying anything.
 
 > **Upgrading from `idrac_ctl`?** Install `redfish_ctl` — the `idrac_ctl` command, `import idrac_ctl`,
 > and the legacy `IDRAC_*` env vars all keep working as a backward-compatible alias. The old
@@ -312,7 +314,6 @@ First-run problems are almost always the connection, not the command:
 - [Fixture capture](docs/fixture-capture.md) - crawl a BMC with `discovery`, sanitize it, and contribute it as a vendor corpus.
 - [CI/CD](docs/ci.md) - the GitHub Actions test + release pipeline, the runner, and the Node.js runtime.
 - [Architecture](docs/architecture.md) - Redfish core, iDRAC layer, command registration, and known debt.
-- [Corpus Library](docs/corpus-library.md) - committed Redfish corpora and extraction workflow.
 - [Telemetry metrics](docs/telemetry-metrics.md) - GB300 MetricReport/MetricReportDefinition reference catalog.
 - [Changelog](CHANGELOG.md) - what each release adds, changes, and fixes; watch **Unreleased** for what the next tag will contain.
 - [Releasing](docs/releasing.md) - local verification, package build, PyPI upload, and tagging.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Author: Mus <spyroot@gmail.com>
 When connecting to a new BMC, run `redfish_ctl system` first. It proves the endpoint, credentials, and
 basic Redfish path before deeper inventory or any staged change.
 
-The table below follows the 122 command names imported by `redfish_ctl/__init__.py`. Run
+The table below follows the command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
 backward-compatible alias for the `redfish_ctl` command, and `IDRAC_*` env vars are still read.)
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -9,6 +9,7 @@ and apply only on an approved target.
 Safety labels:
 
 - **Read**: reads BMC state only.
+- **Guarded**: previews by default or requires an explicit apply flag such as `--confirm`.
 - **Write**: stages or applies BMC or host state.
 
 Platform/vendor labels:
@@ -35,6 +36,18 @@ Use these files with the command's `--from_spec` option unless the table says ot
 | `realtime.opt.spec.json` | `bios-change` | CPU/platform | Write | Low-latency BIOS attributes. |
 | `set_profile_example.json` | `bios-change` | Dell/iDRAC, CPU/platform | Write | Select a Dell `WorkloadProfile`. |
 | `theramal_setting_and_boot_once_example.json` | `attr-update` | Dell/iDRAC, CPU/platform | Write | Thermal and first-boot attributes. |
+
+## Named BIOS Profiles
+
+`specs/profiles/`, the committed named-profile directory, defines profiles for the `bios-profile`
+command. `bios-profile list` and `bios-profile show` are local reads; `bios-profile apply` is guarded
+and stages only with `--confirm`.
+
+| Spec | Command | Platform/vendor | Safety | Purpose |
+|---|---|---|---|---|
+| `profiles/dell-cstates-off.json` | `bios-profile apply` | Dell/iDRAC, CPU/platform | Guarded | Disable processor C-states for latency-sensitive Dell PowerEdge workloads. |
+| `profiles/gb300-extended-gpu-memory.json` | `bios-profile apply` | Supermicro/GB300 | Guarded | Enable Extended GPU Memory on Grace-Blackwell nodes. |
+| `profiles/gb300-power-capped.json` | `bios-profile apply` | Supermicro/GB300 | Guarded | Use 1 s input-power capping for smoother rack-level power draw. |
 
 For command flags, see [Command reference](../docs/commands.md). For the BIOS workflow around these
 files, see [BIOS profiles](../docs/bios-profiles.md).


### PR DESCRIPTION
Summary:
- Clarify README wording for Guarded versus immediate Write commands.
- Add named BIOS profile specs to the specs index with vendor and safety labels.
- Remove stale command-count wording and a duplicate corpus docs link.

Tests:
- git diff --check
- changed-doc local link check: checked=30 broken=0
- command table parity: cli=123 docs=123 missing=0 extra=0
- specs index parity: expected=15 listed=15 missing=0 extra=0
- python -m redfish_ctl.redfish_main --help
- python -m redfish_ctl.redfish_main bios-profile --help
- python -m redfish_ctl.redfish_main bios-change --help
- pytest -q (1068 passed, 58 skipped)