### PR TITLE
Add guarded asset tag command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,7 +5,7 @@ Author: Mus <spyroot@gmail.com>
 When connecting to a new BMC, run `redfish_ctl system` first. It proves the endpoint, credentials, and
 basic Redfish path before deeper inventory or any staged change.
 
-The table below follows the 122 command names imported by `redfish_ctl/__init__.py`. Run
+The table below follows the 123 command names imported by `redfish_ctl/__init__.py`. Run
 `redfish_ctl <command> --help` for flags on your installed version. (`idrac_ctl` remains a
 backward-compatible alias for the `redfish_ctl` command, and `IDRAC_*` env vars are still read.)
 
@@ -77,6 +77,7 @@ Safety labels:
 | `account-svc` | Read AccountService. | Read |
 | `accounts` | Read the account collection; `--usernames` prints only usernames. | Read |
 | `actions` | List Redfish actions exposed by the box and their risk levels. | Read |
+| `asset-tag-set` | Read or set a chassis or system AssetTag; dry-run by default and `--confirm` applies. | Guarded |
 | `attr` | Read manager attributes. | Read |
 | `attr-clear-pending` | Clear pending manager attribute values. | Write |
 | `attr-update` | Stage manager attribute changes. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -80,6 +80,7 @@ from .storage.cmd_convert_to_raid import *
 # chassis cmd
 from .chassis.cmd_chassis_query import *
 from .chassis.cmd_chasis_reset import *
+from .chassis.cmd_asset_tag_set import *
 from .sensors.cmd_sensors import *
 from .controls.cmd_controls import *
 from .thermal.cmd_thermal import *

--- a/redfish_ctl/chassis/cmd_asset_tag_set.py
+++ b/redfish_ctl/chassis/cmd_asset_tag_set.py
@@ -1,0 +1,143 @@
+"""Read or set Redfish AssetTag on Chassis or ComputerSystem resources."""
+
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..idrac_manager import IDracManager
+from ..idrac_shared import ApiRequestType, Singleton
+from ..redfish_manager import CommandResult
+from ..redfish_shared import RedfishApi
+
+_COLLECTIONS = {
+    "chassis": RedfishApi.Chassis,
+    "system": RedfishApi.Systems,
+}
+
+
+class AssetTagSet(IDracManager,
+                  scm_type=ApiRequestType.AssetTagSet,
+                  name="asset-tag-set",
+                  metaclass=Singleton):
+    """Read or set AssetTag on a chassis or system resource."""
+
+    def __init__(self, *args, **kwargs):
+        super(AssetTagSet, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``asset-tag-set`` subcommand."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--resource",
+            choices=sorted(_COLLECTIONS),
+            default="chassis",
+            help="resource collection to search",
+        )
+        cmd_parser.add_argument(
+            "--target-id",
+            required=True,
+            dest="target_id",
+            help="resource Id to read or patch, such as Chassis_0 or System_0",
+        )
+        cmd_parser.add_argument(
+            "--asset-tag",
+            dest="asset_tag",
+            default=None,
+            help="AssetTag value to apply; omit to read the current value",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="apply the PATCH; without it the command only previews",
+        )
+        return cmd_parser, "asset-tag-set", "read or set AssetTag"
+
+    @staticmethod
+    def _members(data):
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _resource_id(uri, data):
+        if isinstance(data, dict) and isinstance(data.get("Id"), str):
+            return data["Id"]
+        return uri.rstrip("/").rsplit("/", 1)[-1]
+
+    def _get(self, uri, do_async):
+        return self.base_query(uri, do_async=do_async).data or {}
+
+    def _resolve(self, resource, target_id, do_async):
+        if resource not in _COLLECTIONS:
+            raise InvalidArgument(f"unsupported AssetTag resource {resource!r}")
+        if not target_id:
+            raise InvalidArgument("target_id is required")
+
+        collection = self._get(_COLLECTIONS[resource], do_async)
+        for uri in self._members(collection):
+            data = self._get(uri, do_async)
+            resource_id = self._resource_id(uri, data)
+            if resource_id != target_id and uri != target_id:
+                continue
+            if "AssetTag" not in data:
+                raise InvalidArgument("target does not expose AssetTag")
+            return {
+                "resource": resource,
+                "target_id": resource_id,
+                "target": uri,
+                "current": data.get("AssetTag"),
+            }
+        raise InvalidArgument(f"No {resource} resource named {target_id}")
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                resource: Optional[str] = "chassis",
+                target_id: Optional[str] = None,
+                asset_tag: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Read, preview, or apply an AssetTag value."""
+        target = self._resolve(resource, target_id, do_async)
+        if asset_tag is None:
+            target["read_only"] = True
+            return CommandResult(target, None, None, None)
+
+        payload = {"AssetTag": str(asset_tag)}
+        if not confirm:
+            return CommandResult({
+                **target,
+                "dry_run": True,
+                "note": "preview only; re-run with --confirm to apply",
+                "payload": payload,
+            }, None, None, None)
+
+        result, status = self.base_patch(
+            target["target"],
+            payload=payload,
+            do_async=do_async,
+            expected_status=200,
+        )
+        observed = self._get(target["target"], do_async).get("AssetTag")
+        return CommandResult({
+            **target,
+            "payload": payload,
+            "applied": {
+                "target": target["target"],
+                "status": str(status),
+                "error": result.error,
+            },
+            "observed": observed,
+        }, None, None, None)

--- a/redfish_ctl/chassis/cmd_asset_tag_set.py
+++ b/redfish_ctl/chassis/cmd_asset_tag_set.py
@@ -39,7 +39,7 @@ class AssetTagSet(IDracManager,
             "--target-id",
             required=True,
             dest="target_id",
-            help="resource Id to read or patch, such as Chassis_0 or System_0",
+            help="resource Id or @odata.id URI to read or patch",
         )
         cmd_parser.add_argument(
             "--asset-tag",
@@ -74,7 +74,10 @@ class AssetTagSet(IDracManager,
         return uri.rstrip("/").rsplit("/", 1)[-1]
 
     def _get(self, uri, do_async):
-        return self.base_query(uri, do_async=do_async).data or {}
+        result = self.base_query(uri, do_async=do_async)
+        if result.error:
+            raise InvalidArgument(f"failed to query {uri}: {result.error}")
+        return result.data or {}
 
     def _resolve(self, resource, target_id, do_async):
         if resource not in _COLLECTIONS:
@@ -128,7 +131,6 @@ class AssetTagSet(IDracManager,
             target["target"],
             payload=payload,
             do_async=do_async,
-            expected_status=200,
         )
         observed = self._get(target["target"], do_async).get("AssetTag")
         return CommandResult({

--- a/redfish_ctl/idrac_shared.py
+++ b/redfish_ctl/idrac_shared.py
@@ -166,6 +166,7 @@ class ApiRequestType(Enum):
     ChassisQuery = auto()
     ChassisReset = auto()
     ChassisUpdate = auto()
+    AssetTagSet = auto()
 
     JobGet = auto()
     JobDel = auto()

--- a/scripts/live_sanity_check/hp/dl360/asset_tag_roundtrip.sh
+++ b/scripts/live_sanity_check/hp/dl360/asset_tag_roundtrip.sh
@@ -1,0 +1,88 @@
+#!/opt/homebrew/bin/bash
+# HPE iLO DL360 AssetTag round-trip for Chassis/1 and Systems/1.
+# Target/creds come from REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD env only.
+set -euo pipefail
+
+: "${REDFISH_IP:?set REDFISH_IP}" "${REDFISH_USERNAME:?}" "${REDFISH_PASSWORD:?}"
+
+if [ "${ASSET_TAG_SANITY_CONFIRM:-}" != "YES" ]; then
+  echo "SKIP: set ASSET_TAG_SANITY_CONFIRM=YES for approved live AssetTag mutation"
+  exit 0
+fi
+
+RCTL=(redfish_ctl --nocolor --json_only)
+CAPTURE_DIR="${TRACE_DIR:-scripts/live_sanity_check/captures/hp/dl360}"
+NEW_TAG="${ASSET_TAG_SANITY_VALUE:-redfish-ctl-asset-tag-roundtrip}"
+mkdir -p "$CAPTURE_DIR"
+
+asset_tag_from() {
+  python3 -c '
+import json
+import sys
+payload = json.load(sys.stdin)
+print(payload.get("data", {}).get("current", ""))
+'
+}
+
+observed_tag_from() {
+  python3 -c '
+import json
+import sys
+payload = json.load(sys.stdin)
+print(payload.get("data", {}).get("observed", ""))
+'
+}
+
+assert_equal() {
+  local actual="$1"
+  local expected="$2"
+  local label="$3"
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: $label expected [$expected], got [$actual]"
+    exit 1
+  fi
+}
+
+roundtrip() {
+  local resource="$1"
+  local target_id="$2"
+  local name="${resource}_${target_id}"
+  local before_file="$CAPTURE_DIR/asset_tag_${name}.before.json"
+  local set_file="$CAPTURE_DIR/asset_tag_${name}.set.ok.json"
+  local restore_file="$CAPTURE_DIR/asset_tag_${name}.restore.ok.json"
+  local err_file="$CAPTURE_DIR/asset_tag_${name}.err.json"
+
+  "${RCTL[@]}" asset-tag-set \
+    --resource "$resource" \
+    --target-id "$target_id" > "$before_file"
+  local before
+  before="$(asset_tag_from < "$before_file")"
+
+  "${RCTL[@]}" asset-tag-set \
+    --resource "$resource" \
+    --target-id "$target_id" \
+    --asset-tag "$NEW_TAG" \
+    --confirm > "$set_file"
+  assert_equal "$(observed_tag_from < "$set_file")" "$NEW_TAG" "$name set"
+
+  "${RCTL[@]}" asset-tag-set \
+    --resource "$resource" \
+    --target-id "$target_id" \
+    --asset-tag "$before" \
+    --confirm > "$restore_file"
+  assert_equal "$(observed_tag_from < "$restore_file")" "$before" "$name restore"
+
+  if "${RCTL[@]}" asset-tag-set \
+      --resource "$resource" \
+      --target-id "missing-$target_id" \
+      --asset-tag "$NEW_TAG" \
+      --confirm > "$err_file" 2>&1; then
+    echo "FAIL: invalid AssetTag target unexpectedly succeeded for $name"
+    exit 1
+  fi
+}
+
+roundtrip chassis 1
+roundtrip system 1
+
+echo "PASS: AssetTag round-trip completed for Chassis/1 and Systems/1"

--- a/scripts/live_sanity_check/hp/dl360/asset_tag_roundtrip.sh
+++ b/scripts/live_sanity_check/hp/dl360/asset_tag_roundtrip.sh
@@ -15,6 +15,29 @@ CAPTURE_DIR="${TRACE_DIR:-scripts/live_sanity_check/captures/hp/dl360}"
 NEW_TAG="${ASSET_TAG_SANITY_VALUE:-redfish-ctl-asset-tag-roundtrip}"
 mkdir -p "$CAPTURE_DIR"
 
+RESTORE_NEEDED=0
+RESTORE_RESOURCE=""
+RESTORE_TARGET_ID=""
+RESTORE_TAG=""
+RESTORE_FILE=""
+
+restore_on_exit() {
+  local status="$?"
+  if [ "$RESTORE_NEEDED" = "1" ]; then
+    RESTORE_NEEDED=0
+    echo "RESTORE: restoring $RESTORE_RESOURCE/$RESTORE_TARGET_ID AssetTag after failure"
+    if ! "${RCTL[@]}" asset-tag-set \
+        --resource "$RESTORE_RESOURCE" \
+        --target-id "$RESTORE_TARGET_ID" \
+        --asset-tag "$RESTORE_TAG" \
+        --confirm > "$RESTORE_FILE" 2>&1; then
+      echo "WARN: restore command failed; inspect $RESTORE_FILE"
+    fi
+  fi
+  exit "$status"
+}
+trap restore_on_exit EXIT
+
 asset_tag_from() {
   python3 -c '
 import json
@@ -39,7 +62,7 @@ assert_equal() {
   local label="$3"
   if [ "$actual" != "$expected" ]; then
     echo "FAIL: $label expected [$expected], got [$actual]"
-    exit 1
+    return 1
   fi
 }
 
@@ -50,6 +73,7 @@ roundtrip() {
   local before_file="$CAPTURE_DIR/asset_tag_${name}.before.json"
   local set_file="$CAPTURE_DIR/asset_tag_${name}.set.ok.json"
   local restore_file="$CAPTURE_DIR/asset_tag_${name}.restore.ok.json"
+  local restore_err_file="$CAPTURE_DIR/asset_tag_${name}.restore.err.json"
   local err_file="$CAPTURE_DIR/asset_tag_${name}.err.json"
 
   "${RCTL[@]}" asset-tag-set \
@@ -57,6 +81,12 @@ roundtrip() {
     --target-id "$target_id" > "$before_file"
   local before
   before="$(asset_tag_from < "$before_file")"
+
+  RESTORE_NEEDED=1
+  RESTORE_RESOURCE="$resource"
+  RESTORE_TARGET_ID="$target_id"
+  RESTORE_TAG="$before"
+  RESTORE_FILE="$restore_err_file"
 
   "${RCTL[@]}" asset-tag-set \
     --resource "$resource" \
@@ -71,6 +101,7 @@ roundtrip() {
     --asset-tag "$before" \
     --confirm > "$restore_file"
   assert_equal "$(observed_tag_from < "$restore_file")" "$before" "$name restore"
+  RESTORE_NEEDED=0
 
   if "${RCTL[@]}" asset-tag-set \
       --resource "$resource" \

--- a/tests/test_asset_tag_set_dualmode.py
+++ b/tests/test_asset_tag_set_dualmode.py
@@ -1,0 +1,134 @@
+"""Dual-mode tests for the asset-tag-set command."""
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+
+def _request_type():
+    request_type = getattr(ApiRequestType, "AssetTagSet", None)
+    assert request_type is not None, "missing ApiRequestType.AssetTagSet"
+    return request_type
+
+
+def _mutating_requests(service):
+    return [
+        request
+        for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    ]
+
+
+def _patch_requests(service):
+    return [request for request in service.requests if request.method == "PATCH"]
+
+
+def test_asset_tag_set_reads_current_chassis_tag_without_patch(
+    redfish_mock_factory,
+):
+    """asset-tag-set reads the current chassis AssetTag when no tag is supplied."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        _request_type(),
+        "asset-tag-set",
+        resource="chassis",
+        target_id="Chassis_0",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "resource": "chassis",
+        "target_id": "Chassis_0",
+        "target": "/redfish/v1/Chassis/Chassis_0",
+        "current": "$PRODUCT_ASSET_TAG",
+        "read_only": True,
+    }
+    assert _mutating_requests(service) == []
+
+
+def test_asset_tag_set_dry_run_previews_system_patch_without_writing(
+    redfish_mock_factory,
+):
+    """asset-tag-set previews the AssetTag PATCH unless confirmed."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        _request_type(),
+        "asset-tag-set",
+        resource="system",
+        target_id="System_0",
+        asset_tag="lab-system-01",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["current"] == ""
+    assert result.data["payload"] == {"AssetTag": "lab-system-01"}
+    assert result.data["target"] == "/redfish/v1/Systems/System_0"
+    assert _mutating_requests(service) == []
+
+
+def test_asset_tag_set_confirm_patches_and_rereads_chassis_tag(
+    redfish_mock_factory,
+):
+    """asset-tag-set --confirm PATCHes only AssetTag and returns observed state."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        _request_type(),
+        "asset-tag-set",
+        resource="chassis",
+        target_id="Chassis_0",
+        asset_tag="restored-tag",
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/chassis/chassis_0"
+    assert patches[0].json() == {"AssetTag": "restored-tag"}
+    assert result.data["applied"] == {
+        "target": "/redfish/v1/Chassis/Chassis_0",
+        "status": "IdracApiRespond.Ok",
+        "error": None,
+    }
+    assert result.data["observed"] == "restored-tag"
+
+
+def test_asset_tag_set_allows_empty_restore_value(redfish_mock_factory):
+    """An empty AssetTag is a valid restore value for vendors that start blank."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        _request_type(),
+        "asset-tag-set",
+        resource="system",
+        target_id="System_0",
+        asset_tag="",
+    )
+
+    assert result.data["payload"] == {"AssetTag": ""}
+    assert result.data["current"] == ""
+    assert _mutating_requests(service) == []
+
+
+def test_asset_tag_set_rejects_missing_target_before_patch(redfish_mock_factory):
+    """asset-tag-set fails closed when the target resource id is absent."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument, match="No chassis resource named Missing"):
+        manager.sync_invoke(
+            _request_type(),
+            "asset-tag-set",
+            resource="chassis",
+            target_id="Missing",
+            asset_tag="lab-system-01",
+            confirm=True,
+        )
+
+    assert _mutating_requests(service) == []

--- a/tests/test_asset_tag_set_dualmode.py
+++ b/tests/test_asset_tag_set_dualmode.py
@@ -90,7 +90,7 @@ def test_asset_tag_set_confirm_patches_and_rereads_chassis_tag(
 
     patches = _patch_requests(service)
     assert len(patches) == 1
-    assert patches[0].path == "/redfish/v1/chassis/chassis_0"
+    assert patches[0].path.lower() == result.data["applied"]["target"].lower()
     assert patches[0].json() == {"AssetTag": "restored-tag"}
     assert result.data["applied"] == {
         "target": "/redfish/v1/Chassis/Chassis_0",


### PR DESCRIPTION
## Summary
- add a guarded asset-tag-set command for chassis and system AssetTag reads, dry-runs, and confirmed PATCHes
- cover read, dry-run, confirmed write, empty restore values, and missing-target failure against the Supermicro corpus
- document the command and add an opt-in HPE DL360 live sanity round-trip script

## Validation
- /Users/spyroot/miniconda3/condabin/conda run --no-capture-output -n idrac_ctl python -m pytest -q tests/test_asset_tag_set_dualmode.py tests/test_cli_subcommand_uniqueness.py -> 8 passed
- /Users/spyroot/miniconda3/condabin/conda run --no-capture-output -n idrac_ctl ruff check redfish_ctl/chassis/cmd_asset_tag_set.py redfish_ctl/__init__.py redfish_ctl/idrac_shared.py tests/test_asset_tag_set_dualmode.py -> All checks passed
- /opt/homebrew/bin/bash -n scripts/live_sanity_check/hp/dl360/asset_tag_roundtrip.sh
- /opt/homebrew/bin/shellcheck scripts/live_sanity_check/hp/dl360/asset_tag_roundtrip.sh
- /Users/spyroot/miniconda3/condabin/conda run --no-capture-output -n idrac_ctl python -m redfish_ctl.redfish_main asset-tag-set --help
- /Users/spyroot/miniconda3/condabin/conda run --no-capture-output -n idrac_ctl python -m pytest -q -> 1074 passed, 58 skipped

Part of #114.