### PR TITLE
Make wait example read-only

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -62,7 +62,7 @@ Run examples from the repository root with `bash examples/<script>`.
 | `example_provision_boot_iso.sh` | generic/vendor-neutral | Write | Mount an installer ISO and boot from it once. |
 | `example_sensors_read.sh` | generic/vendor-neutral | Read | Read and filter temperatures, fans, power supplies, and voltages. |
 | `example_supermicro_provision_from_iso.sh` | Supermicro/GB300 | Write | Mount Supermicro virtual media and boot once. |
-| `example_wait.sh` | generic/vendor-neutral | Write | Wait for Redfish service recovery around a BMC manager reboot. |
+| `example_wait.sh` | generic/vendor-neutral | Read | Wait for Redfish service recovery after an approved BMC restart. |
 | `hpe_ilo_canary.sh` | HPE iLO | Guarded | Run read-only commands and a dry-run reset against the iLO emulator. |
 
 For BIOS profile flow, see [BIOS profiles](../docs/bios-profiles.md). For every command name, see

--- a/examples/example_wait.sh
+++ b/examples/example_wait.sh
@@ -1,4 +1,4 @@
-# Wait for the BMC Redfish service to be reachable — instead of hand-rolled sleep loops.
+# Wait for the BMC Redfish service to be reachable instead of hand-rolled sleep loops.
 # Any HTTP response (200/401/403) means the BMC is up; connection error means not yet.
 
 # Wait up to 5 min for the BMC to answer:
@@ -7,8 +7,7 @@ redfish_ctl wait
 # Tune the wait:
 redfish_ctl wait --timeout 600 --interval 5
 
-# The clean reboot pattern — reset the BMC, then wait for the full down->up cycle:
-redfish_ctl manager-reboot
+# After an operator-approved BMC restart, wait for the full down->up cycle:
 redfish_ctl wait --reboot-cycle --timeout 300
 
 # --reboot-cycle first waits for the BMC to go DOWN, then for it to come back UP,


### PR DESCRIPTION
Summary:
- remove the direct manager-reboot call from the wait example
- label example_wait.sh as a read-only wait helper after an approved BMC restart

Verification:
- git diff --check
- git diff --cached --check
- changed-doc local link check: checked=3 broken=0
- bash -n examples/example_wait.sh
- python -B -m redfish_ctl.redfish_main wait --help
- pytest -q with live Redfish variables unset: 1068 passed, 58 skipped