### PR TITLE
Clarify mutation safety labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ redfish_ctl --help             # every subcommand
 
 Reads are safe. Commands that change hardware are labeled **Guarded** or **Write** in the
 [command reference](docs/commands.md#registered-commands): Guarded commands require an explicit
-intent flag such as `--confirm`, while Write commands may mutate immediately. Preview with
-`--show` or `--dry_run` when the command supports it, then see [Mutating Commands](#mutating-commands)
-below before applying anything.
+intent flag such as `--confirm`; Write commands can mutate immediately and require explicit target
+approval before live use. Preview with `--show` or `--dry_run` when the command supports it, then
+see [Mutating Commands](#mutating-commands) below before applying anything.
 
 > **Upgrading from `idrac_ctl`?** Install `redfish_ctl` — the `idrac_ctl` command, `import idrac_ctl`,
 > and the legacy `IDRAC_*` env vars all keep working as a backward-compatible alias. The old
@@ -233,8 +233,8 @@ opt-in emulator canary in `examples/hpe_ilo_canary.sh`. See [Vendors](docs/vendo
 ## Mutating Commands
 
 Some commands change real hardware: power, BIOS, boot order, storage conversion, virtual media,
-firmware update, and manager reset. Read current state first, preview when the command has
-`--show` or `--dry_run`, then verify after the job or task completes.
+firmware update, and BMC manager reboot (`manager-reboot`). Read current state first, preview when
+the command has `--show` or `--dry_run`, then verify after the job or task completes.
 
 ```bash
 redfish_ctl system-reset --reset_type GracefulRestart --dry_run

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,7 +68,8 @@ Safety labels:
 
 - **Read**: expected to read state only.
 - **Guarded**: does not mutate by default; requires `--confirm` or an equivalent apply flag.
-- **Write**: may mutate when invoked, even if an optional preview flag exists.
+- **Write**: can mutate when invoked; do not run live without explicit target approval, even if an
+  optional preview flag exists.
 
 | Command | Purpose | Safety |
 |---|---|---|
@@ -229,8 +230,8 @@ covered by the Dell, Supermicro, HPE, or generic fixture corpora listed in [Vend
 ## Mutating Workflow Pattern
 
 Commands labeled **Guarded** block or preview writes by default and require an explicit intent flag,
-usually `--confirm`. Commands labeled **Write** can mutate as soon as they are invoked; some still
-offer `--show` or `--dry_run`, but those previews are optional.
+usually `--confirm`. Commands labeled **Write** can mutate as soon as they are invoked; do not run
+them live without explicit target approval, and use `--show` or `--dry_run` first when available.
 
 Before running either kind of write, use the same four phases:
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -76,7 +76,7 @@ export OTEL_EXPORTER_OTLP_HEADERS="X-SF-Token=<your-splunk-access-token>"
 
 # 3. run any operation with tracing enabled
 redfish_ctl --otlp-traces system            # a read; shows redfish-ctl → bmc in the service map
-redfish_ctl --otlp-traces reboot --dry_run   # a guarded mutation, previewed
+redfish_ctl --otlp-traces system-reset --dry_run   # guarded reset preview; no POST
 ```
 
 Within seconds the operation appears in APM: a `redfish-ctl → bmc` service map, a trace waterfall of

--- a/specs/README.md
+++ b/specs/README.md
@@ -10,7 +10,7 @@ Safety labels:
 
 - **Read**: reads BMC state only.
 - **Guarded**: previews by default or requires an explicit apply flag such as `--confirm`.
-- **Write**: stages or applies BMC or host state.
+- **Write**: can stage or apply BMC or host state; do not run live without explicit target approval.
 
 Platform/vendor labels:
 


### PR DESCRIPTION
## Summary
- Clarify that Write-labeled commands still need explicit target approval before live use.
- Replace the observability reset tracing example with the guarded `system-reset --dry_run` path.
- Align the specs index safety label wording with the command reference.

## Verification
- `git diff --check`
- changed-doc local links: `checked=33 broken=0`
- command table parity: `cli=128 docs=128 missing=0 extra=0`
- `python -m redfish_ctl.redfish_main system-reset --help`
- `pytest -q -o cache_dir=/private/tmp/idrac-docs-worker-pytest-cache-20260715`: `1119 passed, 58 skipped in 57.43s`