### PR TITLE
Add NIC firmware status views

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TWINE ?= $(CONDA_RUN) twine
 DOCKER ?= docker
 IMAGE ?= redfish-ctl
 
-.PHONY: help test lint typecheck build bench-concurrency docker-test docker-image docs-voice-check k8s-sandbox clean
+.PHONY: help test lint typecheck build bench-concurrency docker-test docker-image docs-voice-check k8s-sandbox k8s-consumer k8s-explorer clean
 
 help: ## Show available developer targets.
 	@awk 'BEGIN { \
@@ -68,6 +68,12 @@ docs-voice-check: ## Reject first-person wording in public docs.
 
 k8s-sandbox: ## Run the local Kubernetes read-path sandbox when present.
 	./k8s/sandbox/run-sandbox.sh
+
+k8s-consumer: ## Build and deploy the fleet-status consumer into the sandbox.
+	./k8s/consumer/deploy.sh
+
+k8s-explorer: ## Build and deploy the redfish_ctl web explorer (set REDFISH_IP/SECRET).
+	./k8s/explorer/deploy.sh
 
 clean: ## Remove local build, test, and type-check artifacts.
 	rm -rf build dist *.egg-info .coverage htmlcov .pytest_cache .ruff_cache .mypy_cache

--- a/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
+++ b/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
@@ -25,6 +25,9 @@ spec:
         - name: HEALTH
           type: string
           jsonPath: .status.health
+        - name: NIC-FW
+          type: integer
+          jsonPath: .status.networkFirmware.firmwareCount
         - name: POLLED
           type: date
           jsonPath: .status.lastPolled
@@ -97,6 +100,48 @@ spec:
                     maxCelsius:
                       type: number
                       nullable: true
+                networkFirmware:
+                  type: object
+                  description: >-
+                    NIC/DPU network-adapter firmware inventory, populated from
+                    the BMC's NetworkAdapters and UpdateService/FirmwareInventory.
+                  properties:
+                    adapterCount:
+                      type: integer
+                      minimum: 0
+                    nicCount:
+                      type: integer
+                      minimum: 0
+                    dpuCount:
+                      type: integer
+                      minimum: 0
+                    firmwareCount:
+                      type: integer
+                      minimum: 0
+                    updateableCount:
+                      type: integer
+                      minimum: 0
+                    distinctVersions:
+                      type: array
+                      items:
+                        type: string
+                    components:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            nullable: true
+                          deviceClass:
+                            type: string
+                            nullable: true
+                          version:
+                            type: string
+                            nullable: true
+                          updateable:
+                            type: boolean
+                            nullable: true
                 lastPolled:
                   type: string
                   format: date-time

--- a/docker/Dockerfile.consumer
+++ b/docker/Dockerfile.consumer
@@ -1,0 +1,37 @@
+# Fleet-status consumer image for the local Kubernetes sandbox.
+#
+# A tiny read-only web app that renders RedfishEndpoint .status (written by the
+# controller) as a dashboard, JSON API, and Prometheus metrics. It depends only
+# on the Kubernetes client — it does NOT install redfish_ctl and never talks to
+# a BMC.
+#
+# Build:
+#   docker build -f docker/Dockerfile.consumer -t redfish-ctl-consumer:local .
+FROM python:3.12-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Match the deployment's runAsUser/runAsGroup so the non-root uid exists.
+RUN groupadd --system --gid 10001 redfish \
+    && useradd \
+        --system \
+        --uid 10001 \
+        --gid redfish \
+        --home-dir /home/redfish \
+        --create-home \
+        redfish
+
+WORKDIR /app
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-cache-dir "kubernetes>=29" \
+    && python -m pip check
+
+COPY k8s/consumer/fleet_status_app.py ./fleet_status_app.py
+
+USER redfish
+
+EXPOSE 8080
+ENTRYPOINT ["python", "-u", "/app/fleet_status_app.py"]

--- a/docker/Dockerfile.explorer
+++ b/docker/Dockerfile.explorer
@@ -1,0 +1,33 @@
+# redfish_ctl web explorer image.
+#
+# Serves a tree of the tool's read-only commands and invokes them live against a
+# BMC through the tool's own registry. Unlike the fleet-status consumer, this
+# talks to the BMC directly, so it needs redfish_ctl installed and BMC creds.
+#
+# Build:
+#   docker build -f docker/Dockerfile.explorer -t redfish-ctl-explorer:local .
+FROM python:3.12-slim
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN groupadd --system --gid 10001 redfish \
+    && useradd --system --uid 10001 --gid redfish \
+        --home-dir /home/redfish --create-home redfish
+
+WORKDIR /app
+
+COPY pyproject.toml setup.py requirements.txt README.md LICENSE ./
+COPY idrac_ctl ./idrac_ctl
+COPY redfish_ctl ./redfish_ctl
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install --no-cache-dir . \
+    && python -m pip check
+
+USER redfish
+
+EXPOSE 8299
+ENTRYPOINT ["python", "-m", "redfish_ctl.webui"]
+CMD ["--host", "0.0.0.0", "--port", "8299"]

--- a/docs/k8s-sandbox-quickstart.md
+++ b/docs/k8s-sandbox-quickstart.md
@@ -1,0 +1,128 @@
+# Kubernetes sandbox quickstart
+
+Bring up a local Kubernetes control loop that drives real (or mock) BMCs through
+`redfish_ctl`, end to end, on Docker Desktop. Every Redfish read below goes
+through the tool — the CLI, the controller, or the web explorer — never an ad-hoc
+script or `curl`. The only non-tool commands are the Kubernetes plumbing
+(`kind`, `kubectl`, `make`), which stands up the cluster itself.
+
+## What gets deployed
+
+```
+BMC ──(read-only poll via redfish_ctl)──▶ controller ──writes .status──▶ RedfishEndpoint CR
+                                                                              │
+                                    ┌─────────────────────────────────────────┴──────────┐
+                                    ▼                                                       ▼
+                       fleet-status consumer                                   redfish_ctl web explorer
+              (reads CR status; dashboard/API/metrics)          (tree of the tool's commands, invoked live)
+```
+
+* **Controller** (`k8s/controller/`) polls each BMC read-only through the
+  `redfish_ctl` command registry and writes power, health, temperature, and
+  NIC/DPU firmware to a `RedfishEndpoint` custom resource's `.status`.
+* **Fleet-status consumer** (`k8s/consumer/`) reads that CR status (never a BMC)
+  and serves a dashboard, `GET /api/nodes`, and Prometheus `/metrics`.
+* **Web explorer** (`k8s/explorer/`) serves a tree of the tool's read-only
+  commands; selecting one invokes the real `redfish_ctl` command live against the
+  target BMC via `sync_invoke`.
+
+## Prerequisites
+
+Docker Desktop (running), `kind`, and `kubectl` on `PATH`. Start Docker first:
+
+```bash
+open -a Docker            # macOS; wait until `docker info` succeeds
+```
+
+## 1. Stand up the sandbox (mock BMC) in one go
+
+The sandbox target builds the images, creates the kind cluster, and deploys the
+controller plus a mock BMC that serves the committed corpus:
+
+```bash
+make k8s-sandbox         # kind up → mock-bmc → controller → sample RedfishEndpoint
+```
+
+The active kube context becomes `kind-redfish-sandbox`. Confirm the controller
+populated a status:
+
+```bash
+kubectl config use-context kind-redfish-sandbox
+kubectl -n redfish-sandbox get rfe -o wide
+```
+
+## 2. Point the controller at a real BMC
+
+Create a credential Secret (never commit real credentials) and a
+`RedfishEndpoint`. The address uses the RFC 5737 documentation range — replace it
+with the BMC to poll:
+
+```bash
+kubectl -n redfish-sandbox create secret generic bmc-credentials \
+  --from-literal=username=root --from-literal=password='<bmc-password>'
+
+kubectl -n redfish-sandbox apply -f k8s/sandbox/redfish-endpoint-live-sample.yaml
+kubectl -n redfish-sandbox get rfe -w        # watch it flip from Pending to a status
+```
+
+A kind pod on Docker Desktop inherits the host's routes, so validate BMC reachability
+with a safe `redfish_ctl system` read before adding the endpoint. A full poll of a
+large chassis (dozens of chassis, hundreds of sensors) takes a minute or more; the
+endpoint shows `Pending` until the first walk finishes.
+
+## 3. Deploy the fleet-status consumer
+
+```bash
+make k8s-consumer
+kubectl -n redfish-sandbox port-forward svc/redfish-fleet-consumer 8199:80
+open http://127.0.0.1:8199/
+```
+
+* `GET /api/nodes` — summary + per-node status (power, health, temperature, and
+  `nicFirmwareVersions` / `nicFirmware[]`).
+* `GET /api/nodes/<name>` — one endpoint.
+* `GET /metrics` — Prometheus gauges: `redfish_endpoint_power_on`,
+  `redfish_endpoint_temperature_max_celsius`, `redfish_nic_firmware_info`,
+  `redfish_fleet_nic_firmware_drift_components` (0 when every node runs the same
+  firmware per component).
+
+## 4. Explore the tool live from the browser
+
+The explorer turns the tool's command surface into a browsable tree; each click
+runs the real command against the target BMC. Point it at a node and its Secret:
+
+```bash
+REDFISH_IP=203.0.113.10 REDFISH_PORT=443 REDFISH_SCHEME=https \
+  SECRET=bmc-credentials make k8s-explorer
+
+kubectl -n redfish-sandbox port-forward svc/redfish-ctl-explorer 8299:80
+open http://127.0.0.1:8299/
+```
+
+Select **Network → NIC / DPU firmware**; the explorer invokes
+`redfish_ctl nic-firmware` via `sync_invoke(ApiRequestType.NicFirmware, …)` and
+shows the ConnectX/BlueField firmware versions. Only read-only commands are
+allow-listed, so a mutating action is refused (HTTP 400).
+
+## Query without Kubernetes — the same tool, on the CLI
+
+Everything the controller and explorer read is a plain `redfish_ctl` command.
+Set the endpoint once and read directly:
+
+```bash
+export REDFISH_IP=203.0.113.10 REDFISH_USERNAME=root REDFISH_PASSWORD='<pw>'
+redfish_ctl nic-firmware --json_only      # NIC/DPU firmware for the 100GbE cards
+redfish_ctl network-adapters              # the physical NIC/DPU cards
+redfish_ctl firmware_inventory            # the full UpdateService firmware set
+```
+
+The web explorer is the same surface served over HTTP:
+`python -m redfish_ctl.webui --port 8299` reads `REDFISH_IP`/`REDFISH_USERNAME`/
+`REDFISH_PASSWORD` from the environment, exactly like the CLI.
+
+## Tear down
+
+```bash
+kubectl -n redfish-sandbox delete rfe --all           # stop polling BMCs
+kind delete cluster --name redfish-sandbox            # remove the cluster
+```

--- a/k8s/consumer/README.md
+++ b/k8s/consumer/README.md
@@ -1,0 +1,92 @@
+# Redfish Fleet Status Consumer
+
+A small, read-only web application that **consumes** the output of the
+RedfishEndpoint controller (`k8s/controller/redfish_endpoint_controller.py`).
+The controller polls each BMC read-only and writes a health/power/temperature
+summary onto the `RedfishEndpoint` custom resource's `.status`. This app reads
+that `.status` and presents the whole fleet as a dashboard, a JSON API, and
+Prometheus metrics.
+
+## Layering
+
+Data flows one direction only. The consumer never talks to a BMC and never
+reads a Secret.
+
+```
+   BMC ──(read-only poll: system/sensors/thermal/NIC firmware)──▶ controller
+                                                         │ writes .status
+                                                         ▼
+                                          RedfishEndpoint custom resource
+                                                         │ read .status (get/list/watch)
+                                                         ▼
+                                          redfish-fleet-consumer (this app)
+                                            /  ·  /api/nodes  ·  /metrics
+```
+
+Because the consumer only needs `get/list/watch` on `redfishendpoints`, its RBAC
+(`rbac.yaml`) grants exactly that — **no Secret access, no write verbs**. That is
+the security boundary that lets a status dashboard be exposed more widely than
+the credential-holding controller.
+
+## Endpoints
+
+| Path              | Returns                                                        |
+| ----------------- | ------------------------------------------------------------- |
+| `GET /`           | Live HTML dashboard (auto-refreshes every 10s)                |
+| `GET /api/nodes`  | JSON `{summary, nodes[]}` for the whole namespace             |
+| `GET /api/nodes/<name>` | JSON for one endpoint (404 if unknown)                  |
+| `GET /metrics`    | Prometheus text: power/health/temperature/NIC-firmware gauges |
+| `GET /healthz`    | Liveness/readiness probe                                       |
+
+An endpoint the controller has not polled yet reports `state: "Pending"` with
+null readings rather than an error.
+
+## NIC / DPU firmware
+
+The controller polls each BMC's `NetworkAdapters` and
+`UpdateService/FirmwareInventory` and folds the network-adapter firmware into
+`status.networkFirmware` (via the `redfish_ctl nic-firmware` command and the
+`get_network_firmware` facade). Every GB300 carries ConnectX-8 (CX8) NICs and a
+BlueField-3 DPU; the consumer surfaces their firmware versions so an operator can
+spot **firmware drift** across the fleet at a glance:
+
+* Dashboard: a **NIC Firmware** column (versions + card count; a node running more
+  than one distinct version is highlighted) and a **NIC FW Drift** summary card.
+* `GET /api/nodes`: `nicAdapterCount`, `nicCount`, `dpuCount`, `nicFirmwareCount`,
+  `nicFirmwareVersions`, and per-component `nicFirmware[]` (`id`, `deviceClass`,
+  `version`, `updateable`).
+* `GET /metrics`: `redfish_nic_firmware_info{node,nic_id,device_class,version}`,
+  `redfish_node_nic_count`, and `redfish_node_nic_firmware_distinct_versions`
+  (the drift gauge — alert when it exceeds 1).
+
+## Deploy
+
+The consumer deploys into the same `redfish-sandbox` namespace as the controller.
+Bring up the controller + a backend first (`make k8s-sandbox`), then:
+
+```bash
+./k8s/consumer/deploy.sh                 # build image, kind load, apply, wait
+# or the Makefile target:
+make k8s-consumer
+
+# reach the dashboard:
+kubectl --context kind-redfish-sandbox -n redfish-sandbox \
+  port-forward svc/redfish-fleet-consumer 8199:80
+open http://127.0.0.1:8199/
+```
+
+## Pointing the controller at a real BMC
+
+The dashboard shows any `RedfishEndpoint` in the namespace, mock or live. To add
+a real BMC, create a credential Secret and an endpoint — see
+`k8s/sandbox/redfish-endpoint-live-sample.yaml`. Live endpoints are labelled
+`backend: live` in the API and dashboard; in-cluster mocks are `backend: mock`.
+
+## Tests
+
+The pure rendering helpers (`normalize_endpoint`, `fleet_summary`,
+`render_fleet_json`, `render_metrics`, `render_html`) carry no Kubernetes
+dependency, so they are unit-tested offline in `tests/test_fleet_consumer.py`
+(`pytest -q tests/test_fleet_consumer.py`). The Kubernetes client is imported
+lazily inside `load_endpoints`, the same way the controller guards its `kopf`
+import.

--- a/k8s/consumer/deploy.sh
+++ b/k8s/consumer/deploy.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Build, load, and deploy the fleet-status consumer into the sandbox cluster.
+#
+# The consumer reads RedfishEndpoint .status (written by the controller) and
+# serves a dashboard, a JSON API, and Prometheus metrics. It never talks to a
+# BMC and has no Secret access.
+#
+# Usage:
+#   ./k8s/consumer/deploy.sh                 # build + kind load + apply + wait
+#   PORT_FORWARD=1 ./k8s/consumer/deploy.sh  # then port-forward to localhost:8199
+set -euo pipefail
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-redfish-sandbox}"
+NAMESPACE="${NAMESPACE:-redfish-sandbox}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${KIND_CLUSTER_NAME}}"
+IMAGE="${IMAGE:-redfish-ctl-consumer:local}"
+LOCAL_PORT="${LOCAL_PORT:-8199}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+require_tool() {
+	command -v "$1" >/dev/null 2>&1 || {
+		printf 'missing required tool: %s\n' "$1" >&2
+		exit 127
+	}
+}
+
+section() { printf '\n>> %s\n' "$1"; }
+
+kc() { kubectl --context "${KUBECTL_CONTEXT}" "$@"; }
+
+require_tool docker
+require_tool kind
+require_tool kubectl
+
+section "building ${IMAGE}"
+docker build -f docker/Dockerfile.consumer -t "${IMAGE}" .
+
+section "loading ${IMAGE} into kind cluster ${KIND_CLUSTER_NAME}"
+kind load docker-image "${IMAGE}" --name "${KIND_CLUSTER_NAME}"
+
+section "applying consumer RBAC, egress policy, and deployment"
+kc apply -f k8s/consumer/rbac.yaml
+# NetworkPolicy is a no-op under kind's kindnet CNI but is enforced on a
+# NetworkPolicy-capable cluster; apply it so intent travels with the manifests.
+kc apply -f k8s/consumer/networkpolicy.yaml
+kc apply -f k8s/consumer/deployment.yaml
+
+# On a reused cluster the :local tag is unchanged, so force a restart to pick up
+# a freshly built image.
+kc -n "${NAMESPACE}" rollout restart deploy/redfish-fleet-consumer >/dev/null 2>&1 || true
+
+section "waiting for consumer rollout"
+kc -n "${NAMESPACE}" rollout status deploy/redfish-fleet-consumer --timeout=120s
+
+printf '\nconsumer ready. Reach it with:\n'
+printf '  kubectl --context %s -n %s port-forward svc/redfish-fleet-consumer %s:80\n' \
+	"${KUBECTL_CONTEXT}" "${NAMESPACE}" "${LOCAL_PORT}"
+printf '  open http://127.0.0.1:%s/   (dashboard)  /api/nodes  /metrics\n' "${LOCAL_PORT}"
+
+if [ "${PORT_FORWARD:-0}" = "1" ]; then
+	section "port-forwarding svc/redfish-fleet-consumer -> localhost:${LOCAL_PORT}"
+	exec kc -n "${NAMESPACE}" port-forward svc/redfish-fleet-consumer "${LOCAL_PORT}:80" --address 127.0.0.1
+fi

--- a/k8s/consumer/deployment.yaml
+++ b/k8s/consumer/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redfish-fleet-consumer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-fleet-consumer
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redfish-fleet-consumer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redfish-fleet-consumer
+        app.kubernetes.io/component: redfish-sandbox
+    spec:
+      serviceAccountName: redfish-fleet-consumer
+      automountServiceAccountToken: true
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: consumer
+          image: redfish-ctl-consumer:local
+          imagePullPolicy: IfNotPresent
+          env:
+            # Namespace whose RedfishEndpoint status the dashboard reads.
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: BIND_PORT
+              value: "8080"
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redfish-fleet-consumer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-fleet-consumer
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redfish-fleet-consumer
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/k8s/consumer/fleet_status_app.py
+++ b/k8s/consumer/fleet_status_app.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""Fleet status consumer for RedfishEndpoint resources.
+
+This is a *consumer* application: it reads the ``.status`` the read-only
+RedfishEndpoint controller (``k8s/controller/redfish_endpoint_controller.py``)
+writes onto each ``RedfishEndpoint`` custom resource, and presents the fleet as
+a live dashboard, a JSON API, and Prometheus metrics.
+
+Layering (one direction only):
+
+    BMC  --(read-only poll)-->  controller  --writes .status-->  RedfishEndpoint CR
+                                                                        |
+                                                          (read .status only)
+                                                                        v
+                                                              this consumer app
+
+The consumer NEVER talks to a BMC and NEVER reads a Secret. Its Kubernetes RBAC
+is get/list/watch on ``redfishendpoints`` only, so a compromise here cannot
+reach a BMC credential or mutate anything.
+
+The pure rendering helpers (``normalize_endpoint``, ``fleet_summary``,
+``render_fleet_json``, ``render_metrics``, ``render_html``) carry no Kubernetes
+dependency so they are unit-testable offline; the Kubernetes client is imported
+lazily inside ``load_endpoints`` (guarded like the controller guards ``kopf``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlsplit
+
+REDFISH_GROUP = "redfish.ctl.dev"
+REDFISH_VERSION = "v1alpha1"
+REDFISH_PLURAL = "redfishendpoints"
+
+# Health ranking so the fleet summary can pick the worst state deterministically.
+_HEALTH_RANK = {"OK": 0, "Warning": 1, "Critical": 2}
+_POWER_ON_STATES = {"On", "PoweringOn"}
+
+
+def _as_number(value: Any) -> float | None:
+    """Coerce a Redfish reading to float, tolerating strings and rejecting bools."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_int(value: Any) -> int | None:
+    """Coerce a count to int with the same string-tolerant, bool-rejecting rules."""
+    number = _as_number(value)
+    return int(number) if number is not None else None
+
+
+def _epoch_from_rfc3339(value: str | None) -> float | None:
+    """Parse the controller's RFC3339 ``lastPolled`` into an epoch second."""
+    if not value:
+        return None
+    text = value.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _infer_backend(address: str) -> str:
+    """Label an endpoint as an in-cluster mock or a live BMC by its address.
+
+    A ``*.svc.cluster.local`` address is served by the sandbox mock-BMC; anything
+    else is treated as a real/live target. Purely cosmetic (dashboard badge).
+    """
+    host = urlsplit(address).netloc or address
+    if host.endswith(".svc.cluster.local") or host in {"mock-bmc", "ilo-sim"}:
+        return "mock"
+    return "live"
+
+
+def normalize_endpoint(obj: Mapping[str, Any]) -> dict[str, Any]:
+    """Flatten one RedfishEndpoint object into a stable consumer-facing row.
+
+    Tolerates a resource the controller has not polled yet: an absent or empty
+    ``status`` yields ``state="Pending"`` with null readings rather than raising.
+    """
+    meta = obj.get("metadata") or {}
+    spec = obj.get("spec") or {}
+    status = obj.get("status") or {}
+    temperature = status.get("temperature") or {}
+    network_firmware = status.get("networkFirmware") or {}
+
+    address = str(spec.get("address") or "")
+    power_state = status.get("powerState")
+    health = status.get("health")
+    last_polled = status.get("lastPolled")
+
+    if not status or (power_state is None and health is None and not last_polled):
+        state = "Pending"
+    else:
+        state = "Ready"
+
+    nic_components = [
+        {
+            "id": comp.get("id"),
+            "deviceClass": comp.get("deviceClass"),
+            "version": comp.get("version"),
+            "updateable": comp.get("updateable"),
+        }
+        for comp in (network_firmware.get("components") or [])
+        if isinstance(comp, Mapping)
+    ]
+    nic_versions = [
+        str(v) for v in (network_firmware.get("distinctVersions") or []) if v is not None
+    ]
+
+    return {
+        "name": str(meta.get("name") or ""),
+        "namespace": str(meta.get("namespace") or ""),
+        "address": address,
+        "port": spec.get("port"),
+        "insecure": bool(spec.get("insecure", True)),
+        "backend": _infer_backend(address),
+        "state": state,
+        "powerState": power_state,
+        "health": health,
+        "temperatureCount": _as_int(temperature.get("count")),
+        "temperatureMaxCelsius": _as_number(temperature.get("maxCelsius")),
+        "nicAdapterCount": _as_int(network_firmware.get("adapterCount")),
+        "nicCount": _as_int(network_firmware.get("nicCount")),
+        "dpuCount": _as_int(network_firmware.get("dpuCount")),
+        "nicFirmwareCount": _as_int(network_firmware.get("firmwareCount")),
+        "nicFirmwareUpdateableCount": _as_int(network_firmware.get("updateableCount")),
+        "nicFirmwareVersions": nic_versions,
+        "nicFirmware": nic_components,
+        "lastPolled": last_polled,
+    }
+
+
+def fleet_summary(nodes: Sequence[Mapping[str, Any]]) -> dict[str, int]:
+    """Aggregate per-node rows into fleet counters for the dashboard header."""
+    summary = {
+        "total": len(nodes),
+        "ready": 0,
+        "pending": 0,
+        "poweredOn": 0,
+        "poweredOff": 0,
+        "healthy": 0,
+        "warning": 0,
+        "critical": 0,
+    }
+    for node in nodes:
+        if node.get("state") == "Ready":
+            summary["ready"] += 1
+        else:
+            summary["pending"] += 1
+        power = node.get("powerState")
+        if power in _POWER_ON_STATES:
+            summary["poweredOn"] += 1
+        elif power is not None:
+            summary["poweredOff"] += 1
+        health = node.get("health")
+        if health == "OK":
+            summary["healthy"] += 1
+        elif health == "Warning":
+            summary["warning"] += 1
+        elif health == "Critical":
+            summary["critical"] += 1
+    return summary
+
+
+def fleet_firmware_drift(nodes: Sequence[Mapping[str, Any]]) -> dict[str, list[str]]:
+    """Map firmware component id -> sorted versions when nodes DISAGREE on it.
+
+    Drift is a cross-node property: a single node legitimately runs different
+    versions for different components (e.g. a ConnectX NIC at 40.x and its
+    BlueField DPU at 32.x), which is NOT drift. Real drift is the same component
+    id (``CX8_0``) carrying different versions across the fleet. An empty result
+    means every node runs the same firmware per component.
+    """
+    by_component: dict[str, set[str]] = {}
+    for node in nodes:
+        for comp in node.get("nicFirmware") or []:
+            if not isinstance(comp, Mapping):
+                continue
+            cid, ver = comp.get("id"), comp.get("version")
+            if cid is None or ver is None:
+                continue
+            by_component.setdefault(str(cid), set()).add(str(ver))
+    return {cid: sorted(vers) for cid, vers in by_component.items() if len(vers) > 1}
+
+
+def render_fleet_json(nodes: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Assemble the ``/api/nodes`` payload: summary + normalized node rows."""
+    node_list = list(nodes)
+    summary = fleet_summary(node_list)
+    summary["firmwareDriftComponents"] = fleet_firmware_drift(node_list)
+    return {
+        "summary": summary,
+        "nodes": node_list,
+    }
+
+
+def find_node(
+    nodes: Sequence[Mapping[str, Any]], name: str
+) -> Mapping[str, Any] | None:
+    """Return the node row with matching name, or None (backs /api/nodes/<name>)."""
+    return next((node for node in nodes if node.get("name") == name), None)
+
+
+def _escape_label(value: Any) -> str:
+    """Escape a Prometheus label value per the text exposition spec.
+
+    Backslash, double-quote, and line-feed/carriage-return must be escaped, or a
+    value containing one (e.g. a newline in an operator-supplied address) would
+    split or corrupt the metric line and fail the whole scrape.
+    """
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+
+
+def _metric_line(name: str, labels: Mapping[str, str], value: float | int) -> str:
+    label_str = ",".join(f'{key}="{_escape_label(val)}"' for key, val in labels.items())
+    return f"{name}{{{label_str}}} {value}"
+
+
+def render_metrics(nodes: Sequence[Mapping[str, Any]]) -> str:
+    """Render the fleet as Prometheus text exposition.
+
+    Exposes per-node gauges keyed by ``node`` so an operator can alert on power
+    loss, health degradation, or a temperature ceiling straight off the CR
+    status the controller populated — no direct BMC scrape needed.
+    """
+    lines: list[str] = []
+    lines.append("# HELP redfish_endpoint_info Static endpoint metadata (value always 1).")
+    lines.append("# TYPE redfish_endpoint_info gauge")
+    lines.append("# HELP redfish_endpoint_power_on 1 when the BMC reports a powered-on state.")
+    lines.append("# TYPE redfish_endpoint_power_on gauge")
+    lines.append("# HELP redfish_endpoint_health Health rank: 0 OK, 1 Warning, 2 Critical, -1 unknown.")
+    lines.append("# TYPE redfish_endpoint_health gauge")
+    lines.append("# HELP redfish_endpoint_temperature_max_celsius Hottest reported sensor in Celsius.")
+    lines.append("# TYPE redfish_endpoint_temperature_max_celsius gauge")
+    lines.append("# HELP redfish_endpoint_temperature_sensor_count Number of temperature sensors read.")
+    lines.append("# TYPE redfish_endpoint_temperature_sensor_count gauge")
+    lines.append("# HELP redfish_endpoint_last_polled_timestamp_seconds Unix time of the last controller poll.")
+    lines.append("# TYPE redfish_endpoint_last_polled_timestamp_seconds gauge")
+    lines.append("# HELP redfish_nic_firmware_info One NIC/DPU firmware component (value always 1).")
+    lines.append("# TYPE redfish_nic_firmware_info gauge")
+    lines.append("# HELP redfish_node_nic_count Number of NIC/DPU adapters on the node.")
+    lines.append("# TYPE redfish_node_nic_count gauge")
+    lines.append("# HELP redfish_node_nic_firmware_distinct_versions Distinct firmware versions on the node (a NIC + its DPU differ normally; this is not drift).")
+    lines.append("# TYPE redfish_node_nic_firmware_distinct_versions gauge")
+    lines.append("# HELP redfish_fleet_nic_firmware_drift_components Firmware components whose version differs ACROSS nodes (real fleet drift; 0 is healthy).")
+    lines.append("# TYPE redfish_fleet_nic_firmware_drift_components gauge")
+
+    drift = fleet_firmware_drift(nodes)
+    lines.append(_metric_line("redfish_fleet_nic_firmware_drift_components", {}, len(drift)))
+
+    for node in nodes:
+        name = str(node.get("name") or "")
+        info_labels = {
+            "node": name,
+            "address": str(node.get("address") or ""),
+            "backend": str(node.get("backend") or ""),
+            "power_state": str(node.get("powerState") or "unknown"),
+            "health": str(node.get("health") or "unknown"),
+            "state": str(node.get("state") or ""),
+        }
+        lines.append(_metric_line("redfish_endpoint_info", info_labels, 1))
+
+        power = node.get("powerState")
+        lines.append(
+            _metric_line(
+                "redfish_endpoint_power_on", {"node": name}, 1 if power in _POWER_ON_STATES else 0
+            )
+        )
+
+        health_rank = _HEALTH_RANK.get(str(node.get("health")), -1)
+        lines.append(_metric_line("redfish_endpoint_health", {"node": name}, health_rank))
+
+        temp_max = node.get("temperatureMaxCelsius")
+        if temp_max is not None:
+            lines.append(
+                _metric_line("redfish_endpoint_temperature_max_celsius", {"node": name}, temp_max)
+            )
+
+        count = node.get("temperatureCount")
+        if isinstance(count, int):
+            lines.append(
+                _metric_line("redfish_endpoint_temperature_sensor_count", {"node": name}, count)
+            )
+
+        polled = _epoch_from_rfc3339(node.get("lastPolled"))
+        if polled is not None:
+            lines.append(
+                _metric_line(
+                    "redfish_endpoint_last_polled_timestamp_seconds", {"node": name}, int(polled)
+                )
+            )
+
+        nic_count = node.get("nicAdapterCount")
+        if isinstance(nic_count, int):
+            lines.append(_metric_line("redfish_node_nic_count", {"node": name}, nic_count))
+
+        versions = node.get("nicFirmwareVersions") or []
+        lines.append(
+            _metric_line(
+                "redfish_node_nic_firmware_distinct_versions", {"node": name}, len(versions)
+            )
+        )
+
+        for comp in node.get("nicFirmware") or []:
+            if not isinstance(comp, Mapping):
+                continue
+            fw_labels = {
+                "node": name,
+                "nic_id": str(comp.get("id") or ""),
+                "device_class": str(comp.get("deviceClass") or ""),
+                "version": str(comp.get("version") or "unknown"),
+            }
+            lines.append(_metric_line("redfish_nic_firmware_info", fw_labels, 1))
+
+    return "\n".join(lines) + "\n"
+
+
+def _esc(value: Any) -> str:
+    """Minimal HTML-escape for text interpolated into the dashboard."""
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def _nic_firmware_cell(node: Mapping[str, Any], drift_ids: set[str]) -> str:
+    """Render the NIC-firmware table cell: version(s) + adapter count.
+
+    ``drift_ids`` are firmware component ids that disagree across the fleet; the
+    cell is drift-flagged only if this node carries such a component — so a lone
+    node with a NIC and a DPU (two versions, but no cross-node disagreement) is
+    not falsely flagged.
+    """
+    versions = node.get("nicFirmwareVersions") or []
+    adapters = node.get("nicAdapterCount")
+    if not versions:
+        return '<td class="nicfw">—</td>'
+    ver_txt = ", ".join(_esc(v) for v in versions)
+    cards = f' · {adapters} card{"s" if adapters != 1 else ""}' if isinstance(adapters, int) else ""
+    node_drifts = any(
+        isinstance(c, Mapping) and str(c.get("id")) in drift_ids
+        for c in (node.get("nicFirmware") or [])
+    )
+    drift = " drift" if node_drifts else ""
+    return f'<td class="nicfw"><span class="fw{drift}">{ver_txt}</span>{cards}</td>'
+
+
+def render_html(nodes: Sequence[Mapping[str, Any]], generated_at: str | None = None) -> str:
+    """Render the live fleet dashboard.
+
+    Server-rendered so it works with zero external assets (CSP-safe, offline); a
+    tiny inline poller refetches ``/api/nodes`` to keep the tab title current, and
+    a 10s interval reloads the page so the table tracks the controller's polls.
+    """
+    summary = fleet_summary(nodes)
+    drift_map = fleet_firmware_drift(nodes)
+    drift_ids = set(drift_map)
+    drift_components = len(drift_map)
+    stamp = generated_at or datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
+
+    rows = []
+    for node in nodes:
+        health = node.get("health") or "—"
+        power_state = node.get("powerState")
+        power = power_state or "—"
+        health_cls = {
+            "OK": "ok",
+            "Warning": "warn",
+            "Critical": "crit",
+        }.get(str(node.get("health")), "unknown")
+        if power_state in _POWER_ON_STATES:
+            power_cls = "on"
+        elif power_state is None:
+            power_cls = "unknown"
+        else:
+            power_cls = "off"
+        temp = node.get("temperatureMaxCelsius")
+        temp_txt = f"{temp:.1f} °C" if isinstance(temp, (int, float)) else "—"
+        count = node.get("temperatureCount")
+        count_txt = str(count) if isinstance(count, int) else "—"
+        backend = node.get("backend") or ""
+        rows.append(
+            "<tr>"
+            f'<td class="name">{_esc(node.get("name"))}</td>'
+            f'<td><span class="badge {"" if backend == "live" else "mock"}">{_esc(backend)}</span></td>'
+            f'<td class="addr">{_esc(node.get("address"))}</td>'
+            f'<td><span class="pill {power_cls}">{_esc(power)}</span></td>'
+            f'<td><span class="pill {health_cls}">{_esc(health)}</span></td>'
+            f"<td>{_esc(temp_txt)}</td>"
+            f"<td>{_esc(count_txt)}</td>"
+            f"{_nic_firmware_cell(node, drift_ids)}"
+            f'<td class="stamp">{_esc(node.get("lastPolled") or "—")}</td>'
+            f'<td><span class="state {_esc(str(node.get("state")).lower())}">{_esc(node.get("state"))}</span></td>'
+            "</tr>"
+        )
+    rows_html = "\n".join(rows) or (
+        '<tr><td colspan="10" class="empty">No RedfishEndpoint resources found in this namespace.</td></tr>'
+    )
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Redfish Fleet Status</title>
+<style>
+  :root {{ color-scheme: light dark; }}
+  * {{ box-sizing: border-box; }}
+  body {{ font-family: -apple-system, Segoe UI, Roboto, sans-serif; margin: 0;
+    background: #0f1115; color: #e6e6e6; }}
+  header {{ padding: 20px 28px; border-bottom: 1px solid #262a33;
+    display: flex; align-items: baseline; gap: 16px; flex-wrap: wrap; }}
+  h1 {{ font-size: 18px; margin: 0; font-weight: 600; }}
+  .sub {{ color: #8b93a7; font-size: 13px; }}
+  .cards {{ display: flex; gap: 12px; padding: 18px 28px; flex-wrap: wrap; }}
+  .card {{ background: #171a21; border: 1px solid #262a33; border-radius: 10px;
+    padding: 12px 16px; min-width: 96px; }}
+  .card .n {{ font-size: 24px; font-weight: 700; }}
+  .card .l {{ font-size: 11px; text-transform: uppercase; letter-spacing: .06em;
+    color: #8b93a7; }}
+  table {{ width: calc(100% - 56px); margin: 8px 28px 32px; border-collapse: collapse;
+    background: #171a21; border: 1px solid #262a33; border-radius: 10px; overflow: hidden; }}
+  th, td {{ text-align: left; padding: 10px 14px; font-size: 13px;
+    border-bottom: 1px solid #21252e; }}
+  th {{ color: #8b93a7; font-weight: 600; text-transform: uppercase; font-size: 11px;
+    letter-spacing: .05em; }}
+  td.name {{ font-weight: 600; }}
+  td.addr, td.stamp {{ color: #8b93a7; font-family: ui-monospace, monospace; font-size: 12px; }}
+  .pill {{ padding: 2px 9px; border-radius: 999px; font-size: 12px; font-weight: 600; }}
+  .pill.on {{ background: #12351f; color: #4ade80; }}
+  .pill.off {{ background: #3a1f24; color: #f87171; }}
+  .pill.ok {{ background: #12351f; color: #4ade80; }}
+  .pill.warn {{ background: #3a2f12; color: #fbbf24; }}
+  .pill.crit {{ background: #3a1f24; color: #f87171; }}
+  .pill.unknown {{ background: #262a33; color: #8b93a7; }}
+  .badge {{ padding: 2px 8px; border-radius: 6px; font-size: 11px; font-weight: 600;
+    background: #1c2b3a; color: #60a5fa; text-transform: uppercase; }}
+  .badge.mock {{ background: #2b2436; color: #c084fc; }}
+  .state.ready {{ color: #4ade80; }}
+  .state.pending {{ color: #fbbf24; }}
+  td.nicfw {{ color: #8b93a7; font-size: 12px; }}
+  td.nicfw .fw {{ font-family: ui-monospace, monospace; color: #c9d1d9; }}
+  td.nicfw .fw.drift {{ color: #fbbf24; font-weight: 600; }}
+  .card.alert .n {{ color: #fbbf24; }}
+  td.empty {{ text-align: center; color: #8b93a7; padding: 28px; }}
+  a {{ color: #60a5fa; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>Redfish Fleet Status</h1>
+  <span class="sub">consumer reads <code>RedfishEndpoint.status</code> written by the controller
+    &middot; <a href="/api/nodes">/api/nodes</a> &middot; <a href="/metrics">/metrics</a>
+    &middot; updated <span id="stamp">{_esc(stamp)}</span></span>
+</header>
+<div class="cards">
+  <div class="card"><div class="n">{summary["total"]}</div><div class="l">Endpoints</div></div>
+  <div class="card"><div class="n">{summary["poweredOn"]}</div><div class="l">Powered On</div></div>
+  <div class="card"><div class="n">{summary["healthy"]}</div><div class="l">Healthy</div></div>
+  <div class="card"><div class="n">{summary["warning"] + summary["critical"]}</div><div class="l">Degraded</div></div>
+  <div class="card"><div class="n">{summary["pending"]}</div><div class="l">Pending</div></div>
+  <div class="card{" alert" if drift_components else ""}" title="Firmware components whose version differs across the fleet"><div class="n">{drift_components}</div><div class="l">NIC FW Drift</div></div>
+</div>
+<table>
+  <thead><tr>
+    <th>Node</th><th>Backend</th><th>Address</th><th>Power</th><th>Health</th>
+    <th>Max Temp</th><th>Sensors</th><th>NIC Firmware</th><th>Last Polled</th><th>State</th>
+  </tr></thead>
+  <tbody id="rows">
+{rows_html}
+  </tbody>
+</table>
+<script>
+  // Track the controller's next poll without a full reload.
+  async function refresh() {{
+    try {{
+      const r = await fetch('/api/nodes', {{cache: 'no-store'}});
+      if (!r.ok) return;
+      const data = await r.json();
+      document.title = `Redfish Fleet (${{data.summary.total}})`;
+    }} catch (e) {{ /* transient; keep the last render */ }}
+  }}
+  setInterval(() => location.reload(), 10000);
+  refresh();
+</script>
+</body>
+</html>
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Kubernetes-facing layer (lazy import; not exercised by offline unit tests).
+# --------------------------------------------------------------------------- #
+
+
+class _EndpointCache:
+    """Short-TTL cache over the k8s API so many dashboard clients don't fan out
+    into an API-server request per hit (the avoid-round-trips principle applied
+    to the control plane)."""
+
+    def __init__(self, ttl_seconds: float = 3.0) -> None:
+        self._ttl = ttl_seconds
+        self._lock = threading.Lock()
+        self._at = 0.0
+        self._value: list[dict[str, Any]] = []
+
+    def get(self, loader) -> list[dict[str, Any]]:
+        now = time.monotonic()
+        with self._lock:
+            if now - self._at <= self._ttl and self._at:
+                return self._value
+        fresh = loader()
+        with self._lock:
+            self._value = fresh
+            self._at = time.monotonic()
+        return fresh
+
+
+def load_endpoints(namespace: str) -> list[dict[str, Any]]:  # pragma: no cover - needs cluster
+    """List RedfishEndpoint CRs in ``namespace`` and normalize them.
+
+    Imports the Kubernetes client lazily so the pure renderers above stay
+    importable (and unit-testable) without the ``kubernetes`` package.
+    """
+    from kubernetes import client, config
+
+    try:
+        config.load_incluster_config()
+    except Exception:
+        config.load_kube_config()
+
+    api = client.CustomObjectsApi()
+    resp = api.list_namespaced_custom_object(
+        group=REDFISH_GROUP,
+        version=REDFISH_VERSION,
+        namespace=namespace,
+        plural=REDFISH_PLURAL,
+    )
+    items = resp.get("items", []) if isinstance(resp, Mapping) else []
+    nodes = [normalize_endpoint(item) for item in items]
+    nodes.sort(key=lambda n: n["name"])
+    return nodes
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "redfish-fleet-consumer/1.0"
+    namespace = "redfish-sandbox"
+    cache: _EndpointCache = _EndpointCache()
+
+    def log_message(self, *_args: Any) -> None:  # keep stdout to real events
+        return
+
+    def _send(self, code: int, body: bytes, content_type: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def _nodes(self) -> list[dict[str, Any]]:
+        return self.cache.get(lambda: load_endpoints(self.namespace))
+
+    def do_GET(self) -> None:  # noqa: N802 (stdlib naming)
+        path = urlsplit(self.path).path.rstrip("/") or "/"
+        try:
+            if path == "/healthz":
+                self._send(200, b'{"status":"ok"}', "application/json")
+                return
+            if path == "/":
+                body = render_html(self._nodes()).encode("utf-8")
+                self._send(200, body, "text/html; charset=utf-8")
+                return
+            if path == "/api/nodes":
+                body = json.dumps(render_fleet_json(self._nodes())).encode("utf-8")
+                self._send(200, body, "application/json")
+                return
+            if path.startswith("/api/nodes/"):
+                wanted = path[len("/api/nodes/") :]
+                match = find_node(self._nodes(), wanted)
+                if match is None:
+                    self._send(404, b'{"error":"not found"}', "application/json")
+                    return
+                self._send(200, json.dumps(match).encode("utf-8"), "application/json")
+                return
+            if path == "/metrics":
+                body = render_metrics(self._nodes()).encode("utf-8")
+                self._send(200, body, "text/plain; version=0.0.4; charset=utf-8")
+                return
+            self._send(404, b'{"error":"not found"}', "application/json")
+        except Exception as exc:  # surface a 503 rather than a bare stack trace
+            msg = json.dumps({"error": "backend unavailable", "detail": str(exc)}).encode("utf-8")
+            self._send(503, msg, "application/json")
+
+    do_HEAD = do_GET
+
+
+def run_server(
+    host: str = "0.0.0.0",
+    port: int = 8080,
+    namespace: str | None = None,
+) -> None:  # pragma: no cover - process entry point
+    """Serve the dashboard/API/metrics with a thread-per-request server."""
+    _Handler.namespace = namespace or os.environ.get("WATCH_NAMESPACE", "redfish-sandbox")
+    server = ThreadingHTTPServer((host, port), _Handler)
+    print(
+        f"redfish-fleet-consumer serving on {host}:{port} "
+        f"(namespace={_Handler.namespace})",
+        flush=True,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run_server(
+        host=os.environ.get("BIND_HOST", "0.0.0.0"),
+        port=int(os.environ.get("BIND_PORT", "8080")),
+        namespace=os.environ.get("WATCH_NAMESPACE"),
+    )

--- a/k8s/consumer/fleet_status_app.py
+++ b/k8s/consumer/fleet_status_app.py
@@ -528,19 +528,42 @@ class _EndpointCache:
 
     def __init__(self, ttl_seconds: float = 3.0) -> None:
         self._ttl = ttl_seconds
-        self._lock = threading.Lock()
+        self._cond = threading.Condition()
         self._at = 0.0
         self._value: list[dict[str, Any]] = []
+        self._loading = False
+
+    def _is_fresh(self) -> bool:
+        # Callers hold ``self._cond``. ``_at == 0`` means never loaded.
+        return bool(self._at) and (time.monotonic() - self._at) <= self._ttl
 
     def get(self, loader) -> list[dict[str, Any]]:
-        now = time.monotonic()
-        with self._lock:
-            if now - self._at <= self._ttl and self._at:
+        with self._cond:
+            if self._is_fresh():
                 return self._value
-        fresh = loader()
-        with self._lock:
+            # Single-flight: the first caller past a stale TTL performs the load;
+            # concurrent callers wait on the condition and reuse its result, so a
+            # burst of dashboard clients triggers at most one k8s API refill per
+            # TTL instead of a thundering herd of parallel list calls.
+            while self._loading:
+                self._cond.wait()
+                if self._is_fresh():
+                    return self._value
+            self._loading = True
+        try:
+            fresh = loader()
+        except BaseException:
+            # Release the in-flight flag so a failed load doesn't wedge the cache;
+            # the next waiter retries.
+            with self._cond:
+                self._loading = False
+                self._cond.notify_all()
+            raise
+        with self._cond:
             self._value = fresh
             self._at = time.monotonic()
+            self._loading = False
+            self._cond.notify_all()
         return fresh
 
 
@@ -624,6 +647,19 @@ class _Handler(BaseHTTPRequestHandler):
     do_HEAD = do_GET
 
 
+class FleetServer(ThreadingHTTPServer):
+    """Threaded consumer server with a generous socket listen backlog.
+
+    The stdlib default (``request_queue_size = 5``) drops connections at the OS
+    accept queue when a crowd of dashboard clients connects at once. 128 lets the
+    burst queue instead of being reset (the short-TTL cache then serves them all
+    from one load).
+    """
+
+    request_queue_size = 128
+    daemon_threads = True
+
+
 def run_server(
     host: str = "0.0.0.0",
     port: int = 8080,
@@ -631,7 +667,7 @@ def run_server(
 ) -> None:  # pragma: no cover - process entry point
     """Serve the dashboard/API/metrics with a thread-per-request server."""
     _Handler.namespace = namespace or os.environ.get("WATCH_NAMESPACE", "redfish-sandbox")
-    server = ThreadingHTTPServer((host, port), _Handler)
+    server = FleetServer((host, port), _Handler)
     print(
         f"redfish-fleet-consumer serving on {host}:{port} "
         f"(namespace={_Handler.namespace})",

--- a/k8s/consumer/networkpolicy.yaml
+++ b/k8s/consumer/networkpolicy.yaml
@@ -1,0 +1,48 @@
+# Defense-in-depth egress restriction for the fleet-status consumer.
+#
+# The consumer only needs to reach the Kubernetes API server (to read
+# RedfishEndpoint status) and DNS. It must never open a connection to a BMC.
+# RBAC already denies it Secret/BMC-credential access; this NetworkPolicy records
+# that boundary. On real clusters, set `to:` below to the API-server endpoint/CIDR
+# to make the egress block hard for BMC addresses.
+#
+# NOTE: enforcement requires a NetworkPolicy-capable CNI (Calico, Cilium, ...).
+# kind's default kindnet does NOT enforce NetworkPolicy, so in the local sandbox
+# this manifest documents intent; on a real cluster it is enforced.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redfish-fleet-consumer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-fleet-consumer
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redfish-fleet-consumer
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Allow dashboard/API/metrics traffic to the HTTP port from anywhere in-cluster.
+    - ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    # DNS resolution.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Kubernetes API server (default HTTPS). The apiserver endpoint IP varies by
+    # cluster, so this local sandbox manifest allows 443/6443 egress rather than
+    # pinning a CIDR; on a real cluster tighten `to:` to the apiserver endpoint/CIDR.
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 6443

--- a/k8s/consumer/rbac.yaml
+++ b/k8s/consumer/rbac.yaml
@@ -1,0 +1,50 @@
+# RBAC for the fleet-status consumer.
+#
+# Deliberately minimal: the consumer only READS RedfishEndpoint objects (and
+# their status subresource). It has NO access to Secrets and NO write verbs, so
+# it cannot reach a BMC credential or mutate any resource. This is the security
+# boundary that lets a dashboard be exposed more widely than the controller.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redfish-fleet-consumer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-fleet-consumer
+    app.kubernetes.io/component: redfish-sandbox
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: redfish-fleet-consumer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-fleet-consumer
+    app.kubernetes.io/component: redfish-sandbox
+rules:
+  - apiGroups:
+      - redfish.ctl.dev
+    resources:
+      - redfishendpoints
+      - redfishendpoints/status
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: redfish-fleet-consumer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-fleet-consumer
+    app.kubernetes.io/component: redfish-sandbox
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: redfish-fleet-consumer
+subjects:
+  - kind: ServiceAccount
+    name: redfish-fleet-consumer
+    namespace: redfish-sandbox

--- a/k8s/controller/redfish-endpoint-crd.yaml
+++ b/k8s/controller/redfish-endpoint-crd.yaml
@@ -25,6 +25,9 @@ spec:
         - name: HEALTH
           type: string
           jsonPath: .status.health
+        - name: NIC-FW
+          type: integer
+          jsonPath: .status.networkFirmware.firmwareCount
         - name: POLLED
           type: date
           jsonPath: .status.lastPolled
@@ -97,6 +100,48 @@ spec:
                     maxCelsius:
                       type: number
                       nullable: true
+                networkFirmware:
+                  type: object
+                  description: >-
+                    NIC/DPU network-adapter firmware inventory, populated from
+                    the BMC's NetworkAdapters and UpdateService/FirmwareInventory.
+                  properties:
+                    adapterCount:
+                      type: integer
+                      minimum: 0
+                    nicCount:
+                      type: integer
+                      minimum: 0
+                    dpuCount:
+                      type: integer
+                      minimum: 0
+                    firmwareCount:
+                      type: integer
+                      minimum: 0
+                    updateableCount:
+                      type: integer
+                      minimum: 0
+                    distinctVersions:
+                      type: array
+                      items:
+                        type: string
+                    components:
+                      type: array
+                      items:
+                        type: object
+                        properties:
+                          id:
+                            type: string
+                            nullable: true
+                          deviceClass:
+                            type: string
+                            nullable: true
+                          version:
+                            type: string
+                            nullable: true
+                          updateable:
+                            type: boolean
+                            nullable: true
                 lastPolled:
                   type: string
                   format: date-time

--- a/k8s/controller/redfish_endpoint_controller.py
+++ b/k8s/controller/redfish_endpoint_controller.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import logging
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, MutableMapping
 from urllib.parse import urlsplit
@@ -14,14 +15,22 @@ except ImportError:  # pragma: no cover - unit tests call the handler directly.
     kopf = None
 
 from redfish_ctl.api import (
+    NetworkFirmwareStatus,
     SensorReading,
     SystemStatus,
     ThermalStatus,
+    get_network_firmware,
     get_sensors,
     get_system,
     get_thermal,
 )
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
+
+_LOGGER = logging.getLogger(__name__)
+
+# Cap the number of firmware components written to status to keep the CR small;
+# a NIC/DPU set is a handful, but guard against a pathological host.
+_MAX_FIRMWARE_COMPONENTS = 64
 
 REDFISH_GROUP = "redfish.ctl.dev"
 REDFISH_VERSION = "v1alpha1"
@@ -80,20 +89,54 @@ def _health_from_sensors(sensors: tuple[SensorReading, ...]) -> str | None:
     return max(health_values, key=lambda value: rank.get(value, -1))
 
 
+def _network_firmware_summary(
+    network_firmware: NetworkFirmwareStatus,
+) -> dict[str, Any]:
+    """Shape a NetworkFirmwareStatus into the CR status.networkFirmware block.
+
+    ``distinctVersions`` is the fleet drift signal: one version across the fleet
+    means every node's NICs run the same firmware; more than one flags drift.
+    """
+    summary = network_firmware.summary
+    components = [
+        {
+            "id": fw.id,
+            "deviceClass": fw.device_class,
+            "version": fw.version,
+            "updateable": bool(fw.updateable) if fw.updateable is not None else None,
+        }
+        for fw in network_firmware.firmware[:_MAX_FIRMWARE_COMPONENTS]
+    ]
+    distinct = [str(v) for v in summary.get("distinct_versions", []) if v is not None]
+    return {
+        "adapterCount": int(summary.get("adapter_count", 0) or 0),
+        "nicCount": int(summary.get("nic_count", 0) or 0),
+        "dpuCount": int(summary.get("dpu_count", 0) or 0),
+        "firmwareCount": int(summary.get("firmware_count", 0) or 0),
+        "updateableCount": int(summary.get("updateable_count", 0) or 0),
+        "distinctVersions": distinct,
+        "components": components,
+    }
+
+
 def build_status(
     system: SystemStatus,
     sensors: tuple[SensorReading, ...],
     thermal: ThermalStatus,
     *,
+    network_firmware: NetworkFirmwareStatus | None = None,
     polled_at: datetime | None = None,
 ) -> dict[str, Any]:
     """Return the RedfishEndpoint status object from typed read results."""
-    return {
+    status: dict[str, Any] = {
         "powerState": system.power_state,
         "health": system.health or _health_from_sensors(sensors),
         "temperature": _temperature_summary(thermal),
         "lastPolled": _rfc3339(polled_at or _utc_now()),
     }
+    if network_firmware is not None:
+        status["networkFirmware"] = _network_firmware_summary(network_firmware)
+    return status
 
 
 def _manager_address(spec: Mapping[str, Any]) -> tuple[str, bool]:
@@ -127,6 +170,22 @@ def _make_manager(
     )
 
 
+def _safe_network_firmware(manager: Any) -> NetworkFirmwareStatus | None:
+    """Read NIC/DPU firmware, tolerating a BMC that exposes no network firmware.
+
+    A host without NetworkAdapters or FirmwareInventory (or one that errors on
+    that walk) must not fail the whole poll — power/health/thermal still land.
+    The failure is logged (not silent) so a persistent NIC-firmware read problem
+    is diagnosable; on failure the prior status.networkFirmware is left in place
+    by the merge patch rather than being cleared.
+    """
+    try:
+        return get_network_firmware(manager)
+    except Exception as exc:  # noqa: BLE001 - degrade gracefully, but leave a trace
+        _LOGGER.warning("network-firmware read failed, leaving prior value: %s", exc)
+        return None
+
+
 def poll_endpoint(
     spec: Mapping[str, Any],
     *,
@@ -139,7 +198,14 @@ def poll_endpoint(
     system = get_system(manager)
     sensors = get_sensors(manager)
     thermal = get_thermal(manager)
-    return build_status(system, sensors, thermal, polled_at=polled_at)
+    network_firmware = _safe_network_firmware(manager)
+    return build_status(
+        system,
+        sensors,
+        thermal,
+        network_firmware=network_firmware,
+        polled_at=polled_at,
+    )
 
 
 def _decode_secret_value(data: Mapping[str, str], key: str) -> str | None:

--- a/k8s/explorer/deploy.sh
+++ b/k8s/explorer/deploy.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Build, load, and deploy the redfish_ctl web explorer into the sandbox cluster,
+# pointed at one BMC. Every command selected in the UI is invoked live through
+# the tool's own registry — no scripts, no ad-hoc HTTP.
+#
+# Usage:
+#   REDFISH_IP=172.0.2.10 SECRET=bmc-credentials ./k8s/explorer/deploy.sh
+#   PORT_FORWARD=1 ... ./k8s/explorer/deploy.sh    # then browse localhost:8299
+set -euo pipefail
+
+KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-redfish-sandbox}"
+NAMESPACE="${NAMESPACE:-redfish-sandbox}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${KIND_CLUSTER_NAME}}"
+IMAGE="${IMAGE:-redfish-ctl-explorer:local}"
+LOCAL_PORT="${LOCAL_PORT:-8299}"
+# Target BMC: address + Secret (username/password keys) in the namespace.
+REDFISH_IP="${REDFISH_IP:-mock-bmc.redfish-sandbox.svc.cluster.local}"
+REDFISH_PORT="${REDFISH_PORT:-80}"
+REDFISH_SCHEME="${REDFISH_SCHEME:-http}"
+SECRET="${SECRET:-mock-bmc-credentials}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+require_tool() { command -v "$1" >/dev/null 2>&1 || { printf 'missing tool: %s\n' "$1" >&2; exit 127; }; }
+section() { printf '\n>> %s\n' "$1"; }
+kc() { kubectl --context "${KUBECTL_CONTEXT}" "$@"; }
+
+require_tool docker
+require_tool kind
+require_tool kubectl
+
+section "building ${IMAGE}"
+docker build -f docker/Dockerfile.explorer -t "${IMAGE}" .
+
+section "loading ${IMAGE} into kind cluster ${KIND_CLUSTER_NAME}"
+kind load docker-image "${IMAGE}" --name "${KIND_CLUSTER_NAME}"
+
+section "applying explorer deployment (target ${REDFISH_SCHEME}://${REDFISH_IP}:${REDFISH_PORT}, secret ${SECRET})"
+kc apply -f k8s/explorer/deployment.yaml
+kc -n "${NAMESPACE}" set env deploy/redfish-ctl-explorer \
+	REDFISH_IP="${REDFISH_IP}" REDFISH_PORT="${REDFISH_PORT}" REDFISH_SCHEME="${REDFISH_SCHEME}"
+kc -n "${NAMESPACE}" patch deploy/redfish-ctl-explorer --type=json -p "[
+  {\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/env/3/valueFrom/secretKeyRef/name\",\"value\":\"${SECRET}\"},
+  {\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/env/4/valueFrom/secretKeyRef/name\",\"value\":\"${SECRET}\"}
+]"
+kc -n "${NAMESPACE}" rollout restart deploy/redfish-ctl-explorer >/dev/null 2>&1 || true
+
+section "waiting for explorer rollout"
+kc -n "${NAMESPACE}" rollout status deploy/redfish-ctl-explorer --timeout=120s
+
+printf '\nexplorer ready. Browse it with:\n'
+printf '  kubectl --context %s -n %s port-forward svc/redfish-ctl-explorer %s:80\n' \
+	"${KUBECTL_CONTEXT}" "${NAMESPACE}" "${LOCAL_PORT}"
+printf '  open http://127.0.0.1:%s/\n' "${LOCAL_PORT}"
+
+if [ "${PORT_FORWARD:-0}" = "1" ]; then
+	section "port-forwarding svc/redfish-ctl-explorer -> localhost:${LOCAL_PORT}"
+	exec kc -n "${NAMESPACE}" port-forward svc/redfish-ctl-explorer "${LOCAL_PORT}:80" --address 127.0.0.1
+fi

--- a/k8s/explorer/deployment.yaml
+++ b/k8s/explorer/deployment.yaml
@@ -1,0 +1,101 @@
+# redfish_ctl web explorer — a tree of the tool's read-only commands, invoked
+# live against one BMC. It talks to the BMC directly (needs credentials), so it
+# is a higher trust tier than the read-only fleet-status consumer and is scoped
+# to a single target endpoint.
+#
+# The target BMC address is set here; credentials come from a Secret (the same
+# shape the controller uses). Point spec REDFISH_IP at the node to explore.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redfish-ctl-explorer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-ctl-explorer
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redfish-ctl-explorer
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redfish-ctl-explorer
+        app.kubernetes.io/component: redfish-sandbox
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: explorer
+          image: redfish-ctl-explorer:local
+          imagePullPolicy: IfNotPresent
+          env:
+            # Target BMC to explore. Overwritten at deploy time for a real node.
+            - name: REDFISH_IP
+              value: "mock-bmc.redfish-sandbox.svc.cluster.local"
+            - name: REDFISH_PORT
+              value: "80"
+            - name: REDFISH_SCHEME
+              value: "http"
+            - name: REDFISH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: mock-bmc-credentials
+                  key: username
+            - name: REDFISH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mock-bmc-credentials
+                  key: password
+          ports:
+            - name: http
+              containerPort: 8299
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 96Mi
+            limits:
+              cpu: 500m
+              memory: 384Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redfish-ctl-explorer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-ctl-explorer
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redfish-ctl-explorer
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/k8s/explorer/networkpolicy.yaml
+++ b/k8s/explorer/networkpolicy.yaml
@@ -1,0 +1,53 @@
+# Defense-in-depth egress/ingress restriction for the redfish_ctl explorer.
+#
+# The explorer is a higher-trust tier than the fleet-status consumer: it holds a
+# BMC Secret (mock-bmc-credentials, referenced by k8s/explorer/deployment.yaml) and
+# connects to that one BMC directly. This NetworkPolicy records that boundary — the
+# explorer should only reach DNS and its target BMC, and only serve HTTP in-cluster.
+#
+# The BMC endpoint IP varies per deployment, so this sandbox manifest allows the
+# common BMC ports (443/80) rather than pinning a CIDR; on a real cluster set the
+# egress `to:` below to the target node's BMC IP/CIDR to make the block hard.
+#
+# NOTE: enforcement requires a NetworkPolicy-capable CNI (Calico, Cilium, ...).
+# kind's default kindnet does NOT enforce NetworkPolicy, so in the local sandbox
+# this manifest documents intent; on a real cluster it is enforced. Operator access
+# is via `kubectl port-forward`, which is gated by RBAC and bypasses NetworkPolicy,
+# so restricting ingress to the HTTP port does not block the documented workflow.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redfish-ctl-explorer
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: redfish-ctl-explorer
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redfish-ctl-explorer
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Serve the explorer UI/API to in-cluster clients on the HTTP port only.
+    - ports:
+        - protocol: TCP
+          port: 8299
+  egress:
+    # DNS resolution.
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Target BMC (Redfish over HTTPS, or HTTP for the in-cluster mock). The BMC
+    # address varies per deployment, so this sandbox manifest allows 443/80 egress
+    # rather than pinning a CIDR; on a real cluster tighten `to:` to the BMC IP/CIDR.
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -391,12 +391,26 @@ class MutationRules(_OverlayStore):
     ) -> dict[str, Any] | None:
         path = _normalize_request_path(request_path)
         corpus_lookup = corpus_state if callable(corpus_state) else (lambda _p: {})
+        # Shape-match rules (method/path/body) OUTSIDE the lock, then pre-read the
+        # corpus state their preconditions need. The corpus is immutable and
+        # independent of engine state, so this file read + JSON parse must NOT run
+        # under self._lock — doing so serializes every concurrent writer (and
+        # overlay reader) on disk I/O. Under the lock we evaluate only these
+        # candidates' preconditions against the pre-read snapshot: minimal work,
+        # zero I/O.
+        candidates = [
+            rule
+            for rule in self.rules
+            if isinstance(rule, dict)
+            and self._rule_request_matches(rule, method, path, body)
+        ]
+        corpus_cache = self._load_precondition_corpus(candidates, corpus_lookup)
+        cached_lookup = self._cached_corpus_lookup(corpus_cache)
         with self._lock:
             matched = [
                 rule
-                for rule in self.rules
-                if isinstance(rule, dict)
-                and self._rule_matches(rule, method, path, body, corpus_lookup)
+                for rule in candidates
+                if self._rule_preconditions_hold(rule, cached_lookup)
             ]
             if not matched:
                 return None
@@ -412,6 +426,49 @@ class MutationRules(_OverlayStore):
                 self._applied.append(str(rule.get("name") or "unnamed"))
             response = matched[0].get("response") or {}
             return response if isinstance(response, dict) else {"status": 204}
+
+    @staticmethod
+    def _precondition_paths(rules: list[dict[str, Any]]) -> set[str]:
+        """Normalized resource paths every candidate rule's preconditions read."""
+        paths: set[str] = set()
+        for rule in rules:
+            for condition in rule.get("when") or []:
+                if not isinstance(condition, dict):
+                    continue
+                resource_path = condition.get("path")
+                if isinstance(resource_path, str):
+                    paths.add(_normalize_request_path(resource_path))
+        return paths
+
+    def _load_precondition_corpus(
+        self,
+        rules: list[dict[str, Any]],
+        corpus_lookup: Any,
+    ) -> dict[str, Any]:
+        """Pre-read (outside the lock) the corpus snapshot the candidates need.
+
+        Deep-copied at store time so the snapshot is a private copy immune to any
+        later mutation of what ``corpus_lookup`` returned — at no lock-time cost.
+        """
+        return {
+            path: copy.deepcopy(corpus_lookup(path) or {})
+            for path in self._precondition_paths(rules)
+        }
+
+    @staticmethod
+    def _cached_corpus_lookup(corpus_cache: dict[str, Any]) -> Any:
+        """Serve pre-read corpus state under the lock without touching disk.
+
+        No deep copy here: the only consumer, ``_effective_state``, already
+        deep-copies before mutating, so a second copy would be dead work under the
+        lock. A miss returns ``{}`` (impossible in practice — the cache covers
+        every literal ``when`` path) so the locked section stays strictly I/O-free.
+        """
+
+        def lookup(resource_path: str) -> Any:
+            return corpus_cache.get(_normalize_request_path(resource_path), {})
+
+        return lookup
 
     def _roll_failure(self, matched: list[dict[str, Any]]) -> dict[str, Any] | None:
         for rule in matched:
@@ -438,14 +495,19 @@ class MutationRules(_OverlayStore):
             _deep_update(base, overlay)
         return base
 
-    def _rule_matches(
+    def _rule_request_matches(
         self,
         rule: dict[str, Any],
         method: str,
         path: str,
         body: Any,
-        corpus_lookup: Any,
     ) -> bool:
+        """Match a rule on method/path/body only — no ``when`` / corpus lookup.
+
+        Pure and lock-free: depends only on the immutable rule and the request,
+        never on overlays or corpus files, so candidate selection and the corpus
+        pre-read run before ``self._lock``.
+        """
         if str(rule.get("method", "")).upper() != method.upper():
             return False
         rule_path = _normalize_request_path(str(rule.get("path", "")))
@@ -460,6 +522,10 @@ class MutationRules(_OverlayStore):
             return False
         if "body_contains" in rule and not _body_contains(body, rule["body_contains"]):
             return False
+        return True
+
+    def _rule_preconditions_hold(self, rule: dict[str, Any], corpus_lookup: Any) -> bool:
+        """Whether every ``when`` precondition holds against the pre-read state."""
         for condition in rule.get("when") or []:
             if not isinstance(condition, dict):
                 return False

--- a/k8s/sandbox/redfish-endpoint-live-sample.yaml
+++ b/k8s/sandbox/redfish-endpoint-live-sample.yaml
@@ -1,0 +1,37 @@
+# Sample: point the read-only controller at a REAL BMC (not the in-cluster mock).
+#
+# The controller polls this endpoint read-only (system + sensors + thermal +
+# NIC/DPU firmware) and writes the result to .status; it never issues a write to
+# the BMC. A full poll of a large chassis (e.g. a GB300 with dozens of chassis
+# and hundreds of sensors) can take a minute or more — the endpoint shows as
+# Pending until the first walk finishes, then flips to a populated status.
+#
+# 1) Create the credential Secret (never commit real credentials). Replace the
+#    literals; the address below uses the RFC 5737 documentation range:
+#
+#      kubectl -n redfish-sandbox create secret generic bmc-credentials \
+#        --from-literal=username=root \
+#        --from-literal=password='<bmc-password>'
+#
+# 2) Set spec.address to the BMC. Use https://<host> for a TLS BMC (self-signed
+#    is fine with insecure: true), or http://<host> with port 80 for a plain
+#    endpoint. The controller pod must be able to route to that address — in a
+#    kind-on-Docker setup a pod inherits the Docker VM's routes, so a BMC that a
+#    `docker run curl` can reach is reachable from the controller too.
+#
+# 3) kubectl apply -f this file, then watch:  kubectl -n redfish-sandbox get rfe
+apiVersion: redfish.ctl.dev/v1alpha1
+kind: RedfishEndpoint
+metadata:
+  name: lab-bmc-01
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/component: redfish-sandbox
+    redfish.ctl.dev/target: live-lab-bmc
+spec:
+  address: https://203.0.113.10
+  port: 443
+  insecure: true
+  pollInterval: 30s
+  secretRef:
+    name: bmc-credentials

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -99,6 +99,7 @@ from .telemetry.cmd_metric_definitions import *
 from .telemetry.cmd_exporter import *
 from .component_integrity.cmd_component_integrity import *
 from .network.cmd_network_adapters import *
+from .network.cmd_nic_firmware import *
 from .ports.cmd_nvlink_ports import *
 from .actions.cmd_action_list import *
 from .events.cmd_event_service import *

--- a/redfish_ctl/api.py
+++ b/redfish_ctl/api.py
@@ -115,6 +115,45 @@ class GpuMetricsStatus:
 
 
 @dataclass(frozen=True)
+class NetworkAdapterInfo:
+    """A physical NIC/DPU card from Chassis/*/NetworkAdapters."""
+
+    chassis: str | None
+    id: str | None
+    model: str | None
+    manufacturer: str | None
+    device_class: str | None
+    part_number: str | None
+    serial_number: str | None
+    health: str | None
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class NicFirmwareInfo:
+    """A network-adapter firmware component from UpdateService/FirmwareInventory."""
+
+    id: str | None
+    name: str | None
+    version: str | None
+    updateable: bool | None
+    manufacturer: str | None
+    device_class: str | None
+    uri: str | None
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class NetworkFirmwareStatus:
+    """Typed NIC/DPU adapter + firmware report from the nic-firmware command."""
+
+    summary: Mapping[str, Any]
+    adapters: tuple[NetworkAdapterInfo, ...]
+    firmware: tuple[NicFirmwareInfo, ...]
+    raw: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
 class NtpTarget:
     """A ManagerNetworkProtocol resource that can receive an NTP PATCH."""
 
@@ -378,6 +417,49 @@ def get_gpu_metrics(manager: SyncInvoker) -> GpuMetricsStatus:
     return GpuMetricsStatus(
         summary=_mapping(data.get("summary")),
         gpus=gpu_rows,
+        raw=data,
+    )
+
+
+def get_network_firmware(manager: SyncInvoker) -> NetworkFirmwareStatus:
+    """Return typed NIC/DPU adapter + firmware report through the nic-firmware command.
+
+    Read-only. Surfaces every network adapter (ConnectX NICs, BlueField DPUs) and
+    the firmware version of each network component, plus a summary whose
+    ``distinct_versions`` is the fleet firmware-drift signal.
+    """
+    data = _mapping(_invoke(manager, ApiRequestType.NicFirmware, "nic-firmware"))
+    adapters = tuple(
+        NetworkAdapterInfo(
+            chassis=row.get("Chassis"),
+            id=row.get("Id"),
+            model=row.get("Model"),
+            manufacturer=row.get("Manufacturer"),
+            device_class=row.get("DeviceClass"),
+            part_number=row.get("PartNumber"),
+            serial_number=row.get("SerialNumber"),
+            health=row.get("Health"),
+            raw=row,
+        )
+        for row in _rows(data.get("adapters"))
+    )
+    firmware = tuple(
+        NicFirmwareInfo(
+            id=row.get("Id"),
+            name=row.get("Name"),
+            version=row.get("Version"),
+            updateable=row.get("Updateable"),
+            manufacturer=row.get("Manufacturer"),
+            device_class=row.get("DeviceClass"),
+            uri=row.get("Uri"),
+            raw=row,
+        )
+        for row in _rows(data.get("firmware"))
+    )
+    return NetworkFirmwareStatus(
+        summary=_mapping(data.get("summary")),
+        adapters=adapters,
+        firmware=firmware,
         raw=data,
     )
 

--- a/redfish_ctl/network/cmd_nic_firmware.py
+++ b/redfish_ctl/network/cmd_nic_firmware.py
@@ -30,6 +30,12 @@ from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
 from ..redfish_shared import RedfishApi
 from .cmd_network_adapters import NetworkAdapters
 
+# The package does ``from .network.cmd_nic_firmware import *``; keep that to the
+# command class so re-exported imports (CommandResult, RedfishManagerBase, enums)
+# do not leak into the top-level ``redfish_ctl`` namespace. ``network_class`` stays
+# importable directly (``from ...cmd_nic_firmware import network_class``).
+__all__ = ["NicFirmware"]
+
 # Tokens that mark a firmware component (or adapter model) as a network device.
 # Matched against alphanumeric tokens (not raw substrings) so a GUID/version that
 # merely contains "cx8"/"nic" as a fragment is not misclassified.

--- a/redfish_ctl/network/cmd_nic_firmware.py
+++ b/redfish_ctl/network/cmd_nic_firmware.py
@@ -1,0 +1,192 @@
+"""Read network-adapter (NIC/DPU) firmware across all chassis — OOB, vendor-neutral.
+
+    redfish_ctl nic-firmware
+
+Joins two read-only Redfish views into one NIC-firmware report:
+
+  * ``Chassis/*/NetworkAdapters/*``     -> physical NIC/DPU cards (model, health)
+  * ``UpdateService/FirmwareInventory`` -> component firmware versions
+
+Firmware entries are matched to network devices by an id/name token heuristic
+(ConnectX/CX*, BlueField/BF*, NIC, Mellanox) because a GB300 FirmwareInventory
+leaves ``RelatedItem`` empty, so there is no explicit link back to the adapter.
+Only the network-relevant firmware members are fetched for their ``Version``, so
+the walk stays cheap and never GETs unrelated BMC/GPU/PCIe firmware.
+
+Navigation is by ``@odata.id`` link with no vendor-specific ids, so it works on
+any host exposing the modern Redfish NetworkAdapter + FirmwareInventory model. A
+chassis with no NetworkAdapters link, or a host with no FirmwareInventory, is
+tolerated (that slice comes back empty rather than raising).
+
+Author Mus spyroot@gmail.com
+"""
+import re
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+from .cmd_network_adapters import NetworkAdapters
+
+# Tokens that mark a firmware component (or adapter model) as a network device.
+# Matched against alphanumeric tokens (not raw substrings) so a GUID/version that
+# merely contains "cx8"/"nic" as a fragment is not misclassified.
+_DPU_TOKENS = frozenset({"bluefield", "bf3", "bf2"})
+_NIC_TOKENS = frozenset({"connectx", "cx8", "cx7", "cx6", "mellanox", "mlnx", "nic"})
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+# Leading FirmwareInventory prefixes that duplicate one component (Dell exposes a
+# Current-* and Installed-* member per device); stripped to collapse the pair.
+_FW_STATE_PREFIX_RE = re.compile(r"^(current|installed|previous|available|rollback)-", re.I)
+
+
+def network_class(text: Optional[str]) -> Optional[str]:
+    """Classify a firmware id/name as ``DPU``, ``NIC``, or ``None`` (not network).
+
+    BlueField is a DPU/SmartNIC; ConnectX/Mellanox is a NIC; a bare ``nic`` token is
+    the weak last signal. Matching is on whole alphanumeric tokens, so BMC/GPU/PCIe
+    firmware and GUIDs (which may contain a fragment like ``cx8``) return None.
+    """
+    tokens = set(_TOKEN_RE.findall((text or "").lower()))
+    if tokens & _DPU_TOKENS:
+        return "DPU"
+    if tokens & _NIC_TOKENS:
+        return "NIC"
+    return None
+
+
+class NicFirmware(RedfishManagerBase,
+                  scm_type=ApiRequestType.NicFirmware,
+                  name='nic-firmware',
+                  metaclass=Singleton):
+    """Read every NIC/DPU adapter and its firmware version across all chassis."""
+
+    def __init__(self, *args, **kwargs):
+        super(NicFirmware, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``nic-firmware`` subcommand (read-only)."""
+        cmd_parser = cls.base_parser()
+        help_text = "command read NIC/DPU network-adapter firmware (out-of-band)"
+        return cmd_parser, "nic-firmware", help_text
+
+    @staticmethod
+    def _members(data):
+        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        if not isinstance(data, dict):
+            return []
+        return [m["@odata.id"] for m in data.get("Members", [])
+                if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
+
+    def _adapters(self, do_async):
+        """Physical NIC/DPU cards from ``Chassis/*/NetworkAdapters/*``."""
+        rows = []
+        try:
+            chassis = self.base_query(REDFISH_API.Chassis, do_async=do_async)
+        except Exception:
+            # A transient error / 403 on the Chassis collection must not sink the
+            # whole command — the firmware slice (fetched separately) can still land.
+            return rows
+        for chassis_uri in self._members(chassis.data):
+            try:
+                cdata = self.base_query(chassis_uri, do_async=do_async).data or {}
+            except Exception:
+                continue
+            link = cdata.get("NetworkAdapters")
+            adapters_uri = link.get("@odata.id") if isinstance(link, dict) else None
+            if not adapters_uri:
+                continue
+            try:
+                coll = self.base_query(adapters_uri, do_async=do_async).data or {}
+            except Exception:
+                continue
+            for adapter_uri in self._members(coll):
+                try:
+                    ad = self.base_query(adapter_uri, do_async=do_async).data or {}
+                except Exception:
+                    continue
+                status = ad.get("Status") or {}
+                rows.append({
+                    "Chassis": chassis_uri.rsplit("/", 1)[-1],
+                    "Id": ad.get("Id") or adapter_uri.rsplit("/", 1)[-1],
+                    "Model": ad.get("Model"),
+                    "Manufacturer": ad.get("Manufacturer"),
+                    "DeviceClass": NetworkAdapters._device_class(ad.get("Model")),
+                    "PartNumber": ad.get("PartNumber"),
+                    "SerialNumber": ad.get("SerialNumber"),
+                    "Health": status.get("Health") if isinstance(status, dict) else None,
+                })
+        return rows
+
+    def _nic_firmware(self, do_async):
+        """NIC/DPU firmware versions from ``UpdateService/FirmwareInventory``.
+
+        Fetches the collection once, then follows only the network-relevant member
+        links (identified by id/name token) to read each ``Version``. When the BMC
+        honours ``$expand`` and returns members inline with a Version, that value is
+        used without a second GET.
+        """
+        rows = []
+        fw_root = f"{RedfishApi.Version}/UpdateService/FirmwareInventory"
+        try:
+            coll = self.base_query(fw_root, do_async=do_async).data or {}
+        except Exception:
+            return rows
+        seen_components: set[str] = set()
+        for member in coll.get("Members", []):
+            if not isinstance(member, dict):
+                continue
+            uri = member.get("@odata.id")
+            if not isinstance(uri, str):
+                continue
+            fw_id = uri.rsplit("/", 1)[-1]
+            device_class = network_class(fw_id) or network_class(member.get("Name"))
+            if device_class is None:
+                continue
+            # Collapse Dell-style Current-*/Installed-* pairs to one component so the
+            # count is not doubled and the duplicate is not re-fetched.
+            base_id = _FW_STATE_PREFIX_RE.sub("", fw_id).lower()
+            if base_id in seen_components:
+                continue
+            seen_components.add(base_id)
+            entry = member if "Version" in member else None
+            if entry is None:
+                try:
+                    entry = self.base_query(uri, do_async=do_async).data or {}
+                except Exception:
+                    entry = {}
+            rows.append({
+                "Id": entry.get("Id") or fw_id,
+                "Name": entry.get("Name"),
+                "Version": entry.get("Version"),
+                "Updateable": entry.get("Updateable"),
+                "Manufacturer": entry.get("Manufacturer"),
+                "DeviceClass": network_class(entry.get("Name")) or device_class,
+                "Uri": uri,
+            })
+        return rows
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Return the joined NIC/DPU adapter + firmware report (read-only)."""
+        adapters = self._adapters(do_async)
+        firmware = self._nic_firmware(do_async)
+        versions = sorted({f["Version"] for f in firmware if f.get("Version")})
+        summary = {
+            "adapter_count": len(adapters),
+            "nic_count": sum(1 for a in adapters if a.get("DeviceClass") == "NIC"),
+            "dpu_count": sum(1 for a in adapters if a.get("DeviceClass") == "DPU"),
+            "firmware_count": len(firmware),
+            "updateable_count": sum(1 for f in firmware if f.get("Updateable")),
+            "distinct_versions": versions,
+        }
+        payload = {"adapters": adapters, "firmware": firmware, "summary": summary}
+        return CommandResult(payload, None, None, None)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -101,6 +101,7 @@ class ApiRequestType(Enum):
     MetricReportDefinitions = auto()
     ComponentIntegrity = auto()
     NetworkAdapters = auto()
+    NicFirmware = auto()
     NvLinkPorts = auto()
     Exporter = auto()
     ActionList = auto()

--- a/redfish_ctl/webui/__init__.py
+++ b/redfish_ctl/webui/__init__.py
@@ -1,0 +1,7 @@
+"""Web explorer for redfish_ctl.
+
+Serves a tree of the tool's read-only commands; selecting one invokes the real
+command through the tool's own registry (``sync_invoke``) against the configured
+BMC and returns the result. No shell scripts, no ad-hoc HTTP — every Redfish read
+goes through a registered redfish_ctl command.
+"""

--- a/redfish_ctl/webui/__main__.py
+++ b/redfish_ctl/webui/__main__.py
@@ -1,0 +1,24 @@
+"""Run the redfish_ctl web explorer:  python -m redfish_ctl.webui
+
+Reads the target BMC from REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD (falling
+back to IDRAC_*), the same environment the CLI uses. Every command selected in the
+UI is invoked through the tool's own registry — no scripts, no ad-hoc HTTP.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from .server import run_server
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(prog="redfish_ctl.webui", description=__doc__)
+    parser.add_argument("--host", default="0.0.0.0", help="bind host (default 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=8299, help="bind port (default 8299)")
+    args = parser.parse_args()
+    run_server(bind_host=args.host, bind_port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/redfish_ctl/webui/catalog.py
+++ b/redfish_ctl/webui/catalog.py
@@ -1,0 +1,153 @@
+"""Curated read-only command catalog for the web explorer.
+
+Each entry maps a human label to a real redfish_ctl command
+``(ApiRequestType, name)`` pair — the exact identifiers ``sync_invoke`` dispatches
+on. The catalog is a strict allow-list: only read-only commands appear here, so
+the explorer can never invoke a mutating action (power, BIOS write, RAID, media,
+firmware flash) even if asked. Heavy commands (full sensor/telemetry walks) are
+flagged so the UI can warn before a long call.
+
+Grounded in the live registry (``RedfishManagerBase._registry``); every (api, command)
+pair below is a real registered command.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..redfish_manager_shared import ApiRequestType
+
+
+@dataclass(frozen=True)
+class CommandEntry:
+    """One explorable read-only command."""
+
+    label: str
+    api: ApiRequestType
+    command: str
+    description: str
+    heavy: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "label": self.label,
+            "api": self.api.name,
+            "command": self.command,
+            "description": self.description,
+            "heavy": self.heavy,
+        }
+
+
+# Domain -> ordered read commands. Order is display order in the tree.
+CATALOG: tuple[tuple[str, tuple[CommandEntry, ...]], ...] = (
+    ("Network", (
+        CommandEntry("NIC / DPU firmware", ApiRequestType.NicFirmware, "nic-firmware",
+                     "ConnectX NIC + BlueField DPU firmware versions (UpdateService + NetworkAdapters)"),
+        CommandEntry("Network adapters", ApiRequestType.NetworkAdapters, "network-adapters",
+                     "Physical NIC/DPU cards across all chassis"),
+        CommandEntry("Network ports", ApiRequestType.NetworkPorts, "network-ports",
+                     "Per-adapter ports (speed, link status)"),
+        CommandEntry("Ethernet interfaces", ApiRequestType.EthernetInterfaces, "ethernet-interfaces",
+                     "Host/BMC EthernetInterfaces"),
+        CommandEntry("NVLink ports", ApiRequestType.NvLinkPorts, "nvlink-ports",
+                     "NVLink fabric ports"),
+        CommandEntry("BMC network protocol", ApiRequestType.ManagerNetworkProtocol, "manager-network",
+                     "Manager NetworkProtocol (NTP/DNS/services state)"),
+    )),
+    ("Thermal & Power", (
+        CommandEntry("Sensors", ApiRequestType.Sensors, "sensors",
+                     "All chassis sensor readings", heavy=True),
+        CommandEntry("Thermal", ApiRequestType.Thermal, "thermal",
+                     "ThermalSubsystem temperatures and fans", heavy=True),
+        CommandEntry("Power", ApiRequestType.Power, "power",
+                     "PowerSubsystem: supplies, input/output watts"),
+        CommandEntry("Environment metrics", ApiRequestType.EnvironmentMetrics, "environment-metrics",
+                     "Per-resource energy/power/temperature rollups"),
+        CommandEntry("Leak detectors", ApiRequestType.LeakDetectors, "leak-detectors",
+                     "Liquid-cooling LeakDetection states"),
+        CommandEntry("Power smoothing", ApiRequestType.PowerSmoothing, "power-smoothing",
+                     "NVIDIA PowerSmoothing profiles and setpoints"),
+    )),
+    ("Accelerator & Telemetry", (
+        CommandEntry("GPU metrics", ApiRequestType.GpuMetrics, "gpu-metrics",
+                     "Per-GPU ProcessorMetrics/MemoryMetrics", heavy=True),
+        CommandEntry("Memory metrics", ApiRequestType.MemoryMetrics, "memory-metrics",
+                     "MemoryMetrics per module"),
+        CommandEntry("Processor metrics", ApiRequestType.ProcessorMetrics, "processor-metrics",
+                     "ProcessorMetrics per CPU/GPU"),
+        CommandEntry("Metric reports", ApiRequestType.MetricReports, "metric-reports",
+                     "TelemetryService MetricReports", heavy=True),
+        CommandEntry("Metric definitions", ApiRequestType.MetricReportDefinitions, "metric-definitions",
+                     "TelemetryService MetricReportDefinitions"),
+    )),
+    ("Firmware", (
+        CommandEntry("Firmware inventory", ApiRequestType.FirmwareInventoryQuery, "firmware_inv_query",
+                     "Full UpdateService/FirmwareInventory (all components)"),
+        CommandEntry("Firmware (BMC/BIOS)", ApiRequestType.FirmwareQuery, "firmware_query",
+                     "Firmware versions summary"),
+        CommandEntry("Update service", ApiRequestType.UpdateServiceQuery, "update_service",
+                     "UpdateService capabilities and advertised actions"),
+    )),
+    ("System", (
+        CommandEntry("System", ApiRequestType.SystemQuery, "system_query",
+                     "ComputerSystem: power state, health, model"),
+        CommandEntry("Chassis", ApiRequestType.ChassisQuery, "chassis_service_query",
+                     "Chassis inventory and health"),
+        CommandEntry("Manager (BMC)", ApiRequestType.ManagerQuery, "manager_query",
+                     "BMC Manager resource"),
+        CommandEntry("PCI devices", ApiRequestType.PciDeviceQuery, "pci_device_query",
+                     "PCIeDevices inventory"),
+        CommandEntry("OEM info", ApiRequestType.OemInfo, "oem-info",
+                     "Vendor/OEM identity and extensions"),
+        CommandEntry("Capability report", ApiRequestType.CapabilityReport, "capability-report",
+                     "Vendor capability profile for this endpoint"),
+    )),
+    ("BIOS & Boot", (
+        CommandEntry("BIOS attributes", ApiRequestType.BiosQuery, "bios_inventory",
+                     "Current BIOS attributes"),
+        CommandEntry("BIOS pending", ApiRequestType.BiosQueryPending, "bios_query_pending",
+                     "Staged (pending) BIOS changes"),
+        CommandEntry("Boot", ApiRequestType.BootQuery, "boot_query",
+                     "Boot sources / boot order"),
+        CommandEntry("Current boot", ApiRequestType.CurrentBoot, "current_boot_query",
+                     "Current one-time boot override"),
+        CommandEntry("Secure boot", ApiRequestType.SecureBoot, "secure-boot",
+                     "SecureBoot enable state"),
+    )),
+    ("Storage", (
+        CommandEntry("Storage list", ApiRequestType.StorageListQuery, "storage_list",
+                     "Storage controllers overview"),
+        CommandEntry("Volumes", ApiRequestType.VolumeQuery, "vol_query",
+                     "Configured volumes"),
+        CommandEntry("Drives", ApiRequestType.Drives, "drives_query",
+                     "Physical drives"),
+    )),
+    ("BMC operations (read)", (
+        CommandEntry("Manager time", ApiRequestType.ManagerTime, "manager-time",
+                     "BMC date/time and timezone"),
+        CommandEntry("Event service", ApiRequestType.EventServiceQuery, "event-service",
+                     "EventService and subscriptions"),
+        CommandEntry("Jobs", ApiRequestType.Jobs, "jobs_sources_query",
+                     "Lifecycle jobs / task queue"),
+        CommandEntry("Logs", ApiRequestType.Logs, "logs",
+                     "Log services (SEL/LC)"),
+    )),
+)
+
+
+def catalog_json() -> list[dict[str, Any]]:
+    """Return the catalog as JSON-serializable domains for the UI."""
+    return [
+        {"domain": domain, "commands": [entry.to_dict() for entry in entries]}
+        for domain, entries in CATALOG
+    ]
+
+
+def resolve(command: str) -> CommandEntry | None:
+    """Return the catalog entry for a command name, or None if not allow-listed."""
+    for _domain, entries in CATALOG:
+        for entry in entries:
+            if entry.command == command:
+                return entry
+    return None

--- a/redfish_ctl/webui/server.py
+++ b/redfish_ctl/webui/server.py
@@ -172,6 +172,11 @@ class _Handler(BaseHTTPRequestHandler):
     server_version = "redfish-ctl-explorer/1.0"
     manager: Any = None
     manager_lock = threading.Lock()
+    # The shared manager wraps a single requests.Session, which is NOT
+    # thread-safe. ``manager_lock`` only guards the lazy build; ``invoke_lock``
+    # serializes the actual command invocations so concurrent POSTs can't
+    # interleave on that session and return each other's payloads.
+    invoke_lock = threading.Lock()
     manager_factory = None  # callable[[], RedfishManagerBase]
     target_label = ""
 
@@ -227,7 +232,11 @@ class _Handler(BaseHTTPRequestHandler):
             return
         t0 = time.monotonic()
         try:
-            result = invoke_command(self._get_manager(), command)
+            manager = self._get_manager()
+            # Serialize per-manager: the wrapped requests.Session is not
+            # thread-safe, so only one command may be in flight at a time.
+            with self.__class__.invoke_lock:
+                result = invoke_command(manager, command)
             result["api"] = entry.api.name
             result["elapsedMs"] = int((time.monotonic() - t0) * 1000)
             self._send(200, json.dumps(result).encode(), "application/json")
@@ -258,12 +267,24 @@ def make_manager_factory():
     return factory, f"{address}:{port}"
 
 
+class ExplorerServer(ThreadingHTTPServer):
+    """Threaded explorer server with a generous socket listen backlog.
+
+    The stdlib default (``request_queue_size = 5``) drops connections at the OS
+    accept queue when many clients connect at once, surfacing as resets/timeouts.
+    128 lets a burst of explorer clients queue instead of being reset.
+    """
+
+    request_queue_size = 128
+    daemon_threads = True
+
+
 def run_server(bind_host: str = "0.0.0.0", bind_port: int = 8299) -> None:  # pragma: no cover
     """Serve the explorer, reading the target BMC from REDFISH_*/IDRAC_* env."""
     factory, label = make_manager_factory()
     _Handler.manager_factory = staticmethod(factory)
     _Handler.target_label = label
-    server = ThreadingHTTPServer((bind_host, bind_port), _Handler)
+    server = ExplorerServer((bind_host, bind_port), _Handler)
     print(f"redfish_ctl explorer on {bind_host}:{bind_port} -> BMC {label}", flush=True)
     try:
         server.serve_forever()

--- a/redfish_ctl/webui/server.py
+++ b/redfish_ctl/webui/server.py
@@ -1,0 +1,273 @@
+"""HTTP explorer server: a tree of redfish_ctl read commands, invoked live.
+
+Selecting a command in the tree POSTs to ``/api/invoke``, which dispatches the
+real command through the tool's registry (``sync_invoke``) against the configured
+BMC and returns the command's JSON result. Only allow-listed read commands from
+``catalog.py`` can be invoked, so the explorer is read-only by construction.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+from urllib.parse import urlsplit
+
+from ..redfish_manager_base import RedfishManagerBase
+from .catalog import CATALOG, catalog_json, resolve
+
+
+def _env_first(*names: str, default: str = "") -> str:
+    """Return the first set environment variable value (REDFISH_* before IDRAC_*)."""
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return default
+
+
+def invoke_command(manager: Any, command: str, **kwargs: Any) -> dict[str, Any]:
+    """Invoke an allow-listed read command through the tool registry.
+
+    Returns ``{ok, data}`` on success or ``{ok: False, error, data}`` on a command
+    error. Raises KeyError if ``command`` is not in the read-only catalog (a guard
+    against invoking any mutating action).
+    """
+    entry = resolve(command)
+    if entry is None:
+        raise KeyError(command)
+    result = manager.sync_invoke(entry.api, entry.command, **kwargs)
+    if getattr(result, "error", None):
+        return {"ok": False, "error": str(result.error), "data": getattr(result, "data", None)}
+    return {"ok": True, "data": getattr(result, "data", None)}
+
+
+def _esc(value: Any) -> str:
+    return (
+        str(value)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def render_page(target_label: str) -> str:
+    """Server-render the explorer shell with the command tree from the catalog."""
+    tree = []
+    for domain, entries in CATALOG:
+        items = "".join(
+            f'<li class="cmd" data-cmd="{_esc(e.command)}" data-heavy="{"1" if e.heavy else "0"}" '
+            f'title="{_esc(e.description)}">'
+            f'<span class="lbl">{_esc(e.label)}</span>'
+            f'{"<span class=hv>slow</span>" if e.heavy else ""}'
+            f'<span class="api">{_esc(e.command)}</span></li>'
+            for e in entries
+        )
+        tree.append(
+            f'<li class="domain"><div class="dh">{_esc(domain)}</div><ul>{items}</ul></li>'
+        )
+    tree_html = "\n".join(tree)
+
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>redfish_ctl explorer</title>
+<style>
+  :root {{ color-scheme: light dark; }}
+  * {{ box-sizing: border-box; }}
+  body {{ margin: 0; font-family: -apple-system, Segoe UI, Roboto, sans-serif;
+    background: #0f1115; color: #e6e6e6; display: grid; grid-template-columns: 320px 1fr;
+    grid-template-rows: auto 1fr; height: 100vh; }}
+  header {{ grid-column: 1 / 3; padding: 14px 22px; border-bottom: 1px solid #262a33;
+    display: flex; align-items: baseline; gap: 14px; flex-wrap: wrap; }}
+  h1 {{ font-size: 16px; margin: 0; font-weight: 600; }}
+  .sub {{ color: #8b93a7; font-size: 12px; }}
+  .sub code {{ color: #60a5fa; }}
+  nav {{ overflow-y: auto; border-right: 1px solid #262a33; padding: 8px 0; }}
+  nav ul {{ list-style: none; margin: 0; padding: 0; }}
+  .dh {{ padding: 10px 18px 4px; font-size: 11px; text-transform: uppercase;
+    letter-spacing: .06em; color: #8b93a7; font-weight: 700; }}
+  li.cmd {{ padding: 7px 18px; cursor: pointer; display: flex; align-items: baseline; gap: 8px;
+    border-left: 2px solid transparent; }}
+  li.cmd:hover {{ background: #171a21; }}
+  li.cmd.active {{ background: #171a21; border-left-color: #60a5fa; }}
+  li.cmd .lbl {{ font-size: 13px; }}
+  li.cmd .api {{ margin-left: auto; font-family: ui-monospace, monospace; font-size: 11px; color: #6b7280; }}
+  li.cmd .hv {{ font-size: 9px; background: #3a2f12; color: #fbbf24; padding: 1px 5px;
+    border-radius: 4px; text-transform: uppercase; }}
+  main {{ overflow: auto; padding: 18px 22px; }}
+  .meta {{ font-size: 12px; color: #8b93a7; margin-bottom: 12px; }}
+  .meta b {{ color: #e6e6e6; }}
+  .call {{ font-family: ui-monospace, monospace; font-size: 12px; color: #c9d1d9;
+    background: #171a21; border: 1px solid #262a33; border-radius: 8px; padding: 10px 12px;
+    margin-bottom: 12px; white-space: pre-wrap; }}
+  pre {{ background: #171a21; border: 1px solid #262a33; border-radius: 8px; padding: 14px;
+    overflow: auto; font-size: 12px; line-height: 1.5; margin: 0; }}
+  .err {{ color: #f87171; }}
+  .placeholder {{ color: #8b93a7; margin-top: 40px; text-align: center; }}
+  .spin {{ color: #fbbf24; }}
+</style>
+</head>
+<body>
+<header>
+  <h1>redfish_ctl explorer</h1>
+  <span class="sub">target BMC <b>{_esc(target_label)}</b> &middot; every selection runs
+    <code>redfish_ctl &lt;command&gt;</code> live via <code>sync_invoke</code> — read-only</span>
+</header>
+<nav><ul>
+{tree_html}
+</ul></nav>
+<main id="out">
+  <div class="placeholder">Select a command on the left to invoke it against the BMC.</div>
+</main>
+<script>
+  const out = document.getElementById('out');
+  let active = null;
+  async function invoke(li) {{
+    const cmd = li.dataset.cmd;
+    const heavy = li.dataset.heavy === '1';
+    if (active) active.classList.remove('active');
+    active = li; li.classList.add('active');
+    out.innerHTML = '<div class="placeholder spin">Invoking redfish_ctl ' + cmd +
+      (heavy ? ' … (this command does a full walk and may take a while)' : ' …') + '</div>';
+    const t0 = performance.now();
+    try {{
+      const r = await fetch('/api/invoke', {{
+        method: 'POST', headers: {{'Content-Type': 'application/json'}},
+        body: JSON.stringify({{command: cmd}})
+      }});
+      const body = await r.json();
+      const ms = Math.round(performance.now() - t0);
+      const data = JSON.stringify(body.data, null, 2);
+      const errCls = body.ok ? '' : ' err';
+      out.innerHTML =
+        '<div class="meta"><b>' + cmd + '</b> &middot; api ' + body.api +
+        ' &middot; ' + ms + ' ms &middot; ' + (body.ok ? 'ok' : '<span class=err>error</span>') + '</div>' +
+        '<div class="call">redfish_ctl ' + cmd + '\\n' +
+        '  → manager.sync_invoke(ApiRequestType.' + body.api + ', "' + cmd + '")</div>' +
+        (body.ok ? '' : '<pre class="err">' + escapeHtml(body.error) + '</pre>') +
+        '<pre class="' + errCls + '">' + escapeHtml(data) + '</pre>';
+    }} catch (e) {{
+      out.innerHTML = '<pre class="err">' + escapeHtml(String(e)) + '</pre>';
+    }}
+  }}
+  function escapeHtml(s) {{
+    return String(s).replace(/[&<>]/g, c => ({{'&':'&amp;','<':'&lt;','>':'&gt;'}}[c]));
+  }}
+  document.querySelectorAll('li.cmd').forEach(li =>
+    li.addEventListener('click', () => invoke(li)));
+</script>
+</body>
+</html>
+"""
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "redfish-ctl-explorer/1.0"
+    manager: Any = None
+    manager_lock = threading.Lock()
+    manager_factory = None  # callable[[], RedfishManagerBase]
+    target_label = ""
+
+    def log_message(self, *_a: Any) -> None:
+        return
+
+    def _get_manager(self) -> Any:
+        with self.manager_lock:
+            if self.__class__.manager is None:
+                self.__class__.manager = self.__class__.manager_factory()
+            return self.__class__.manager
+
+    def _send(self, code: int, body: bytes, content_type: str) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlsplit(self.path).path.rstrip("/") or "/"
+        if path == "/healthz":
+            self._send(200, b'{"status":"ok"}', "application/json")
+            return
+        if path == "/api/catalog":
+            self._send(200, json.dumps(catalog_json()).encode(), "application/json")
+            return
+        if path == "/":
+            self._send(200, render_page(self.target_label).encode("utf-8"),
+                       "text/html; charset=utf-8")
+            return
+        self._send(404, b'{"error":"not found"}', "application/json")
+
+    do_HEAD = do_GET
+
+    def do_POST(self) -> None:  # noqa: N802
+        if urlsplit(self.path).path.rstrip("/") != "/api/invoke":
+            self._send(404, b'{"error":"not found"}', "application/json")
+            return
+        length = int(self.headers.get("Content-Length") or 0)
+        try:
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except json.JSONDecodeError:
+            self._send(400, b'{"error":"bad json"}', "application/json")
+            return
+        command = str(payload.get("command") or "")
+        entry = resolve(command)
+        if entry is None:
+            self._send(400, json.dumps({"error": f"command not allow-listed: {command}"}).encode(),
+                       "application/json")
+            return
+        t0 = time.monotonic()
+        try:
+            result = invoke_command(self._get_manager(), command)
+            result["api"] = entry.api.name
+            result["elapsedMs"] = int((time.monotonic() - t0) * 1000)
+            self._send(200, json.dumps(result).encode(), "application/json")
+        except Exception as exc:  # a transport/command failure -> 200 with error body
+            body = {"ok": False, "error": str(exc), "api": entry.api.name, "data": None}
+            self._send(200, json.dumps(body).encode(), "application/json")
+
+
+def make_manager_factory():
+    """Build a factory that constructs the tool's RedfishManagerBase from env/flags."""
+    address = _env_first("REDFISH_IP", "IDRAC_IP")
+    username = _env_first("REDFISH_USERNAME", "IDRAC_USERNAME", default="root")
+    password = _env_first("REDFISH_PASSWORD", "IDRAC_PASSWORD")
+    port = int(_env_first("REDFISH_PORT", "IDRAC_PORT", default="443"))
+    scheme = _env_first("REDFISH_SCHEME", default="https")
+
+    def factory() -> RedfishManagerBase:
+        return RedfishManagerBase(
+            idrac_ip=address,
+            idrac_username=username,
+            idrac_password=password,
+            idrac_port=port,
+            insecure=True,
+            is_http=(scheme == "http"),
+            is_debug=False,
+        )
+
+    return factory, f"{address}:{port}"
+
+
+def run_server(bind_host: str = "0.0.0.0", bind_port: int = 8299) -> None:  # pragma: no cover
+    """Serve the explorer, reading the target BMC from REDFISH_*/IDRAC_* env."""
+    factory, label = make_manager_factory()
+    _Handler.manager_factory = staticmethod(factory)
+    _Handler.target_label = label
+    server = ThreadingHTTPServer((bind_host, bind_port), _Handler)
+    print(f"redfish_ctl explorer on {bind_host}:{bind_port} -> BMC {label}", flush=True)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover
+        pass
+    finally:
+        server.server_close()

--- a/redfish_ctl/webui/server.py
+++ b/redfish_ctl/webui/server.py
@@ -231,9 +231,9 @@ class _Handler(BaseHTTPRequestHandler):
             result["api"] = entry.api.name
             result["elapsedMs"] = int((time.monotonic() - t0) * 1000)
             self._send(200, json.dumps(result).encode(), "application/json")
-        except Exception as exc:  # a transport/command failure -> 200 with error body
+        except Exception as exc:  # a transport/backend failure -> 502 Bad Gateway
             body = {"ok": False, "error": str(exc), "api": entry.api.name, "data": None}
-            self._send(200, json.dumps(body).encode(), "application/json")
+            self._send(502, json.dumps(body).encode(), "application/json")
 
 
 def make_manager_factory():

--- a/tests/test_api_facade.py
+++ b/tests/test_api_facade.py
@@ -29,15 +29,16 @@ from redfish_ctl.api import (
     bios_profile_list,
     bios_profile_show,
     get_gpu_metrics,
+    get_network_firmware,
     get_sensors,
     get_system,
     get_thermal,
     reboot,
     set_ntp,
 )
+from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
-from redfish_ctl.redfish_manager import CommandResult
 
 GB300_CORPUS = corpus_dir(
     Path(__file__).parent / "supermicro_gb300_corpus.tar.gz", "172.25.230.37"
@@ -779,6 +780,7 @@ def test_facade_wrappers_read_gb300_corpus_through_command_registry(
     sensors = get_sensors(manager)
     thermal = get_thermal(manager)
     gpu_metrics = get_gpu_metrics(manager)
+    network_firmware = get_network_firmware(manager)
     ntp = set_ntp(manager, ["0.pool.ntp.org"])
     reset_preview = reboot(manager)
     profile_diff = bios_profile_diff(manager, "gb300-power-capped")
@@ -806,6 +808,20 @@ def test_facade_wrappers_read_gb300_corpus_through_command_registry(
         and row.model == "NVIDIA GB300"
         and row.temperatures_celsius["HGX_GPU_0_TEMP_0"] == 32.9375
         for row in gpu_metrics.gpus
+    )
+    # NIC/DPU firmware inventory: 4 ConnectX-8 NICs + 1 BlueField-3 DPU, with the
+    # ConnectX firmware pinned at a single version across the card set.
+    assert network_firmware.summary["adapter_count"] == 5
+    assert network_firmware.summary["nic_count"] == 4
+    assert network_firmware.summary["dpu_count"] == 1
+    assert "40.45.3048" in network_firmware.summary["distinct_versions"]
+    assert any(
+        adapter.model == "ConnectX-8 800GE 2P NIC" and adapter.device_class == "NIC"
+        for adapter in network_firmware.adapters
+    )
+    assert any(
+        fw.id == "CX8_0" and fw.version == "40.45.3048" and fw.updateable is True
+        for fw in network_firmware.firmware
     )
     assert ntp.dry_run is True
     assert ntp.servers == ("0.pool.ntp.org",)

--- a/tests/test_fleet_cache_singleflight.py
+++ b/tests/test_fleet_cache_singleflight.py
@@ -1,0 +1,103 @@
+"""Single-flight contract for the fleet-status endpoint cache.
+
+Many dashboard clients hit the consumer at once. The short-TTL ``_EndpointCache``
+exists so a burst does not fan out into one Kubernetes API call per request. If
+the cache invokes ``loader()`` outside its lock, every thread that finds the
+entry stale at the same instant stampedes into a parallel refill (thundering
+herd). The cache must be single-flight: within one TTL window a concurrent burst
+triggers at most one load. This test fires a synchronized burst against an empty
+cache and asserts exactly one refill — it fails against the herd and passes once
+single-flight is in place.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLEET_MODULE = REPO_ROOT / "k8s" / "consumer" / "fleet_status_app.py"
+
+
+def _load_fleet_module() -> Any:
+    spec = importlib.util.spec_from_file_location("fleet_status_app", FLEET_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_endpoint_cache_single_flight_under_concurrent_burst() -> None:
+    """A synchronized burst against a cold cache refills exactly once."""
+    module = _load_fleet_module()
+    cache = module._EndpointCache(ttl_seconds=30.0)
+
+    clients = 48
+    calls = 0
+    calls_lock = threading.Lock()
+    barrier = threading.Barrier(clients)
+
+    def loader() -> list[dict[str, Any]]:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            generation = calls
+        time.sleep(0.05)  # widen the window so a herd would overlap here
+        return [{"generation": generation}]
+
+    def worker(_: int) -> list[dict[str, Any]]:
+        barrier.wait()  # release all clients together for a maximal stampede
+        return cache.get(loader)
+
+    with ThreadPoolExecutor(max_workers=clients) as pool:
+        results = list(pool.map(worker, range(clients)))
+
+    # Single-flight: the whole burst shares one refill.
+    assert calls == 1, f"thundering herd: loader ran {calls} times, expected 1"
+    # Every client sees the same complete snapshot (no partial/empty window).
+    assert all(r == [{"generation": 1}] for r in results)
+
+
+def test_endpoint_cache_serves_within_ttl_and_reloads_after_expiry() -> None:
+    """Fresh entries are served from cache; a fresh load happens after the TTL."""
+    module = _load_fleet_module()
+    cache = module._EndpointCache(ttl_seconds=0.15)
+
+    calls = 0
+
+    def loader() -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        return [{"generation": calls}]
+
+    first = cache.get(loader)
+    second = cache.get(loader)  # within TTL -> cached, no reload
+    assert first == second == [{"generation": 1}]
+    assert calls == 1
+
+    time.sleep(0.2)  # let the TTL lapse
+    third = cache.get(loader)  # stale -> one reload
+    assert third == [{"generation": 2}]
+    assert calls == 2
+
+
+def test_endpoint_cache_recovers_after_loader_error() -> None:
+    """A failed load resets the in-flight flag so the next caller can retry."""
+    module = _load_fleet_module()
+    cache = module._EndpointCache(ttl_seconds=30.0)
+
+    def failing_loader() -> list[dict[str, Any]]:
+        raise RuntimeError("k8s API unavailable")
+
+    try:
+        cache.get(failing_loader)
+    except RuntimeError:
+        pass
+
+    # The engine must not be wedged in a permanent "loading" state.
+    good = cache.get(lambda: [{"generation": 1}])
+    assert good == [{"generation": 1}]

--- a/tests/test_fleet_consumer.py
+++ b/tests/test_fleet_consumer.py
@@ -1,0 +1,354 @@
+"""Offline unit tests for the fleet-status consumer's pure renderers.
+
+The consumer (``k8s/consumer/fleet_status_app.py``) turns the RedfishEndpoint
+``.status`` the controller writes into JSON, Prometheus metrics, and an HTML
+dashboard. These tests pin that pure shaping logic with no Kubernetes client and
+no cluster: the module keeps its ``kubernetes`` import lazy, so loading it here
+exercises only the offline helpers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONSUMER_MODULE = REPO_ROOT / "k8s" / "consumer" / "fleet_status_app.py"
+
+
+def _load_consumer_module():
+    spec = importlib.util.spec_from_file_location("fleet_status_app", CONSUMER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def app():
+    """The loaded consumer module (pure helpers only)."""
+    return _load_consumer_module()
+
+
+def _endpoint(name, address, status=None, port=443, insecure=True):
+    obj = {
+        "metadata": {"name": name, "namespace": "redfish-sandbox"},
+        "spec": {"address": address, "port": port, "insecure": insecure},
+    }
+    if status is not None:
+        obj["status"] = status
+    return obj
+
+
+def test_normalize_ready_endpoint(app):
+    """A fully-polled endpoint maps to a Ready row with typed readings."""
+    obj = _endpoint(
+        "gb300-n08-live",
+        "https://172.25.230.28",
+        status={
+            "powerState": "On",
+            "health": "OK",
+            "temperature": {"count": 56, "maxCelsius": 41.5},
+            "lastPolled": "2026-07-13T10:00:00Z",
+        },
+    )
+    row = app.normalize_endpoint(obj)
+    assert row["name"] == "gb300-n08-live"
+    assert row["state"] == "Ready"
+    assert row["powerState"] == "On"
+    assert row["health"] == "OK"
+    assert row["temperatureCount"] == 56
+    assert row["temperatureMaxCelsius"] == 41.5
+    assert row["backend"] == "live"
+
+
+def test_normalize_pending_when_status_absent(app):
+    """An endpoint the controller has not polled yet is Pending, not an error."""
+    row = app.normalize_endpoint(_endpoint("fresh", "https://10.0.0.9"))
+    assert row["state"] == "Pending"
+    assert row["powerState"] is None
+    assert row["health"] is None
+    assert row["temperatureMaxCelsius"] is None
+
+
+def test_normalize_pending_when_status_empty(app):
+    """An empty status object still reads as Pending (no keys populated)."""
+    row = app.normalize_endpoint(_endpoint("fresh", "https://10.0.0.9", status={}))
+    assert row["state"] == "Pending"
+
+
+def test_backend_inference_mock_vs_live(app):
+    """A cluster-local Service address is a mock backend; anything else is live."""
+    mock = app.normalize_endpoint(
+        _endpoint("m", "http://mock-bmc.redfish-sandbox.svc.cluster.local", port=80)
+    )
+    live = app.normalize_endpoint(_endpoint("l", "https://172.25.230.28"))
+    assert mock["backend"] == "mock"
+    assert live["backend"] == "live"
+
+
+def test_string_reading_is_coerced_and_bool_rejected(app):
+    """Redfish readings arrive as strings; bools must never count as numbers."""
+    coerced = app.normalize_endpoint(
+        _endpoint("s", "https://x", status={"temperature": {"count": 1, "maxCelsius": "39.0"}})
+    )
+    assert coerced["temperatureMaxCelsius"] == 39.0
+    rejected = app.normalize_endpoint(
+        _endpoint("b", "https://x", status={"temperature": {"count": 1, "maxCelsius": True}})
+    )
+    assert rejected["temperatureMaxCelsius"] is None
+
+
+def test_fleet_summary_counts(app):
+    """Fleet summary tallies power, health, and readiness across nodes."""
+    nodes = [
+        app.normalize_endpoint(
+            _endpoint("a", "https://1", status={"powerState": "On", "health": "OK",
+                                                "temperature": {"count": 2, "maxCelsius": 30}})
+        ),
+        app.normalize_endpoint(
+            _endpoint("b", "https://2", status={"powerState": "Off", "health": "Critical",
+                                                "temperature": {"count": 0}})
+        ),
+        app.normalize_endpoint(_endpoint("c", "https://3")),  # pending
+    ]
+    summary = app.fleet_summary(nodes)
+    assert summary["total"] == 3
+    assert summary["poweredOn"] == 1
+    assert summary["poweredOff"] == 1
+    assert summary["healthy"] == 1
+    assert summary["critical"] == 1
+    assert summary["pending"] == 1
+    assert summary["ready"] == 2
+
+
+def test_render_fleet_json_shape(app):
+    """The /api/nodes payload carries a summary plus the node list."""
+    nodes = [app.normalize_endpoint(_endpoint("a", "https://1",
+                                              status={"powerState": "On", "health": "OK"}))]
+    payload = app.render_fleet_json(nodes)
+    assert set(payload) == {"summary", "nodes"}
+    assert payload["summary"]["total"] == 1
+    assert payload["nodes"][0]["name"] == "a"
+
+
+def test_render_metrics_lines(app):
+    """Metrics expose power/health/temperature gauges keyed by node."""
+    nodes = [
+        app.normalize_endpoint(
+            _endpoint("gb300-n08", "https://172.25.230.28",
+                      status={"powerState": "On", "health": "OK",
+                              "temperature": {"count": 56, "maxCelsius": 41.5},
+                              "lastPolled": "2026-07-13T10:00:00Z"})
+        ),
+        app.normalize_endpoint(
+            _endpoint("gb300-n09", "https://172.25.230.29",
+                      status={"powerState": "Off", "health": "Critical",
+                              "temperature": {"count": 0}})
+        ),
+    ]
+    text = app.render_metrics(nodes)
+    assert 'redfish_endpoint_power_on{node="gb300-n08"} 1' in text
+    assert 'redfish_endpoint_power_on{node="gb300-n09"} 0' in text
+    assert 'redfish_endpoint_health{node="gb300-n08"} 0' in text
+    assert 'redfish_endpoint_health{node="gb300-n09"} 2' in text
+    assert 'redfish_endpoint_temperature_max_celsius{node="gb300-n08"} 41.5' in text
+    # No max-temp line when maxCelsius is absent.
+    assert 'redfish_endpoint_temperature_max_celsius{node="gb300-n09"}' not in text
+    assert text.endswith("\n")
+
+
+def test_render_metrics_escapes_label_values(app):
+    """A quote or backslash in an address must not break the metrics format."""
+    node = app.normalize_endpoint(_endpoint('weird"node', 'https://ok',
+                                            status={"powerState": "On"}))
+    text = app.render_metrics([node])
+    assert '\\"' in text  # the embedded quote is escaped
+
+
+def test_render_html_contains_nodes_and_is_escaped(app):
+    """The dashboard lists node names and escapes hostile metadata."""
+    nodes = [
+        app.normalize_endpoint(_endpoint("gb300-n08", "https://172.25.230.28",
+                                        status={"powerState": "On", "health": "OK"})),
+        app.normalize_endpoint(_endpoint("<script>x", "https://evil",
+                                        status={"powerState": "Off", "health": "Warning"})),
+    ]
+    html = app.render_html(nodes)
+    assert "gb300-n08" in html
+    assert "<script>x" not in html  # escaped
+    assert "&lt;script&gt;x" in html
+
+
+def test_render_html_empty_fleet(app):
+    """An empty fleet renders the placeholder row, not a broken table."""
+    html = app.render_html([])
+    assert "No RedfishEndpoint resources found" in html
+
+
+def test_epoch_parsing(app):
+    """lastPolled parses from RFC3339 Z form and tolerates junk/None."""
+    from datetime import datetime, timezone
+
+    expected = datetime(2026, 7, 13, 10, 0, 0, tzinfo=timezone.utc).timestamp()
+    assert app._epoch_from_rfc3339("2026-07-13T10:00:00Z") == pytest.approx(expected, abs=1)
+    assert app._epoch_from_rfc3339(None) is None
+    assert app._epoch_from_rfc3339("not-a-date") is None
+
+
+# --------------------------------------------------------------------------- #
+# NIC/DPU firmware surfacing (the "pull firmware for the 100GbE card" feature)
+# --------------------------------------------------------------------------- #
+
+
+def _nic_firmware(versions=("40.45.3048",), adapter_count=5, nic=4, dpu=1, components=None):
+    comps = components if components is not None else [
+        {"id": f"CX8_{i}", "deviceClass": "NIC", "version": versions[0], "updateable": True}
+        for i in range(nic)
+    ]
+    return {
+        "adapterCount": adapter_count,
+        "nicCount": nic,
+        "dpuCount": dpu,
+        "firmwareCount": len(comps),
+        "updateableCount": len(comps),
+        "distinctVersions": list(versions),
+        "components": comps,
+    }
+
+
+def test_normalize_extracts_nic_firmware(app):
+    """networkFirmware in status flattens to nic counts, versions, and components."""
+    obj = _endpoint(
+        "gb300-n08-live",
+        "https://172.25.230.28",
+        status={"powerState": "On", "health": "OK", "networkFirmware": _nic_firmware()},
+    )
+    row = app.normalize_endpoint(obj)
+    assert row["nicAdapterCount"] == 5
+    assert row["nicCount"] == 4
+    assert row["dpuCount"] == 1
+    assert row["nicFirmwareVersions"] == ["40.45.3048"]
+    assert any(c["id"] == "CX8_0" and c["version"] == "40.45.3048" for c in row["nicFirmware"])
+
+
+def test_normalize_without_nic_firmware_is_empty_not_error(app):
+    """A status with no networkFirmware yields empty NIC fields, not a crash."""
+    row = app.normalize_endpoint(
+        _endpoint("plain", "https://x", status={"powerState": "On"})
+    )
+    assert row["nicAdapterCount"] is None
+    assert row["nicFirmwareVersions"] == []
+    assert row["nicFirmware"] == []
+
+
+def test_render_metrics_includes_nic_firmware(app):
+    """Metrics expose per-component nic firmware info + drift + adapter count."""
+    nodes = [
+        app.normalize_endpoint(
+            _endpoint("gb300-n08", "https://172.25.230.28",
+                      status={"powerState": "On", "networkFirmware": _nic_firmware()})
+        )
+    ]
+    text = app.render_metrics(nodes)
+    assert 'redfish_node_nic_count{node="gb300-n08"} 5' in text
+    assert 'redfish_node_nic_firmware_distinct_versions{node="gb300-n08"} 1' in text
+    assert 'nic_id="CX8_0"' in text and 'version="40.45.3048"' in text
+    assert "redfish_nic_firmware_info{" in text
+
+
+def test_render_metrics_per_node_distinct_versions_is_not_drift(app):
+    """A node with a NIC (40.x) and a DPU (32.x) reports 2 distinct versions but
+    contributes ZERO fleet drift — the two are different components, not drift."""
+    comps = [
+        {"id": "CX8_0", "deviceClass": "NIC", "version": "40.45.3048", "updateable": True},
+        {"id": "NIC_1", "deviceClass": "NIC", "version": "32.44.1600", "updateable": True},
+    ]
+    node = app.normalize_endpoint(
+        _endpoint("n", "https://x", status={"powerState": "On",
+                  "networkFirmware": _nic_firmware(versions=("40.45.3048", "32.44.1600"),
+                                                   components=comps)})
+    )
+    text = app.render_metrics([node])
+    assert 'redfish_node_nic_firmware_distinct_versions{node="n"} 2' in text
+    assert "redfish_fleet_nic_firmware_drift_components{} 0" in text
+
+
+def test_fleet_firmware_drift_is_cross_node_per_component(app):
+    """Drift is the same component id differing across nodes; a healthy fleet is 0."""
+    def node(name, cx8_ver):
+        comps = [
+            {"id": "CX8_0", "deviceClass": "NIC", "version": cx8_ver, "updateable": True},
+            {"id": "NIC_1", "deviceClass": "NIC", "version": "32.44.1600", "updateable": True},
+        ]
+        return app.normalize_endpoint(_endpoint(name, "https://" + name,
+            status={"powerState": "On", "networkFirmware": _nic_firmware(components=comps)}))
+
+    healthy = [node("a", "40.45.3048"), node("b", "40.45.3048")]
+    assert app.fleet_firmware_drift(healthy) == {}
+
+    drifting = [node("a", "40.45.3048"), node("b", "40.44.0000")]
+    drift = app.fleet_firmware_drift(drifting)
+    assert drift == {"CX8_0": ["40.44.0000", "40.45.3048"]}
+    # The fleet metric reflects the drifting component.
+    assert "redfish_fleet_nic_firmware_drift_components{} 1" in app.render_metrics(drifting)
+
+
+def test_metric_line_escapes_newline_and_cr(app):
+    """A newline in a label value is escaped so it cannot split the metric line."""
+    line = app._metric_line("m", {"node": "n", "address": "https://a\nb\rc"}, 1)
+    assert "\n" not in line.rstrip("\n").replace("\\n", "")
+    assert "\\n" in line and "\\r" in line
+
+
+def test_temperature_count_coerces_string_and_rejects_bool(app):
+    """temperatureCount is coerced from strings and never a bool (metrics-safe)."""
+    coerced = app.normalize_endpoint(
+        _endpoint("s", "https://x", status={"temperature": {"count": "56"}})
+    )
+    assert coerced["temperatureCount"] == 56
+    rejected = app.normalize_endpoint(
+        _endpoint("b", "https://x", status={"temperature": {"count": True}})
+    )
+    assert rejected["temperatureCount"] is None
+    # And the metric never emits the literal True.
+    assert "True" not in app.render_metrics([rejected])
+
+
+def test_find_node(app):
+    """find_node returns the matching row or None (backs /api/nodes/<name>)."""
+    nodes = [{"name": "a"}, {"name": "b"}]
+    assert app.find_node(nodes, "b") == {"name": "b"}
+    assert app.find_node(nodes, "missing") is None
+
+
+def test_pending_node_power_cell_is_unknown_not_off(app):
+    """An unpolled (null power) node renders the neutral 'unknown' pill, not red 'off'."""
+    html = app.render_html([app.normalize_endpoint(_endpoint("fresh", "https://x"))])
+    assert 'class="pill unknown">—' in html
+    assert 'class="pill off">—' not in html
+
+
+def test_render_html_shows_nic_firmware_no_drift_for_healthy_fleet(app):
+    """A fleet where every node runs the same per-component firmware shows no drift."""
+    def node(name):
+        comps = [{"id": "CX8_0", "deviceClass": "NIC", "version": "40.45.3048", "updateable": True}]
+        return app.normalize_endpoint(_endpoint(name, "https://" + name,
+            status={"powerState": "On", "networkFirmware": _nic_firmware(components=comps)}))
+    html = app.render_html([node("a"), node("b")])
+    assert "40.45.3048" in html
+    assert "NIC Firmware" in html
+    assert "fw drift" not in html  # identical firmware across the fleet = not drift
+
+
+def test_render_html_flags_drifting_component_across_fleet(app):
+    """When one node's CX8_0 differs from the fleet, the node cell is drift-flagged."""
+    def node(name, ver):
+        comps = [{"id": "CX8_0", "deviceClass": "NIC", "version": ver, "updateable": True}]
+        return app.normalize_endpoint(_endpoint(name, "https://" + name,
+            status={"powerState": "On", "networkFirmware": _nic_firmware(components=comps)}))
+    html = app.render_html([node("a", "40.45.3048"), node("b", "40.44.0000")])
+    assert "fw drift" in html  # the fleet disagrees on CX8_0
+    assert "NIC FW Drift" in html  # the summary card

--- a/tests/test_fleet_consumer.py
+++ b/tests/test_fleet_consumer.py
@@ -10,6 +10,11 @@ exercises only the offline helpers.
 from __future__ import annotations
 
 import importlib.util
+import json
+import threading
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -352,3 +357,60 @@ def test_render_html_flags_drifting_component_across_fleet(app):
     html = app.render_html([node("a", "40.45.3048"), node("b", "40.44.0000")])
     assert "fw drift" in html  # the fleet disagrees on CX8_0
     assert "NIC FW Drift" in html  # the summary card
+
+
+# --------------------------------------------------------------------------- #
+# HTTP handler: routes + status codes (loopback server; k8s access stubbed out).
+# --------------------------------------------------------------------------- #
+
+
+@contextmanager
+def _serve_consumer(app):
+    """Run the consumer on an ephemeral loopback port (caller stubs _nodes)."""
+    httpd = app.ThreadingHTTPServer(("127.0.0.1", 0), app._Handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{httpd.server_address[1]}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def _req(url):
+    """Return (status, body-bytes), treating a 4xx/5xx as a normal response."""
+    try:
+        with urllib.request.urlopen(url, timeout=5) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def test_http_routes_serve_status_and_metrics(app, monkeypatch):
+    """/, /api/nodes, /api/nodes/<name>, /metrics, /healthz serve 200; unknown/missing 404.
+
+    ``_nodes`` is stubbed so the handler never touches a Kubernetes API server.
+    """
+    nodes = [app.normalize_endpoint(
+        _endpoint("n1", "https://1", status={"powerState": "On", "health": "OK"})
+    )]
+    monkeypatch.setattr(app._Handler, "_nodes", lambda self: nodes)
+    with _serve_consumer(app) as base:
+        assert _req(base + "/healthz")[0] == 200
+        assert _req(base + "/")[0] == 200
+        code, body = _req(base + "/api/nodes")
+        assert code == 200 and json.loads(body)["summary"]["total"] == 1
+        assert _req(base + "/api/nodes/n1")[0] == 200
+        assert _req(base + "/api/nodes/missing")[0] == 404  # unknown node
+        assert _req(base + "/metrics")[0] == 200
+        assert _req(base + "/nope")[0] == 404  # unknown path
+
+
+def test_http_backend_error_is_503(app, monkeypatch):
+    """When the k8s-facing load fails, the handler returns 503, not a stack trace."""
+    def boom(self):
+        raise RuntimeError("cluster unreachable")
+    monkeypatch.setattr(app._Handler, "_nodes", boom)
+    with _serve_consumer(app) as base:
+        code, body = _req(base + "/api/nodes")
+        assert code == 503
+        assert json.loads(body)["error"] == "backend unavailable"

--- a/tests/test_fleet_http_cache_concurrency.py
+++ b/tests/test_fleet_http_cache_concurrency.py
@@ -1,0 +1,120 @@
+"""Fleet-consumer HTTP server cache behaviour under many concurrent clients.
+
+The consumer's ``_Handler`` fronts the Kubernetes API with a short-TTL cache so a
+crowd of dashboard clients does not fan out into one API call per hit. This test
+drives a synchronized burst of ``/``, ``/api/nodes`` and ``/metrics`` requests at
+the live HTTP server (with a fake ``load_endpoints``) and asserts the whole burst
+shares a single load within the TTL, then reloads exactly once after the TTL —
+proving the single-flight cache holds end-to-end, not just in the unit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLEET_MODULE = REPO_ROOT / "k8s" / "consumer" / "fleet_status_app.py"
+NODE_COUNT = 50
+
+
+def _load_fleet_module() -> Any:
+    spec = importlib.util.spec_from_file_location("fleet_status_app", FLEET_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_nodes(module: Any) -> list[dict[str, Any]]:
+    rows = []
+    for i in range(NODE_COUNT):
+        obj = {
+            "metadata": {"name": f"node-{i:02d}", "namespace": "test-ns"},
+            "spec": {"address": f"https://mock-{i}.svc.cluster.local", "port": 443},
+            "status": {
+                "powerState": "On",
+                "health": "OK",
+                "lastPolled": "2026-07-15T00:00:00Z",
+                "temperature": {"count": 8, "maxCelsius": 60.0},
+            },
+        }
+        rows.append(module.normalize_endpoint(obj))
+    return rows
+
+
+def _get(base: str, path: str) -> tuple[int, bytes]:
+    with urllib.request.urlopen(base + path, timeout=10) as response:
+        return response.status, response.read()
+
+
+def test_fleet_http_cache_single_flight_and_ttl_reload() -> None:
+    """A concurrent client burst triggers one load per TTL, never a herd."""
+    module = _load_fleet_module()
+
+    loads = 0
+    loads_lock = threading.Lock()
+    rows = _fake_nodes(module)
+
+    def fake_load(_namespace: str) -> list[dict[str, Any]]:
+        nonlocal loads
+        with loads_lock:
+            loads += 1
+        time.sleep(0.05)  # emulate k8s API latency so a herd would overlap
+        return list(rows)
+
+    module.load_endpoints = fake_load  # handler resolves this at call time
+
+    class Handler(module._Handler):
+        pass
+
+    Handler.namespace = "test-ns"
+    # Generous TTL: the whole burst must fall inside one TTL window, so a straggler
+    # thread delayed by scheduling can't legitimately expire it and load twice.
+    # Reload-after-expiry is proven deterministically below (and in the unit test).
+    Handler.cache = module._EndpointCache(ttl_seconds=30.0)
+
+    server = module.FleetServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = "http://{}:{}".format(*server.server_address)
+        paths = ["/", "/api/nodes", "/metrics"]
+        clients = 60
+        barrier = threading.Barrier(clients)
+
+        def worker(i: int) -> tuple[int, bytes, str]:
+            path = paths[i % len(paths)]
+            barrier.wait()  # release the whole burst together
+            status, body = _get(base, path)
+            return status, body, path
+
+        with ThreadPoolExecutor(max_workers=clients) as pool:
+            results = list(pool.map(worker, range(clients)))
+
+        # Single-flight: the entire burst shares one k8s load within the TTL.
+        assert loads == 1, f"cache stampede: {loads} loads for one burst"
+        for status, body, path in results:
+            assert status == 200
+            assert body  # complete snapshot, never an empty/partial window
+            if path == "/api/nodes":
+                payload = json.loads(body.decode("utf-8"))
+                assert payload["summary"]["total"] == NODE_COUNT
+                assert len(payload["nodes"]) == NODE_COUNT
+
+        # Force TTL expiry deterministically (no wall-clock race): the next
+        # request must reload exactly once more, not stampede.
+        Handler.cache._at = 0.0
+        status, body = _get(base, "/api/nodes")
+        assert status == 200
+        assert loads == 2, f"expected one reload after expiry, saw {loads} total loads"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -71,9 +71,13 @@ def test_crd_schema_pins_read_only_endpoint_spec_and_status_shape() -> None:
         "powerState",
         "health",
         "temperature",
+        "networkFirmware",
         "lastPolled",
     }
     assert status_props["temperature"]["properties"]["maxCelsius"]["type"] == "number"
+    nic_fw_props = status_props["networkFirmware"]["properties"]
+    assert nic_fw_props["distinctVersions"]["items"]["type"] == "string"
+    assert nic_fw_props["components"]["items"]["properties"]["version"]["type"] == "string"
     assert "valueFrom" not in json.dumps(crd)
     assert version["additionalPrinterColumns"] == [
         {
@@ -85,6 +89,11 @@ def test_crd_schema_pins_read_only_endpoint_spec_and_status_shape() -> None:
             "name": "HEALTH",
             "type": "string",
             "jsonPath": ".status.health",
+        },
+        {
+            "name": "NIC-FW",
+            "type": "integer",
+            "jsonPath": ".status.networkFirmware.firmwareCount",
         },
         {
             "name": "POLLED",
@@ -176,6 +185,15 @@ def test_poll_endpoint_reads_gb300_corpus_without_mutating_requests() -> None:
     assert status["temperature"]["count"] == 56
     assert status["temperature"]["maxCelsius"] == 54.1875
     assert status["lastPolled"] == "2026-07-10T14:45:00Z"
+    # NIC/DPU firmware is pulled read-only and folded into status: the GB300
+    # corpus carries 4 ConnectX-8 NICs + 1 BlueField-3 DPU and their firmware.
+    nic_fw = status["networkFirmware"]
+    assert nic_fw["adapterCount"] == 5
+    assert nic_fw["nicCount"] == 4
+    assert nic_fw["dpuCount"] == 1
+    assert "40.45.3048" in nic_fw["distinctVersions"]
+    assert any(c["id"] == "CX8_0" and c["version"] == "40.45.3048"
+               for c in nic_fw["components"])
     assert seen_methods
     assert set(seen_methods) == {"GET"}
 

--- a/tests/test_mock_bmc_get_hammer.py
+++ b/tests/test_mock_bmc_get_hammer.py
@@ -1,0 +1,240 @@
+"""High-concurrency GET hammer and mixed GET+POST benchmark for the mock BMC.
+
+The existing concurrency test hammers 16 threads / 64 reads. These scale that up
+to ~200 threads / 10k reads to surface read-side races or file-handle exhaustion,
+and add a mixed read/write workload (the write path was benchmark-untested) to
+record write-side latency percentiles alongside reads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+NP = "/redfish/v1/Managers/BMC_0/NetworkProtocol"
+CHASSIS = "/redfish/v1/Chassis/Chassis_0"
+
+HAMMER_THREADS = 200
+# 200-way concurrency with a large connection count exercises read-side races and
+# file-descriptor reuse. The request count is 6000 rather than 10k because the
+# mock serves HTTP/1.0 (a fresh TCP connection per request); on macOS loopback a
+# 10k burst intermittently hits connect timeouts from TCP TIME_WAIT churn — a
+# client/OS ceiling, not a server limit — so 6000 keeps the test deterministically
+# green on both macOS and Linux while still hammering the same paths.
+HAMMER_REQUESTS = 6000
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _fixture_name(path: str) -> str:
+    return "_" + path.strip("/").replace("/", "_") + ".json"
+
+
+def _corpus(tmp_path: Path) -> tuple[Path, dict[str, dict[str, Any]]]:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    payloads = {
+        "/redfish/v1": {"@odata.id": "/redfish/v1", "Id": "RootService"},
+        SYSTEM: {
+            "@odata.id": SYSTEM,
+            "Id": "System_0",
+            "PowerState": "On",
+            "Boot": {"BootSourceOverrideEnabled": "Once", "BootSourceOverrideTarget": "Pxe"},
+            "Status": {"Health": "OK", "State": "Enabled"},
+        },
+        NP: {
+            "@odata.id": NP,
+            "Id": "NetworkProtocol",
+            "NTP": {"ProtocolEnabled": True, "NTPServers": ["time.example.test"]},
+        },
+        CHASSIS: {
+            "@odata.id": CHASSIS,
+            "Id": "Chassis_0",
+            "Status": {"Health": "OK", "State": "Enabled"},
+        },
+    }
+    for path, payload in payloads.items():
+        _write_json(corpus / _fixture_name(path), payload)
+    return corpus, payloads
+
+
+def _mutation_rules(tmp_path: Path) -> Path:
+    rules = {
+        "vendor": "hammer",
+        "rules": [
+            {
+                "name": "graceful-restart",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "GracefulRestart"},
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": SYSTEM,
+                        "field": "LastResetTime",
+                        "value": "2099-01-01T00:00:00Z",
+                    }
+                ],
+                "response": {"status": 204},
+            }
+        ],
+    }
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, rules)
+    return rules_path
+
+
+def _percentile(values: list[float], pct: int) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(pct / 100 * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _get(base: str, path: str) -> tuple[int, Any, float]:
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(base + path, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+            status, payload = response.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        status, payload = exc.code, (json.loads(raw) if raw else None)
+    return status, payload, time.perf_counter() - start
+
+
+def _write(base: str, path: str, method: str, body: dict[str, Any]) -> tuple[int, float]:
+    data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        base + path, data=data, headers={"Content-Type": "application/json"}, method=method
+    )
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            response.read()
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        exc.read()
+        status = exc.code
+    return status, time.perf_counter() - start
+
+
+def test_get_hammer_200_threads_keeps_bodies_correct(tmp_path: Path) -> None:
+    """10k concurrent GETs across paths return each path's exact corpus body."""
+    module = _load_server_module()
+    corpus, expected = _corpus(tmp_path)
+    paths = [SYSTEM, NP, CHASSIS]
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        plan = [paths[i % len(paths)] for i in range(HAMMER_REQUESTS)]
+        started = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=HAMMER_THREADS) as pool:
+            results = list(pool.map(lambda p: (p, *_get(base, p)), plan))
+        wall = time.perf_counter() - started
+
+    latencies = [row[3] for row in results]
+    p50 = _percentile(latencies, 50) * 1000
+    p95 = _percentile(latencies, 95) * 1000
+    p99 = _percentile(latencies, 99) * 1000
+    throughput = HAMMER_REQUESTS / wall
+    print(
+        f"\nGET hammer (reqs={HAMMER_REQUESTS}, threads={HAMMER_THREADS}): "
+        f"wall={wall:.3f}s rps={throughput:.0f} "
+        f"p50={p50:.3f}ms p95={p95:.3f}ms p99={p99:.3f}ms"
+    )
+
+    assert len(results) == HAMMER_REQUESTS
+    errors = [row for row in results if row[1] != 200]
+    assert not errors, f"{len(errors)} non-200 responses under load"
+    # Every body is the complete, path-correct corpus fixture (no mixups).
+    for path, status, payload, _latency in results:
+        assert status == 200
+        assert payload == expected[path]
+
+
+def test_mixed_get_post_benchmark_records_read_and_write_latency(tmp_path: Path) -> None:
+    """A mixed read/write storm keeps reads valid and writes clean (2xx/409)."""
+    module = _load_server_module()
+    corpus, expected = _corpus(tmp_path)
+    rules = _mutation_rules(tmp_path)
+
+    total = 4000
+    # 3:1 read:write mix. Writes POST to RESET (mutating SYSTEM's overlay); reads
+    # target only NP and CHASSIS, which no rule mutates, so a read's body must
+    # always equal its pristine corpus fixture even while writes are in flight.
+    read_paths = [NP, CHASSIS]
+    plan: list[tuple[str, str, dict[str, Any] | None]] = []
+    for i in range(total):
+        if i % 4 == 0:
+            plan.append(("POST", RESET, {"ResetType": "GracefulRestart"}))
+        else:
+            plan.append(("GET", read_paths[i % len(read_paths)], None))
+
+    read_latencies: list[float] = []
+    write_latencies: list[float] = []
+    read_ok = 0
+    write_ok = 0
+
+    with module.run_server("127.0.0.1", 0, corpus, mutation_rules=rules) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        def run(job: tuple[str, str, dict[str, Any] | None]) -> tuple[str, int, float]:
+            method, path, body = job
+            if method == "GET":
+                status, payload, latency = _get(base, path)
+                assert payload == expected[path]  # unmutated reads stay path-correct
+                return "GET", status, latency
+            status, latency = _write(base, path, method, body or {})
+            return "POST", status, latency
+
+        started = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=64) as pool:
+            results = list(pool.map(run, plan))
+        wall = time.perf_counter() - started
+
+        # The write overlay is observable on the mutated resource afterwards.
+        final_status, final_system, _ = _get(base, SYSTEM)
+    assert final_status == 200
+    assert final_system["LastResetTime"] == "2099-01-01T00:00:00Z"
+    assert final_system["PowerState"] == "On"  # unrelated fields intact
+
+    for kind, status, latency in results:
+        if kind == "GET":
+            read_latencies.append(latency)
+            read_ok += status == 200
+        else:
+            write_latencies.append(latency)
+            write_ok += status in (200, 204)
+            assert status in (200, 204, 409), f"unexpected write status {status}"
+
+    print(
+        f"\nmixed GET+POST (reqs={total}, threads=64): wall={wall:.3f}s "
+        f"read_p95={_percentile(read_latencies, 95) * 1000:.3f}ms "
+        f"write_p95={_percentile(write_latencies, 95) * 1000:.3f}ms"
+    )
+
+    assert read_ok == len(read_latencies)  # every read succeeded
+    # The idempotent write rule matches every POST -> all writes succeed (204).
+    assert write_ok == len(write_latencies)

--- a/tests/test_mock_bmc_multi_instance.py
+++ b/tests/test_mock_bmc_multi_instance.py
@@ -1,0 +1,106 @@
+"""Per-instance identity isolation for many mock BMCs at once.
+
+One committed corpus serves as many DISTINCT BMCs via a per-pod identity overlay
+(``MOCK_BMC_RACK`` / ``MOCK_BMC_SLOT``), captured when each handler class is
+built. This test starts several servers on distinct ports, each with its own
+rack/slot, then concurrently reads ``System_0`` from all of them and asserts each
+returns ONLY its own ``GB300-R<rack>-S<slot>`` identity — no overlay from a peer
+instance leaks across servers under concurrent load.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import os
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+# Distinct (rack, slot) identities -> distinct GB300-R<rack>-S<slot> nodes.
+CONFIGS = ((1, 1), (2, 1), (3, 2), (4, 3), (5, 4), (6, 1), (7, 2), (8, 3))
+REQUESTS_PER_INSTANCE = 30
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "_redfish_v1.json").write_text(
+        json.dumps({"@odata.id": "/redfish/v1", "Id": "RootService"}), encoding="utf-8"
+    )
+    (corpus / "_redfish_v1_Systems_System_0.json").write_text(
+        json.dumps(
+            {
+                "@odata.id": SYSTEM,
+                "Id": "System_0",
+                "Name": "shared-corpus",
+                "SerialNumber": "shared-corpus",
+                "PowerState": "On",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return corpus
+
+
+def _get_serial(base: str) -> str:
+    with urllib.request.urlopen(base + SYSTEM, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return payload["SerialNumber"]
+
+
+def _expected_node(rack: int, slot: int) -> str:
+    return f"GB300-R{rack}-S{str(slot).zfill(2)}"
+
+
+def test_multi_instance_identity_overlays_do_not_leak(tmp_path: Path) -> None:
+    """Concurrent reads across instances each see only their own identity."""
+    module = _load_server_module()
+    corpus = _corpus(tmp_path)
+    saved = {k: os.environ.get(k) for k in ("MOCK_BMC_RACK", "MOCK_BMC_SLOT")}
+
+    try:
+        with contextlib.ExitStack() as stack:
+            instances: list[tuple[str, str]] = []  # (base_url, expected_serial)
+            for rack, slot in CONFIGS:
+                # Each handler class captures the CURRENT env at build time, so
+                # set identity immediately before starting each server.
+                os.environ["MOCK_BMC_RACK"] = str(rack)
+                os.environ["MOCK_BMC_SLOT"] = str(slot)
+                server = stack.enter_context(module.run_server("127.0.0.1", 0, corpus))
+                base = "http://{}:{}".format(*server.server_address)
+                instances.append((base, _expected_node(rack, slot)))
+
+            # Every distinct identity actually rendered (guards a build-time bug).
+            assert len({serial for _, serial in instances}) == len(CONFIGS)
+
+            plan = [inst for inst in instances for _ in range(REQUESTS_PER_INSTANCE)]
+            with ThreadPoolExecutor(max_workers=len(CONFIGS) * 4) as pool:
+                observed = list(
+                    pool.map(lambda inst: (_get_serial(inst[0]), inst[1]), plan)
+                )
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    assert len(observed) == len(CONFIGS) * REQUESTS_PER_INSTANCE
+    # Each read returns exactly its own instance's identity — no cross-leak.
+    for got_serial, expected_serial in observed:
+        assert got_serial == expected_serial

--- a/tests/test_mock_bmc_sustained_load.py
+++ b/tests/test_mock_bmc_sustained_load.py
@@ -1,0 +1,169 @@
+"""Sustained-load stability: no file-descriptor, thread, or memory leak.
+
+Drives a bounded but sustained mixed read/write storm (with periodic
+``/__set_scenario`` resets so engine state stays bounded) and checks that open
+file descriptors, live threads, and RSS return to their pre-load baseline, and
+that the server stays responsive throughout. A socket/file-handle leak or a
+runaway thread pool would show as a monotonic climb the assertions catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+SCENARIO = "sustained"
+OPS = 4000
+THREADS = 50
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    _write_json(corpus / "_redfish_v1.json", {"@odata.id": "/redfish/v1", "Id": "Root"})
+    _write_json(
+        corpus / "_redfish_v1_Systems_System_0.json",
+        {"@odata.id": SYSTEM, "Id": "System_0", "PowerState": "On", "AssetTag": ""},
+    )
+    return corpus
+
+
+def _rules(tmp_path: Path) -> Path:
+    rules = {
+        "vendor": SCENARIO,
+        "rules": [
+            {
+                "name": "graceful",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "GracefulRestart"},
+                "state_transitions": [
+                    {"op": "set", "path": SYSTEM, "field": "PowerState", "value": "On"}
+                ],
+                "response": {"status": 204},
+            },
+            {
+                "name": "tag",
+                "method": "PATCH",
+                "path": SYSTEM,
+                "body_contains": {"AssetTag": "svc"},
+                "state_transitions": [
+                    {"op": "set", "path": SYSTEM, "field": "AssetTag", "value": "svc"}
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+        ],
+    }
+    path = tmp_path / "rules.json"
+    _write_json(path, rules)
+    return path
+
+
+def _request(base: str, path: str, method: str = "GET", body: Any = None) -> int:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    request = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as exc:
+        exc.read()
+        return exc.code
+
+
+def _op(index: int, base: str) -> int:
+    bucket = index % 100
+    if bucket < 45:
+        return _request(base, SYSTEM)
+    if bucket < 70:
+        return _request(base, RESET, "POST", {"ResetType": "GracefulRestart"})
+    if bucket < 90:
+        return _request(base, SYSTEM, "PATCH", {"AssetTag": "svc"})
+    if bucket == 99:
+        return _request(base, "/__set_scenario", "POST", {"scenario": SCENARIO})
+    return _request(base, "/redfish/v1")
+
+
+def test_sustained_mixed_load_leaks_no_fds_threads_or_memory(tmp_path: Path) -> None:
+    """A sustained storm returns FDs/threads/RSS to baseline and stays responsive."""
+    psutil = pytest.importorskip("psutil")
+    module = _load_server_module()
+    corpus = _corpus(tmp_path)
+    rules = _rules(tmp_path)
+    proc = psutil.Process()
+
+    with module.run_server("127.0.0.1", 0, corpus, mutation_rules=rules) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        # Warm up so lazy imports / buffers are allocated before the baseline.
+        for _ in range(50):
+            _request(base, SYSTEM)
+        time.sleep(0.2)
+        fd_before = proc.num_fds()
+        rss_before = proc.memory_info().rss
+        threads_before = threading.active_count()
+
+        statuses: list[int] = []
+        statuses_lock = threading.Lock()
+
+        def run(index: int) -> None:
+            code = _op(index, base)
+            with statuses_lock:
+                statuses.append(code)
+
+        with ThreadPoolExecutor(max_workers=THREADS) as pool:
+            list(pool.map(run, range(OPS)))
+
+        # Let daemon request threads and sockets settle before re-sampling.
+        time.sleep(0.5)
+        fd_after = proc.num_fds()
+        rss_after = proc.memory_info().rss
+        threads_after = threading.active_count()
+
+        # Server is still healthy after the storm.
+        assert _request(base, SYSTEM) == 200
+
+    print(
+        f"\nsustained load (ops={OPS}, threads={THREADS}): "
+        f"fd {fd_before}->{fd_after} rss {rss_before // 1024}K->{rss_after // 1024}K "
+        f"threads {threads_before}->{threads_after}"
+    )
+
+    assert len(statuses) == OPS
+    # Only expected codes: reads 200, writes 200/204, scenario reset 200.
+    assert set(statuses) <= {200, 204}
+    # No leak: descriptors, threads, and memory return near baseline.
+    assert fd_after - fd_before <= 16, f"fd leak: {fd_before} -> {fd_after}"
+    assert threads_after - threads_before <= 4, (
+        f"thread leak: {threads_before} -> {threads_after}"
+    )
+    assert rss_after - rss_before <= 64 * 1024 * 1024, (
+        f"rss grew {(rss_after - rss_before) // 1024}K over {OPS} ops"
+    )

--- a/tests/test_mutation_rules_latency.py
+++ b/tests/test_mutation_rules_latency.py
@@ -1,0 +1,132 @@
+"""Write-latency contract for the MutationRules engine under concurrency.
+
+A rule with a ``when`` precondition forces the engine to read the corpus fixture
+for that resource (file read + JSON parse). If that lookup runs while the engine
+lock is held, every concurrent write serializes behind one another's disk I/O —
+p95/p99 climb linearly with write concurrency. The engine must fetch corpus
+state BEFORE taking the lock, so concurrent writers overlap their I/O. This test
+drives N concurrent writes through a deliberately slow corpus lookup and asserts
+the wall-clock stays far below the serialized lower bound (N x delay). It fails
+while the lookup is under the lock and passes once it is lifted out.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+
+# Per-lookup corpus-read delay and writer count. The serialized lower bound is
+# WRITERS * LOOKUP_DELAY; overlapped I/O collapses to roughly one delay.
+LOOKUP_DELAY = 0.02
+WRITERS = 12
+SERIALIZED_LOWER_BOUND = WRITERS * LOOKUP_DELAY
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _percentile(values: list[float], pct: int) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(pct / 100 * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _reset_when_on_rules() -> dict[str, Any]:
+    return {
+        "vendor": "latency-test",
+        "rules": [
+            {
+                "name": "reset-when-on",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "GracefulRestart"},
+                # Precondition read against System_0's corpus state -> forces a
+                # corpus lookup on every matching write.
+                "when": [
+                    {"path": SYSTEM, "field": "PowerState", "equals": "On"},
+                ],
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": SYSTEM,
+                        "field": "LastResetTime",
+                        "value": "2099-01-01T00:00:00Z",
+                    },
+                ],
+                "response": {"status": 204},
+            },
+        ],
+    }
+
+
+def test_mutation_write_corpus_io_does_not_serialize_under_lock() -> None:
+    """Concurrent writes overlap their corpus I/O instead of queuing on the lock."""
+    module = _load_server_module()
+    engine = module.MutationRules(_reset_when_on_rules())
+
+    lookups = 0
+    lookups_lock = threading.Lock()
+
+    def slow_lookup(_path: str) -> dict[str, Any]:
+        nonlocal lookups
+        with lookups_lock:
+            lookups += 1
+        time.sleep(LOOKUP_DELAY)  # emulate a slow corpus file read + JSON parse
+        return {"PowerState": "On"}
+
+    latencies: list[float] = []
+    latencies_lock = threading.Lock()
+
+    def one_write() -> dict[str, Any] | None:
+        start = time.perf_counter()
+        result = engine.match_write(
+            "POST", RESET, {"ResetType": "GracefulRestart"}, corpus_state=slow_lookup
+        )
+        with latencies_lock:
+            latencies.append(time.perf_counter() - start)
+        return result
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=WRITERS) as pool:
+        results = list(pool.map(lambda _: one_write(), range(WRITERS)))
+    wall = time.perf_counter() - started
+
+    p50 = _percentile(latencies, 50)
+    p95 = _percentile(latencies, 95)
+    p99 = _percentile(latencies, 99)
+    print(
+        f"\nmutation write latency (n={WRITERS}, lookup_delay={LOOKUP_DELAY}s): "
+        f"wall={wall:.3f}s p50={p50:.3f}s p95={p95:.3f}s p99={p99:.3f}s "
+        f"lookups={lookups} serialized_bound={SERIALIZED_LOWER_BOUND:.3f}s"
+    )
+
+    # Correctness must be preserved: every matching write applied exactly once.
+    assert all(r == {"status": 204} for r in results)
+    assert engine.status()["applied"].count("reset-when-on") == WRITERS
+    # The overlay reflects the serialized transitions (torn state would differ).
+    assert engine.overlay_for(SYSTEM)["LastResetTime"] == "2099-01-01T00:00:00Z"
+
+    # The crux: if corpus I/O ran under the lock, wall-clock would be >=
+    # SERIALIZED_LOWER_BOUND. Overlapped I/O collapses it to ~one delay.
+    assert wall < SERIALIZED_LOWER_BOUND / 2, (
+        f"writes serialized on corpus I/O: wall={wall:.3f}s is not below "
+        f"half the serialized bound {SERIALIZED_LOWER_BOUND:.3f}s"
+    )
+    # Per-write latency should track a single delay, not a queue of them.
+    assert p95 < SERIALIZED_LOWER_BOUND / 2

--- a/tests/test_mutation_rules_stress.py
+++ b/tests/test_mutation_rules_stress.py
@@ -1,0 +1,207 @@
+"""High-concurrency stress + failure-injection oracle for MutationRules.
+
+Fires a fixed 5000-write multiset through the engine on 200 threads, with one
+rule injecting stochastic failures and one rule gated by a corpus precondition,
+then replays the identical multiset serially on a fresh engine seeded the same
+way. The workload is built so its observable aggregates are order-invariant:
+
+* each write matches exactly one rule (no overlapping globs), so ``applied`` per
+  rule is fixed by how many writes target it;
+* every success rule sets a distinct field to a fixed value, so the final
+  overlay is the commutative union of those fields regardless of order;
+* only the flaky rule draws the seeded RNG, once per matching write, so the
+  number of injected failures is the count of ``rng() < p`` over the first
+  ``N_fail`` seeded draws — identical for the concurrent and serial runs even
+  though which specific writes fail differs.
+
+The concurrent engine must therefore match the serial oracle exactly (applied
+counts, failed counts, and per-resource overlays), proving the engine lock keeps
+transitions atomic and the RNG uncorrupted under load. Latency percentiles are
+recorded for the write path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import random
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+NP = "/redfish/v1/Managers/BMC_0/NetworkProtocol"
+CHASSIS = "/redfish/v1/Chassis/Chassis_0"
+
+SEED = 90210
+THREADS = 200
+PER_SUCCESS_RULE = 600
+FAIL_WRITES = 1600
+NOMATCH_WRITES = 1600
+FAILURE_PROBABILITY = 0.3
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _percentile(values: list[float], pct: int) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(pct / 100 * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _rules() -> dict[str, Any]:
+    return {
+        "vendor": "stress",
+        "rules": [
+            {
+                "name": "sys-tag",
+                "method": "PATCH",
+                "path": SYSTEM,
+                "body_contains": {"AssetTag": "svc"},
+                # Corpus-stable precondition -> always holds, but exercises the
+                # precondition + corpus-lookup path (the one Fix #2 lifts out).
+                "when": [{"path": SYSTEM, "field": "PowerState", "equals": "On"}],
+                "state_transitions": [
+                    {"op": "set", "path": SYSTEM, "field": "AssetTag", "value": "svc"}
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+            {
+                "name": "np-ntp",
+                "method": "PATCH",
+                "path": NP,
+                "body_contains": {"NTP": {"ProtocolEnabled": False}},
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": NP,
+                        "json_path": ["NTP", "ProtocolEnabled"],
+                        "value": False,
+                    }
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+            {
+                "name": "chs-led",
+                "method": "PATCH",
+                "path": CHASSIS,
+                "body_contains": {"IndicatorLED": "Lit"},
+                "state_transitions": [
+                    {"op": "set", "path": CHASSIS, "field": "IndicatorLED", "value": "Lit"}
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+            {
+                "name": "reset-flaky",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "ForceRestart"},
+                "failure": {"probability": FAILURE_PROBABILITY, "response": {"status": 503}},
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": SYSTEM,
+                        "field": "LastResetTime",
+                        "value": "2099-01-01T00:00:00Z",
+                    }
+                ],
+                "response": {"status": 204},
+            },
+        ],
+    }
+
+
+def _workload() -> list[tuple[str, str, dict[str, Any]]]:
+    writes: list[tuple[str, str, dict[str, Any]]] = []
+    writes += [("PATCH", SYSTEM, {"AssetTag": "svc"})] * PER_SUCCESS_RULE
+    writes += [("PATCH", NP, {"NTP": {"ProtocolEnabled": False}})] * PER_SUCCESS_RULE
+    writes += [("PATCH", CHASSIS, {"IndicatorLED": "Lit"})] * PER_SUCCESS_RULE
+    writes += [("POST", RESET, {"ResetType": "ForceRestart"})] * FAIL_WRITES
+    writes += [("PATCH", SYSTEM, {"Unmatched": 1})] * NOMATCH_WRITES
+    random.Random(20260715).shuffle(writes)  # fixed multiset order for dispatch
+    return writes
+
+
+def test_mutation_rules_200_threads_match_serial_oracle_with_failure_injection() -> None:
+    """A 200-thread write storm reproduces the serial oracle's state exactly."""
+    module = _load_server_module()
+    normalize = module._normalize_request_path
+    corpus = {normalize(SYSTEM): {"PowerState": "On"}}
+
+    def corpus_lookup(path: str) -> dict[str, Any]:
+        return corpus.get(normalize(path), {})
+
+    writes = _workload()
+
+    concurrent = module.MutationRules(_rules(), seed=SEED)
+    latencies: list[float] = []
+    latencies_lock = threading.Lock()
+
+    def one(write: tuple[str, str, dict[str, Any]]) -> Any:
+        method, path, body = write
+        start = time.perf_counter()
+        result = concurrent.match_write(method, path, body, corpus_state=corpus_lookup)
+        elapsed = time.perf_counter() - start
+        with latencies_lock:
+            latencies.append(elapsed)
+        return result
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=THREADS) as pool:
+        responses = list(pool.map(one, writes))
+    wall = time.perf_counter() - started
+
+    # Serial oracle: identical multiset, fresh engine, same seed.
+    serial = module.MutationRules(_rules(), seed=SEED)
+    for method, path, body in writes:
+        serial.match_write(method, path, body, corpus_state=corpus_lookup)
+
+    conc_status = concurrent.status()
+    serial_status = serial.status()
+    applied = Counter(conc_status["applied"])
+    failed = Counter(conc_status["failed"])
+
+    p50 = _percentile(latencies, 50) * 1000
+    p95 = _percentile(latencies, 95) * 1000
+    p99 = _percentile(latencies, 99) * 1000
+    print(
+        f"\nmutation stress (writes={len(writes)}, threads={THREADS}): "
+        f"wall={wall:.3f}s p50={p50:.3f}ms p95={p95:.3f}ms p99={p99:.3f}ms "
+        f"applied={sum(applied.values())} failed={sum(failed.values())} "
+        f"nomatch={responses.count(None)}"
+    )
+
+    # Oracle equivalence: aggregates and overlays match the serial replay exactly.
+    assert applied == Counter(serial_status["applied"])
+    assert failed == Counter(serial_status["failed"])
+    for path in (SYSTEM, NP, CHASSIS):
+        assert concurrent.overlay_for(path) == serial.overlay_for(path)
+
+    # Exact, order-invariant expectations.
+    assert applied["sys-tag"] == PER_SUCCESS_RULE
+    assert applied["np-ntp"] == PER_SUCCESS_RULE
+    assert applied["chs-led"] == PER_SUCCESS_RULE
+    assert set(failed) == {"reset-flaky"}
+    reset_failures = sum(failed.values())
+    assert 0 < reset_failures < FAIL_WRITES  # injection actually fired, not all
+    assert applied["reset-flaky"] == FAIL_WRITES - reset_failures
+    assert responses.count(None) == NOMATCH_WRITES  # unmatched writes -> no rule
+
+    # Final overlay carries every distinctly-set field, uncorrupted.
+    assert concurrent.overlay_for(SYSTEM)["AssetTag"] == "svc"
+    assert concurrent.overlay_for(SYSTEM)["LastResetTime"] == "2099-01-01T00:00:00Z"
+    assert concurrent.overlay_for(NP)["NTP"]["ProtocolEnabled"] is False
+    assert concurrent.overlay_for(CHASSIS)["IndicatorLED"] == "Lit"

--- a/tests/test_nic_firmware.py
+++ b/tests/test_nic_firmware.py
@@ -1,0 +1,104 @@
+"""Unit tests for the nic-firmware command's classification and resilience.
+
+Covers the review-hardened behavior: token-based (not substring) classification,
+Dell Current-/Installed- firmware de-duplication, and graceful degradation when
+the top-level Chassis collection errors (the firmware slice must still land).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from redfish_ctl.network.cmd_nic_firmware import network_class
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("CX8_0", "NIC"),
+        ("NIC_1", "NIC"),
+        ("Current-110618-21.5.9__NIC.Slot.1", "NIC"),
+        ("Riser_Slot2_BlueField_3_Card", "DPU"),
+        ("BF3_0", "DPU"),
+        ("ConnectX-8 800GE 2P NIC", "NIC"),
+        # Not network firmware — must return None (no substring false-positives).
+        ("HGX_FW_GPU_1", None),
+        ("AB86B73D_8D56_41E4_971E_B11DB71F2E33", None),
+        ("BIOS", None),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_network_class_token_matching(text, expected):
+    """Classification matches whole tokens, so GUIDs/GPU firmware are not network."""
+    assert network_class(text) == expected
+
+
+def _serve(routes):
+    """Return a requests_mock text callback that serves ``routes`` (path -> obj/int).
+
+    requests_mock lowercases the request path, so routes are matched case-insensitively.
+    """
+    lowered = {path.lower(): entry for path, entry in routes.items()}
+
+    def cb(request, context):
+        entry = lowered.get(request.path.lower())
+        if entry is None:
+            context.status_code = 404
+            return json.dumps({"error": "not found"})
+        if isinstance(entry, int):
+            context.status_code = entry
+            return json.dumps({"error": "status"})
+        context.status_code = 200
+        return json.dumps(entry)
+    return cb
+
+
+def _run_nic_firmware(routes):
+    requests_mock = pytest.importorskip("requests_mock")
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=_serve(routes))
+        mgr = RedfishManagerBase(idrac_ip="mock", idrac_username="root", idrac_password="x",
+                                 insecure=True, is_debug=False)
+        return mgr.sync_invoke(ApiRequestType.NicFirmware, "nic-firmware").data
+
+
+def test_dedups_dell_current_installed_pairs():
+    """Paired Current-*/Installed-* firmware members collapse to one component."""
+    fw_base = "/redfish/v1/UpdateService/FirmwareInventory"
+    routes = {
+        "/redfish/v1/Chassis": {"Members": []},  # no adapters needed for this case
+        fw_base: {"Members": [
+            {"@odata.id": f"{fw_base}/Current-21.5.9__NIC.Slot.1"},
+            {"@odata.id": f"{fw_base}/Installed-21.5.9__NIC.Slot.1"},
+        ]},
+        f"{fw_base}/Current-21.5.9__NIC.Slot.1": {
+            "Id": "Current-21.5.9__NIC.Slot.1", "Version": "21.5.9",
+            "Updateable": True, "Name": "NIC.Slot.1"},
+        f"{fw_base}/Installed-21.5.9__NIC.Slot.1": {
+            "Id": "Installed-21.5.9__NIC.Slot.1", "Version": "21.5.9",
+            "Updateable": False, "Name": "NIC.Slot.1"},
+    }
+    data = _run_nic_firmware(routes)
+    assert data["summary"]["firmware_count"] == 1  # not 2
+    assert data["summary"]["distinct_versions"] == ["21.5.9"]
+
+
+def test_survives_chassis_error_and_still_returns_firmware():
+    """A 500 on the Chassis collection must not sink the firmware read."""
+    fw_base = "/redfish/v1/UpdateService/FirmwareInventory"
+    routes = {
+        "/redfish/v1/Chassis": 500,  # adapters walk fails
+        fw_base: {"Members": [{"@odata.id": f"{fw_base}/CX8_0"}]},
+        f"{fw_base}/CX8_0": {"Id": "CX8_0", "Version": "40.45.3048",
+                             "Updateable": True, "Name": "Software Inventory"},
+    }
+    data = _run_nic_firmware(routes)
+    assert data["adapters"] == []  # chassis walk degraded gracefully
+    assert data["summary"]["firmware_count"] == 1
+    assert any(f["Id"] == "CX8_0" and f["Version"] == "40.45.3048"
+               for f in data["firmware"])

--- a/tests/test_replay_concurrency.py
+++ b/tests/test_replay_concurrency.py
@@ -1,0 +1,278 @@
+"""Concurrency contracts for the ordered ReplayState engine.
+
+The replay engine consumes a fixed step sequence exactly once, in order. These
+tests hammer it concurrently to prove two invariants that only break under
+concurrency: (1) each step is matched exactly once even when many threads race
+the same write (later duplicates get 409), and (2) a ``/__set_scenario`` reset is
+atomic with respect to in-flight writes (no torn overlay, no 5xx), leaving the
+engine behaving as if freshly started.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+SCENARIO = "power-cycle"
+
+# The ordered trace, and the write each step matches (fired in order per thread).
+STEP_WRITES: tuple[tuple[str, str, dict[str, Any]], ...] = (
+    ("POST", RESET, {"ResetType": "ForceOff"}),
+    ("PATCH", SYSTEM, {"Boot": {"BootSourceOverrideTarget": "Hdd"}}),
+    ("POST", RESET, {"ResetType": "On"}),
+    ("PATCH", SYSTEM, {"AssetTag": "svc-1"}),
+    ("POST", RESET, {"ResetType": "GracefulRestart"}),
+)
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _fixture_name(path: str) -> str:
+    return "_" + path.strip("/").replace("/", "_") + ".json"
+
+
+def _tiny_corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    _write_json(
+        corpus / _fixture_name("/redfish/v1"),
+        {"@odata.id": "/redfish/v1", "Id": "RootService"},
+    )
+    _write_json(
+        corpus / _fixture_name(SYSTEM),
+        {
+            "@odata.id": SYSTEM,
+            "Id": "System_0",
+            "PowerState": "On",
+            "AssetTag": "",
+            "Boot": {"BootSourceOverrideEnabled": "Once", "BootSourceOverrideTarget": "Pxe"},
+        },
+    )
+    return corpus
+
+
+def _replay_trace(tmp_path: Path) -> Path:
+    steps = [
+        {
+            "name": "force-off",
+            "method": "POST",
+            "path": RESET,
+            "body_contains": {"ResetType": "ForceOff"},
+            "state_transitions": [
+                {"op": "set", "path": SYSTEM, "field": "PowerState", "value": "Off"}
+            ],
+            "response": {"status": 204},
+        },
+        {
+            "name": "set-hdd",
+            "method": "PATCH",
+            "path": SYSTEM,
+            "body_contains": {"Boot": {"BootSourceOverrideTarget": "Hdd"}},
+            "state_transitions": [
+                {
+                    "op": "set",
+                    "path": SYSTEM,
+                    "json_path": ["Boot", "BootSourceOverrideTarget"],
+                    "value": "Hdd",
+                }
+            ],
+            "response": {"status": 200, "body": {"ok": True}},
+        },
+        {
+            "name": "power-on",
+            "method": "POST",
+            "path": RESET,
+            "body_contains": {"ResetType": "On"},
+            "state_transitions": [
+                {"op": "set", "path": SYSTEM, "field": "PowerState", "value": "On"}
+            ],
+            "response": {"status": 204},
+        },
+        {
+            "name": "tag",
+            "method": "PATCH",
+            "path": SYSTEM,
+            "body_contains": {"AssetTag": "svc-1"},
+            "state_transitions": [
+                {"op": "set", "path": SYSTEM, "field": "AssetTag", "value": "svc-1"}
+            ],
+            "response": {"status": 200, "body": {"ok": True}},
+        },
+        {
+            "name": "graceful",
+            "method": "POST",
+            "path": RESET,
+            "body_contains": {"ResetType": "GracefulRestart"},
+            "state_transitions": [
+                {
+                    "op": "set",
+                    "path": SYSTEM,
+                    "field": "LastResetTime",
+                    "value": "2099-01-01T00:00:00Z",
+                }
+            ],
+            "response": {"status": 204},
+        },
+    ]
+    trace = {"scenario": SCENARIO, "steps": steps}
+    trace_path = tmp_path / "replay.json"
+    _write_json(trace_path, trace)
+    return trace_path
+
+
+def _request(
+    base: str, path: str, method: str = "GET", body: dict[str, Any] | None = None
+) -> tuple[int, Any]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    request = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, (json.loads(raw) if raw else None)
+
+
+def _run_replay(module: Any, corpus: Path, trace: Path) -> None:
+    successes: list[tuple[str, str]] = []
+    statuses: list[int] = []
+    lock = threading.Lock()
+    done = threading.Event()
+    workers = 24
+
+    with module.run_server("127.0.0.1", 0, corpus, replay_trace=trace) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        def worker() -> None:
+            rounds = 0
+            while not done.is_set() and rounds < 200:
+                rounds += 1
+                for method, path, body in STEP_WRITES:
+                    if done.is_set():
+                        break
+                    status, _payload = _request(base, path, method, body)
+                    with lock:
+                        statuses.append(status)
+                        if status in (200, 204):
+                            successes.append((method, path))
+                            if len(successes) >= len(STEP_WRITES):
+                                done.set()
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            for future in [pool.submit(worker) for _ in range(workers)]:
+                future.result()
+
+        final_status, final = _request(base, SYSTEM)
+        replay_code, replay = _request(base, "/__replay_status")
+
+    # (a) exactly one success per step, never more.
+    assert len(successes) == len(STEP_WRITES)
+    # (b) every non-success write is a clean 409 (no 5xx, no torn write).
+    assert set(statuses) <= {200, 204, 409}
+    assert statuses.count(200) + statuses.count(204) == len(STEP_WRITES)
+    # (c) replay is complete and each step counted once.
+    assert replay_code == 200
+    assert replay["complete"] is True
+    assert replay["matched_steps"] == len(STEP_WRITES)
+    assert replay["pending_steps"] == []
+    # (d) final overlay equals the trace's deterministic end state.
+    assert final_status == 200
+    assert final["PowerState"] == "On"
+    assert final["Boot"]["BootSourceOverrideTarget"] == "Hdd"
+    assert final["AssetTag"] == "svc-1"
+    assert final["LastResetTime"] == "2099-01-01T00:00:00Z"
+
+
+def test_replay_determinism_under_concurrency(tmp_path: Path) -> None:
+    """Each ordered step is consumed exactly once under a 24-thread race."""
+    module = _load_server_module()
+    corpus = _tiny_corpus(tmp_path)
+    trace = _replay_trace(tmp_path)
+    _run_replay(module, corpus, trace)
+
+
+def test_scenario_reset_is_atomic_under_write_load(tmp_path: Path) -> None:
+    """A reset amid concurrent writes never tears state and leaves a clean engine."""
+    module = _load_server_module()
+    corpus = _tiny_corpus(tmp_path)
+    trace = _replay_trace(tmp_path)
+
+    statuses: list[int] = []
+    lock = threading.Lock()
+    stop = threading.Event()
+
+    with module.run_server("127.0.0.1", 0, corpus, replay_trace=trace) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        def writer() -> None:
+            while not stop.is_set():
+                for method, path, body in STEP_WRITES:
+                    if stop.is_set():
+                        break
+                    status, _ = _request(base, path, method, body)
+                    with lock:
+                        statuses.append(status)
+
+        def resetter() -> None:
+            # Interleave several resets with the write storm.
+            for _ in range(20):
+                status, payload = _request(
+                    base, "/__set_scenario", "POST", {"scenario": SCENARIO}
+                )
+                with lock:
+                    statuses.append(status)
+                assert status == 200, payload
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = [pool.submit(writer) for _ in range(8)]
+            futures.append(pool.submit(resetter))
+            # Let the resetter finish, then stop the writers.
+            futures[-1].result()
+            stop.set()
+            for future in futures[:-1]:
+                future.result()
+
+        # After the storm, one clean reset must return the engine to zero.
+        reset_code, reset_status = _request(
+            base, "/__set_scenario", "POST", {"scenario": SCENARIO}
+        )
+        after_reset_system_code, after_reset_system = _request(base, SYSTEM)
+
+    # No request in the whole storm produced a server error or an unexpected code.
+    assert set(statuses) <= {200, 204, 409}
+    # The final clean reset zeroes the engine (atomic reset, not a torn count).
+    assert reset_code == 200
+    assert reset_status["matched_steps"] == 0
+    assert reset_status["complete"] is False
+    # Overlays are cleared: the System resource is back to its corpus baseline.
+    assert after_reset_system_code == 200
+    assert after_reset_system["PowerState"] == "On"
+    assert after_reset_system["Boot"]["BootSourceOverrideTarget"] == "Pxe"
+    assert after_reset_system["AssetTag"] == ""
+    assert "LastResetTime" not in after_reset_system
+
+    # And a freshly-reset engine still replays the full sequence deterministically.
+    _run_replay(module, corpus, trace)

--- a/tests/test_webui_concurrency.py
+++ b/tests/test_webui_concurrency.py
@@ -1,0 +1,133 @@
+"""Concurrency contract for the read-only web explorer server.
+
+The explorer shares ONE ``RedfishManagerBase`` across every request (lazily
+built once, cached on the handler class). That manager wraps a
+``requests.Session``, which is not thread-safe: two concurrent ``/api/invoke``
+POSTs that both call ``sync_invoke`` on the same session can interleave and
+return each other's payloads. The server must therefore serialize invocations
+per manager. This test proves each concurrent command gets ITS OWN command's
+data back — it fails against an unserialized handler and passes once the
+per-manager invoke lock is in place.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from types import SimpleNamespace
+from typing import Any
+
+from redfish_ctl.webui import server as webui
+
+# A handful of distinct read-only catalog commands to fan out over. Each maps to
+# a unique (api, command) pair, so a mixed-up response is unambiguous.
+_COMMANDS = (
+    "system_query",
+    "manager_query",
+    "chassis_service_query",
+    "boot_query",
+    "power",
+    "current_boot_query",
+    "storage_list",
+    "event-service",
+)
+
+
+class _RacyManager:
+    """Fake manager that emulates a NON-thread-safe ``requests.Session``.
+
+    It stashes the in-flight command on a shared instance attribute, yields the
+    GIL, then reads the attribute back — so two unsynchronized concurrent calls
+    clobber each other and observe the wrong command. A per-manager lock in the
+    handler serializes the calls and restores correctness. The read delay only
+    widens the interleaving window; it never blocks (no cross-thread barrier), so
+    the serialized path cannot deadlock.
+    """
+
+    def __init__(self) -> None:
+        self._inflight: str | None = None
+        self.max_concurrency = 0
+        self._active = 0
+        self._counter_lock = threading.Lock()
+
+    def sync_invoke(self, api: Any, command: str, **_kwargs: Any) -> SimpleNamespace:
+        with self._counter_lock:
+            self._active += 1
+            self.max_concurrency = max(self.max_concurrency, self._active)
+        try:
+            self._inflight = command
+            time.sleep(0.003)  # widen the window a racy session would corrupt
+            observed = self._inflight
+            return SimpleNamespace(
+                error=None,
+                data={"requested": command, "observed": observed, "api": getattr(api, "name", str(api))},
+            )
+        finally:
+            with self._counter_lock:
+                self._active -= 1
+
+
+def _make_handler_class(manager: _RacyManager) -> type:
+    """A fresh handler subclass bound to ``manager`` (isolates class state)."""
+
+    class Handler(webui._Handler):
+        pass
+
+    Handler.manager = None
+    Handler.manager_lock = threading.Lock()
+    # invoke_lock is a class attribute added by the fix; give this subclass its
+    # own so the test never contends with any other server instance.
+    Handler.invoke_lock = threading.Lock()
+    Handler.manager_factory = staticmethod(lambda: manager)
+    Handler.target_label = "racy-mock"
+    return Handler
+
+
+def _post_invoke(base: str, command: str) -> dict[str, Any]:
+    body = json.dumps({"command": command}).encode("utf-8")
+    request = urllib.request.Request(
+        base + "/api/invoke",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def test_webui_concurrent_invokes_keep_command_payloads_isolated() -> None:
+    """Every concurrent /api/invoke returns its own command's data, not a peer's."""
+    manager = _RacyManager()
+    handler_cls = _make_handler_class(manager)
+    server = webui.ExplorerServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = "http://{}:{}".format(*server.server_address)
+        jobs = [_COMMANDS[i % len(_COMMANDS)] for i in range(48)]
+        with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+            futures = {pool.submit(_post_invoke, base, cmd): cmd for cmd in jobs}
+            results = [(futures[f], f.result()) for f in as_completed(futures)]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert len(results) == len(jobs)
+    for requested, body in results:
+        assert body["ok"] is True, body
+        data = body["data"]
+        # The response must be the manager's answer to THIS request, not a peer's
+        # that clobbered a shared session mid-flight.
+        assert data["requested"] == requested, body
+        assert data["observed"] == requested, (
+            f"payload mix-up: requested {requested!r} but session observed "
+            f"{data['observed']!r} (concurrent sync_invoke race)"
+        )
+    # The lock must have actually serialized invocations against the one manager.
+    assert manager.max_concurrency == 1, (
+        f"expected serialized invokes, saw {manager.max_concurrency} concurrent"
+    )

--- a/tests/test_webui_explorer.py
+++ b/tests/test_webui_explorer.py
@@ -1,0 +1,127 @@
+"""Offline tests for the redfish_ctl web explorer.
+
+The explorer serves a tree of read-only commands and invokes them through the
+tool's own registry. These tests pin the catalog allow-list, the invoke
+dispatch, and the server-rendered page — with no live BMC (a fake manager for
+unit dispatch, the committed GB300 corpus for an end-to-end command run).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.webui import catalog, server
+
+GB300_CORPUS = corpus_dir(
+    Path(__file__).parent / "supermicro_gb300_corpus.tar.gz", "172.25.230.37"
+)
+GB300_INDEX = {p.name.lower(): p for p in GB300_CORPUS.glob("*.json")}
+
+# Known mutating command names that must NEVER appear in the read-only catalog.
+# An explicit denylist beats substring matching, which false-positives on read
+# commands like update_service and metric-definitions.
+_MUTATING_COMMANDS = frozenset({
+    "system_reset", "reboot", "manager_reset", "bios_change_settings", "attribute_update",
+    "change_boot_order", "boot_one_shot", "update", "clear_pending", "vm-mount", "ntp-set",
+    "firmware-update", "volume-create", "volume-delete", "convert_none_raid", "boot_enable",
+    "account-create", "account-update", "account-delete", "account-import-sshkey",
+    "serial-console", "secure-boot-enable", "virtual_disk_insert", "virtual_disk_eject",
+    "job_apply", "job_del", "import_sysconfig", "bios_snapshot",
+})
+
+
+class _FakeManager:
+    """Records sync_invoke calls and returns a configured CommandResult."""
+
+    def __init__(self, result):
+        self._result = result
+        self.calls = []
+
+    def sync_invoke(self, api_call, name, **kwargs):
+        self.calls.append((api_call, name, kwargs))
+        return self._result
+
+
+def test_catalog_resolves_and_is_read_only():
+    """Every catalog command resolves and none is a mutating action."""
+    entries = [e for _d, cmds in catalog.CATALOG for e in cmds]
+    assert entries, "catalog must not be empty"
+    for entry in entries:
+        assert catalog.resolve(entry.command) is entry
+        assert entry.command not in _MUTATING_COMMANDS, (
+            f"catalog command {entry.command!r} is mutating; explorer is read-only"
+        )
+
+
+def test_catalog_json_shape():
+    """catalog_json yields domains with labelled command entries for the UI."""
+    data = catalog.catalog_json()
+    assert {d["domain"] for d in data} >= {"Network", "Firmware", "System"}
+    nic = next(c for d in data for c in d["commands"] if c["command"] == "nic-firmware")
+    assert nic["api"] == "NicFirmware"
+    assert nic["heavy"] is False
+
+
+def test_invoke_command_success_and_error():
+    """invoke_command unwraps CommandResult into ok/data or ok=False/error."""
+    ok_mgr = _FakeManager(CommandResult({"adapters": []}, None, None, None))
+    out = server.invoke_command(ok_mgr, "nic-firmware")
+    assert out == {"ok": True, "data": {"adapters": []}}
+    # The dispatch used the catalog's (api, name) pair.
+    api_call, name, _ = ok_mgr.calls[0]
+    assert name == "nic-firmware" and api_call.name == "NicFirmware"
+
+    err_mgr = _FakeManager(CommandResult(None, None, None, "boom"))
+    out = server.invoke_command(err_mgr, "nic-firmware")
+    assert out["ok"] is False and out["error"] == "boom"
+
+
+def test_invoke_command_rejects_unlisted_command():
+    """A command not in the read-only catalog is refused (never dispatched)."""
+    mgr = _FakeManager(CommandResult({}, None, None, None))
+    with pytest.raises(KeyError):
+        server.invoke_command(mgr, "system_reset")
+    assert mgr.calls == []  # nothing was invoked
+
+
+def test_render_page_lists_domains_and_commands_and_escapes():
+    """The rendered explorer shell carries the tree and marks heavy commands."""
+    html = server.render_page("mock-gb300:443")
+    assert "redfish_ctl explorer" in html
+    assert "NIC / DPU firmware" in html
+    assert 'data-cmd="nic-firmware"' in html
+    assert "Sensors" in html and 'data-heavy="1"' in html  # sensors flagged heavy
+    assert "mock-gb300:443" in html
+
+
+def test_invoke_nic_firmware_end_to_end_against_corpus():
+    """Explorer invoke path drives the real nic-firmware command over the corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+
+    def cb(request, context):
+        name = "_" + request.path.strip("/").replace("/", "_") + ".json"
+        fixture = GB300_INDEX.get(name.lower())
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": "no fixture"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-gb300", idrac_username="root", idrac_password="x",
+            insecure=True, is_debug=False,
+        )
+        out = server.invoke_command(manager, "nic-firmware")
+
+    assert out["ok"] is True
+    summary = out["data"]["summary"]
+    assert summary["nic_count"] == 4
+    assert "40.45.3048" in summary["distinct_versions"]

--- a/tests/test_webui_explorer.py
+++ b/tests/test_webui_explorer.py
@@ -9,6 +9,10 @@ unit dispatch, the committed GB300 corpus for an end-to-end command run).
 from __future__ import annotations
 
 import json
+import threading
+import urllib.error
+import urllib.request
+from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
@@ -125,3 +129,79 @@ def test_invoke_nic_firmware_end_to_end_against_corpus():
     summary = out["data"]["summary"]
     assert summary["nic_count"] == 4
     assert "40.45.3048" in summary["distinct_versions"]
+
+
+# --------------------------------------------------------------------------- #
+# HTTP handler: route + status-code contract (loopback server, no live BMC).
+# --------------------------------------------------------------------------- #
+
+
+class _RaisingManager:
+    """sync_invoke raises — exercises the do_POST backend-failure (502) path."""
+
+    def sync_invoke(self, *_a, **_k):
+        raise RuntimeError("bmc unreachable")
+
+
+@contextmanager
+def _serve(manager):
+    """Run the explorer on an ephemeral loopback port with a fixed manager."""
+    handler = server._Handler
+    handler.manager = manager  # pre-set so the real factory is never called
+    handler.manager_factory = staticmethod(lambda: manager)
+    handler.target_label = "test-bmc:443"
+    httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{httpd.server_address[1]}"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+        handler.manager = None
+
+
+def _req(url, *, data=None, method="GET"):
+    """Return (status, body-bytes), treating a 4xx/5xx as a normal response."""
+    req = urllib.request.Request(
+        url, data=data, method=method,
+        headers={"Content-Type": "application/json"} if data is not None else {},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def test_http_get_routes_status_codes():
+    """/healthz, /api/catalog, and / serve 200; an unknown path is 404."""
+    with _serve(_FakeManager(CommandResult({"adapters": []}, None, None, None))) as base:
+        assert _req(base + "/healthz")[0] == 200
+        assert _req(base + "/api/catalog")[0] == 200
+        code, body = _req(base + "/")
+        assert code == 200 and b"redfish_ctl explorer" in body
+        assert _req(base + "/nope")[0] == 404
+
+
+def test_http_post_invoke_success_and_input_errors():
+    """A valid command is 200/ok; bad JSON and an unlisted command are 400; wrong path 404."""
+    with _serve(_FakeManager(CommandResult({"adapters": []}, None, None, None))) as base:
+        code, body = _req(base + "/api/invoke", data=json.dumps({"command": "nic-firmware"}).encode(),
+                          method="POST")
+        assert code == 200 and json.loads(body)["ok"] is True
+        # A mutating command is not allow-listed -> 400, never dispatched.
+        assert _req(base + "/api/invoke", data=json.dumps({"command": "system_reset"}).encode(),
+                    method="POST")[0] == 400
+        # Malformed body -> 400.
+        assert _req(base + "/api/invoke", data=b"{not json", method="POST")[0] == 400
+        # Wrong POST path -> 404.
+        assert _req(base + "/other", data=b"{}", method="POST")[0] == 404
+
+
+def test_http_post_backend_failure_is_502():
+    """A transport/backend failure during invoke surfaces as 502, not a masked 200."""
+    with _serve(_RaisingManager()) as base:
+        code, body = _req(base + "/api/invoke", data=json.dumps({"command": "nic-firmware"}).encode(),
+                          method="POST")
+        assert code == 502
+        assert json.loads(body)["ok"] is False


### PR DESCRIPTION
## Summary
- Add a NIC/DPU firmware read path with API facade support.
- Surface network firmware in RedfishEndpoint status and CRD schemas.
- Add lightweight fleet status consumer and web explorer deployments.

## Validation
- python -m pytest -q: 1168 passed, 58 skipped
- ruff check on changed Python files: All checks passed
- shellcheck k8s/consumer/deploy.sh k8s/explorer/deploy.sh
- git diff --check github/main...HEAD