### PR TITLE
Harden subscription mutation responses

### DIFF
--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -1,11 +1,20 @@
 """Create and delete Redfish EventDestination subscriptions."""
 
+import asyncio
+import inspect
+import json
 from typing import Optional
 
 from ..cmd_exceptions import InvalidArgument
-from ..redfish_manager_base import RedfishManagerBase
-from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import (
+    REDFISH_API,
+    ApiRequestType,
+    HTTPMethod,
+    RedfishApiRespond,
+    Singleton,
+)
 
 
 def _as_list(values) -> list[str]:
@@ -29,7 +38,18 @@ class _SubscriptionBase(RedfishManagerBase):
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
+    @staticmethod
+    def _ensure_event_loop():
+        try:
+            return asyncio.get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop
+
     def _subscription_collection_uri(self, do_async):
+        if do_async:
+            self._ensure_event_loop()
         service = self.base_query(
             REDFISH_API.EventServiceQuery,
             do_async=do_async,
@@ -40,6 +60,8 @@ class _SubscriptionBase(RedfishManagerBase):
         return subscriptions_uri
 
     def _subscription_members(self, subscriptions_uri, do_async):
+        if do_async:
+            self._ensure_event_loop()
         collection = self.base_query(subscriptions_uri, do_async=do_async).data or {}
         members = collection.get("Members")
         if not isinstance(members, list):
@@ -70,6 +92,107 @@ class _SubscriptionBase(RedfishManagerBase):
             if member_uri.rsplit("/", 1)[-1] == value or member_uri == value:
                 return member_uri
         raise InvalidArgument(f"subscription {value!r} was not found")
+
+    @staticmethod
+    def _location(response):
+        if response is None or response.headers is None:
+            return None
+        return response.headers.get("Location")
+
+    def _response_status(self, response, expected_status):
+        mapped_status = self._http_code_mapping.get(response.status_code)
+        if response.status_code == expected_status:
+            return mapped_status or RedfishApiRespond.Success
+        if 200 <= response.status_code < 300:
+            return mapped_status or RedfishApiRespond.Ok
+        return RedfishApiRespond.Error
+
+    def _error_text(self, response):
+        try:
+            return str(self.parse_error(response))
+        except Exception as exc:
+            return str(exc)
+
+    @staticmethod
+    async def _await_async_response(response_or_future):
+        response = await response_or_future
+        if inspect.isawaitable(response):
+            return await response
+        return response
+
+    def _send_subscription_request(self, method, request, body, headers, do_async):
+        if not do_async:
+            if method == HTTPMethod.POST:
+                return self.api_post_call(request, json.dumps(body), headers)
+            if method == HTTPMethod.DELETE:
+                return self.api_delete_call(request, headers)
+        loop = self._ensure_event_loop()
+        if method == HTTPMethod.POST:
+            return loop.run_until_complete(
+                self._await_async_response(
+                    self.api_async_post_call(
+                        loop,
+                        request,
+                        json.dumps(body),
+                        headers,
+                    )
+                )
+            )
+        if method == HTTPMethod.DELETE:
+            return loop.run_until_complete(
+                self._await_async_response(
+                    self.api_async_delete_call(loop, request, "", headers)
+                )
+            )
+        raise InvalidArgument(f"unsupported subscription method {method}")
+
+    def _subscription_mutation(
+        self,
+        method,
+        target,
+        action,
+        payload=None,
+        expected_status=204,
+        do_async=False,
+    ):
+        body = payload or {}
+        headers = {}
+        headers.update(self.json_content_type)
+        request = f"{self._default_method}{self.redfish_ip}{target}"
+        response = None
+        try:
+            response = self._send_subscription_request(
+                method,
+                request,
+                body,
+                headers,
+                do_async,
+            )
+        except Exception as exc:
+            error = str(exc)
+            data = {
+                "action": action,
+                "target": target,
+                "status": str(RedfishApiRespond.Error),
+                "status_code": None,
+                "error": error,
+            }
+            if method == HTTPMethod.POST:
+                data["location"] = None
+            return CommandResult(data, None, None, error), RedfishApiRespond.Error
+
+        status = self._response_status(response, expected_status)
+        error = None if status != RedfishApiRespond.Error else self._error_text(response)
+        data = {
+            "action": action,
+            "target": target,
+            "status": str(status),
+            "status_code": response.status_code,
+            "error": error,
+        }
+        if method == HTTPMethod.POST:
+            data["location"] = self._location(response)
+        return CommandResult(data, None, None, error), status
 
 
 class SubscriptionCreate(_SubscriptionBase,
@@ -176,20 +299,15 @@ class SubscriptionCreate(_SubscriptionBase,
                 "note": "preview only; re-run with --confirm to create subscription",
             }, None, None, None)
 
-        result, status = self.base_post(
+        result, _ = self._subscription_mutation(
+            HTTPMethod.POST,
             target,
+            "create",
             payload=payload,
-            do_async=do_async,
             expected_status=201,
+            do_async=do_async,
         )
-        data = {
-            "action": "create",
-            "target": target,
-            "status": str(status),
-            "location": None,
-            "error": result.error,
-        }
-        return CommandResult(data, None, None, result.error)
+        return result
 
 
 class SubscriptionDelete(_SubscriptionBase,
@@ -238,15 +356,11 @@ class SubscriptionDelete(_SubscriptionBase,
                 "note": "preview only; re-run with --confirm to delete subscription",
             }, None, None, None)
 
-        result, status = self.base_delete(
+        result, _ = self._subscription_mutation(
+            HTTPMethod.DELETE,
             target,
-            do_async=do_async,
+            "delete",
             expected_status=204,
+            do_async=do_async,
         )
-        data = {
-            "action": "delete",
-            "target": target,
-            "status": str(status),
-            "error": result.error,
-        }
-        return CommandResult(data, None, None, result.error)
+        return result

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -1,4 +1,8 @@
-"""Create and delete Redfish EventDestination subscriptions."""
+"""Create and delete Redfish EventDestination subscriptions.
+
+    redfish_ctl subscription-create --destination https://listener/events --protocol Redfish --confirm
+    redfish_ctl subscription-delete --subscription <id-or-uri> --confirm
+"""
 
 import asyncio
 import inspect

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -70,6 +70,12 @@ class _SubscriptionBase(RedfishManagerBase):
         return subscriptions_uri
 
     def _subscription_members(self, subscriptions_uri, do_async):
+        """List the member URIs in the Subscriptions collection.
+
+        :param subscriptions_uri: the Subscriptions collection URI.
+        :param do_async: prime the async event loop when True.
+        :return: the ``@odata.id`` of each subscription member (possibly empty).
+        """
         if do_async:
             self._ensure_event_loop()
         collection = self.base_query(subscriptions_uri, do_async=do_async).data or {}
@@ -430,7 +436,17 @@ class SubscriptionDelete(_SubscriptionBase,
                 subscription: Optional[str] = None,
                 confirm: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Preview or delete an EventDestination subscription."""
+        """Preview (dry-run) or delete an EventDestination subscription.
+
+        :param filename: optional path to save the result payload to.
+        :param data_type: output serialization format (``json`` or ``yaml``).
+        :param verbose: emit extra diagnostics when True.
+        :param do_async: issue the delete over the async Redfish path when True.
+        :param do_expanded: request an expanded ($expand) response where supported.
+        :param subscription: the subscription id or member URI to remove (required).
+        :param confirm: actually delete; without it the command only previews.
+        :return: a CommandResult with the delete outcome, or the dry-run preview.
+        """
         subscriptions_uri = self._subscription_collection_uri(do_async)
         target = self._resolve_subscription_uri(
             subscription,

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -40,6 +40,10 @@ class _SubscriptionBase(RedfishManagerBase):
 
     @staticmethod
     def _ensure_event_loop():
+        """Return the current asyncio event loop, creating one if none is set.
+
+        :return: an asyncio event loop usable for the async Redfish calls.
+        """
         try:
             return asyncio.get_event_loop()
         except RuntimeError:
@@ -48,6 +52,12 @@ class _SubscriptionBase(RedfishManagerBase):
             return loop
 
     def _subscription_collection_uri(self, do_async):
+        """Resolve the EventService Subscriptions collection URI.
+
+        :param do_async: prime the async event loop when True.
+        :return: the Subscriptions collection URI.
+        :raises InvalidArgument: when the EventService Subscriptions link is absent.
+        """
         if do_async:
             self._ensure_event_loop()
         service = self.base_query(
@@ -73,6 +83,15 @@ class _SubscriptionBase(RedfishManagerBase):
         ]
 
     def _resolve_subscription_uri(self, subscription, subscriptions_uri, do_async):
+        """Resolve a subscription id or URI to a full collection-member URI.
+
+        :param subscription: a subscription id or a full member URI.
+        :param subscriptions_uri: the Subscriptions collection URI.
+        :param do_async: prime the async event loop when True.
+        :return: the resolved subscription member URI.
+        :raises InvalidArgument: when empty, when the value is the collection URI
+            itself, when it falls outside the collection, or when it is not found.
+        """
         if not subscription or not str(subscription).strip():
             raise InvalidArgument("subscription id or URI is required")
         value = str(subscription).strip()
@@ -95,11 +114,22 @@ class _SubscriptionBase(RedfishManagerBase):
 
     @staticmethod
     def _location(response):
+        """Return the ``Location`` header (the new subscription URI) of a response.
+
+        :param response: the HTTP response from a create request.
+        :return: the Location header value, or None when it is absent.
+        """
         if response is None or response.headers is None:
             return None
         return response.headers.get("Location")
 
     def _response_status(self, response, expected_status):
+        """Map an HTTP status code to a RedfishApiRespond result.
+
+        :param response: the HTTP response to classify.
+        :param expected_status: the status a success is expected to return.
+        :return: Success on the expected status, Ok on any other 2xx, else Error.
+        """
         mapped_status = self._http_code_mapping.get(response.status_code)
         if response.status_code == expected_status:
             return mapped_status or RedfishApiRespond.Success
@@ -108,6 +138,11 @@ class _SubscriptionBase(RedfishManagerBase):
         return RedfishApiRespond.Error
 
     def _error_text(self, response):
+        """Extract a human-readable error message from an error response.
+
+        :param response: the HTTP response to parse.
+        :return: the parsed error text, or the exception text if parsing fails.
+        """
         try:
             return str(self.parse_error(response))
         except Exception as exc:
@@ -115,12 +150,27 @@ class _SubscriptionBase(RedfishManagerBase):
 
     @staticmethod
     async def _await_async_response(response_or_future):
+        """Await an async Redfish call, unwrapping a doubly-awaitable result.
+
+        :param response_or_future: the awaitable returned by an async HTTP call.
+        :return: the resolved HTTP response.
+        """
         response = await response_or_future
         if inspect.isawaitable(response):
             return await response
         return response
 
     def _send_subscription_request(self, method, request, body, headers, do_async):
+        """Send a subscription create/delete over the sync or async HTTP path.
+
+        :param method: the HTTP method — POST to create, DELETE to remove.
+        :param request: the fully-qualified request URL.
+        :param body: the JSON-serializable request body (ignored for DELETE).
+        :param headers: the request headers.
+        :param do_async: run the call on the async event loop when True.
+        :return: the HTTP response object.
+        :raises InvalidArgument: when the method is neither POST nor DELETE.
+        """
         if not do_async:
             if method == HTTPMethod.POST:
                 return self.api_post_call(request, json.dumps(body), headers)
@@ -155,6 +205,16 @@ class _SubscriptionBase(RedfishManagerBase):
         expected_status=204,
         do_async=False,
     ):
+        """Run a subscription create or delete and shape the CommandResult.
+
+        :param method: the HTTP method — POST to create, DELETE to remove.
+        :param target: the subscription collection URI (create) or member URI (delete).
+        :param action: a short label for the operation, used in messages.
+        :param payload: the request body for a create (None for a delete).
+        :param expected_status: the HTTP status a success returns (201 create / 204 delete).
+        :param do_async: run the call on the async event loop when True.
+        :return: a CommandResult with the outcome (and the Location URI on create).
+        """
         body = payload or {}
         headers = {}
         headers.update(self.json_content_type)
@@ -240,6 +300,18 @@ class SubscriptionCreate(_SubscriptionBase,
     @staticmethod
     def _payload(destination, protocol, event_format_type, event_types,
                  registry_prefixes, resource_types, context):
+        """Build the EventDestination create body from the CLI options.
+
+        :param destination: the subscriber URL events are delivered to (required).
+        :param protocol: the event protocol, e.g. Redfish (required).
+        :param event_format_type: the delivered payload format, or None to omit.
+        :param event_types: event types to subscribe to (list or comma string).
+        :param registry_prefixes: message-registry prefixes to filter on.
+        :param resource_types: resource types to filter on.
+        :param context: an opaque context string echoed back on each event.
+        :return: the subscription request body dict.
+        :raises InvalidArgument: when destination or protocol is missing.
+        """
         if not destination or not str(destination).strip():
             raise InvalidArgument("destination URI is required")
         if not protocol or not str(protocol).strip():
@@ -279,7 +351,23 @@ class SubscriptionCreate(_SubscriptionBase,
                 context: Optional[str] = None,
                 confirm: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Preview or create an EventDestination subscription."""
+        """Preview (dry-run) or create an EventDestination subscription.
+
+        :param filename: optional path to save the result payload to.
+        :param data_type: output serialization format (``json`` or ``yaml``).
+        :param verbose: emit extra diagnostics when True.
+        :param do_async: issue the create over the async Redfish path when True.
+        :param do_expanded: request an expanded ($expand) response where supported.
+        :param destination: subscriber URL events are delivered to (required to create).
+        :param protocol: the event protocol (default ``Redfish``).
+        :param event_format_type: the delivered payload format, or None to omit.
+        :param event_types: event types to subscribe to (list or comma string).
+        :param registry_prefixes: message-registry prefixes to filter on.
+        :param resource_types: resource types to filter on.
+        :param context: an opaque context string echoed back on each event.
+        :param confirm: actually create; without it the command only previews.
+        :return: a CommandResult with the created subscription, or the dry-run preview.
+        """
         target = self._subscription_collection_uri(do_async)
         payload = self._payload(
             destination,
@@ -317,6 +405,7 @@ class SubscriptionDelete(_SubscriptionBase,
     """Delete an EventDestination subscription after dry-run preview."""
 
     def __init__(self, *args, **kwargs):
+        """Construct the subscription-delete command (delegates to the base)."""
         super(SubscriptionDelete, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/tests/test_subscription_lifecycle_dualmode.py
+++ b/tests/test_subscription_lifecycle_dualmode.py
@@ -1,5 +1,6 @@
 """Dual-mode tests for EventDestination subscription lifecycle commands."""
 
+import json
 import os
 import shutil
 import subprocess
@@ -7,15 +8,21 @@ import textwrap
 from pathlib import Path
 
 import pytest
+import requests
 
 from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.events.cmd_subscription_lifecycle import (
+    SubscriptionCreate,
+    SubscriptionDelete,
+)
+from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
-from redfish_ctl.redfish_manager import CommandResult
 
 SUBSCRIPTIONS_PATH = "/redfish/v1/EventService/Subscriptions"
 SUBSCRIPTION_ONE_PATH = f"{SUBSCRIPTIONS_PATH}/1"
 DESTINATION = "https://listener.example.com/redfish/events"
+CREATED_SUBSCRIPTION_PATH = f"{SUBSCRIPTIONS_PATH}/created"
 
 
 def _request_type(name):
@@ -44,6 +51,52 @@ def _seed_subscription(service):
         "Destination": DESTINATION,
         "Protocol": "Redfish",
     }
+
+
+def _error_payload(status_code):
+    return {
+        "error": {
+            "code": f"Base.1.12.Status{status_code}",
+            "message": f"subscription mutation failed with {status_code}",
+        }
+    }
+
+
+def _response(status_code, body="{}", headers=None):
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = body.encode("utf-8")
+    for key, value in (headers or {}).items():
+        response.headers[key] = value
+    return response
+
+
+def _replace_post_response(service, status_code, headers=None):
+    requests_mock = pytest.importorskip("requests_mock")
+
+    def post_cb(request, context):
+        service.requests.append(request)
+        context.status_code = status_code
+        for key, value in (headers or {}).items():
+            context.headers[key] = value
+        if status_code >= 400:
+            return json.dumps(_error_payload(status_code))
+        return "{}"
+
+    service.mocker.post(requests_mock.ANY, text=post_cb)
+
+
+def _replace_delete_response(service, status_code):
+    requests_mock = pytest.importorskip("requests_mock")
+
+    def delete_cb(request, context):
+        service.requests.append(request)
+        context.status_code = status_code
+        if status_code >= 400:
+            return json.dumps(_error_payload(status_code))
+        return ""
+
+    service.mocker.delete(requests_mock.ANY, text=delete_cb)
 
 
 def test_subscription_create_dry_run_builds_payload_without_post(
@@ -109,6 +162,124 @@ def test_subscription_create_confirm_posts_event_destination_payload(
         "RegistryPrefixes": ["Base", "TaskEvent"],
         "ResourceTypes": ["Task"],
     }
+
+
+def test_subscription_create_confirm_returns_created_location(
+    redfish_mock_factory,
+):
+    """subscription-create reports the 201 Location of the new EventDestination."""
+    manager, service = redfish_mock_factory("supermicro")
+    _replace_post_response(
+        service,
+        201,
+        headers={"Location": CREATED_SUBSCRIPTION_PATH},
+    )
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionCreate"),
+        "subscription-create",
+        destination=DESTINATION,
+        confirm=True,
+    )
+
+    posts = [request for request in service.requests if request.method == "POST"]
+    assert result.error is None
+    assert result.data["action"] == "create"
+    assert result.data["target"] == SUBSCRIPTIONS_PATH
+    assert result.data["status"] == "RedfishApiRespond.Created"
+    assert result.data["status_code"] == 201
+    assert result.data["location"] == CREATED_SUBSCRIPTION_PATH
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SUBSCRIPTIONS_PATH.lower()
+
+
+def test_subscription_create_confirm_async_returns_created_location(
+    redfish_mock_factory,
+):
+    """subscription-create --async preserves the EventDestination Location."""
+    manager, service = redfish_mock_factory("supermicro")
+    _replace_post_response(
+        service,
+        201,
+        headers={"Location": CREATED_SUBSCRIPTION_PATH},
+    )
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionCreate"),
+        "subscription-create",
+        destination=DESTINATION,
+        confirm=True,
+        do_async=True,
+    )
+
+    posts = [request for request in service.requests if request.method == "POST"]
+    assert result.error is None
+    assert result.data["action"] == "create"
+    assert result.data["target"] == SUBSCRIPTIONS_PATH
+    assert result.data["status"] == "RedfishApiRespond.Created"
+    assert result.data["status_code"] == 201
+    assert result.data["location"] == CREATED_SUBSCRIPTION_PATH
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SUBSCRIPTIONS_PATH.lower()
+
+
+def test_subscription_create_async_accepts_direct_response_from_transport(
+    redfish_mock_factory,
+    monkeypatch,
+):
+    """subscription-create --async handles transports that return a response."""
+    manager, _service = redfish_mock_factory("supermicro")
+
+    async def post_response(self, loop, req, payload, hdr):
+        return _response(
+            201,
+            headers={"Location": CREATED_SUBSCRIPTION_PATH},
+        )
+
+    monkeypatch.setattr(
+        SubscriptionCreate,
+        "api_async_post_call",
+        post_response,
+    )
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionCreate"),
+        "subscription-create",
+        destination=DESTINATION,
+        confirm=True,
+        do_async=True,
+    )
+
+    assert result.error is None
+    assert result.data["status"] == "RedfishApiRespond.Created"
+    assert result.data["status_code"] == 201
+    assert result.data["location"] == CREATED_SUBSCRIPTION_PATH
+
+
+@pytest.mark.parametrize("status_code", [400, 404, 409])
+def test_subscription_create_confirm_reports_http_error_without_success(
+    redfish_mock_factory,
+    status_code,
+):
+    """subscription-create surfaces 4xx Redfish errors as command errors."""
+    manager, service = redfish_mock_factory("supermicro")
+    _replace_post_response(service, status_code)
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionCreate"),
+        "subscription-create",
+        destination=DESTINATION,
+        confirm=True,
+    )
+
+    posts = [request for request in service.requests if request.method == "POST"]
+    assert len(posts) == 1
+    assert result.error
+    assert result.data["action"] == "create"
+    assert result.data["target"] == SUBSCRIPTIONS_PATH
+    assert result.data["status"] == "RedfishApiRespond.Error"
+    assert result.data["status_code"] == status_code
+    assert result.data["location"] is None
 
 
 def test_subscription_create_splits_comma_separated_filters(
@@ -185,6 +356,92 @@ def test_subscription_delete_confirm_deletes_resolved_member(
     assert result.data["status"] == "RedfishApiRespond.Ok"
     assert len(deletes) == 1
     assert deletes[0].path.lower() == SUBSCRIPTION_ONE_PATH.lower()
+
+
+def test_subscription_delete_confirm_async_reports_http_error_without_success(
+    redfish_mock_factory,
+):
+    """subscription-delete --async surfaces Redfish errors as command errors."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_subscription(service)
+    _replace_delete_response(service, 409)
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionDelete"),
+        "subscription-delete",
+        subscription=SUBSCRIPTION_ONE_PATH,
+        confirm=True,
+        do_async=True,
+    )
+
+    deletes = [request for request in service.requests if request.method == "DELETE"]
+    assert len(deletes) == 1
+    assert deletes[0].path.lower() == SUBSCRIPTION_ONE_PATH.lower()
+    assert result.error
+    assert result.data["action"] == "delete"
+    assert result.data["target"] == SUBSCRIPTION_ONE_PATH
+    assert result.data["status"] == "RedfishApiRespond.Error"
+    assert result.data["status_code"] == 409
+
+
+def test_subscription_delete_async_accepts_direct_response_from_transport(
+    redfish_mock_factory,
+    monkeypatch,
+):
+    """subscription-delete --async handles transports that return a response."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_subscription(service)
+
+    async def delete_response(self, loop, req, payload, hdr):
+        return _response(
+            409,
+            body=json.dumps(_error_payload(409)),
+        )
+
+    monkeypatch.setattr(
+        SubscriptionDelete,
+        "api_async_delete_call",
+        delete_response,
+    )
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionDelete"),
+        "subscription-delete",
+        subscription=SUBSCRIPTION_ONE_PATH,
+        confirm=True,
+        do_async=True,
+    )
+
+    assert result.error
+    assert result.data["status"] == "RedfishApiRespond.Error"
+    assert result.data["status_code"] == 409
+
+
+@pytest.mark.parametrize("status_code", [400, 404, 409])
+def test_subscription_delete_confirm_reports_http_error_without_success(
+    redfish_mock_factory,
+    status_code,
+):
+    """subscription-delete surfaces 4xx Redfish errors as command errors."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_subscription(service)
+    _replace_delete_response(service, status_code)
+
+    result = manager.sync_invoke(
+        _request_type("SubscriptionDelete"),
+        "subscription-delete",
+        subscription=SUBSCRIPTION_ONE_PATH,
+        confirm=True,
+    )
+
+    deletes = [request for request in service.requests if request.method == "DELETE"]
+    assert len(deletes) == 1
+    assert deletes[0].path.lower() == SUBSCRIPTION_ONE_PATH.lower()
+    assert result.error
+    assert result.data["action"] == "delete"
+    assert result.data["target"] == SUBSCRIPTION_ONE_PATH
+    assert result.data["status"] == "RedfishApiRespond.Error"
+    assert result.data["status_code"] == status_code
 
 
 def test_subscription_delete_rejects_collection_uri_without_delete(


### PR DESCRIPTION
## Summary
- Preserve the EventDestination resource Location returned by subscription-create on 201 responses.
- Return structured command errors for subscription create/delete 4xx responses instead of raising or reporting a false success.
- Harden subscription create/delete async mutations and add offline regression coverage for sync and async paths.

## Validation
- python -m pytest -q tests/test_subscription_lifecycle_dualmode.py: 21 passed
- python -m pytest -q: 1132 passed, 58 skipped
- ruff check redfish_ctl/events/cmd_subscription_lifecycle.py tests/test_subscription_lifecycle_dualmode.py: All checks passed
- git diff --check
