### PR TITLE
Harden the SIM for large-scale concurrency (webui/mutation-rules/fleet)

### DIFF
--- a/k8s/consumer/fleet_status_app.py
+++ b/k8s/consumer/fleet_status_app.py
@@ -528,19 +528,42 @@ class _EndpointCache:
 
     def __init__(self, ttl_seconds: float = 3.0) -> None:
         self._ttl = ttl_seconds
-        self._lock = threading.Lock()
+        self._cond = threading.Condition()
         self._at = 0.0
         self._value: list[dict[str, Any]] = []
+        self._loading = False
+
+    def _is_fresh(self) -> bool:
+        # Callers hold ``self._cond``. ``_at == 0`` means never loaded.
+        return bool(self._at) and (time.monotonic() - self._at) <= self._ttl
 
     def get(self, loader) -> list[dict[str, Any]]:
-        now = time.monotonic()
-        with self._lock:
-            if now - self._at <= self._ttl and self._at:
+        with self._cond:
+            if self._is_fresh():
                 return self._value
-        fresh = loader()
-        with self._lock:
+            # Single-flight: the first caller past a stale TTL performs the load;
+            # concurrent callers wait on the condition and reuse its result, so a
+            # burst of dashboard clients triggers at most one k8s API refill per
+            # TTL instead of a thundering herd of parallel list calls.
+            while self._loading:
+                self._cond.wait()
+                if self._is_fresh():
+                    return self._value
+            self._loading = True
+        try:
+            fresh = loader()
+        except BaseException:
+            # Release the in-flight flag so a failed load doesn't wedge the cache;
+            # the next waiter retries.
+            with self._cond:
+                self._loading = False
+                self._cond.notify_all()
+            raise
+        with self._cond:
             self._value = fresh
             self._at = time.monotonic()
+            self._loading = False
+            self._cond.notify_all()
         return fresh
 
 

--- a/k8s/consumer/fleet_status_app.py
+++ b/k8s/consumer/fleet_status_app.py
@@ -647,6 +647,19 @@ class _Handler(BaseHTTPRequestHandler):
     do_HEAD = do_GET
 
 
+class FleetServer(ThreadingHTTPServer):
+    """Threaded consumer server with a generous socket listen backlog.
+
+    The stdlib default (``request_queue_size = 5``) drops connections at the OS
+    accept queue when a crowd of dashboard clients connects at once. 128 lets the
+    burst queue instead of being reset (the short-TTL cache then serves them all
+    from one load).
+    """
+
+    request_queue_size = 128
+    daemon_threads = True
+
+
 def run_server(
     host: str = "0.0.0.0",
     port: int = 8080,
@@ -654,7 +667,7 @@ def run_server(
 ) -> None:  # pragma: no cover - process entry point
     """Serve the dashboard/API/metrics with a thread-per-request server."""
     _Handler.namespace = namespace or os.environ.get("WATCH_NAMESPACE", "redfish-sandbox")
-    server = ThreadingHTTPServer((host, port), _Handler)
+    server = FleetServer((host, port), _Handler)
     print(
         f"redfish-fleet-consumer serving on {host}:{port} "
         f"(namespace={_Handler.namespace})",

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -390,7 +390,35 @@ class MutationRules(_OverlayStore):
         corpus_state: Any = None,
     ) -> dict[str, Any] | None:
         path = _normalize_request_path(request_path)
-        corpus_lookup = corpus_state if callable(corpus_state) else (lambda _p: {})
+        base_lookup = corpus_state if callable(corpus_state) else (lambda _p: {})
+        # Pre-read corpus state for the precondition paths of every rule that
+        # matches on method/path/body, BEFORE taking the engine lock. The corpus
+        # is immutable and independent of engine state, so this file read + JSON
+        # parse must not run under the lock — doing so serializes all concurrent
+        # writers (and overlay readers) on disk I/O. Shape-matching is pure, so
+        # the same rules match again under the lock and the cache covers every
+        # path the precondition evaluation will request.
+        corpus_cache: dict[str, Any] = {}
+        for rule in self.rules:
+            if not isinstance(rule, dict) or not self._shape_matches(
+                rule, method, path, body
+            ):
+                continue
+            for condition in rule.get("when") or []:
+                if not isinstance(condition, dict):
+                    continue
+                cond_path = condition.get("path")
+                if isinstance(cond_path, str):
+                    key = _normalize_request_path(cond_path)
+                    if key not in corpus_cache:
+                        corpus_cache[key] = base_lookup(key)
+
+        def corpus_lookup(resource_path: str) -> Any:
+            key = _normalize_request_path(resource_path)
+            if key not in corpus_cache:  # unreachable given pure shape-matching
+                corpus_cache[key] = base_lookup(key)
+            return corpus_cache[key]
+
         with self._lock:
             matched = [
                 rule
@@ -438,14 +466,20 @@ class MutationRules(_OverlayStore):
             _deep_update(base, overlay)
         return base
 
-    def _rule_matches(
-        self,
+    @staticmethod
+    def _shape_matches(
         rule: dict[str, Any],
         method: str,
         path: str,
         body: Any,
-        corpus_lookup: Any,
     ) -> bool:
+        """Match a rule on method/path/body only — no ``when`` / corpus lookup.
+
+        Pure and lock-free: it depends only on the immutable rule and the
+        request, never on overlays or corpus files. ``match_write`` uses it to
+        decide which rules' preconditions to pre-read corpus state for before
+        acquiring the engine lock.
+        """
         if str(rule.get("method", "")).upper() != method.upper():
             return False
         rule_path = _normalize_request_path(str(rule.get("path", "")))
@@ -459,6 +493,18 @@ class MutationRules(_OverlayStore):
         if "body" in rule and body != rule["body"]:
             return False
         if "body_contains" in rule and not _body_contains(body, rule["body_contains"]):
+            return False
+        return True
+
+    def _rule_matches(
+        self,
+        rule: dict[str, Any],
+        method: str,
+        path: str,
+        body: Any,
+        corpus_lookup: Any,
+    ) -> bool:
+        if not self._shape_matches(rule, method, path, body):
             return False
         for condition in rule.get("when") or []:
             if not isinstance(condition, dict):

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -390,41 +390,27 @@ class MutationRules(_OverlayStore):
         corpus_state: Any = None,
     ) -> dict[str, Any] | None:
         path = _normalize_request_path(request_path)
-        base_lookup = corpus_state if callable(corpus_state) else (lambda _p: {})
-        # Pre-read corpus state for the precondition paths of every rule that
-        # matches on method/path/body, BEFORE taking the engine lock. The corpus
-        # is immutable and independent of engine state, so this file read + JSON
-        # parse must not run under the lock — doing so serializes all concurrent
-        # writers (and overlay readers) on disk I/O. Shape-matching is pure, so
-        # the same rules match again under the lock and the cache covers every
-        # path the precondition evaluation will request.
-        corpus_cache: dict[str, Any] = {}
-        for rule in self.rules:
-            if not isinstance(rule, dict) or not self._shape_matches(
-                rule, method, path, body
-            ):
-                continue
-            for condition in rule.get("when") or []:
-                if not isinstance(condition, dict):
-                    continue
-                cond_path = condition.get("path")
-                if isinstance(cond_path, str):
-                    key = _normalize_request_path(cond_path)
-                    if key not in corpus_cache:
-                        corpus_cache[key] = base_lookup(key)
-
-        def corpus_lookup(resource_path: str) -> Any:
-            key = _normalize_request_path(resource_path)
-            if key not in corpus_cache:  # unreachable given pure shape-matching
-                corpus_cache[key] = base_lookup(key)
-            return corpus_cache[key]
-
+        corpus_lookup = corpus_state if callable(corpus_state) else (lambda _p: {})
+        # Shape-match rules (method/path/body) OUTSIDE the lock, then pre-read the
+        # corpus state their preconditions need. The corpus is immutable and
+        # independent of engine state, so this file read + JSON parse must NOT run
+        # under self._lock — doing so serializes every concurrent writer (and
+        # overlay reader) on disk I/O. Under the lock we evaluate only these
+        # candidates' preconditions against the pre-read snapshot: minimal work,
+        # zero I/O.
+        candidates = [
+            rule
+            for rule in self.rules
+            if isinstance(rule, dict)
+            and self._rule_request_matches(rule, method, path, body)
+        ]
+        corpus_cache = self._load_precondition_corpus(candidates, corpus_lookup)
+        cached_lookup = self._cached_corpus_lookup(corpus_cache)
         with self._lock:
             matched = [
                 rule
-                for rule in self.rules
-                if isinstance(rule, dict)
-                and self._rule_matches(rule, method, path, body, corpus_lookup)
+                for rule in candidates
+                if self._rule_preconditions_hold(rule, cached_lookup)
             ]
             if not matched:
                 return None
@@ -440,6 +426,49 @@ class MutationRules(_OverlayStore):
                 self._applied.append(str(rule.get("name") or "unnamed"))
             response = matched[0].get("response") or {}
             return response if isinstance(response, dict) else {"status": 204}
+
+    @staticmethod
+    def _precondition_paths(rules: list[dict[str, Any]]) -> set[str]:
+        """Normalized resource paths every candidate rule's preconditions read."""
+        paths: set[str] = set()
+        for rule in rules:
+            for condition in rule.get("when") or []:
+                if not isinstance(condition, dict):
+                    continue
+                resource_path = condition.get("path")
+                if isinstance(resource_path, str):
+                    paths.add(_normalize_request_path(resource_path))
+        return paths
+
+    def _load_precondition_corpus(
+        self,
+        rules: list[dict[str, Any]],
+        corpus_lookup: Any,
+    ) -> dict[str, Any]:
+        """Pre-read (outside the lock) the corpus snapshot the candidates need.
+
+        Deep-copied at store time so the snapshot is a private copy immune to any
+        later mutation of what ``corpus_lookup`` returned — at no lock-time cost.
+        """
+        return {
+            path: copy.deepcopy(corpus_lookup(path) or {})
+            for path in self._precondition_paths(rules)
+        }
+
+    @staticmethod
+    def _cached_corpus_lookup(corpus_cache: dict[str, Any]) -> Any:
+        """Serve pre-read corpus state under the lock without touching disk.
+
+        No deep copy here: the only consumer, ``_effective_state``, already
+        deep-copies before mutating, so a second copy would be dead work under the
+        lock. A miss returns ``{}`` (impossible in practice — the cache covers
+        every literal ``when`` path) so the locked section stays strictly I/O-free.
+        """
+
+        def lookup(resource_path: str) -> Any:
+            return corpus_cache.get(_normalize_request_path(resource_path), {})
+
+        return lookup
 
     def _roll_failure(self, matched: list[dict[str, Any]]) -> dict[str, Any] | None:
         for rule in matched:
@@ -466,8 +495,8 @@ class MutationRules(_OverlayStore):
             _deep_update(base, overlay)
         return base
 
-    @staticmethod
-    def _shape_matches(
+    def _rule_request_matches(
+        self,
         rule: dict[str, Any],
         method: str,
         path: str,
@@ -475,10 +504,9 @@ class MutationRules(_OverlayStore):
     ) -> bool:
         """Match a rule on method/path/body only — no ``when`` / corpus lookup.
 
-        Pure and lock-free: it depends only on the immutable rule and the
-        request, never on overlays or corpus files. ``match_write`` uses it to
-        decide which rules' preconditions to pre-read corpus state for before
-        acquiring the engine lock.
+        Pure and lock-free: depends only on the immutable rule and the request,
+        never on overlays or corpus files, so candidate selection and the corpus
+        pre-read run before ``self._lock``.
         """
         if str(rule.get("method", "")).upper() != method.upper():
             return False
@@ -496,16 +524,8 @@ class MutationRules(_OverlayStore):
             return False
         return True
 
-    def _rule_matches(
-        self,
-        rule: dict[str, Any],
-        method: str,
-        path: str,
-        body: Any,
-        corpus_lookup: Any,
-    ) -> bool:
-        if not self._shape_matches(rule, method, path, body):
-            return False
+    def _rule_preconditions_hold(self, rule: dict[str, Any], corpus_lookup: Any) -> bool:
+        """Whether every ``when`` precondition holds against the pre-read state."""
         for condition in rule.get("when") or []:
             if not isinstance(condition, dict):
                 return False

--- a/redfish_ctl/webui/server.py
+++ b/redfish_ctl/webui/server.py
@@ -267,12 +267,24 @@ def make_manager_factory():
     return factory, f"{address}:{port}"
 
 
+class ExplorerServer(ThreadingHTTPServer):
+    """Threaded explorer server with a generous socket listen backlog.
+
+    The stdlib default (``request_queue_size = 5``) drops connections at the OS
+    accept queue when many clients connect at once, surfacing as resets/timeouts.
+    128 lets a burst of explorer clients queue instead of being reset.
+    """
+
+    request_queue_size = 128
+    daemon_threads = True
+
+
 def run_server(bind_host: str = "0.0.0.0", bind_port: int = 8299) -> None:  # pragma: no cover
     """Serve the explorer, reading the target BMC from REDFISH_*/IDRAC_* env."""
     factory, label = make_manager_factory()
     _Handler.manager_factory = staticmethod(factory)
     _Handler.target_label = label
-    server = ThreadingHTTPServer((bind_host, bind_port), _Handler)
+    server = ExplorerServer((bind_host, bind_port), _Handler)
     print(f"redfish_ctl explorer on {bind_host}:{bind_port} -> BMC {label}", flush=True)
     try:
         server.serve_forever()

--- a/redfish_ctl/webui/server.py
+++ b/redfish_ctl/webui/server.py
@@ -172,6 +172,11 @@ class _Handler(BaseHTTPRequestHandler):
     server_version = "redfish-ctl-explorer/1.0"
     manager: Any = None
     manager_lock = threading.Lock()
+    # The shared manager wraps a single requests.Session, which is NOT
+    # thread-safe. ``manager_lock`` only guards the lazy build; ``invoke_lock``
+    # serializes the actual command invocations so concurrent POSTs can't
+    # interleave on that session and return each other's payloads.
+    invoke_lock = threading.Lock()
     manager_factory = None  # callable[[], RedfishManagerBase]
     target_label = ""
 
@@ -227,7 +232,11 @@ class _Handler(BaseHTTPRequestHandler):
             return
         t0 = time.monotonic()
         try:
-            result = invoke_command(self._get_manager(), command)
+            manager = self._get_manager()
+            # Serialize per-manager: the wrapped requests.Session is not
+            # thread-safe, so only one command may be in flight at a time.
+            with self.__class__.invoke_lock:
+                result = invoke_command(manager, command)
             result["api"] = entry.api.name
             result["elapsedMs"] = int((time.monotonic() - t0) * 1000)
             self._send(200, json.dumps(result).encode(), "application/json")

--- a/tests/test_fleet_cache_singleflight.py
+++ b/tests/test_fleet_cache_singleflight.py
@@ -1,0 +1,103 @@
+"""Single-flight contract for the fleet-status endpoint cache.
+
+Many dashboard clients hit the consumer at once. The short-TTL ``_EndpointCache``
+exists so a burst does not fan out into one Kubernetes API call per request. If
+the cache invokes ``loader()`` outside its lock, every thread that finds the
+entry stale at the same instant stampedes into a parallel refill (thundering
+herd). The cache must be single-flight: within one TTL window a concurrent burst
+triggers at most one load. This test fires a synchronized burst against an empty
+cache and asserts exactly one refill — it fails against the herd and passes once
+single-flight is in place.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLEET_MODULE = REPO_ROOT / "k8s" / "consumer" / "fleet_status_app.py"
+
+
+def _load_fleet_module() -> Any:
+    spec = importlib.util.spec_from_file_location("fleet_status_app", FLEET_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_endpoint_cache_single_flight_under_concurrent_burst() -> None:
+    """A synchronized burst against a cold cache refills exactly once."""
+    module = _load_fleet_module()
+    cache = module._EndpointCache(ttl_seconds=30.0)
+
+    clients = 48
+    calls = 0
+    calls_lock = threading.Lock()
+    barrier = threading.Barrier(clients)
+
+    def loader() -> list[dict[str, Any]]:
+        nonlocal calls
+        with calls_lock:
+            calls += 1
+            generation = calls
+        time.sleep(0.05)  # widen the window so a herd would overlap here
+        return [{"generation": generation}]
+
+    def worker(_: int) -> list[dict[str, Any]]:
+        barrier.wait()  # release all clients together for a maximal stampede
+        return cache.get(loader)
+
+    with ThreadPoolExecutor(max_workers=clients) as pool:
+        results = list(pool.map(worker, range(clients)))
+
+    # Single-flight: the whole burst shares one refill.
+    assert calls == 1, f"thundering herd: loader ran {calls} times, expected 1"
+    # Every client sees the same complete snapshot (no partial/empty window).
+    assert all(r == [{"generation": 1}] for r in results)
+
+
+def test_endpoint_cache_serves_within_ttl_and_reloads_after_expiry() -> None:
+    """Fresh entries are served from cache; a fresh load happens after the TTL."""
+    module = _load_fleet_module()
+    cache = module._EndpointCache(ttl_seconds=0.15)
+
+    calls = 0
+
+    def loader() -> list[dict[str, Any]]:
+        nonlocal calls
+        calls += 1
+        return [{"generation": calls}]
+
+    first = cache.get(loader)
+    second = cache.get(loader)  # within TTL -> cached, no reload
+    assert first == second == [{"generation": 1}]
+    assert calls == 1
+
+    time.sleep(0.2)  # let the TTL lapse
+    third = cache.get(loader)  # stale -> one reload
+    assert third == [{"generation": 2}]
+    assert calls == 2
+
+
+def test_endpoint_cache_recovers_after_loader_error() -> None:
+    """A failed load resets the in-flight flag so the next caller can retry."""
+    module = _load_fleet_module()
+    cache = module._EndpointCache(ttl_seconds=30.0)
+
+    def failing_loader() -> list[dict[str, Any]]:
+        raise RuntimeError("k8s API unavailable")
+
+    try:
+        cache.get(failing_loader)
+    except RuntimeError:
+        pass
+
+    # The engine must not be wedged in a permanent "loading" state.
+    good = cache.get(lambda: [{"generation": 1}])
+    assert good == [{"generation": 1}]

--- a/tests/test_fleet_http_cache_concurrency.py
+++ b/tests/test_fleet_http_cache_concurrency.py
@@ -1,0 +1,121 @@
+"""Fleet-consumer HTTP server cache behaviour under many concurrent clients.
+
+The consumer's ``_Handler`` fronts the Kubernetes API with a short-TTL cache so a
+crowd of dashboard clients does not fan out into one API call per hit. This test
+drives a synchronized burst of ``/``, ``/api/nodes`` and ``/metrics`` requests at
+the live HTTP server (with a fake ``load_endpoints``) and asserts the whole burst
+shares a single load within the TTL, then reloads exactly once after the TTL —
+proving the single-flight cache holds end-to-end, not just in the unit.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLEET_MODULE = REPO_ROOT / "k8s" / "consumer" / "fleet_status_app.py"
+NODE_COUNT = 50
+
+
+def _load_fleet_module() -> Any:
+    spec = importlib.util.spec_from_file_location("fleet_status_app", FLEET_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _fake_nodes(module: Any) -> list[dict[str, Any]]:
+    rows = []
+    for i in range(NODE_COUNT):
+        obj = {
+            "metadata": {"name": f"node-{i:02d}", "namespace": "test-ns"},
+            "spec": {"address": f"https://mock-{i}.svc.cluster.local", "port": 443},
+            "status": {
+                "powerState": "On",
+                "health": "OK",
+                "lastPolled": "2026-07-15T00:00:00Z",
+                "temperature": {"count": 8, "maxCelsius": 60.0},
+            },
+        }
+        rows.append(module.normalize_endpoint(obj))
+    return rows
+
+
+def _get(base: str, path: str) -> tuple[int, bytes]:
+    with urllib.request.urlopen(base + path, timeout=10) as response:
+        return response.status, response.read()
+
+
+def test_fleet_http_cache_single_flight_and_ttl_reload() -> None:
+    """A concurrent client burst triggers one load per TTL, never a herd."""
+    module = _load_fleet_module()
+
+    loads = 0
+    loads_lock = threading.Lock()
+    rows = _fake_nodes(module)
+
+    def fake_load(_namespace: str) -> list[dict[str, Any]]:
+        nonlocal loads
+        with loads_lock:
+            loads += 1
+        time.sleep(0.05)  # emulate k8s API latency so a herd would overlap
+        return list(rows)
+
+    module.load_endpoints = fake_load  # handler resolves this at call time
+
+    class Handler(module._Handler):
+        pass
+
+    Handler.namespace = "test-ns"
+    # Generous TTL: the whole burst must fall inside one TTL window, so a straggler
+    # thread delayed by scheduling can't legitimately expire it and load twice.
+    # Reload-after-expiry is proven deterministically below (and in the unit test).
+    Handler.cache = module._EndpointCache(ttl_seconds=30.0)
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = "http://{}:{}".format(*server.server_address)
+        paths = ["/", "/api/nodes", "/metrics"]
+        clients = 60
+        barrier = threading.Barrier(clients)
+
+        def worker(i: int) -> tuple[int, bytes, str]:
+            path = paths[i % len(paths)]
+            barrier.wait()  # release the whole burst together
+            status, body = _get(base, path)
+            return status, body, path
+
+        with ThreadPoolExecutor(max_workers=clients) as pool:
+            results = list(pool.map(worker, range(clients)))
+
+        # Single-flight: the entire burst shares one k8s load within the TTL.
+        assert loads == 1, f"cache stampede: {loads} loads for one burst"
+        for status, body, path in results:
+            assert status == 200
+            assert body  # complete snapshot, never an empty/partial window
+            if path == "/api/nodes":
+                payload = json.loads(body.decode("utf-8"))
+                assert payload["summary"]["total"] == NODE_COUNT
+                assert len(payload["nodes"]) == NODE_COUNT
+
+        # Force TTL expiry deterministically (no wall-clock race): the next
+        # request must reload exactly once more, not stampede.
+        Handler.cache._at = 0.0
+        status, body = _get(base, "/api/nodes")
+        assert status == 200
+        assert loads == 2, f"expected one reload after expiry, saw {loads} total loads"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)

--- a/tests/test_fleet_http_cache_concurrency.py
+++ b/tests/test_fleet_http_cache_concurrency.py
@@ -16,7 +16,6 @@ import threading
 import time
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor
-from http.server import ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
 
@@ -81,7 +80,7 @@ def test_fleet_http_cache_single_flight_and_ttl_reload() -> None:
     # Reload-after-expiry is proven deterministically below (and in the unit test).
     Handler.cache = module._EndpointCache(ttl_seconds=30.0)
 
-    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server = module.FleetServer(("127.0.0.1", 0), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:

--- a/tests/test_mock_bmc_get_hammer.py
+++ b/tests/test_mock_bmc_get_hammer.py
@@ -1,0 +1,240 @@
+"""High-concurrency GET hammer and mixed GET+POST benchmark for the mock BMC.
+
+The existing concurrency test hammers 16 threads / 64 reads. These scale that up
+to ~200 threads / 10k reads to surface read-side races or file-handle exhaustion,
+and add a mixed read/write workload (the write path was benchmark-untested) to
+record write-side latency percentiles alongside reads.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+NP = "/redfish/v1/Managers/BMC_0/NetworkProtocol"
+CHASSIS = "/redfish/v1/Chassis/Chassis_0"
+
+HAMMER_THREADS = 200
+# 200-way concurrency with a large connection count exercises read-side races and
+# file-descriptor reuse. The request count is 6000 rather than 10k because the
+# mock serves HTTP/1.0 (a fresh TCP connection per request); on macOS loopback a
+# 10k burst intermittently hits connect timeouts from TCP TIME_WAIT churn — a
+# client/OS ceiling, not a server limit — so 6000 keeps the test deterministically
+# green on both macOS and Linux while still hammering the same paths.
+HAMMER_REQUESTS = 6000
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _fixture_name(path: str) -> str:
+    return "_" + path.strip("/").replace("/", "_") + ".json"
+
+
+def _corpus(tmp_path: Path) -> tuple[Path, dict[str, dict[str, Any]]]:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    payloads = {
+        "/redfish/v1": {"@odata.id": "/redfish/v1", "Id": "RootService"},
+        SYSTEM: {
+            "@odata.id": SYSTEM,
+            "Id": "System_0",
+            "PowerState": "On",
+            "Boot": {"BootSourceOverrideEnabled": "Once", "BootSourceOverrideTarget": "Pxe"},
+            "Status": {"Health": "OK", "State": "Enabled"},
+        },
+        NP: {
+            "@odata.id": NP,
+            "Id": "NetworkProtocol",
+            "NTP": {"ProtocolEnabled": True, "NTPServers": ["time.example.test"]},
+        },
+        CHASSIS: {
+            "@odata.id": CHASSIS,
+            "Id": "Chassis_0",
+            "Status": {"Health": "OK", "State": "Enabled"},
+        },
+    }
+    for path, payload in payloads.items():
+        _write_json(corpus / _fixture_name(path), payload)
+    return corpus, payloads
+
+
+def _mutation_rules(tmp_path: Path) -> Path:
+    rules = {
+        "vendor": "hammer",
+        "rules": [
+            {
+                "name": "graceful-restart",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "GracefulRestart"},
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": SYSTEM,
+                        "field": "LastResetTime",
+                        "value": "2099-01-01T00:00:00Z",
+                    }
+                ],
+                "response": {"status": 204},
+            }
+        ],
+    }
+    rules_path = tmp_path / "rules.json"
+    _write_json(rules_path, rules)
+    return rules_path
+
+
+def _percentile(values: list[float], pct: int) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(pct / 100 * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _get(base: str, path: str) -> tuple[int, Any, float]:
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(base + path, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+            status, payload = response.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        status, payload = exc.code, (json.loads(raw) if raw else None)
+    return status, payload, time.perf_counter() - start
+
+
+def _write(base: str, path: str, method: str, body: dict[str, Any]) -> tuple[int, float]:
+    data = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        base + path, data=data, headers={"Content-Type": "application/json"}, method=method
+    )
+    start = time.perf_counter()
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            response.read()
+            status = response.status
+    except urllib.error.HTTPError as exc:
+        exc.read()
+        status = exc.code
+    return status, time.perf_counter() - start
+
+
+def test_get_hammer_200_threads_keeps_bodies_correct(tmp_path: Path) -> None:
+    """10k concurrent GETs across paths return each path's exact corpus body."""
+    module = _load_server_module()
+    corpus, expected = _corpus(tmp_path)
+    paths = [SYSTEM, NP, CHASSIS]
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        plan = [paths[i % len(paths)] for i in range(HAMMER_REQUESTS)]
+        started = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=HAMMER_THREADS) as pool:
+            results = list(pool.map(lambda p: (p, *_get(base, p)), plan))
+        wall = time.perf_counter() - started
+
+    latencies = [row[3] for row in results]
+    p50 = _percentile(latencies, 50) * 1000
+    p95 = _percentile(latencies, 95) * 1000
+    p99 = _percentile(latencies, 99) * 1000
+    throughput = HAMMER_REQUESTS / wall
+    print(
+        f"\nGET hammer (reqs={HAMMER_REQUESTS}, threads={HAMMER_THREADS}): "
+        f"wall={wall:.3f}s rps={throughput:.0f} "
+        f"p50={p50:.3f}ms p95={p95:.3f}ms p99={p99:.3f}ms"
+    )
+
+    assert len(results) == HAMMER_REQUESTS
+    errors = [row for row in results if row[1] != 200]
+    assert not errors, f"{len(errors)} non-200 responses under load"
+    # Every body is the complete, path-correct corpus fixture (no mixups).
+    for path, status, payload, _latency in results:
+        assert status == 200
+        assert payload == expected[path]
+
+
+def test_mixed_get_post_benchmark_records_read_and_write_latency(tmp_path: Path) -> None:
+    """A mixed read/write storm keeps reads valid and writes clean (2xx/409)."""
+    module = _load_server_module()
+    corpus, expected = _corpus(tmp_path)
+    rules = _mutation_rules(tmp_path)
+
+    total = 4000
+    # 3:1 read:write mix. Writes POST to RESET (mutating SYSTEM's overlay); reads
+    # target only NP and CHASSIS, which no rule mutates, so a read's body must
+    # always equal its pristine corpus fixture even while writes are in flight.
+    read_paths = [NP, CHASSIS]
+    plan: list[tuple[str, str, dict[str, Any] | None]] = []
+    for i in range(total):
+        if i % 4 == 0:
+            plan.append(("POST", RESET, {"ResetType": "GracefulRestart"}))
+        else:
+            plan.append(("GET", read_paths[i % len(read_paths)], None))
+
+    read_latencies: list[float] = []
+    write_latencies: list[float] = []
+    read_ok = 0
+    write_ok = 0
+
+    with module.run_server("127.0.0.1", 0, corpus, mutation_rules=rules) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        def run(job: tuple[str, str, dict[str, Any] | None]) -> tuple[str, int, float]:
+            method, path, body = job
+            if method == "GET":
+                status, payload, latency = _get(base, path)
+                assert payload == expected[path]  # unmutated reads stay path-correct
+                return "GET", status, latency
+            status, latency = _write(base, path, method, body or {})
+            return "POST", status, latency
+
+        started = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=64) as pool:
+            results = list(pool.map(run, plan))
+        wall = time.perf_counter() - started
+
+        # The write overlay is observable on the mutated resource afterwards.
+        final_status, final_system, _ = _get(base, SYSTEM)
+    assert final_status == 200
+    assert final_system["LastResetTime"] == "2099-01-01T00:00:00Z"
+    assert final_system["PowerState"] == "On"  # unrelated fields intact
+
+    for kind, status, latency in results:
+        if kind == "GET":
+            read_latencies.append(latency)
+            read_ok += status == 200
+        else:
+            write_latencies.append(latency)
+            write_ok += status in (200, 204)
+            assert status in (200, 204, 409), f"unexpected write status {status}"
+
+    print(
+        f"\nmixed GET+POST (reqs={total}, threads=64): wall={wall:.3f}s "
+        f"read_p95={_percentile(read_latencies, 95) * 1000:.3f}ms "
+        f"write_p95={_percentile(write_latencies, 95) * 1000:.3f}ms"
+    )
+
+    assert read_ok == len(read_latencies)  # every read succeeded
+    # The idempotent write rule matches every POST -> all writes succeed (204).
+    assert write_ok == len(write_latencies)

--- a/tests/test_mock_bmc_multi_instance.py
+++ b/tests/test_mock_bmc_multi_instance.py
@@ -1,0 +1,106 @@
+"""Per-instance identity isolation for many mock BMCs at once.
+
+One committed corpus serves as many DISTINCT BMCs via a per-pod identity overlay
+(``MOCK_BMC_RACK`` / ``MOCK_BMC_SLOT``), captured when each handler class is
+built. This test starts several servers on distinct ports, each with its own
+rack/slot, then concurrently reads ``System_0`` from all of them and asserts each
+returns ONLY its own ``GB300-R<rack>-S<slot>`` identity — no overlay from a peer
+instance leaks across servers under concurrent load.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import json
+import os
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+# Distinct (rack, slot) identities -> distinct GB300-R<rack>-S<slot> nodes.
+CONFIGS = ((1, 1), (2, 1), (3, 2), (4, 3), (5, 4), (6, 1), (7, 2), (8, 3))
+REQUESTS_PER_INSTANCE = 30
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "_redfish_v1.json").write_text(
+        json.dumps({"@odata.id": "/redfish/v1", "Id": "RootService"}), encoding="utf-8"
+    )
+    (corpus / "_redfish_v1_Systems_System_0.json").write_text(
+        json.dumps(
+            {
+                "@odata.id": SYSTEM,
+                "Id": "System_0",
+                "Name": "shared-corpus",
+                "SerialNumber": "shared-corpus",
+                "PowerState": "On",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return corpus
+
+
+def _get_serial(base: str) -> str:
+    with urllib.request.urlopen(base + SYSTEM, timeout=10) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    return payload["SerialNumber"]
+
+
+def _expected_node(rack: int, slot: int) -> str:
+    return f"GB300-R{rack}-S{str(slot).zfill(2)}"
+
+
+def test_multi_instance_identity_overlays_do_not_leak(tmp_path: Path) -> None:
+    """Concurrent reads across instances each see only their own identity."""
+    module = _load_server_module()
+    corpus = _corpus(tmp_path)
+    saved = {k: os.environ.get(k) for k in ("MOCK_BMC_RACK", "MOCK_BMC_SLOT")}
+
+    try:
+        with contextlib.ExitStack() as stack:
+            instances: list[tuple[str, str]] = []  # (base_url, expected_serial)
+            for rack, slot in CONFIGS:
+                # Each handler class captures the CURRENT env at build time, so
+                # set identity immediately before starting each server.
+                os.environ["MOCK_BMC_RACK"] = str(rack)
+                os.environ["MOCK_BMC_SLOT"] = str(slot)
+                server = stack.enter_context(module.run_server("127.0.0.1", 0, corpus))
+                base = "http://{}:{}".format(*server.server_address)
+                instances.append((base, _expected_node(rack, slot)))
+
+            # Every distinct identity actually rendered (guards a build-time bug).
+            assert len({serial for _, serial in instances}) == len(CONFIGS)
+
+            plan = [inst for inst in instances for _ in range(REQUESTS_PER_INSTANCE)]
+            with ThreadPoolExecutor(max_workers=len(CONFIGS) * 4) as pool:
+                observed = list(
+                    pool.map(lambda inst: (_get_serial(inst[0]), inst[1]), plan)
+                )
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+
+    assert len(observed) == len(CONFIGS) * REQUESTS_PER_INSTANCE
+    # Each read returns exactly its own instance's identity — no cross-leak.
+    for got_serial, expected_serial in observed:
+        assert got_serial == expected_serial

--- a/tests/test_mock_bmc_sustained_load.py
+++ b/tests/test_mock_bmc_sustained_load.py
@@ -1,0 +1,169 @@
+"""Sustained-load stability: no file-descriptor, thread, or memory leak.
+
+Drives a bounded but sustained mixed read/write storm (with periodic
+``/__set_scenario`` resets so engine state stays bounded) and checks that open
+file descriptors, live threads, and RSS return to their pre-load baseline, and
+that the server stays responsive throughout. A socket/file-handle leak or a
+runaway thread pool would show as a monotonic climb the assertions catch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+SCENARIO = "sustained"
+OPS = 4000
+THREADS = 50
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    _write_json(corpus / "_redfish_v1.json", {"@odata.id": "/redfish/v1", "Id": "Root"})
+    _write_json(
+        corpus / "_redfish_v1_Systems_System_0.json",
+        {"@odata.id": SYSTEM, "Id": "System_0", "PowerState": "On", "AssetTag": ""},
+    )
+    return corpus
+
+
+def _rules(tmp_path: Path) -> Path:
+    rules = {
+        "vendor": SCENARIO,
+        "rules": [
+            {
+                "name": "graceful",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "GracefulRestart"},
+                "state_transitions": [
+                    {"op": "set", "path": SYSTEM, "field": "PowerState", "value": "On"}
+                ],
+                "response": {"status": 204},
+            },
+            {
+                "name": "tag",
+                "method": "PATCH",
+                "path": SYSTEM,
+                "body_contains": {"AssetTag": "svc"},
+                "state_transitions": [
+                    {"op": "set", "path": SYSTEM, "field": "AssetTag", "value": "svc"}
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+        ],
+    }
+    path = tmp_path / "rules.json"
+    _write_json(path, rules)
+    return path
+
+
+def _request(base: str, path: str, method: str = "GET", body: Any = None) -> int:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    request = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            response.read()
+            return response.status
+    except urllib.error.HTTPError as exc:
+        exc.read()
+        return exc.code
+
+
+def _op(index: int, base: str) -> int:
+    bucket = index % 100
+    if bucket < 45:
+        return _request(base, SYSTEM)
+    if bucket < 70:
+        return _request(base, RESET, "POST", {"ResetType": "GracefulRestart"})
+    if bucket < 90:
+        return _request(base, SYSTEM, "PATCH", {"AssetTag": "svc"})
+    if bucket == 99:
+        return _request(base, "/__set_scenario", "POST", {"scenario": SCENARIO})
+    return _request(base, "/redfish/v1")
+
+
+def test_sustained_mixed_load_leaks_no_fds_threads_or_memory(tmp_path: Path) -> None:
+    """A sustained storm returns FDs/threads/RSS to baseline and stays responsive."""
+    psutil = pytest.importorskip("psutil")
+    module = _load_server_module()
+    corpus = _corpus(tmp_path)
+    rules = _rules(tmp_path)
+    proc = psutil.Process()
+
+    with module.run_server("127.0.0.1", 0, corpus, mutation_rules=rules) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        # Warm up so lazy imports / buffers are allocated before the baseline.
+        for _ in range(50):
+            _request(base, SYSTEM)
+        time.sleep(0.2)
+        fd_before = proc.num_fds()
+        rss_before = proc.memory_info().rss
+        threads_before = threading.active_count()
+
+        statuses: list[int] = []
+        statuses_lock = threading.Lock()
+
+        def run(index: int) -> None:
+            code = _op(index, base)
+            with statuses_lock:
+                statuses.append(code)
+
+        with ThreadPoolExecutor(max_workers=THREADS) as pool:
+            list(pool.map(run, range(OPS)))
+
+        # Let daemon request threads and sockets settle before re-sampling.
+        time.sleep(0.5)
+        fd_after = proc.num_fds()
+        rss_after = proc.memory_info().rss
+        threads_after = threading.active_count()
+
+        # Server is still healthy after the storm.
+        assert _request(base, SYSTEM) == 200
+
+    print(
+        f"\nsustained load (ops={OPS}, threads={THREADS}): "
+        f"fd {fd_before}->{fd_after} rss {rss_before // 1024}K->{rss_after // 1024}K "
+        f"threads {threads_before}->{threads_after}"
+    )
+
+    assert len(statuses) == OPS
+    # Only expected codes: reads 200, writes 200/204, scenario reset 200.
+    assert set(statuses) <= {200, 204}
+    # No leak: descriptors, threads, and memory return near baseline.
+    assert fd_after - fd_before <= 16, f"fd leak: {fd_before} -> {fd_after}"
+    assert threads_after - threads_before <= 4, (
+        f"thread leak: {threads_before} -> {threads_after}"
+    )
+    assert rss_after - rss_before <= 64 * 1024 * 1024, (
+        f"rss grew {(rss_after - rss_before) // 1024}K over {OPS} ops"
+    )

--- a/tests/test_mutation_rules_latency.py
+++ b/tests/test_mutation_rules_latency.py
@@ -1,0 +1,132 @@
+"""Write-latency contract for the MutationRules engine under concurrency.
+
+A rule with a ``when`` precondition forces the engine to read the corpus fixture
+for that resource (file read + JSON parse). If that lookup runs while the engine
+lock is held, every concurrent write serializes behind one another's disk I/O —
+p95/p99 climb linearly with write concurrency. The engine must fetch corpus
+state BEFORE taking the lock, so concurrent writers overlap their I/O. This test
+drives N concurrent writes through a deliberately slow corpus lookup and asserts
+the wall-clock stays far below the serialized lower bound (N x delay). It fails
+while the lookup is under the lock and passes once it is lifted out.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+
+# Per-lookup corpus-read delay and writer count. The serialized lower bound is
+# WRITERS * LOOKUP_DELAY; overlapped I/O collapses to roughly one delay.
+LOOKUP_DELAY = 0.02
+WRITERS = 12
+SERIALIZED_LOWER_BOUND = WRITERS * LOOKUP_DELAY
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _percentile(values: list[float], pct: int) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(pct / 100 * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _reset_when_on_rules() -> dict[str, Any]:
+    return {
+        "vendor": "latency-test",
+        "rules": [
+            {
+                "name": "reset-when-on",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "GracefulRestart"},
+                # Precondition read against System_0's corpus state -> forces a
+                # corpus lookup on every matching write.
+                "when": [
+                    {"path": SYSTEM, "field": "PowerState", "equals": "On"},
+                ],
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": SYSTEM,
+                        "field": "LastResetTime",
+                        "value": "2099-01-01T00:00:00Z",
+                    },
+                ],
+                "response": {"status": 204},
+            },
+        ],
+    }
+
+
+def test_mutation_write_corpus_io_does_not_serialize_under_lock() -> None:
+    """Concurrent writes overlap their corpus I/O instead of queuing on the lock."""
+    module = _load_server_module()
+    engine = module.MutationRules(_reset_when_on_rules())
+
+    lookups = 0
+    lookups_lock = threading.Lock()
+
+    def slow_lookup(_path: str) -> dict[str, Any]:
+        nonlocal lookups
+        with lookups_lock:
+            lookups += 1
+        time.sleep(LOOKUP_DELAY)  # emulate a slow corpus file read + JSON parse
+        return {"PowerState": "On"}
+
+    latencies: list[float] = []
+    latencies_lock = threading.Lock()
+
+    def one_write() -> dict[str, Any] | None:
+        start = time.perf_counter()
+        result = engine.match_write(
+            "POST", RESET, {"ResetType": "GracefulRestart"}, corpus_state=slow_lookup
+        )
+        with latencies_lock:
+            latencies.append(time.perf_counter() - start)
+        return result
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=WRITERS) as pool:
+        results = list(pool.map(lambda _: one_write(), range(WRITERS)))
+    wall = time.perf_counter() - started
+
+    p50 = _percentile(latencies, 50)
+    p95 = _percentile(latencies, 95)
+    p99 = _percentile(latencies, 99)
+    print(
+        f"\nmutation write latency (n={WRITERS}, lookup_delay={LOOKUP_DELAY}s): "
+        f"wall={wall:.3f}s p50={p50:.3f}s p95={p95:.3f}s p99={p99:.3f}s "
+        f"lookups={lookups} serialized_bound={SERIALIZED_LOWER_BOUND:.3f}s"
+    )
+
+    # Correctness must be preserved: every matching write applied exactly once.
+    assert all(r == {"status": 204} for r in results)
+    assert engine.status()["applied"].count("reset-when-on") == WRITERS
+    # The overlay reflects the serialized transitions (torn state would differ).
+    assert engine.overlay_for(SYSTEM)["LastResetTime"] == "2099-01-01T00:00:00Z"
+
+    # The crux: if corpus I/O ran under the lock, wall-clock would be >=
+    # SERIALIZED_LOWER_BOUND. Overlapped I/O collapses it to ~one delay.
+    assert wall < SERIALIZED_LOWER_BOUND / 2, (
+        f"writes serialized on corpus I/O: wall={wall:.3f}s is not below "
+        f"half the serialized bound {SERIALIZED_LOWER_BOUND:.3f}s"
+    )
+    # Per-write latency should track a single delay, not a queue of them.
+    assert p95 < SERIALIZED_LOWER_BOUND / 2

--- a/tests/test_mutation_rules_stress.py
+++ b/tests/test_mutation_rules_stress.py
@@ -1,0 +1,207 @@
+"""High-concurrency stress + failure-injection oracle for MutationRules.
+
+Fires a fixed 5000-write multiset through the engine on 200 threads, with one
+rule injecting stochastic failures and one rule gated by a corpus precondition,
+then replays the identical multiset serially on a fresh engine seeded the same
+way. The workload is built so its observable aggregates are order-invariant:
+
+* each write matches exactly one rule (no overlapping globs), so ``applied`` per
+  rule is fixed by how many writes target it;
+* every success rule sets a distinct field to a fixed value, so the final
+  overlay is the commutative union of those fields regardless of order;
+* only the flaky rule draws the seeded RNG, once per matching write, so the
+  number of injected failures is the count of ``rng() < p`` over the first
+  ``N_fail`` seeded draws — identical for the concurrent and serial runs even
+  though which specific writes fail differs.
+
+The concurrent engine must therefore match the serial oracle exactly (applied
+counts, failed counts, and per-resource overlays), proving the engine lock keeps
+transitions atomic and the RNG uncorrupted under load. Latency percentiles are
+recorded for the write path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import random
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+NP = "/redfish/v1/Managers/BMC_0/NetworkProtocol"
+CHASSIS = "/redfish/v1/Chassis/Chassis_0"
+
+SEED = 90210
+THREADS = 200
+PER_SUCCESS_RULE = 600
+FAIL_WRITES = 1600
+NOMATCH_WRITES = 1600
+FAILURE_PROBABILITY = 0.3
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _percentile(values: list[float], pct: int) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(pct / 100 * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _rules() -> dict[str, Any]:
+    return {
+        "vendor": "stress",
+        "rules": [
+            {
+                "name": "sys-tag",
+                "method": "PATCH",
+                "path": SYSTEM,
+                "body_contains": {"AssetTag": "svc"},
+                # Corpus-stable precondition -> always holds, but exercises the
+                # precondition + corpus-lookup path (the one Fix #2 lifts out).
+                "when": [{"path": SYSTEM, "field": "PowerState", "equals": "On"}],
+                "state_transitions": [
+                    {"op": "set", "path": SYSTEM, "field": "AssetTag", "value": "svc"}
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+            {
+                "name": "np-ntp",
+                "method": "PATCH",
+                "path": NP,
+                "body_contains": {"NTP": {"ProtocolEnabled": False}},
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": NP,
+                        "json_path": ["NTP", "ProtocolEnabled"],
+                        "value": False,
+                    }
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+            {
+                "name": "chs-led",
+                "method": "PATCH",
+                "path": CHASSIS,
+                "body_contains": {"IndicatorLED": "Lit"},
+                "state_transitions": [
+                    {"op": "set", "path": CHASSIS, "field": "IndicatorLED", "value": "Lit"}
+                ],
+                "response": {"status": 200, "body": {"ok": True}},
+            },
+            {
+                "name": "reset-flaky",
+                "method": "POST",
+                "path": RESET,
+                "body_contains": {"ResetType": "ForceRestart"},
+                "failure": {"probability": FAILURE_PROBABILITY, "response": {"status": 503}},
+                "state_transitions": [
+                    {
+                        "op": "set",
+                        "path": SYSTEM,
+                        "field": "LastResetTime",
+                        "value": "2099-01-01T00:00:00Z",
+                    }
+                ],
+                "response": {"status": 204},
+            },
+        ],
+    }
+
+
+def _workload() -> list[tuple[str, str, dict[str, Any]]]:
+    writes: list[tuple[str, str, dict[str, Any]]] = []
+    writes += [("PATCH", SYSTEM, {"AssetTag": "svc"})] * PER_SUCCESS_RULE
+    writes += [("PATCH", NP, {"NTP": {"ProtocolEnabled": False}})] * PER_SUCCESS_RULE
+    writes += [("PATCH", CHASSIS, {"IndicatorLED": "Lit"})] * PER_SUCCESS_RULE
+    writes += [("POST", RESET, {"ResetType": "ForceRestart"})] * FAIL_WRITES
+    writes += [("PATCH", SYSTEM, {"Unmatched": 1})] * NOMATCH_WRITES
+    random.Random(20260715).shuffle(writes)  # fixed multiset order for dispatch
+    return writes
+
+
+def test_mutation_rules_200_threads_match_serial_oracle_with_failure_injection() -> None:
+    """A 200-thread write storm reproduces the serial oracle's state exactly."""
+    module = _load_server_module()
+    normalize = module._normalize_request_path
+    corpus = {normalize(SYSTEM): {"PowerState": "On"}}
+
+    def corpus_lookup(path: str) -> dict[str, Any]:
+        return corpus.get(normalize(path), {})
+
+    writes = _workload()
+
+    concurrent = module.MutationRules(_rules(), seed=SEED)
+    latencies: list[float] = []
+    latencies_lock = threading.Lock()
+
+    def one(write: tuple[str, str, dict[str, Any]]) -> Any:
+        method, path, body = write
+        start = time.perf_counter()
+        result = concurrent.match_write(method, path, body, corpus_state=corpus_lookup)
+        elapsed = time.perf_counter() - start
+        with latencies_lock:
+            latencies.append(elapsed)
+        return result
+
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=THREADS) as pool:
+        responses = list(pool.map(one, writes))
+    wall = time.perf_counter() - started
+
+    # Serial oracle: identical multiset, fresh engine, same seed.
+    serial = module.MutationRules(_rules(), seed=SEED)
+    for method, path, body in writes:
+        serial.match_write(method, path, body, corpus_state=corpus_lookup)
+
+    conc_status = concurrent.status()
+    serial_status = serial.status()
+    applied = Counter(conc_status["applied"])
+    failed = Counter(conc_status["failed"])
+
+    p50 = _percentile(latencies, 50) * 1000
+    p95 = _percentile(latencies, 95) * 1000
+    p99 = _percentile(latencies, 99) * 1000
+    print(
+        f"\nmutation stress (writes={len(writes)}, threads={THREADS}): "
+        f"wall={wall:.3f}s p50={p50:.3f}ms p95={p95:.3f}ms p99={p99:.3f}ms "
+        f"applied={sum(applied.values())} failed={sum(failed.values())} "
+        f"nomatch={responses.count(None)}"
+    )
+
+    # Oracle equivalence: aggregates and overlays match the serial replay exactly.
+    assert applied == Counter(serial_status["applied"])
+    assert failed == Counter(serial_status["failed"])
+    for path in (SYSTEM, NP, CHASSIS):
+        assert concurrent.overlay_for(path) == serial.overlay_for(path)
+
+    # Exact, order-invariant expectations.
+    assert applied["sys-tag"] == PER_SUCCESS_RULE
+    assert applied["np-ntp"] == PER_SUCCESS_RULE
+    assert applied["chs-led"] == PER_SUCCESS_RULE
+    assert set(failed) == {"reset-flaky"}
+    reset_failures = sum(failed.values())
+    assert 0 < reset_failures < FAIL_WRITES  # injection actually fired, not all
+    assert applied["reset-flaky"] == FAIL_WRITES - reset_failures
+    assert responses.count(None) == NOMATCH_WRITES  # unmatched writes -> no rule
+
+    # Final overlay carries every distinctly-set field, uncorrupted.
+    assert concurrent.overlay_for(SYSTEM)["AssetTag"] == "svc"
+    assert concurrent.overlay_for(SYSTEM)["LastResetTime"] == "2099-01-01T00:00:00Z"
+    assert concurrent.overlay_for(NP)["NTP"]["ProtocolEnabled"] is False
+    assert concurrent.overlay_for(CHASSIS)["IndicatorLED"] == "Lit"

--- a/tests/test_replay_concurrency.py
+++ b/tests/test_replay_concurrency.py
@@ -1,0 +1,278 @@
+"""Concurrency contracts for the ordered ReplayState engine.
+
+The replay engine consumes a fixed step sequence exactly once, in order. These
+tests hammer it concurrently to prove two invariants that only break under
+concurrency: (1) each step is matched exactly once even when many threads race
+the same write (later duplicates get 409), and (2) a ``/__set_scenario`` reset is
+atomic with respect to in-flight writes (no torn overlay, no 5xx), leaving the
+engine behaving as if freshly started.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import threading
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+
+SYSTEM = "/redfish/v1/Systems/System_0"
+RESET = f"{SYSTEM}/Actions/ComputerSystem.Reset"
+SCENARIO = "power-cycle"
+
+# The ordered trace, and the write each step matches (fired in order per thread).
+STEP_WRITES: tuple[tuple[str, str, dict[str, Any]], ...] = (
+    ("POST", RESET, {"ResetType": "ForceOff"}),
+    ("PATCH", SYSTEM, {"Boot": {"BootSourceOverrideTarget": "Hdd"}}),
+    ("POST", RESET, {"ResetType": "On"}),
+    ("PATCH", SYSTEM, {"AssetTag": "svc-1"}),
+    ("POST", RESET, {"ResetType": "GracefulRestart"}),
+)
+
+
+def _load_server_module() -> Any:
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _fixture_name(path: str) -> str:
+    return "_" + path.strip("/").replace("/", "_") + ".json"
+
+
+def _tiny_corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    _write_json(
+        corpus / _fixture_name("/redfish/v1"),
+        {"@odata.id": "/redfish/v1", "Id": "RootService"},
+    )
+    _write_json(
+        corpus / _fixture_name(SYSTEM),
+        {
+            "@odata.id": SYSTEM,
+            "Id": "System_0",
+            "PowerState": "On",
+            "AssetTag": "",
+            "Boot": {"BootSourceOverrideEnabled": "Once", "BootSourceOverrideTarget": "Pxe"},
+        },
+    )
+    return corpus
+
+
+def _replay_trace(tmp_path: Path) -> Path:
+    steps = [
+        {
+            "name": "force-off",
+            "method": "POST",
+            "path": RESET,
+            "body_contains": {"ResetType": "ForceOff"},
+            "state_transitions": [
+                {"op": "set", "path": SYSTEM, "field": "PowerState", "value": "Off"}
+            ],
+            "response": {"status": 204},
+        },
+        {
+            "name": "set-hdd",
+            "method": "PATCH",
+            "path": SYSTEM,
+            "body_contains": {"Boot": {"BootSourceOverrideTarget": "Hdd"}},
+            "state_transitions": [
+                {
+                    "op": "set",
+                    "path": SYSTEM,
+                    "json_path": ["Boot", "BootSourceOverrideTarget"],
+                    "value": "Hdd",
+                }
+            ],
+            "response": {"status": 200, "body": {"ok": True}},
+        },
+        {
+            "name": "power-on",
+            "method": "POST",
+            "path": RESET,
+            "body_contains": {"ResetType": "On"},
+            "state_transitions": [
+                {"op": "set", "path": SYSTEM, "field": "PowerState", "value": "On"}
+            ],
+            "response": {"status": 204},
+        },
+        {
+            "name": "tag",
+            "method": "PATCH",
+            "path": SYSTEM,
+            "body_contains": {"AssetTag": "svc-1"},
+            "state_transitions": [
+                {"op": "set", "path": SYSTEM, "field": "AssetTag", "value": "svc-1"}
+            ],
+            "response": {"status": 200, "body": {"ok": True}},
+        },
+        {
+            "name": "graceful",
+            "method": "POST",
+            "path": RESET,
+            "body_contains": {"ResetType": "GracefulRestart"},
+            "state_transitions": [
+                {
+                    "op": "set",
+                    "path": SYSTEM,
+                    "field": "LastResetTime",
+                    "value": "2099-01-01T00:00:00Z",
+                }
+            ],
+            "response": {"status": 204},
+        },
+    ]
+    trace = {"scenario": SCENARIO, "steps": steps}
+    trace_path = tmp_path / "replay.json"
+    _write_json(trace_path, trace)
+    return trace_path
+
+
+def _request(
+    base: str, path: str, method: str = "GET", body: dict[str, Any] | None = None
+) -> tuple[int, Any]:
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    headers = {"Content-Type": "application/json"} if data is not None else {}
+    request = urllib.request.Request(base + path, data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(request, timeout=10) as response:
+            raw = response.read().decode("utf-8")
+            return response.status, (json.loads(raw) if raw else None)
+    except urllib.error.HTTPError as exc:
+        raw = exc.read().decode("utf-8")
+        return exc.code, (json.loads(raw) if raw else None)
+
+
+def _run_replay(module: Any, corpus: Path, trace: Path) -> None:
+    successes: list[tuple[str, str]] = []
+    statuses: list[int] = []
+    lock = threading.Lock()
+    done = threading.Event()
+    workers = 24
+
+    with module.run_server("127.0.0.1", 0, corpus, replay_trace=trace) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        def worker() -> None:
+            rounds = 0
+            while not done.is_set() and rounds < 200:
+                rounds += 1
+                for method, path, body in STEP_WRITES:
+                    if done.is_set():
+                        break
+                    status, _payload = _request(base, path, method, body)
+                    with lock:
+                        statuses.append(status)
+                        if status in (200, 204):
+                            successes.append((method, path))
+                            if len(successes) >= len(STEP_WRITES):
+                                done.set()
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            for future in [pool.submit(worker) for _ in range(workers)]:
+                future.result()
+
+        final_status, final = _request(base, SYSTEM)
+        replay_code, replay = _request(base, "/__replay_status")
+
+    # (a) exactly one success per step, never more.
+    assert len(successes) == len(STEP_WRITES)
+    # (b) every non-success write is a clean 409 (no 5xx, no torn write).
+    assert set(statuses) <= {200, 204, 409}
+    assert statuses.count(200) + statuses.count(204) == len(STEP_WRITES)
+    # (c) replay is complete and each step counted once.
+    assert replay_code == 200
+    assert replay["complete"] is True
+    assert replay["matched_steps"] == len(STEP_WRITES)
+    assert replay["pending_steps"] == []
+    # (d) final overlay equals the trace's deterministic end state.
+    assert final_status == 200
+    assert final["PowerState"] == "On"
+    assert final["Boot"]["BootSourceOverrideTarget"] == "Hdd"
+    assert final["AssetTag"] == "svc-1"
+    assert final["LastResetTime"] == "2099-01-01T00:00:00Z"
+
+
+def test_replay_determinism_under_concurrency(tmp_path: Path) -> None:
+    """Each ordered step is consumed exactly once under a 24-thread race."""
+    module = _load_server_module()
+    corpus = _tiny_corpus(tmp_path)
+    trace = _replay_trace(tmp_path)
+    _run_replay(module, corpus, trace)
+
+
+def test_scenario_reset_is_atomic_under_write_load(tmp_path: Path) -> None:
+    """A reset amid concurrent writes never tears state and leaves a clean engine."""
+    module = _load_server_module()
+    corpus = _tiny_corpus(tmp_path)
+    trace = _replay_trace(tmp_path)
+
+    statuses: list[int] = []
+    lock = threading.Lock()
+    stop = threading.Event()
+
+    with module.run_server("127.0.0.1", 0, corpus, replay_trace=trace) as server:
+        base = "http://{}:{}".format(*server.server_address)
+
+        def writer() -> None:
+            while not stop.is_set():
+                for method, path, body in STEP_WRITES:
+                    if stop.is_set():
+                        break
+                    status, _ = _request(base, path, method, body)
+                    with lock:
+                        statuses.append(status)
+
+        def resetter() -> None:
+            # Interleave several resets with the write storm.
+            for _ in range(20):
+                status, payload = _request(
+                    base, "/__set_scenario", "POST", {"scenario": SCENARIO}
+                )
+                with lock:
+                    statuses.append(status)
+                assert status == 200, payload
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            futures = [pool.submit(writer) for _ in range(8)]
+            futures.append(pool.submit(resetter))
+            # Let the resetter finish, then stop the writers.
+            futures[-1].result()
+            stop.set()
+            for future in futures[:-1]:
+                future.result()
+
+        # After the storm, one clean reset must return the engine to zero.
+        reset_code, reset_status = _request(
+            base, "/__set_scenario", "POST", {"scenario": SCENARIO}
+        )
+        after_reset_system_code, after_reset_system = _request(base, SYSTEM)
+
+    # No request in the whole storm produced a server error or an unexpected code.
+    assert set(statuses) <= {200, 204, 409}
+    # The final clean reset zeroes the engine (atomic reset, not a torn count).
+    assert reset_code == 200
+    assert reset_status["matched_steps"] == 0
+    assert reset_status["complete"] is False
+    # Overlays are cleared: the System resource is back to its corpus baseline.
+    assert after_reset_system_code == 200
+    assert after_reset_system["PowerState"] == "On"
+    assert after_reset_system["Boot"]["BootSourceOverrideTarget"] == "Pxe"
+    assert after_reset_system["AssetTag"] == ""
+    assert "LastResetTime" not in after_reset_system
+
+    # And a freshly-reset engine still replays the full sequence deterministically.
+    _run_replay(module, corpus, trace)

--- a/tests/test_webui_concurrency.py
+++ b/tests/test_webui_concurrency.py
@@ -17,7 +17,6 @@ import threading
 import time
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from http.server import ThreadingHTTPServer
 from types import SimpleNamespace
 from typing import Any
 
@@ -103,7 +102,7 @@ def test_webui_concurrent_invokes_keep_command_payloads_isolated() -> None:
     """Every concurrent /api/invoke returns its own command's data, not a peer's."""
     manager = _RacyManager()
     handler_cls = _make_handler_class(manager)
-    server = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    server = webui.ExplorerServer(("127.0.0.1", 0), handler_cls)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:

--- a/tests/test_webui_concurrency.py
+++ b/tests/test_webui_concurrency.py
@@ -1,0 +1,134 @@
+"""Concurrency contract for the read-only web explorer server.
+
+The explorer shares ONE ``RedfishManagerBase`` across every request (lazily
+built once, cached on the handler class). That manager wraps a
+``requests.Session``, which is not thread-safe: two concurrent ``/api/invoke``
+POSTs that both call ``sync_invoke`` on the same session can interleave and
+return each other's payloads. The server must therefore serialize invocations
+per manager. This test proves each concurrent command gets ITS OWN command's
+data back — it fails against an unserialized handler and passes once the
+per-manager invoke lock is in place.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from http.server import ThreadingHTTPServer
+from types import SimpleNamespace
+from typing import Any
+
+from redfish_ctl.webui import server as webui
+
+# A handful of distinct read-only catalog commands to fan out over. Each maps to
+# a unique (api, command) pair, so a mixed-up response is unambiguous.
+_COMMANDS = (
+    "system_query",
+    "manager_query",
+    "chassis_service_query",
+    "boot_query",
+    "power",
+    "current_boot_query",
+    "storage_list",
+    "event-service",
+)
+
+
+class _RacyManager:
+    """Fake manager that emulates a NON-thread-safe ``requests.Session``.
+
+    It stashes the in-flight command on a shared instance attribute, yields the
+    GIL, then reads the attribute back — so two unsynchronized concurrent calls
+    clobber each other and observe the wrong command. A per-manager lock in the
+    handler serializes the calls and restores correctness. The read delay only
+    widens the interleaving window; it never blocks (no cross-thread barrier), so
+    the serialized path cannot deadlock.
+    """
+
+    def __init__(self) -> None:
+        self._inflight: str | None = None
+        self.max_concurrency = 0
+        self._active = 0
+        self._counter_lock = threading.Lock()
+
+    def sync_invoke(self, api: Any, command: str, **_kwargs: Any) -> SimpleNamespace:
+        with self._counter_lock:
+            self._active += 1
+            self.max_concurrency = max(self.max_concurrency, self._active)
+        try:
+            self._inflight = command
+            time.sleep(0.003)  # widen the window a racy session would corrupt
+            observed = self._inflight
+            return SimpleNamespace(
+                error=None,
+                data={"requested": command, "observed": observed, "api": getattr(api, "name", str(api))},
+            )
+        finally:
+            with self._counter_lock:
+                self._active -= 1
+
+
+def _make_handler_class(manager: _RacyManager) -> type:
+    """A fresh handler subclass bound to ``manager`` (isolates class state)."""
+
+    class Handler(webui._Handler):
+        pass
+
+    Handler.manager = None
+    Handler.manager_lock = threading.Lock()
+    # invoke_lock is a class attribute added by the fix; give this subclass its
+    # own so the test never contends with any other server instance.
+    Handler.invoke_lock = threading.Lock()
+    Handler.manager_factory = staticmethod(lambda: manager)
+    Handler.target_label = "racy-mock"
+    return Handler
+
+
+def _post_invoke(base: str, command: str) -> dict[str, Any]:
+    body = json.dumps({"command": command}).encode("utf-8")
+    request = urllib.request.Request(
+        base + "/api/invoke",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def test_webui_concurrent_invokes_keep_command_payloads_isolated() -> None:
+    """Every concurrent /api/invoke returns its own command's data, not a peer's."""
+    manager = _RacyManager()
+    handler_cls = _make_handler_class(manager)
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        base = "http://{}:{}".format(*server.server_address)
+        jobs = [_COMMANDS[i % len(_COMMANDS)] for i in range(48)]
+        with ThreadPoolExecutor(max_workers=len(jobs)) as pool:
+            futures = {pool.submit(_post_invoke, base, cmd): cmd for cmd in jobs}
+            results = [(futures[f], f.result()) for f in as_completed(futures)]
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert len(results) == len(jobs)
+    for requested, body in results:
+        assert body["ok"] is True, body
+        data = body["data"]
+        # The response must be the manager's answer to THIS request, not a peer's
+        # that clobbered a shared session mid-flight.
+        assert data["requested"] == requested, body
+        assert data["observed"] == requested, (
+            f"payload mix-up: requested {requested!r} but session observed "
+            f"{data['observed']!r} (concurrent sync_invoke race)"
+        )
+    # The lock must have actually serialized invocations against the one manager.
+    assert manager.max_concurrency == 1, (
+        f"expected serialized invokes, saw {manager.max_concurrency} concurrent"
+    )


### PR DESCRIPTION
Harden the corpus-backed Redfish simulator for large-scale concurrency. Each fix was verified locally first and lands with a focused regression test.

> Stacked on #140, which introduces `redfish_ctl/webui/` and `k8s/consumer/fleet_status_app.py`. Base is `neroshige/restored-stash-on-rename`; merge after #140. `k8s/sandbox/mock_bmc_server.py` is already on `main`.

## Fixes

1. **webui: serialize command invocations per manager.** `_Handler` shares one `RedfishManagerBase` and its `requests.Session` across concurrent `/api/invoke` POST requests. Added `invoke_lock` so command execution is serialized per manager; `manager_lock` still guards only lazy construction.

2. **mock BMC: read corpus state before taking the MutationRules lock.** `MutationRules.match_write` no longer holds the engine lock across corpus file reads and JSON parsing. It now prefilters request/body matches, pre-reads corpus state, and keeps overlay-dependent checks/transitions under the lock.

3. **fleet consumer: single-flight endpoint cache.** `_EndpointCache.get` now lets one caller refresh a stale cache entry while concurrent callers wait and reuse the result, avoiding duplicate Kubernetes list calls.

## Smoke tests

- replay determinism under concurrent writes;
- `__set_scenario` reset atomicity under write load;
- mutation-rules write storm with failure injection and latency percentile checks;
- concurrent GET hammer and mixed GET/POST load;
- fleet HTTP cache single-flight behavior;
- multi-instance identity isolation;
- sustained mixed-load FD/thread/RSS leak check.

## Gate

- `pytest -q` with no `IDRAC_IP`: 1186 passed, 58 skipped.
- `ruff check` clean on changed files.
- Offline and loopback-only; no live BMC or credentials.