### PR TITLE
Make RedfishEndpoint controller concurrency-safe at fleet scale

### DIFF
--- a/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
+++ b/charts/redfish-controller/crds/redfish-endpoint-crd.yaml
@@ -100,3 +100,38 @@ spec:
                 lastPolled:
                   type: string
                   format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                      - lastTransitionTime
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                consecutiveFailures:
+                  type: integer
+                  minimum: 0
+                lastError:
+                  type: string
+                  nullable: true
+                nextPollAfter:
+                  type: string
+                  format: date-time
+                  nullable: true

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -49,6 +49,17 @@ rack7-node3   On      OK       2026-07-11T02:10:41Z
 A node that loses power or cooling shows up here without anyone SSH-ing
 anywhere — the read path is the fleet's heartbeat.
 
+`spec.pollInterval` sets each endpoint's cadence. The controller's kopf timer
+fires at a base cadence — 30s by default, retunable per deployment via the
+`REDFISH_CONTROLLER_POLL_INTERVAL` env var (the Helm chart renders it from
+`controller.pollInterval`) — and each endpoint polls no more often than that
+base; a larger `pollInterval` slows an individual endpoint down. When a BMC is unreachable the poll does not fail the
+object: the controller records an `EndpointReachable=False` condition plus a
+`lastError` and backs off (`nextPollAfter`) with exponential growth, while the
+last good `powerState`/`health`/`temperature` and `lastPolled` are preserved.
+Editing the spec (e.g. fixing a bad `address`) re-polls immediately rather than
+waiting out the interval or backoff.
+
 ## Scenario: stream telemetry to the collector
 
 For dashboards and alerting, status snapshots are not enough — run one

--- a/k8s/controller/deployment.yaml
+++ b/k8s/controller/deployment.yaml
@@ -39,6 +39,12 @@ spec:
             # plan/approve/apply write path.
             - /app/k8s/controller/redfish_endpoint_controller.py
             - /app/k8s/controller/redfish_node_profile_controller.py
+          env:
+            # Base cadence for the endpoint controller's poll timer. Per-CR
+            # spec.pollInterval slows individual endpoints below this floor.
+            # (Helm renders the same var from .Values.controller.pollInterval.)
+            - name: REDFISH_CONTROLLER_POLL_INTERVAL
+              value: "30s"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/controller/redfish-endpoint-crd.yaml
+++ b/k8s/controller/redfish-endpoint-crd.yaml
@@ -100,3 +100,38 @@ spec:
                 lastPolled:
                   type: string
                   format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                      - lastTransitionTime
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                consecutiveFailures:
+                  type: integer
+                  minimum: 0
+                lastError:
+                  type: string
+                  nullable: true
+                nextPollAfter:
+                  type: string
+                  format: date-time
+                  nullable: true

--- a/k8s/controller/redfish_endpoint_controller.py
+++ b/k8s/controller/redfish_endpoint_controller.py
@@ -4,9 +4,13 @@
 from __future__ import annotations
 
 import base64
-from datetime import datetime, timezone
+import os
+import re
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Mapping, MutableMapping
 from urllib.parse import urlsplit
+
+import requests
 
 try:  # pragma: no cover - exercised only in a deployed controller image.
     import kopf
@@ -14,12 +18,20 @@ except ImportError:  # pragma: no cover - unit tests call the handler directly.
     kopf = None
 
 from redfish_ctl.api import (
+    RedfishApiError,
     SensorReading,
     SystemStatus,
     ThermalStatus,
     get_sensors,
     get_system,
     get_thermal,
+)
+from redfish_ctl.cmd_exceptions import AuthenticationFailed, ResourceNotFound
+from redfish_ctl.kube_client import get_core_v1_api
+from redfish_ctl.redfish_exceptions import (
+    RedfishException,
+    RedfishForbidden,
+    RedfishUnauthorized,
 )
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 
@@ -29,7 +41,40 @@ REDFISH_PLURAL = "redfishendpoints"
 DEFAULT_PORT = 443
 DEFAULT_USERNAME = "root"
 
+#: Fallback cadence when the CR omits ``spec.pollInterval`` and no env override
+#: is set. Also the kopf timer's base firing interval (see ``base_interval_seconds``).
+DEFAULT_POLL_INTERVAL_SECONDS = 30.0
+
+#: Slack allowed when deciding a poll is "due", so a base-cadence timer fire that
+#: lands a hair short of ``spec.pollInterval`` (sub-second jitter) still polls
+#: instead of skipping a full cycle.
+POLL_DUE_TOLERANCE_SECONDS = 1.0
+
+#: Ceiling for the exponential backoff applied after repeated BMC failures.
+MAX_BACKOFF_SECONDS = 600.0
+
+#: Condition type surfaced on ``.status`` describing BMC reachability.
+REACHABLE_CONDITION = "EndpointReachable"
+
+#: Errors that mean "the BMC could not be read this cycle" rather than a bug in
+#: the controller. These are caught, recorded on ``.status`` with a backoff, and
+#: retried on the next timer fire instead of raising forever.
+POLL_ERRORS: tuple[type[BaseException], ...] = (
+    RedfishApiError,
+    RedfishException,
+    AuthenticationFailed,
+    ResourceNotFound,
+    requests.exceptions.RequestException,
+    ConnectionError,
+    TimeoutError,
+    OSError,
+)
+
 ManagerFactory = Callable[..., Any]
+
+#: Manager class the handler builds per poll. Indirected through a module global
+#: so tests can substitute a fake BMC facade without a real network.
+MANAGER_FACTORY: ManagerFactory = RedfishManagerBase
 
 
 def _utc_now() -> datetime:
@@ -96,6 +141,223 @@ def build_status(
     }
 
 
+_INTERVAL_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smh]?)\s*$")
+_UNIT_SECONDS = {"": 1.0, "s": 1.0, "m": 60.0, "h": 3600.0}
+
+
+def parse_interval_seconds(text: Any, default: float) -> float:
+    """Parse a ``spec.pollInterval`` string ("30s"/"5m"/"1h") into seconds.
+
+    Returns ``default`` for missing, malformed, or non-positive values, so a bad
+    CR field degrades to the base cadence rather than breaking the poll loop.
+    """
+    if text is None:
+        return default
+    if isinstance(text, bool):
+        return default
+    if isinstance(text, (int, float)):
+        return float(text) if text > 0 else default
+    match = _INTERVAL_RE.match(str(text))
+    if not match:
+        return default
+    value = float(match.group(1)) * _UNIT_SECONDS[match.group(2)]
+    return value if value > 0 else default
+
+
+#: Env var the deployment/Helm chart sets from ``controller.pollInterval`` to
+#: retune the controller's base timer cadence. The old handler hard-coded
+#: ``interval=30`` and never read it, so this knob was wired but dead.
+POLL_INTERVAL_ENV = "REDFISH_CONTROLLER_POLL_INTERVAL"
+
+
+def base_interval_seconds() -> float:
+    """The kopf timer's base firing cadence, overridable via env.
+
+    Reads ``REDFISH_CONTROLLER_POLL_INTERVAL`` (a duration like ``30s``/``1m``),
+    the value the Helm chart's ``controller.pollInterval`` already renders into
+    the controller container, so an operator can retune the deployment without
+    editing code. Per-CR ``spec.pollInterval`` still governs each endpoint on
+    top of this floor.
+    """
+    return parse_interval_seconds(
+        os.environ.get(POLL_INTERVAL_ENV),
+        DEFAULT_POLL_INTERVAL_SECONDS,
+    )
+
+
+def _parse_rfc3339(text: Any) -> datetime | None:
+    if not isinstance(text, str) or not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def poll_due(
+    spec: Mapping[str, Any],
+    status: Mapping[str, Any],
+    now: datetime,
+) -> bool:
+    """Decide whether this timer fire should poll the BMC.
+
+    Honors two per-CR gates written into ``.status``:
+
+    * ``nextPollAfter`` — an exponential backoff set after a failed poll, so an
+      unreachable BMC is not hammered on every base-cadence timer fire.
+    * ``spec.pollInterval`` vs ``lastPolled`` — lets an endpoint poll slower than
+      the base cadence. (The base cadence is the floor; a CR asking to poll
+      faster than the deployment's timer is bounded by it.)
+
+    A CR with no prior successful poll is always due.
+    """
+    next_after = _parse_rfc3339(status.get("nextPollAfter"))
+    if next_after is not None and now < next_after:
+        return False
+    last_polled = _parse_rfc3339(status.get("lastPolled"))
+    if last_polled is None:
+        return True
+    desired = parse_interval_seconds(spec.get("pollInterval"), base_interval_seconds())
+    elapsed = (now - last_polled).total_seconds()
+    return elapsed + POLL_DUE_TOLERANCE_SECONDS >= desired
+
+
+def backoff_seconds(failures: int, base: float, cap: float = MAX_BACKOFF_SECONDS) -> float:
+    """Exponential backoff for consecutive failures, capped.
+
+    ``failures`` is 1 for the first failure. Delay doubles each failure from the
+    base cadence up to ``cap``.
+    """
+    if failures < 1:
+        return base
+    delay = base * (2 ** (failures - 1))
+    return min(delay, cap)
+
+
+def _condition(
+    condition_type: str,
+    status: bool,
+    reason: str,
+    *,
+    message: str,
+    changed_at: datetime,
+) -> dict[str, str]:
+    condition = {
+        "type": condition_type,
+        "status": "True" if status else "False",
+        "reason": reason,
+        "lastTransitionTime": _rfc3339(changed_at),
+    }
+    if message:
+        condition["message"] = message
+    return condition
+
+
+def _classify_poll_error(exc: BaseException) -> tuple[str, str]:
+    """Map a BMC read failure to a (reason, message) for the status condition."""
+    message = str(exc) or exc.__class__.__name__
+    if isinstance(exc, (RedfishUnauthorized, RedfishForbidden, AuthenticationFailed)):
+        return "AuthenticationFailed", message
+    if isinstance(exc, ResourceNotFound):
+        return "ResourceNotFound", message
+    if isinstance(
+        exc,
+        (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout, TimeoutError),
+    ):
+        return "Timeout", message
+    if isinstance(exc, (requests.exceptions.ConnectionError, ConnectionError, OSError)):
+        return "BMCUnreachable", message
+    return "PollFailed", message
+
+
+def build_error_status(
+    prev_status: Mapping[str, Any],
+    exc: BaseException,
+    *,
+    now: datetime,
+    base_interval: float,
+) -> dict[str, Any]:
+    """Status patch for a failed poll.
+
+    Deliberately omits ``powerState``/``health``/``temperature``/``lastPolled``:
+    a RedfishEndpoint ``.status`` update is a JSON merge-patch (RFC 7386), so
+    omitting those keys preserves the last successful readings while recording
+    the failure and a backoff. ``lastPolled`` stays at the last *successful*
+    poll, and the failure is explained by the condition + ``lastError`` rather
+    than freezing silently.
+    """
+    failures = _int(prev_status.get("consecutiveFailures")) + 1
+    reason, message = _classify_poll_error(exc)
+    delay = backoff_seconds(failures, base_interval)
+    return {
+        "conditions": [
+            _condition(
+                REACHABLE_CONDITION,
+                False,
+                reason,
+                message=message,
+                changed_at=now,
+            )
+        ],
+        "consecutiveFailures": failures,
+        "lastError": message,
+        "nextPollAfter": _rfc3339(now + timedelta(seconds=delay)),
+    }
+
+
+def build_success_status(
+    readings: Mapping[str, Any],
+    *,
+    now: datetime,
+) -> dict[str, Any]:
+    """Merge the core readings with a healthy condition and cleared failure fields."""
+    status = dict(readings)
+    status["conditions"] = [
+        _condition(
+            REACHABLE_CONDITION,
+            True,
+            "PollSucceeded",
+            message="",
+            changed_at=now,
+        )
+    ]
+    status["consecutiveFailures"] = 0
+    # Null clears the field via merge-patch when the endpoint recovers.
+    status["lastError"] = None
+    status["nextPollAfter"] = None
+    return status
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _close_manager(manager: Any) -> None:
+    """Best-effort close of the manager's pooled HTTP session.
+
+    ``RedfishManagerBase`` lazily caches a keep-alive ``requests.Session`` (with
+    its urllib3 connection pool) in ``_session_cache``. The controller builds one
+    manager per poll, so at fleet scale unclosed sessions would leak sockets/FDs.
+    """
+    session = getattr(manager, "_session_cache", None)
+    if session is None:
+        return
+    try:
+        session.close()
+    except Exception:  # pragma: no cover - close must never break a poll.
+        pass
+
+
 def _manager_address(spec: Mapping[str, Any]) -> tuple[str, bool]:
     raw_address = str(spec.get("address") or "").strip()
     if not raw_address:
@@ -134,12 +396,19 @@ def poll_endpoint(
     manager_factory: ManagerFactory = RedfishManagerBase,
     polled_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Read a BMC through the facade and return a status patch payload."""
+    """Read a BMC through the facade and return a status patch payload.
+
+    Always closes the per-poll manager's pooled session, even on error, so a
+    fleet of endpoints does not leak sockets one failed/slow poll at a time.
+    """
     manager = _make_manager(spec, credentials or {}, manager_factory)
-    system = get_system(manager)
-    sensors = get_sensors(manager)
-    thermal = get_thermal(manager)
-    return build_status(system, sensors, thermal, polled_at=polled_at)
+    try:
+        system = get_system(manager)
+        sensors = get_sensors(manager)
+        thermal = get_thermal(manager)
+        return build_status(system, sensors, thermal, polled_at=polled_at)
+    finally:
+        _close_manager(manager)
 
 
 def _decode_secret_value(data: Mapping[str, str], key: str) -> str | None:
@@ -153,23 +422,21 @@ def load_secret_credentials(
     namespace: str | None,
     secret_ref: Mapping[str, Any] | None,
 ) -> dict[str, str]:
-    """Read credentials from the Secret named by spec.secretRef when available."""
+    """Read credentials from the Secret named by spec.secretRef when available.
+
+    Uses the process-wide client from :mod:`redfish_ctl.kube_client`, which
+    loads the kube config once and is safe to share across kopf's handler
+    threads. Falls back to empty credentials whenever a client is unavailable
+    (kubernetes not installed, or no in-cluster/local config), matching the
+    offline behaviour the test suite relies on.
+    """
     if not namespace or not secret_ref or not secret_ref.get("name"):
         return {}
-    try:  # pragma: no cover - requires a Kubernetes client in-cluster or locally.
-        from kubernetes import client, config
-    except ImportError:  # pragma: no cover - controller images carry this dependency.
+    try:
+        api = get_core_v1_api()
+    except Exception:  # pragma: no cover - kubernetes/config unavailable offline.
         return {}
 
-    try:  # pragma: no cover - not exercised by offline tests.
-        config.load_incluster_config()
-    except Exception:
-        try:
-            config.load_kube_config()
-        except Exception:
-            return {}
-
-    api = client.CoreV1Api()
     secret = api.read_namespaced_secret(str(secret_ref["name"]), namespace)
     data = secret.data or {}
     username_key = str(secret_ref.get("usernameKey") or "username")
@@ -191,6 +458,8 @@ def poll_redfish_endpoint(
     name: str | None = None,
     logger: Any | None = None,
     patch: MutableMapping[str, Any] | None = None,
+    status: Mapping[str, Any] | None = None,
+    force: bool = False,
     **_: Any,
 ) -> None:
     """Kopf callback that updates only the RedfishEndpoint status subresource.
@@ -200,30 +469,68 @@ def poll_redfish_endpoint(
     ``status.poll_redfish_endpoint``, a field the structural CRD schema
     rejects, which surfaces a "merge-patching finished with inconsistencies"
     warning on every poll.
+
+    Per-CR ``spec.pollInterval`` and post-failure backoff are honored: the timer
+    fires at the deployment's base cadence, and :func:`poll_due` decides whether
+    this fire actually polls. Lifecycle events (create/update) pass ``force=True``
+    so an operator's spec change — e.g. fixing a bad address mid-backoff — takes
+    effect immediately instead of waiting out the interval/backoff. A BMC read
+    failure is caught, recorded on ``.status`` with an exponential backoff, and
+    retried next cycle instead of raising forever; the last successful readings
+    are preserved (merge-patch).
     """
+    current_status = status if status is not None else _mapping(body).get("status")
+    current_status = _mapping(current_status)
+    now = _utc_now()
+    if not force and not poll_due(spec, current_status, now):
+        return None
+
     credentials = load_secret_credentials(namespace, spec.get("secretRef"))
-    status = poll_endpoint(spec, credentials=credentials)
+    base = base_interval_seconds()
+    try:
+        readings = poll_endpoint(
+            spec,
+            credentials=credentials,
+            manager_factory=MANAGER_FACTORY,
+            polled_at=now,
+        )
+    except POLL_ERRORS as exc:
+        new_status = build_error_status(
+            current_status, exc, now=now, base_interval=base
+        )
+        if logger is not None:
+            logger.warning(
+                "RedfishEndpoint %s/%s poll failed (%s): %s",
+                namespace or "",
+                name or "",
+                new_status["consecutiveFailures"],
+                new_status["lastError"],
+            )
+    else:
+        new_status = build_success_status(readings, now=now)
+        if logger is not None:
+            logger.info("polled RedfishEndpoint %s/%s", namespace or "", name or "")
+
     if patch is not None:
-        patch.setdefault("status", {}).update(status)
-    if logger is not None:
-        logger.info("polled RedfishEndpoint %s/%s", namespace or "", name or "")
+        patch.setdefault("status", {}).update(new_status)
+    return None
+
+
+def poll_on_change(**kwargs: Any) -> None:  # pragma: no cover - runtime kopf wiring.
+    """Create/update entrypoint: poll immediately, bypassing the cadence gate."""
+    return poll_redfish_endpoint(force=True, **kwargs)
 
 
 if kopf is not None:  # pragma: no cover - decorator wiring is runtime-only.
-    poll_redfish_endpoint = kopf.on.create(
+    # Lifecycle events poll now (force=True); the timer polls on the per-CR
+    # cadence via poll_due. Distinct functions so kopf registers distinct
+    # handler ids for the change causes vs the timer.
+    kopf.on.create(REDFISH_GROUP, REDFISH_VERSION, REDFISH_PLURAL)(poll_on_change)
+    kopf.on.update(REDFISH_GROUP, REDFISH_VERSION, REDFISH_PLURAL)(poll_on_change)
+    kopf.timer(
         REDFISH_GROUP,
         REDFISH_VERSION,
         REDFISH_PLURAL,
-    )(poll_redfish_endpoint)
-    poll_redfish_endpoint = kopf.on.update(
-        REDFISH_GROUP,
-        REDFISH_VERSION,
-        REDFISH_PLURAL,
-    )(poll_redfish_endpoint)
-    poll_redfish_endpoint = kopf.timer(
-        REDFISH_GROUP,
-        REDFISH_VERSION,
-        REDFISH_PLURAL,
-        interval=30,
+        interval=base_interval_seconds(),
         sharp=True,
     )(poll_redfish_endpoint)

--- a/k8s/controller/redfish_node_profile_controller.py
+++ b/k8s/controller/redfish_node_profile_controller.py
@@ -15,6 +15,7 @@ try:  # pragma: no cover - exercised only in a deployed controller image.
 except ImportError:  # pragma: no cover - unit tests call the handler directly.
     kopf = None
 
+from redfish_ctl.kube_client import get_core_v1_api
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 
 REDFISH_GROUP = "redfish.ctl.dev"
@@ -326,23 +327,19 @@ def load_secret_credentials(
     namespace: str | None,
     secret_ref: Mapping[str, Any] | None,
 ) -> dict[str, str]:
-    """Read credentials from the Secret named by spec.endpoint.secretRef when available."""
+    """Read credentials from the Secret named by spec.endpoint.secretRef when available.
+
+    Shares the process-wide client from :mod:`redfish_ctl.kube_client` with the
+    endpoint controller (both run in one kopf process), so the kube config is
+    loaded once for the whole process instead of on every handler thread.
+    """
     if not namespace or not secret_ref or not secret_ref.get("name"):
         return {}
-    try:  # pragma: no cover - requires a Kubernetes client in-cluster or locally.
-        from kubernetes import client, config
-    except ImportError:  # pragma: no cover - controller images carry this dependency.
+    try:
+        api = get_core_v1_api()
+    except Exception:  # pragma: no cover - kubernetes/config unavailable offline.
         return {}
 
-    try:  # pragma: no cover - not exercised by offline tests.
-        config.load_incluster_config()
-    except Exception:
-        try:
-            config.load_kube_config()
-        except Exception:
-            return {}
-
-    api = client.CoreV1Api()
     secret = api.read_namespaced_secret(str(secret_ref["name"]), namespace)
     data = secret.data or {}
     username_key = str(secret_ref.get("usernameKey") or "username")

--- a/redfish_ctl/kube_client.py
+++ b/redfish_ctl/kube_client.py
@@ -1,0 +1,79 @@
+"""Process-wide Kubernetes client shared by the redfish_ctl controllers.
+
+kopf dispatches synchronous resource handlers on a ``ThreadPoolExecutor``, so
+at fleet scale many handler threads run concurrently. The previous controllers
+each called ``config.load_incluster_config()`` / ``config.load_kube_config()``
+and built a fresh ``client.CoreV1Api()`` on *every* handler invocation. Both the
+config loaders mutate the kubernetes client's process-global default
+``Configuration`` singleton, so concurrent handler threads raced on that global
+and rebuilt a client (and its connection pool) per poll.
+
+This module loads the kube config exactly once, behind a lock, and hands every
+caller the same thread-safe ``CoreV1Api`` (its underlying ``urllib3`` pool is
+safe to share across threads). Both the endpoint and node-profile controllers
+run in one kopf process and import this module, so they share a single client.
+
+The ``kubernetes`` package is imported lazily inside the seams below: the
+offline test suite does not install it, and importing at module load would make
+the controllers unimportable in tests. The seams (`_load_kube_config`,
+`_build_core_v1_api`) are also the injection points the concurrency tests
+monkeypatch to prove the config is loaded once under load without a real cluster.
+
+Author Mus <spyroot@gmail.com>
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+_LOCK = threading.Lock()
+_CORE_V1_API: Any | None = None
+
+
+def _load_kube_config() -> None:  # pragma: no cover - needs a real cluster/kubeconfig.
+    """Load in-cluster config, falling back to a local kubeconfig."""
+    from kubernetes import config
+
+    try:
+        config.load_incluster_config()
+    except Exception:
+        config.load_kube_config()
+
+
+def _build_core_v1_api() -> Any:  # pragma: no cover - needs the kubernetes package.
+    """Return a fresh CoreV1Api bound to the loaded configuration."""
+    from kubernetes import client
+
+    return client.CoreV1Api()
+
+
+def get_core_v1_api() -> Any:
+    """Return the one process-wide CoreV1Api, loading kube config once.
+
+    Uses double-checked locking so the common path (client already built) never
+    takes the lock, while the first concurrent burst of handler threads loads the
+    config and builds the client exactly once. Raises ``ImportError`` (or the
+    underlying config error) if kubernetes is unavailable; callers that must
+    degrade offline catch that and fall back.
+    """
+    global _CORE_V1_API
+    api = _CORE_V1_API
+    if api is not None:
+        return api
+    with _LOCK:
+        if _CORE_V1_API is None:
+            _load_kube_config()
+            _CORE_V1_API = _build_core_v1_api()
+        return _CORE_V1_API
+
+
+def reset_client_cache() -> None:
+    """Drop the cached client so the next call rebuilds it.
+
+    Used by tests to isolate the singleton, and available as a hook to force a
+    reconnect (e.g. after an in-cluster token rotation).
+    """
+    global _CORE_V1_API
+    with _LOCK:
+        _CORE_V1_API = None

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
-from datetime import datetime, timezone
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -72,8 +74,24 @@ def test_crd_schema_pins_read_only_endpoint_spec_and_status_shape() -> None:
         "health",
         "temperature",
         "lastPolled",
+        "conditions",
+        "consecutiveFailures",
+        "lastError",
+        "nextPollAfter",
     }
     assert status_props["temperature"]["properties"]["maxCelsius"]["type"] == "number"
+    # Reachability/backoff fields the error path writes; the structural CRD must
+    # allow them or the API server would prune them and the freeze stays silent.
+    assert status_props["consecutiveFailures"]["type"] == "integer"
+    assert status_props["lastError"]["nullable"] is True
+    assert status_props["nextPollAfter"]["nullable"] is True
+    condition_item = status_props["conditions"]["items"]
+    assert set(condition_item["required"]) == {
+        "type",
+        "status",
+        "reason",
+        "lastTransitionTime",
+    }
     assert "valueFrom" not in json.dumps(crd)
     assert version["additionalPrinterColumns"] == [
         {
@@ -184,9 +202,11 @@ def test_kopf_handler_patches_status_only(monkeypatch) -> None:
     """The handler writes status through the kopf patch, returns None, never mutates."""
     module = _load_controller_module()
     calls: list[tuple[dict, dict]] = []
+    fixed_now = datetime(2026, 7, 10, 14, 50, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(module, "_utc_now", lambda: fixed_now)
 
-    def fake_poll_endpoint(spec, credentials):
-        calls.append((spec, credentials))
+    def fake_poll_endpoint(spec, credentials=None, manager_factory=None, polled_at=None):
+        calls.append((dict(spec), dict(credentials or {})))
         return {
             "powerState": "On",
             "health": "OK",
@@ -216,6 +236,17 @@ def test_kopf_handler_patches_status_only(monkeypatch) -> None:
             "health": "OK",
             "temperature": {"count": 1, "maxCelsius": 24.4},
             "lastPolled": "2026-07-10T14:50:00Z",
+            "conditions": [
+                {
+                    "type": "EndpointReachable",
+                    "status": "True",
+                    "reason": "PollSucceeded",
+                    "lastTransitionTime": "2026-07-10T14:50:00Z",
+                }
+            ],
+            "consecutiveFailures": 0,
+            "lastError": None,
+            "nextPollAfter": None,
         }
     }
     assert calls == [
@@ -246,3 +277,323 @@ def test_sensor_health_falls_back_when_system_health_absent() -> None:
     assert status["powerState"] == "Off"
     assert status["health"] == "Warning"
     assert status["temperature"] == {"count": 0, "maxCelsius": None}
+
+
+# ---------------------------------------------------------------------------
+# P0 - shared, thread-safe Kubernetes client
+#
+# kopf runs sync handlers on a ThreadPoolExecutor. The old code loaded the kube
+# config and built a CoreV1Api on every handler call, racing on the kubernetes
+# client's process-global default Configuration. These tests pin the fix: the
+# config is loaded exactly once and one client is shared, even when 50 handler
+# threads request it simultaneously.
+# ---------------------------------------------------------------------------
+
+
+def test_kube_client_loads_config_once_under_concurrency(monkeypatch) -> None:
+    """50 concurrent callers trigger exactly one config load and one client build."""
+    from redfish_ctl import kube_client
+
+    kube_client.reset_client_cache()
+    try:
+        load_calls: list[int] = []
+        build_calls: list[int] = []
+        sentinel = object()
+
+        def fake_load() -> None:
+            load_calls.append(1)
+
+        def fake_build():
+            build_calls.append(1)
+            return sentinel
+
+        monkeypatch.setattr(kube_client, "_load_kube_config", fake_load)
+        monkeypatch.setattr(kube_client, "_build_core_v1_api", fake_build)
+
+        # A barrier releases all workers at once so they collide on the unbuilt
+        # singleton — the exact window the old per-call code raced in.
+        workers = 50
+        barrier = threading.Barrier(workers)
+
+        def worker():
+            barrier.wait()
+            return kube_client.get_core_v1_api()
+
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            results = [f.result() for f in [pool.submit(worker) for _ in range(workers)]]
+
+        assert all(result is sentinel for result in results)
+        assert load_calls == [1], "kube config must load exactly once for the process"
+        assert build_calls == [1], "exactly one CoreV1Api must be shared"
+    finally:
+        kube_client.reset_client_cache()
+
+
+def test_load_secret_credentials_uses_shared_client_and_decodes(monkeypatch) -> None:
+    """The handler decodes Secret data through the shared client, no per-call config load."""
+    import base64
+
+    from redfish_ctl import kube_client
+
+    module = _load_controller_module()
+    kube_client.reset_client_cache()
+    try:
+        load_calls: list[int] = []
+
+        class FakeSecret:
+            data = {
+                "username": base64.b64encode(b"bmc-admin").decode("ascii"),
+                "password": base64.b64encode(b"s3cr3t").decode("ascii"),
+            }
+
+        read_args: list[tuple[str, str]] = []
+
+        class FakeApi:
+            def read_namespaced_secret(self, name, namespace):
+                read_args.append((name, namespace))
+                return FakeSecret()
+
+        def fake_load() -> None:
+            load_calls.append(1)
+
+        monkeypatch.setattr(kube_client, "_load_kube_config", fake_load)
+        monkeypatch.setattr(kube_client, "_build_core_v1_api", lambda: FakeApi())
+
+        creds_first = module.load_secret_credentials("bmc-ns", {"name": "bmc-login"})
+        creds_second = module.load_secret_credentials("bmc-ns", {"name": "bmc-login"})
+
+        assert creds_first == {"username": "bmc-admin", "password": "s3cr3t"}
+        assert creds_second == creds_first
+        # Two credential reads, but the config was loaded once for the process.
+        assert load_calls == [1]
+        assert read_args == [("bmc-login", "bmc-ns"), ("bmc-login", "bmc-ns")]
+    finally:
+        kube_client.reset_client_cache()
+
+
+def test_load_secret_credentials_degrades_when_client_unavailable(monkeypatch) -> None:
+    """Offline (no kubernetes/config), credentials fall back to empty, never raising."""
+    from redfish_ctl import kube_client
+
+    module = _load_controller_module()
+    kube_client.reset_client_cache()
+    try:
+        def boom() -> None:
+            raise ImportError("No module named 'kubernetes'")
+
+        monkeypatch.setattr(kube_client, "_load_kube_config", boom)
+
+        assert module.load_secret_credentials("bmc-ns", {"name": "bmc-login"}) == {}
+        # No secretRef / namespace short-circuits before touching any client.
+        assert module.load_secret_credentials(None, {"name": "bmc-login"}) == {}
+        assert module.load_secret_credentials("bmc-ns", None) == {}
+    finally:
+        kube_client.reset_client_cache()
+
+
+# ---------------------------------------------------------------------------
+# P2 - honor per-CR spec.pollInterval (the old timer hard-coded interval=30)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_interval_seconds_handles_units_and_bad_input() -> None:
+    """pollInterval strings parse to seconds; junk falls back to the default."""
+    module = _load_controller_module()
+    assert module.parse_interval_seconds("30s", 99.0) == 30.0
+    assert module.parse_interval_seconds("5m", 99.0) == 300.0
+    assert module.parse_interval_seconds("1h", 99.0) == 3600.0
+    assert module.parse_interval_seconds("45", 99.0) == 45.0  # bare number = seconds
+    assert module.parse_interval_seconds(120, 99.0) == 120.0
+    # Bad / empty / non-positive values degrade to the base cadence.
+    assert module.parse_interval_seconds(None, 99.0) == 99.0
+    assert module.parse_interval_seconds("", 99.0) == 99.0
+    assert module.parse_interval_seconds("soon", 99.0) == 99.0
+    assert module.parse_interval_seconds("0s", 99.0) == 99.0
+    assert module.parse_interval_seconds(True, 99.0) == 99.0
+
+
+def test_base_interval_seconds_reads_env(monkeypatch) -> None:
+    """The timer's base cadence reads the chart's env var, defaulting to 30s."""
+    module = _load_controller_module()
+    # Same env name the Helm chart renders from controller.pollInterval.
+    assert module.POLL_INTERVAL_ENV == "REDFISH_CONTROLLER_POLL_INTERVAL"
+    monkeypatch.delenv(module.POLL_INTERVAL_ENV, raising=False)
+    assert module.base_interval_seconds() == module.DEFAULT_POLL_INTERVAL_SECONDS
+    monkeypatch.setenv(module.POLL_INTERVAL_ENV, "15")
+    assert module.base_interval_seconds() == 15.0
+    # Chart passes a duration string like "45s"; parse it too.
+    monkeypatch.setenv(module.POLL_INTERVAL_ENV, "45s")
+    assert module.base_interval_seconds() == 45.0
+    monkeypatch.setenv(module.POLL_INTERVAL_ENV, "nonsense")
+    assert module.base_interval_seconds() == module.DEFAULT_POLL_INTERVAL_SECONDS
+
+
+def test_poll_due_respects_pollInterval_and_backoff() -> None:
+    """poll_due gates on per-CR interval and on the post-failure backoff window."""
+    module = _load_controller_module()
+    now = datetime(2026, 7, 10, 15, 0, 0, tzinfo=timezone.utc)
+
+    def polled_ago(seconds: int) -> str:
+        return module._rfc3339(now - timedelta(seconds=seconds))
+
+    spec = {"address": "bmc", "pollInterval": "60s"}
+    # No prior successful poll: always due.
+    assert module.poll_due(spec, {}, now) is True
+    # 30s since last poll but the CR wants 60s: not due yet.
+    assert module.poll_due(spec, {"lastPolled": polled_ago(30)}, now) is False
+    # 60s elapsed: due.
+    assert module.poll_due(spec, {"lastPolled": polled_ago(60)}, now) is True
+    # Backoff window still open overrides an otherwise-due interval.
+    backing_off = {
+        "lastPolled": polled_ago(300),
+        "nextPollAfter": module._rfc3339(now + timedelta(seconds=45)),
+    }
+    assert module.poll_due(spec, backing_off, now) is False
+    # Backoff elapsed: due again.
+    expired = {
+        "lastPolled": polled_ago(300),
+        "nextPollAfter": module._rfc3339(now - timedelta(seconds=1)),
+    }
+    assert module.poll_due(spec, expired, now) is True
+
+
+def test_handler_skips_poll_when_not_due(monkeypatch) -> None:
+    """A not-due timer fire patches nothing and never touches the BMC."""
+    module = _load_controller_module()
+    now = datetime(2026, 7, 10, 15, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(module, "_utc_now", lambda: now)
+
+    called = []
+    monkeypatch.setattr(
+        module,
+        "poll_endpoint",
+        lambda *a, **k: called.append(1) or {},
+    )
+
+    patch: dict = {}
+    recent = module._rfc3339(now - timedelta(seconds=5))
+    result = module.poll_redfish_endpoint(
+        spec={"address": "bmc", "pollInterval": "60s"},
+        body={"status": {"lastPolled": recent}},
+        namespace="default",
+        name="node-a",
+        patch=patch,
+    )
+
+    assert result is None
+    assert patch == {}
+    assert called == []
+
+
+def test_handler_force_polls_even_when_not_due(monkeypatch) -> None:
+    """force=True (create/update path) polls immediately, ignoring the cadence gate."""
+    module = _load_controller_module()
+    now = datetime(2026, 7, 10, 15, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(module, "_utc_now", lambda: now)
+
+    called = []
+
+    def fake_poll(spec, credentials=None, manager_factory=None, polled_at=None):
+        called.append(1)
+        return {
+            "powerState": "On",
+            "health": "OK",
+            "temperature": {"count": 0, "maxCelsius": None},
+            "lastPolled": module._rfc3339(now),
+        }
+
+    monkeypatch.setattr(module, "poll_endpoint", fake_poll)
+
+    patch: dict = {}
+    recent = module._rfc3339(now - timedelta(seconds=1))
+    module.poll_redfish_endpoint(
+        spec={"address": "bmc", "pollInterval": "1h"},
+        body={"status": {"lastPolled": recent}},
+        namespace="default",
+        name="node-a",
+        patch=patch,
+        force=True,
+    )
+
+    # Would be skipped without force (1s elapsed vs 1h interval); force overrides.
+    assert called == [1]
+    assert patch["status"]["powerState"] == "On"
+    assert patch["status"]["conditions"][0]["status"] == "True"
+
+
+# ---------------------------------------------------------------------------
+# P3 - BMC error handling: catch, backoff, record an error condition, and keep
+#      the last good readings instead of raising forever or freezing silently.
+# ---------------------------------------------------------------------------
+
+
+def test_handler_records_error_condition_and_backoff_on_bmc_failure(monkeypatch) -> None:
+    """An unreachable BMC yields an error condition + backoff, no exception raised."""
+    module = _load_controller_module()
+    now = datetime(2026, 7, 10, 15, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(module, "_utc_now", lambda: now)
+
+    def raise_conn(*_a, **_k):
+        raise ConnectionError("connection refused")
+
+    monkeypatch.setattr(module, "poll_endpoint", raise_conn)
+
+    patch: dict = {}
+    result = module.poll_redfish_endpoint(
+        spec={"address": "bmc", "pollInterval": "30s"},
+        body={"status": {}},
+        namespace="default",
+        name="node-a",
+        patch=patch,
+    )
+
+    assert result is None
+    status = patch["status"]
+    # Error path records reachability + backoff, and never writes the readings
+    # keys (so a merge-patch preserves the last good ones).
+    assert status["consecutiveFailures"] == 1
+    assert status["lastError"] == "connection refused"
+    assert status["conditions"][0]["type"] == "EndpointReachable"
+    assert status["conditions"][0]["status"] == "False"
+    assert status["conditions"][0]["reason"] == "BMCUnreachable"
+    assert status["nextPollAfter"] == module._rfc3339(now + timedelta(seconds=30))
+    assert "powerState" not in status
+    assert "lastPolled" not in status
+
+
+def test_backoff_grows_with_consecutive_failures() -> None:
+    """Backoff doubles per failure from the base cadence, capped."""
+    module = _load_controller_module()
+    assert module.backoff_seconds(1, 30.0) == 30.0
+    assert module.backoff_seconds(2, 30.0) == 60.0
+    assert module.backoff_seconds(3, 30.0) == 120.0
+    assert module.backoff_seconds(99, 30.0) == module.MAX_BACKOFF_SECONDS
+
+
+def test_handler_error_increments_prior_failure_count(monkeypatch) -> None:
+    """A repeat failure grows the counter and the backoff window."""
+    module = _load_controller_module()
+    now = datetime(2026, 7, 10, 15, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(module, "_utc_now", lambda: now)
+    monkeypatch.setattr(
+        module,
+        "poll_endpoint",
+        lambda *a, **k: (_ for _ in ()).throw(TimeoutError("read timed out")),
+    )
+
+    patch: dict = {}
+    module.poll_redfish_endpoint(
+        spec={"address": "bmc", "pollInterval": "30s"},
+        body={"status": {"consecutiveFailures": 2, "lastPolled": "2026-07-10T14:00:00Z"}},
+        namespace="default",
+        name="node-a",
+        patch=patch,
+    )
+
+    status = patch["status"]
+    assert status["consecutiveFailures"] == 3
+    assert status["conditions"][0]["reason"] == "Timeout"
+    # base 30s * 2**(3-1) = 120s backoff.
+    assert status["nextPollAfter"] == module._rfc3339(now + timedelta(seconds=120))
+    # lastPolled from the prior success is untouched by the error patch.
+    assert "lastPolled" not in status

--- a/tests/test_k8s_controller_concurrency.py
+++ b/tests/test_k8s_controller_concurrency.py
@@ -1,0 +1,637 @@
+"""Fleet-scale concurrency smoke tests for the RedfishEndpoint controller.
+
+kopf dispatches the sync poll handler on a ThreadPoolExecutor, so at fleet scale
+many endpoints reconcile at once. There is no cluster or BMC here, so this module
+builds a *fake kopf engine*:
+
+* :class:`FakeApiServer` — an in-memory CR store keyed by ``(namespace, name)``
+  with a monotonic ``resourceVersion``. ``patch_status`` computes a real RFC 7386
+  merge-patch and raises :class:`Conflict` when the caller's resourceVersion is
+  stale, exactly like the real ``/status`` subresource under optimistic
+  concurrency. Any write (spec or status) bumps the version.
+* :func:`reconcile_once` — wraps the handler the way kopf does: fetch, run the
+  handler against a fresh ``patch``, then apply it with a re-fetch+retry loop on
+  conflict, serialized per object.
+* A fake BMC facade (:class:`FakeManager` + patched ``get_system``/``get_sensors``/
+  ``get_thermal``) that returns per-address readings and can hang or fail, and
+  tracks pooled-session open/close so socket leaks are observable.
+
+Every test is offline: no cluster, no network, no live BMC.
+
+Author Mus <spyroot@gmail.com>
+"""
+
+from __future__ import annotations
+
+import base64
+import copy
+import importlib.util
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from redfish_ctl import kube_client
+from redfish_ctl.api import SystemStatus, TemperatureReading, ThermalStatus
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONTROLLER_MODULE = REPO_ROOT / "k8s" / "controller" / "redfish_endpoint_controller.py"
+
+
+def _load_controller_module():
+    spec = importlib.util.spec_from_file_location(
+        "redfish_endpoint_controller_concurrency",
+        CONTROLLER_MODULE,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def module():
+    mod = _load_controller_module()
+    kube_client.reset_client_cache()
+    yield mod
+    kube_client.reset_client_cache()
+
+
+# ---------------------------------------------------------------------------
+# Fake kopf engine
+# ---------------------------------------------------------------------------
+
+
+class Conflict(Exception):
+    """Raised by patch_status when the caller's resourceVersion is stale."""
+
+
+def apply_merge_patch(target, patch):
+    """RFC 7386 JSON merge-patch: null deletes, dicts recurse, omitted keys stay."""
+    if not isinstance(patch, dict):
+        return copy.deepcopy(patch)
+    result = dict(target) if isinstance(target, dict) else {}
+    for key, value in patch.items():
+        if value is None:
+            result.pop(key, None)
+        elif isinstance(value, dict):
+            result[key] = apply_merge_patch(result.get(key, {}), value)
+        else:
+            result[key] = copy.deepcopy(value)
+    return result
+
+
+class FakeApiServer:
+    """In-memory RedfishEndpoint store with optimistic-concurrency status writes."""
+
+    def __init__(self) -> None:
+        self._store: dict[tuple[str, str], dict] = {}
+        self._cr_locks: dict[tuple[str, str], threading.Lock] = {}
+        self._struct_lock = threading.Lock()
+        self.patch_calls = 0
+        self.conflict_count = 0
+
+    def create(self, ns, name, spec, status=None):
+        with self._struct_lock:
+            self._store[(ns, name)] = {
+                "spec": copy.deepcopy(spec),
+                "status": copy.deepcopy(status or {}),
+                "rv": 1,
+            }
+            self._cr_locks.setdefault((ns, name), threading.Lock())
+
+    def cr_lock(self, ns, name) -> threading.Lock:
+        with self._struct_lock:
+            return self._cr_locks.setdefault((ns, name), threading.Lock())
+
+    def get(self, ns, name):
+        with self._struct_lock:
+            rec = self._store[(ns, name)]
+            return copy.deepcopy(rec["spec"]), copy.deepcopy(rec["status"]), rec["rv"]
+
+    def set_spec(self, ns, name, spec):
+        """Update spec and bump resourceVersion (a competing writer)."""
+        with self._struct_lock:
+            rec = self._store[(ns, name)]
+            rec["spec"] = copy.deepcopy(spec)
+            rec["rv"] += 1
+
+    def patch_status(self, ns, name, resource_version, status_patch):
+        with self._struct_lock:
+            self.patch_calls += 1
+            rec = self._store[(ns, name)]
+            if rec["rv"] != resource_version:
+                self.conflict_count += 1
+                raise Conflict(
+                    f"{ns}/{name}: stale resourceVersion "
+                    f"{resource_version} != {rec['rv']}"
+                )
+            rec["status"] = apply_merge_patch(rec["status"], status_patch)
+            rec["rv"] += 1
+            return rec["rv"]
+
+    def status_of(self, ns, name):
+        with self._struct_lock:
+            return copy.deepcopy(self._store[(ns, name)]["status"])
+
+    def names(self):
+        with self._struct_lock:
+            return list(self._store)
+
+
+class ConcurrencyTracker:
+    """Records the peak number of handlers running for each CR key."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._active: dict[tuple[str, str], int] = {}
+        self.peak: dict[tuple[str, str], int] = {}
+
+    def enter(self, key):
+        with self._lock:
+            self._active[key] = self._active.get(key, 0) + 1
+            self.peak[key] = max(self.peak.get(key, 0), self._active[key])
+
+    def exit(self, key):
+        with self._lock:
+            self._active[key] -= 1
+
+    def global_peak(self) -> int:
+        return max(self.peak.values(), default=0)
+
+
+def reconcile_once(module, server, ns, name, *, max_retries=8, tracker=None, before_patch=None):
+    """Drive the handler like kopf: fetch, handle, apply status with retry-on-conflict.
+
+    Serialized per object via the CR lock, matching kopf's guarantee that a single
+    resource is never handled by two workers at once.
+    """
+    key = (ns, name)
+    with server.cr_lock(ns, name):
+        for attempt in range(max_retries):
+            spec, status, resource_version = server.get(ns, name)
+            patch: dict = {}
+            if tracker is not None:
+                tracker.enter(key)
+            try:
+                module.poll_redfish_endpoint(
+                    spec=spec,
+                    body={"spec": spec, "status": status},
+                    namespace=ns,
+                    name=name,
+                    patch=patch,
+                    status=status,
+                    logger=None,
+                )
+            finally:
+                if tracker is not None:
+                    tracker.exit(key)
+            status_patch = patch.get("status")
+            if not status_patch:  # poll skipped (not due) — nothing to persist
+                return patch
+            if before_patch is not None:
+                before_patch(attempt)  # test hook: inject a competing write
+            try:
+                server.patch_status(ns, name, resource_version, status_patch)
+                return patch
+            except Conflict:
+                continue
+        raise AssertionError(f"reconcile of {ns}/{name} exhausted {max_retries} retries")
+
+
+# ---------------------------------------------------------------------------
+# Fake BMC facade
+# ---------------------------------------------------------------------------
+
+
+class SessionRegistry:
+    """Counts pooled-session opens/closes so leaks are observable."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.opened = 0
+        self.closed = 0
+        self.peak_live = 0
+        self.built_addresses: list[str] = []
+
+    def opened_session(self, address):
+        with self._lock:
+            self.opened += 1
+            self.built_addresses.append(address)
+            self.peak_live = max(self.peak_live, self.opened - self.closed)
+
+    def closed_session(self):
+        with self._lock:
+            self.closed += 1
+
+    @property
+    def live(self) -> int:
+        with self._lock:
+            return self.opened - self.closed
+
+
+class FakeSession:
+    def __init__(self, registry: SessionRegistry, address: str) -> None:
+        self._registry = registry
+        self._closed = False
+        registry.opened_session(address)
+
+    def close(self):
+        if not self._closed:
+            self._closed = True
+            self._registry.closed_session()
+
+
+class FakeManager:
+    """Stand-in for RedfishManagerBase: records creds and a closable session."""
+
+    def __init__(self, *, registry, behaviors, hang_event, idrac_ip, idrac_username,
+                 idrac_password, **_):
+        self.address = idrac_ip
+        self.username = idrac_username
+        self.password = idrac_password
+        self.behavior = behaviors.get(idrac_ip, "ok")
+        self._hang_event = hang_event
+        self._session_cache = FakeSession(registry, idrac_ip)
+
+
+def _address_temp(address: str) -> float:
+    """Deterministic per-address temperature so cross-contamination is detectable."""
+    digits = "".join(ch for ch in address if ch.isdigit())
+    return float(int(digits)) if digits else -1.0
+
+
+def install_fake_bmc(monkeypatch, module, *, behaviors, hang_event=None):
+    """Wire a fake BMC facade into the controller module. Returns a SessionRegistry."""
+    registry = SessionRegistry()
+
+    def factory(**kwargs):
+        return FakeManager(
+            registry=registry,
+            behaviors=behaviors,
+            hang_event=hang_event,
+            **kwargs,
+        )
+
+    def _run_behavior(manager):
+        if manager.behavior == "error":
+            raise ConnectionError(f"BMC unreachable: {manager.address}")
+        if manager.behavior in {"slow", "hang"} and manager._hang_event is not None:
+            # Bounded wait so a wedged test can never hang CI forever.
+            manager._hang_event.wait(timeout=30)
+
+    def fake_get_system(manager):
+        _run_behavior(manager)
+        return SystemStatus(
+            id=manager.address,
+            name=manager.address,
+            power_state=manager.address,  # echo address to detect any bleed
+            health="OK",
+            state="Enabled",
+            raw={},
+        )
+
+    def fake_get_sensors(manager):
+        return ()
+
+    def fake_get_thermal(manager):
+        reading = TemperatureReading(
+            "Chassis_0", "Inlet", "Intake", _address_temp(manager.address), "/s/1", {}
+        )
+        return ThermalStatus(summary={}, temperatures=(reading,), fans=(), raw={})
+
+    monkeypatch.setattr(module, "MANAGER_FACTORY", factory)
+    monkeypatch.setattr(module, "get_system", fake_get_system)
+    monkeypatch.setattr(module, "get_sensors", fake_get_sensors)
+    monkeypatch.setattr(module, "get_thermal", fake_get_thermal)
+    return registry
+
+
+def install_counting_secret_client(monkeypatch, creds_holder):
+    """Route load_secret_credentials through the shared client with counting seams.
+
+    ``creds_holder`` is a one-item list ``[{"username":..., "password":...}]`` that
+    tests may mutate to simulate rotation. Returns a dict of counters.
+    """
+    counters = {"config_loads": 0, "secret_reads": 0}
+    lock = threading.Lock()
+
+    class FakeSecret:
+        def __init__(self, creds):
+            self.data = {
+                "username": base64.b64encode(creds["username"].encode()).decode(),
+                "password": base64.b64encode(creds["password"].encode()).decode(),
+            }
+
+    class FakeApi:
+        def read_namespaced_secret(self, name, namespace):
+            with lock:
+                counters["secret_reads"] += 1
+            return FakeSecret(creds_holder[0])
+
+    def fake_load():
+        with lock:
+            counters["config_loads"] += 1
+
+    monkeypatch.setattr(kube_client, "_load_kube_config", fake_load)
+    monkeypatch.setattr(kube_client, "_build_core_v1_api", lambda: FakeApi())
+    return counters
+
+
+def _endpoint_spec(address, **overrides):
+    spec = {
+        "address": address,
+        "port": 443,
+        "insecure": True,
+        "pollInterval": "30s",
+        "secretRef": {"name": "bmc-login"},
+    }
+    spec.update(overrides)
+    return spec
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+def test_200_endpoints_reconcile_concurrently_without_cross_contamination(monkeypatch, module):
+    """200 CRs polled concurrently (pool 50): each status reflects only its own BMC."""
+    server = FakeApiServer()
+    registry = install_fake_bmc(monkeypatch, module, behaviors={})
+    creds = [{"username": "root", "password": "pw"}]
+    counters = install_counting_secret_client(monkeypatch, creds)
+    tracker = ConcurrencyTracker()
+
+    names = [f"node-{i:03d}" for i in range(200)]
+    for i, name in enumerate(names):
+        server.create("fleet", name, _endpoint_spec(f"bmc-{i:03d}"))
+
+    with ThreadPoolExecutor(max_workers=50) as pool:
+        futures = [
+            pool.submit(reconcile_once, module, server, "fleet", name, tracker=tracker)
+            for name in names
+        ]
+        for future in futures:
+            future.result()
+
+    for i, name in enumerate(names):
+        status = server.status_of("fleet", name)
+        address = f"bmc-{i:03d}"
+        assert status["powerState"] == address, f"{name} got another BMC's power state"
+        assert status["temperature"]["maxCelsius"] == float(i)
+        assert status["conditions"][0]["status"] == "True"
+        assert status["consecutiveFailures"] == 0
+
+    # Shared client: one config load for the whole fleet; one secret read per CR.
+    assert counters["config_loads"] == 1
+    assert counters["secret_reads"] == 200
+    # No CR handled by two workers at once.
+    assert tracker.global_peak() == 1
+    # Every pooled session opened was closed — no socket leak.
+    assert registry.opened == 200
+    assert registry.closed == 200
+
+
+def test_conflict_on_status_write_is_retried_not_dropped(monkeypatch, module):
+    """A stale-resourceVersion 409 triggers a re-fetch+retry; the poll is not lost."""
+    server = FakeApiServer()
+    install_fake_bmc(monkeypatch, module, behaviors={})
+    install_counting_secret_client(monkeypatch, [{"username": "root", "password": "pw"}])
+    server.create("fleet", "node-x", _endpoint_spec("bmc-042"))
+
+    injected = {"done": False}
+
+    def bump_once(attempt):
+        # On the first attempt, a competing writer bumps the resourceVersion
+        # between our get() and patch_status(), forcing a single conflict.
+        if not injected["done"]:
+            injected["done"] = True
+            server.set_spec("fleet", "node-x", _endpoint_spec("bmc-042", insecure=False))
+
+    reconcile_once(module, server, "fleet", "node-x", before_patch=bump_once)
+
+    assert server.conflict_count == 1, "expected exactly one forced conflict"
+    status = server.status_of("fleet", "node-x")
+    # The retried poll's result is what landed — status was persisted, not dropped.
+    assert status["powerState"] == "bmc-042"
+    assert status["conditions"][0]["status"] == "True"
+
+
+def test_failing_bmc_does_not_starve_pool_or_leak_sockets(monkeypatch, module):
+    """One unreachable BMC records an error + backoff; the other CRs still complete."""
+    server = FakeApiServer()
+    behaviors = {"bmc-005": "error"}
+    registry = install_fake_bmc(monkeypatch, module, behaviors=behaviors)
+    install_counting_secret_client(monkeypatch, [{"username": "root", "password": "pw"}])
+
+    names = [f"node-{i:03d}" for i in range(20)]
+    for i, name in enumerate(names):
+        server.create("fleet", name, _endpoint_spec(f"bmc-{i:03d}"))
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {
+            name: pool.submit(reconcile_once, module, server, "fleet", name)
+            for name in names
+        }
+        for name, future in futures.items():
+            future.result()  # none hang — the failing one returns an error status
+
+    healthy = server.status_of("fleet", "node-000")
+    assert healthy["powerState"] == "bmc-000"
+    assert healthy["conditions"][0]["status"] == "True"
+
+    failed = server.status_of("fleet", "node-005")
+    assert failed["conditions"][0]["status"] == "False"
+    assert failed["conditions"][0]["reason"] == "BMCUnreachable"
+    assert failed["consecutiveFailures"] == 1
+    assert failed["nextPollAfter"]  # backoff recorded
+    assert "powerState" not in failed  # no readings written on failure
+
+    # Both the success and the error path close their pooled session.
+    assert registry.opened == 20
+    assert registry.closed == 20
+
+
+def test_hanging_bmc_does_not_block_other_endpoints(monkeypatch, module):
+    """A wedged BMC in-flight does not stop the rest of the fleet from finishing."""
+    server = FakeApiServer()
+    hang_event = threading.Event()
+    behaviors = {"bmc-000": "hang"}
+    registry = install_fake_bmc(
+        monkeypatch, module, behaviors=behaviors, hang_event=hang_event
+    )
+    install_counting_secret_client(monkeypatch, [{"username": "root", "password": "pw"}])
+
+    names = [f"node-{i:03d}" for i in range(12)]
+    for i, name in enumerate(names):
+        server.create("fleet", name, _endpoint_spec(f"bmc-{i:03d}"))
+
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        hanging = pool.submit(reconcile_once, module, server, "fleet", "node-000")
+        others = {
+            name: pool.submit(reconcile_once, module, server, "fleet", name)
+            for name in names[1:]
+        }
+        # The other endpoints finish while node-000 is still wedged.
+        for name, future in others.items():
+            future.result(timeout=20)
+            assert server.status_of("fleet", name)["powerState"] == f"bmc-{names.index(name):03d}"
+        assert not hanging.done()
+
+        hang_event.set()  # release the wedged poll
+        hanging.result(timeout=20)
+
+    # Even the wedged endpoint eventually closed its session.
+    assert registry.opened == registry.closed == 12
+
+
+def test_rapid_spec_churn_same_cr_serialized_latest_spec_wins(monkeypatch, module):
+    """Concurrent churn on one CR is serialized; the last committed spec wins."""
+    server = FakeApiServer()
+    install_fake_bmc(monkeypatch, module, behaviors={})
+    install_counting_secret_client(monkeypatch, [{"username": "root", "password": "pw"}])
+    # Polls always due so every churn iteration actually reconciles.
+    monkeypatch.setattr(module, "poll_due", lambda *a, **k: True)
+    server.create("fleet", "node-churn", _endpoint_spec("bmc-000"))
+    tracker = ConcurrencyTracker()
+
+    def churn(i):
+        server.set_spec("fleet", "node-churn", _endpoint_spec(f"bmc-{i:03d}"))
+        reconcile_once(module, server, "fleet", "node-churn", tracker=tracker)
+
+    with ThreadPoolExecutor(max_workers=16) as pool:
+        list(pool.map(churn, range(1, 41)))
+
+    # Serialized: the CR was never handled by two workers at once.
+    assert tracker.peak[("fleet", "node-churn")] == 1
+    # A final quiescent reconcile reflects the current (latest) spec.
+    spec, _status, _rv = server.get("fleet", "node-churn")
+    reconcile_once(module, server, "fleet", "node-churn")
+    status = server.status_of("fleet", "node-churn")
+    assert status["powerState"] == spec["address"]
+    # Internally consistent: power state and temperature come from the same poll.
+    assert status["temperature"]["maxCelsius"] == _address_temp(spec["address"])
+
+
+def test_secret_rotation_mid_poll_uses_consistent_snapshot(monkeypatch, module):
+    """Credentials are snapshotted per poll; a rotation during a poll is not torn."""
+    server = FakeApiServer()
+    creds = [{"username": "root", "password": "old-pw"}]
+    install_counting_secret_client(monkeypatch, creds)
+    monkeypatch.setattr(module, "poll_due", lambda *a, **k: True)
+
+    registry = SessionRegistry()
+    built: list[FakeManager] = []
+
+    def factory(**kwargs):
+        manager = FakeManager(registry=registry, behaviors={}, hang_event=None, **kwargs)
+        built.append(manager)
+        return manager
+
+    monkeypatch.setattr(module, "MANAGER_FACTORY", factory)
+
+    def rotating_get_system(manager):
+        # Rotate the Secret *after* the manager was built for this poll: the poll
+        # must keep using the snapshot it read at the start.
+        creds[0] = {"username": "root", "password": "new-pw"}
+        return SystemStatus(manager.address, manager.address, "On", "OK", "Enabled", {})
+
+    monkeypatch.setattr(module, "get_system", rotating_get_system)
+    monkeypatch.setattr(module, "get_sensors", lambda m: ())
+    monkeypatch.setattr(
+        module,
+        "get_thermal",
+        lambda m: ThermalStatus(summary={}, temperatures=(), fans=(), raw={}),
+    )
+
+    server.create("fleet", "node-rot", _endpoint_spec("bmc-000"))
+
+    reconcile_once(module, server, "fleet", "node-rot")
+    assert built[-1].password == "old-pw"  # poll 1 used the pre-rotation snapshot
+
+    reconcile_once(module, server, "fleet", "node-rot")
+    assert built[-1].password == "new-pw"  # poll 2 picks up the rotated Secret
+
+    assert server.status_of("fleet", "node-rot")["conditions"][0]["status"] == "True"
+    assert registry.opened == registry.closed == 2  # no leaked session across rotation
+
+
+def test_1000_endpoint_fleet_stress_bounded_calls_and_no_leaks(monkeypatch, module):
+    """1000 CRs: bounded API calls, one shared client, every session closed."""
+    server = FakeApiServer()
+    registry = install_fake_bmc(monkeypatch, module, behaviors={})
+    counters = install_counting_secret_client(monkeypatch, [{"username": "r", "password": "p"}])
+
+    fleet = 1000
+    names = [f"node-{i:04d}" for i in range(fleet)]
+    for i, name in enumerate(names):
+        server.create("fleet", name, _endpoint_spec(f"bmc-{i:04d}"))
+
+    with ThreadPoolExecutor(max_workers=50) as pool:
+        futures = [
+            pool.submit(reconcile_once, module, server, "fleet", name) for name in names
+        ]
+        for future in futures:
+            future.result()
+
+    # One manager (and one pooled session) per CR poll — nothing unbounded.
+    assert len(registry.built_addresses) == fleet
+    assert registry.opened == fleet
+    assert registry.closed == fleet  # stable FDs: everything opened was closed
+    assert registry.live == 0
+    assert registry.peak_live <= 50  # concurrency bounded by the pool
+    # Shared client: kube config loaded exactly once for the whole 1000-CR fleet.
+    assert counters["config_loads"] == 1
+    assert counters["secret_reads"] == fleet
+    # Every endpoint got a healthy status.
+    assert all(
+        server.status_of("fleet", name)["conditions"][0]["status"] == "True"
+        for name in names
+    )
+
+
+# ---------------------------------------------------------------------------
+# P1 (VERIFY) — merge-patch preserves prior good readings on a transient failure.
+#
+# Pro's P1 claimed a transient sub-read failure wipes a status field. This
+# controller has no networkFirmware field, but the same principle applies to the
+# readings it does write: a failed poll must not clobber the last good
+# powerState/health/temperature. Confirmed here end-to-end through the fake
+# merge-patch engine (the real /status subresource is also RFC 7386).
+# ---------------------------------------------------------------------------
+
+
+def test_transient_read_failure_retains_prior_good_readings(monkeypatch, module):
+    """Poll 1 succeeds; poll 2's BMC read raises → poll 1's readings are retained."""
+    server = FakeApiServer()
+    behaviors = {"bmc-007": "ok"}
+    install_fake_bmc(monkeypatch, module, behaviors=behaviors)
+    install_counting_secret_client(monkeypatch, [{"username": "root", "password": "pw"}])
+    monkeypatch.setattr(module, "poll_due", lambda *a, **k: True)
+    server.create("fleet", "node-flap", _endpoint_spec("bmc-007"))
+
+    # Poll 1: healthy.
+    reconcile_once(module, server, "fleet", "node-flap")
+    good = server.status_of("fleet", "node-flap")
+    assert good["powerState"] == "bmc-007"
+    assert good["temperature"]["maxCelsius"] == 7.0
+    assert good["conditions"][0]["status"] == "True"
+
+    # Poll 2: the thermal read raises mid-poll.
+    def boom_thermal(manager):
+        raise ConnectionError("thermal read failed")
+
+    monkeypatch.setattr(module, "get_thermal", boom_thermal)
+    reconcile_once(module, server, "fleet", "node-flap")
+
+    after = server.status_of("fleet", "node-flap")
+    # The readings from poll 1 survive the failed poll (merge-patch preserves them).
+    assert after["powerState"] == "bmc-007"
+    assert after["temperature"]["maxCelsius"] == 7.0
+    assert after["lastPolled"] == good["lastPolled"]  # not advanced by the failure
+    # ...while the failure is surfaced, not silent.
+    assert after["conditions"][0]["status"] == "False"
+    assert after["consecutiveFailures"] == 1
+    assert after["lastError"] == "thermal read failed"


### PR DESCRIPTION
## Why

`kopf` dispatches the RedfishEndpoint poll handler on a `ThreadPoolExecutor`, so fleet-scale endpoints reconcile concurrently. Three defects surface under that load; this PR fixes them with offline regression coverage and a concurrency harness.

The controller currently has no `networkFirmware` field. The transient sub-read behavior is covered by the in-repo regression listed under Testing.

## What

**P0 — shared, thread-safe Kubernetes client.** `load_secret_credentials()` used to call `load_incluster_config()`/`load_kube_config()` and build a fresh `CoreV1Api()` on every handler call, racing on the Kubernetes client's process-global default `Configuration`. New `redfish_ctl.kube_client` loads the config once behind a lock and shares one thread-safe client.

**P2 — honor `spec.pollInterval`.** The timer hard-coded `interval=30` and never read the field. It now fires at a base cadence read from `REDFISH_CONTROLLER_POLL_INTERVAL`, and each CR polls no more often than that floor. Create/update lifecycle events poll immediately so operator spec fixes are not stuck behind the interval or a backoff window.

**P3 — BMC error handling.** An unreachable BMC used to make the handler raise while the timer kept firing. The controller now catches connection/read/auth errors, records an `EndpointReachable=False` condition plus `lastError` and exponential `nextPollAfter` backoff on `.status`, and retries next cycle. Last-good readings are preserved by merge-patch semantics. Each poll's pooled HTTP session is also closed so a large fleet does not leak sockets or file descriptors.

CRD `status` schema is extended in both controller and chart copies with `conditions`, `consecutiveFailures`, `lastError`, and `nextPollAfter`.

## Testing

Offline only: no cluster, no live BMC, no network. The harness mocks the Kubernetes API and BMC facade. It covers:

- 200 CRs reconciled concurrently with no cross-CR contamination;
- one config load for the fleet;
- forced 409 conflict retry;
- failing or hanging BMC without pool starvation or session leaks;
- rapid spec churn with latest spec winning;
- secret rotation mid-poll with a consistent per-poll credential snapshot;
- 1000-CR fleet stress with bounded API calls;
- transient sub-read failure preserving poll-1 good readings.

Gate: `pytest -q` green with no `IDRAC_IP` (1141 passed, 58 skipped), `ruff check` clean on changed files, and the k8s suite re-run inside `ubuntu:24.04` for macOS/Linux parity.