### PR TITLE
Document storage command constructors (docstring coverage)

### DIFF
--- a/redfish_ctl/storage/cmd_convert_none_raid.py
+++ b/redfish_ctl/storage/cmd_convert_none_raid.py
@@ -26,6 +26,7 @@ class ConvertNoneRaid(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the convert_none_raid command."""
         super(ConvertNoneRaid, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/storage/cmd_convert_to_raid.py
+++ b/redfish_ctl/storage/cmd_convert_to_raid.py
@@ -30,6 +30,7 @@ class ConvertToRaid(
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the convert-to-raid command."""
         super(ConvertToRaid, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/storage/cmd_drives.py
+++ b/redfish_ctl/storage/cmd_drives.py
@@ -18,6 +18,7 @@ class DrivesQuery(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the drives_query command."""
         super(DrivesQuery, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/storage/cmd_storage_controllers.py
+++ b/redfish_ctl/storage/cmd_storage_controllers.py
@@ -45,6 +45,7 @@ class StorageQuery(RedfishManagerBase, scm_type=ApiRequestType.StorageQuery,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the storage_query command."""
         super(StorageQuery, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/storage/cmd_storage_get.py
+++ b/redfish_ctl/storage/cmd_storage_get.py
@@ -33,6 +33,7 @@ class StorageView(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the storage_get command."""
         super(StorageView, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/storage/cmd_storage_list.py
+++ b/redfish_ctl/storage/cmd_storage_list.py
@@ -23,6 +23,7 @@ class StorageListView(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the storage_list command."""
         super(StorageListView, self).__init__(*args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/storage/`.

Adds one-line docstrings to the six storage command `__init__` methods (all trivial `super().__init__` constructors: convert-to-raid, convert-none-raid, drives, storage controllers/get/list).

Docstrings only — no behavior change.

Gates: AST gap-finder reports 0 remaining gaps in `storage/`; ruff introduces no new findings (pre-existing `I001` untouched); `pytest -q` green on main.