### PR TITLE
Neutralize storage command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/storage/cmd_convert_none_raid.py
+++ b/redfish_ctl/storage/cmd_convert_none_raid.py
@@ -1,11 +1,11 @@
-"""iDRAC
+"""Convert RAID physical disks to non-RAID.
 
 The method is used to convert a physical disks in RAID state of "Ready"
 to a Non-RAID state. After the method is successfully executed, the
 DCIM_PhysicalDiskView.RAIDStatus property of that physical disk should
 reflect the new state.
 
-python redfish_ctl.py storage-convert-noraid -c AHCI.Embedded.2-1
+redfish_ctl storage-convert-noraid -c AHCI.Embedded.2-1
 
 Author Mus spyroot@gmail.com
 """
@@ -22,7 +22,7 @@ class ConvertNoneRaid(RedfishManagerBase,
                       scm_type=ApiRequestType.ConvertNoneRaid,
                       name='convert_none_raid',
                       metaclass=Singleton):
-    """iDRACs REST API fetch storage information.
+    """Convert RAID physical disks to non-RAID via the Dell RAID service.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/storage/cmd_convert_to_raid.py
+++ b/redfish_ctl/storage/cmd_convert_to_raid.py
@@ -1,13 +1,13 @@
-"""iDRAC
+"""Convert non-RAID physical disks to RAID.
 
-The ConvertToNonRAID() method is used to convert a physical disks in
-RAID state of "Ready" to a Non-RAID state.
+The method is used to convert physical disks in a Non-RAID state to a
+RAID-capable state.
 
 After the method is successfully executed, the
 DCIM_PhysicalDiskView.RAIDStatus property of that physical
 disk should reflect the new state.
 
-python redfish_ctl.py storage-convert-noraid -c AHCI.Embedded.2-1
+redfish_ctl storage-convert-raid -c AHCI.Embedded.2-1
 
 Author Mus spyroot@gmail.com
 """
@@ -25,8 +25,7 @@ class ConvertToRaid(
     scm_type=ApiRequestType.ConvertToRaid,
     name='convert_none_raid',
     metaclass=Singleton):
-    """iDRACs REST API convert none raid disk to raid
-    for a target controller.
+    """Convert non-RAID disks to RAID for a target controller via the Dell RAID service.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/storage/cmd_drives.py
+++ b/redfish_ctl/storage/cmd_drives.py
@@ -1,4 +1,10 @@
-"""iDRAC
+"""Storage drive inventory command.
+
+Fetch the physical drives behind a storage controller from a Redfish
+endpoint and report each drive's RAID state.
+
+redfish_ctl storage-drives -c AHCI.Embedded.2-1
+
 Author Mus spyroot@gmail.com
 """
 from abc import abstractmethod
@@ -14,7 +20,7 @@ class DrivesQuery(RedfishManagerBase,
                   scm_type=ApiRequestType.Drives,
                   name='drives_query',
                   metaclass=Singleton):
-    """iDRACs REST API fetch storage information.
+    """Fetch storage drive information over the Redfish API.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/storage/cmd_storage_controllers.py
+++ b/redfish_ctl/storage/cmd_storage_controllers.py
@@ -1,7 +1,7 @@
-"""iDRAC storage controller query
+"""Storage controller query command.
 
 Command provides the option to retrieve storage controller information
-from iDRAC and serialize back as caller as JSON, YAML, or XML. In addition,
+from a Redfish endpoint and serialize back as caller as JSON, YAML, or XML. In addition,
 it automatically registered to the command line ctl tool. Similarly to
 the rest command caller can save to a file and consume asynchronously
 or synchronously.
@@ -13,10 +13,10 @@ On return will hold list of controller in CommandResult.data
  'AHCI.Slot.4-1',
  'AHCI.Embedded.2-1']
 
-python redfish_ctl.py storage
+redfish_ctl storage-controllers
 
 Example: filter by controller type
-redfish_ctl.py --json storage --filter AHCI
+redfish_ctl --json storage-controllers --filter AHCI
 
 [
     "AHCI.Embedded.1-1",
@@ -80,7 +80,7 @@ class StorageQuery(RedfishManagerBase, scm_type=ApiRequestType.StorageQuery,
                 do_async: Optional[bool] = False,
                 id_filter: Optional[str] = "",
                 **kwargs) -> CommandResult:
-        """Query storage controller from idrac.
+        """Query storage controllers from a Redfish endpoint.
 
          Example of members
          "Members": [

--- a/redfish_ctl/storage/cmd_storage_get.py
+++ b/redfish_ctl/storage/cmd_storage_get.py
@@ -1,19 +1,19 @@
-"""iDRAC storage cmd
+"""Storage controller detail command.
 
 Command provides the option to retrieve storage information for specific
-controller disk from iDRAC.
+controller disk from a Redfish endpoint.
 
 Example
-python redfish_ctl.py storage-get --storage_controller NonRAID.Slot.6-1
+redfish_ctl storage-get --storage_controller NonRAID.Slot.6-1
 
 Expanded
-python redfish_ctl.py storage-get --storage_controller NonRAID.Slot.6-1 -e
+redfish_ctl storage-get --storage_controller NonRAID.Slot.6-1 -e
 
 Filter by OEM
-python redfish_ctl.py storage-get -c AHCI.Embedded.2-1 --filter Oem
+redfish_ctl storage-get -c AHCI.Embedded.2-1 --filter Oem
 
 Filter by Drives and Volumes
-python redfish_ctl.py storage-get -c AHCI.Embedded.2-1 --filter Drives,Volumes
+redfish_ctl storage-get -c AHCI.Embedded.2-1 --filter Drives,Volumes
 
 Author Mus spyroot@gmail.com
 """
@@ -29,7 +29,7 @@ class StorageView(RedfishManagerBase,
                   scm_type=ApiRequestType.StorageViewQuery,
                   name='storage_get',
                   metaclass=Singleton):
-    """iDRACs REST API fetch storage information.
+    """Fetch storage information over the Redfish API.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/storage/cmd_storage_list.py
+++ b/redfish_ctl/storage/cmd_storage_list.py
@@ -1,9 +1,9 @@
-"""iDRAC storage list view
+"""Storage controller list command.
 
 Command provides the option to retrieve list of storage controllers.
 
 Example expanded
-python redfish_ctl.py storage-list -e
+redfish_ctl storage-list -e
 
 Author Mus spyroot@gmail.com
 """
@@ -19,7 +19,7 @@ class StorageListView(RedfishManagerBase,
                       scm_type=ApiRequestType.StorageListQuery,
                       name='storage_list',
                       metaclass=Singleton):
-    """iDRACs REST API fetch storage list information.
+    """Fetch the storage controller list over the Redfish API.
     """
 
     def __init__(self, *args, **kwargs):

--- a/tests/test_ast_conventions.py
+++ b/tests/test_ast_conventions.py
@@ -52,7 +52,7 @@ LEGACY_UNGUARDED_MUTATION_CALLS = {
     "redfish_ctl/manager/cmd_manager_reset.py:92 execute base_post",
     "redfish_ctl/manager/cmd_manager_time.py:108 execute base_patch",
     "redfish_ctl/storage/cmd_convert_none_raid.py:114 execute base_post",
-    "redfish_ctl/storage/cmd_convert_to_raid.py:117 execute base_post",
+    "redfish_ctl/storage/cmd_convert_to_raid.py:116 execute base_post",
     "redfish_ctl/system/cmd_system_config.py:116 execute base_post",
     "redfish_ctl/system/cmd_system_import.py:151 execute base_post",
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:122 execute base_post",


### PR DESCRIPTION
Vendor-neutrality doc scrub for the storage commands (comments/docstrings only, no behavior change).

- Reword generic-Redfish prose that said "iDRAC" to "Redfish endpoint"/"the Redfish API" across the six storage command modules.
- Modernize usage examples from `python redfish_ctl.py <cmd>` to the `redfish_ctl <cmd>` console-script form, and correct two stale example command names (`storage-convert-raid`, `storage-controllers`).
- Fix the copy-pasted `storage-convert-raid` module docstring body so it describes converting to RAID (matching the command) instead of to non-RAID.
- Keep genuinely Dell-specific mentions (`DellRaidService`) and all functional/wire strings (paths, identifiers, enum values).
- Re-pin one line number in the `test_ast_conventions.py` mutation-guard baseline, which tracks unguarded write call-sites by line and shifted when a docstring shrank by a line.

Offline suite: 1121 passed, 58 skipped. No new ruff findings on the changed files.