### PR TITLE
Document power command methods (docstring coverage)

### DIFF
--- a/redfish_ctl/power/cmd_power.py
+++ b/redfish_ctl/power/cmd_power.py
@@ -1,4 +1,12 @@
-"""Read Redfish Chassis PowerSubsystem resources."""
+"""Read Redfish Chassis PowerSubsystem resources.
+
+    redfish_ctl power
+
+Walks ``/redfish/v1/Chassis`` -> each chassis ``PowerSubsystem`` -> its
+``PowerSupplies`` and ``Batteries`` collections, aggregating subsystem
+allocation, per-supply metrics, and battery state. Navigation is by
+ServiceRoot links and ``@odata.id`` with no hardcoded ids.
+"""
 
 from abc import abstractmethod
 from typing import Optional
@@ -15,17 +23,27 @@ class Power(RedfishManagerBase,
     """Read chassis power subsystems, supplies, metrics, and batteries."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the power command."""
         super(Power, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the read-only ``power`` subcommand."""
+        """Register the read-only ``power`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         return cmd_parser, "power", "command read chassis power subsystem data"
 
     @staticmethod
     def _members(data):
+        """Extract member ``@odata.id`` URIs from a Redfish collection.
+
+        :param data: parsed collection resource that may hold ``Members``.
+        :return: list of member ``@odata.id`` strings, empty when absent
+            or malformed.
+        """
         if not isinstance(data, dict):
             return []
         return [
@@ -37,6 +55,12 @@ class Power(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
+        """Return the ``@odata.id`` referenced by ``data[key]``.
+
+        :param data: parsed resource that may hold a link object under ``key``.
+        :param key: name of the link property to dereference.
+        :return: the ``@odata.id`` string, or None when absent or malformed.
+        """
         value = data.get(key) if isinstance(data, dict) else None
         if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
             return value["@odata.id"]
@@ -44,33 +68,68 @@ class Power(RedfishManagerBase,
 
     @staticmethod
     def _status(data):
+        """Return the ``Status`` sub-object of a resource.
+
+        :param data: parsed resource that may carry a ``Status`` block.
+        :return: the ``Status`` dict, or an empty dict when absent.
+        """
         status = data.get("Status") if isinstance(data, dict) else None
         return status if isinstance(status, dict) else {}
 
     @staticmethod
     def _chassis_id(chassis_uri):
+        """Derive the chassis id from a chassis URI.
+
+        :param chassis_uri: chassis ``@odata.id`` path.
+        :return: the trailing path segment used as the chassis id.
+        """
         return chassis_uri.rstrip("/").rsplit("/", 1)[-1]
 
     @staticmethod
     def _reading(value):
+        """Unwrap a Redfish metric value to its numeric reading.
+
+        :param value: a metric object carrying a ``Reading`` key, or a
+            bare value.
+        :return: ``value["Reading"]`` when ``value`` is a dict, otherwise
+            ``value``.
+        """
         if isinstance(value, dict):
             return value.get("Reading")
         return value
 
     @staticmethod
     def _first_present(*values):
+        """Return the first argument that is not None.
+
+        :return: the first non-None value, or None when all are None.
+        """
         for value in values:
             if value is not None:
                 return value
         return None
 
     def _query_optional(self, uri, do_async=False):
+        """Query a URI and return its data, swallowing errors.
+
+        :param uri: Redfish resource path to GET.
+        :param do_async: when True, issue the query on the async event loop.
+        :return: the response data dict, or an empty dict on any failure.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
             return {}
 
     def _read_power_supplies(self, chassis_id, supplies_uri, do_async=False):
+        """Read a chassis PowerSupplies collection and its members.
+
+        :param chassis_id: chassis id the supplies belong to.
+        :param supplies_uri: ``PowerSupplies`` collection URI to walk.
+        :param do_async: when True, issue queries on the async event loop.
+        :return: tuple of (collection summary dict, list of supply dicts),
+            or (None, []) when the response is not a dict.
+        """
         data = self._query_optional(supplies_uri, do_async=do_async)
         if not isinstance(data, dict):
             return None, []
@@ -131,6 +190,14 @@ class Power(RedfishManagerBase,
         return collection, supplies
 
     def _read_batteries(self, chassis_id, batteries_uri, do_async=False):
+        """Read a chassis Batteries collection and its members.
+
+        :param chassis_id: chassis id the batteries belong to.
+        :param batteries_uri: ``Batteries`` collection URI to walk.
+        :param do_async: when True, issue queries on the async event loop.
+        :return: tuple of (collection summary dict, list of battery dicts),
+            or (None, []) when the response is not a dict.
+        """
         data = self._query_optional(batteries_uri, do_async=do_async)
         if not isinstance(data, dict):
             return None, []
@@ -173,6 +240,22 @@ class Power(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
+        """Read chassis power subsystems, supplies, metrics, and batteries.
+
+        Walks every ``/redfish/v1/Chassis`` member to its ``PowerSubsystem``,
+        then its ``PowerSupplies`` and ``Batteries`` collections, aggregating
+        subsystem allocation, per-supply metrics, and battery state.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this
+            command.
+        :param do_async: when True, run Redfish queries on the async event
+            loop.
+        :param do_expanded: accepted for CLI compatibility; not used by this
+            command.
+        :return: CommandResult holding the aggregated power data and a summary.
+        """
         data = {
             "summary": {},
             "subsystems": [],

--- a/redfish_ctl/power/cmd_power_smoothing.py
+++ b/redfish_ctl/power/cmd_power_smoothing.py
@@ -1,4 +1,11 @@
-"""Read NVIDIA PowerSmoothing resources exposed through GPU processors."""
+"""Read NVIDIA PowerSmoothing resources exposed through GPU processors.
+
+    redfish_ctl power-smoothing
+
+Walks ``/redfish/v1/Systems`` -> each system ``Processors`` -> GPU
+processors -> ``Oem/Nvidia/PowerSmoothing``, aggregating smoothing state,
+preset profiles, and admin override profiles.
+"""
 
 from abc import abstractmethod
 from typing import Optional
@@ -16,18 +23,28 @@ class PowerSmoothing(RedfishManagerBase,
     """Read GPU PowerSmoothing state and profile setpoints."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the power-smoothing command."""
         super(PowerSmoothing, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the read-only ``power-smoothing`` subcommand."""
+        """Register the read-only ``power-smoothing`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read NVIDIA GPU PowerSmoothing profiles"
         return cmd_parser, "power-smoothing", help_text
 
     @staticmethod
     def _members(data):
+        """Extract member ``@odata.id`` URIs from a Redfish collection.
+
+        :param data: parsed collection resource that may hold ``Members``.
+        :return: list of member ``@odata.id`` strings, empty when absent
+            or malformed.
+        """
         if not isinstance(data, dict):
             return []
         return [
@@ -39,6 +56,12 @@ class PowerSmoothing(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
+        """Return the ``@odata.id`` referenced by ``data[key]``.
+
+        :param data: parsed resource that may hold a link object under ``key``.
+        :param key: name of the link property to dereference.
+        :return: the ``@odata.id`` string, or None when absent or malformed.
+        """
         value = data.get(key) if isinstance(data, dict) else None
         if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
             return value["@odata.id"]
@@ -46,6 +69,12 @@ class PowerSmoothing(RedfishManagerBase,
 
     @staticmethod
     def _nested_link(data, *keys):
+        """Follow a chain of nested keys and return the final ``@odata.id``.
+
+        :param data: parsed resource to descend into.
+        :return: the ``@odata.id`` at the end of the key chain, or None when
+            any step is missing or malformed.
+        """
         value = data
         for key in keys:
             if not isinstance(value, dict):
@@ -57,10 +86,21 @@ class PowerSmoothing(RedfishManagerBase,
 
     @staticmethod
     def _resource_id(uri):
+        """Derive the resource id from a Redfish URI.
+
+        :param uri: resource ``@odata.id`` path.
+        :return: the trailing path segment used as the resource id.
+        """
         return uri.rstrip("/").rsplit("/", 1)[-1]
 
     @staticmethod
     def _action_target(data, key):
+        """Return the POST ``target`` of a named Redfish action.
+
+        :param data: parsed resource carrying an ``Actions`` block.
+        :param key: action name to look up under ``Actions``.
+        :return: the action ``target`` URI string, or None when absent.
+        """
         actions = data.get("Actions") if isinstance(data, dict) else None
         action = actions.get(key) if isinstance(actions, dict) else None
         if isinstance(action, dict) and isinstance(action.get("target"), str):
@@ -69,6 +109,14 @@ class PowerSmoothing(RedfishManagerBase,
 
     @staticmethod
     def _profile(system_id, gpu_id, profile, fallback_uri):
+        """Build a flat profile row from a PowerSmoothing profile resource.
+
+        :param system_id: system id the profile belongs to.
+        :param gpu_id: GPU processor id the profile belongs to.
+        :param profile: parsed profile resource.
+        :param fallback_uri: URI used when the profile omits ``@odata.id``.
+        :return: dict of the selected profile setpoint fields.
+        """
         return {
             "System": system_id,
             "GPU": gpu_id,
@@ -84,12 +132,26 @@ class PowerSmoothing(RedfishManagerBase,
         }
 
     def _query_optional(self, uri, do_async=False):
+        """Query a URI and return its data, swallowing errors.
+
+        :param uri: Redfish resource path to GET.
+        :param do_async: when True, issue the query on the async event loop.
+        :return: the response data dict, or an empty dict on any failure.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
             return {}
 
     def _read_profile(self, system_id, gpu_id, profile_uri, do_async=False):
+        """Read a single PowerSmoothing profile and flatten it.
+
+        :param system_id: system id the profile belongs to.
+        :param gpu_id: GPU processor id the profile belongs to.
+        :param profile_uri: profile resource URI to GET.
+        :param do_async: when True, issue the query on the async event loop.
+        :return: the flattened profile dict, or None when the resource is empty.
+        """
         profile = self._query_optional(profile_uri, do_async=do_async)
         if not isinstance(profile, dict) or not profile:
             return None
@@ -100,6 +162,15 @@ class PowerSmoothing(RedfishManagerBase,
                               gpu_id,
                               profiles_uri,
                               do_async=False):
+        """Read a PresetProfiles collection and its member profiles.
+
+        :param system_id: system id the profiles belong to.
+        :param gpu_id: GPU processor id the profiles belong to.
+        :param profiles_uri: ``PresetProfiles`` collection URI to walk.
+        :param do_async: when True, issue queries on the async event loop.
+        :return: tuple of (collection summary dict, list of profile dicts),
+            or (None, []) when the collection is empty.
+        """
         collection = self._query_optional(profiles_uri, do_async=do_async)
         if not isinstance(collection, dict) or not collection:
             return None, []
@@ -135,6 +206,17 @@ class PowerSmoothing(RedfishManagerBase,
                                     gpu_id,
                                     smoothing_uri,
                                     do_async=False):
+        """Read one GPU PowerSmoothing resource and append it to ``data``.
+
+        Appends the smoothing row plus any preset-profile collection and
+        admin override profile to the corresponding lists in ``data``.
+
+        :param data: aggregation dict mutated in place with smoothing results.
+        :param system_id: system id the GPU belongs to.
+        :param gpu_id: GPU processor id being read.
+        :param smoothing_uri: ``PowerSmoothing`` resource URI to GET.
+        :param do_async: when True, issue queries on the async event loop.
+        """
         smoothing = self._query_optional(smoothing_uri, do_async=do_async)
         if not isinstance(smoothing, dict) or not smoothing:
             return
@@ -202,6 +284,23 @@ class PowerSmoothing(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
+        """Read NVIDIA GPU PowerSmoothing state and profiles across systems.
+
+        Walks every ``/redfish/v1/Systems`` member to its GPU processors and
+        their ``Oem/Nvidia/PowerSmoothing`` resource, aggregating smoothing
+        state, preset profiles, and admin override profiles.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this
+            command.
+        :param do_async: when True, run Redfish queries on the async event
+            loop.
+        :param do_expanded: accepted for CLI compatibility; not used by this
+            command.
+        :return: CommandResult holding the aggregated smoothing data and a
+            summary.
+        """
         data = {
             "summary": {},
             "power_smoothing": [],

--- a/redfish_ctl/power/cmd_workload_power.py
+++ b/redfish_ctl/power/cmd_workload_power.py
@@ -1,4 +1,12 @@
-"""Guard NVIDIA WorkloadPower profile enable and disable actions."""
+"""Guard NVIDIA WorkloadPower profile enable and disable actions.
+
+    redfish_ctl workload-power --gpu ID --profile-mask 0x1 --mode enable
+
+Locates a GPU's ``Oem/Nvidia/WorkloadPowerProfile`` resource and previews
+or POSTs an EnableProfiles/DisableProfiles action for a profile bit mask.
+The action only fires with ``--confirm`` and stays a preview under
+``--dry_run``.
+"""
 
 import re
 from abc import abstractmethod
@@ -18,6 +26,12 @@ _ACTION_TYPES = {
 
 
 def _normalize_profile_mask(profile_mask: str) -> str:
+    """Validate and normalize a profile bit-mask string.
+
+    :param profile_mask: hex mask such as ``0x1`` selecting profile bits.
+    :return: the mask normalized to lowercase ``0x`` hex form.
+    :raises InvalidArgument: when the mask is not hex or selects no bits.
+    """
     mask = str(profile_mask or "").strip()
     if not _PROFILE_MASK.fullmatch(mask):
         raise InvalidArgument("profile mask must be a hex value like 0x1")
@@ -34,12 +48,16 @@ class WorkloadPower(RedfishManagerBase,
     """Preview or apply NVIDIA WorkloadPower profile actions."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the workload-power command."""
         super(WorkloadPower, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the guarded ``workload-power`` subcommand."""
+        """Register the guarded ``workload-power`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             "--gpu", dest="gpu_id", required=True, metavar="ID",
@@ -61,6 +79,12 @@ class WorkloadPower(RedfishManagerBase,
 
     @staticmethod
     def _members(data):
+        """Extract member ``@odata.id`` URIs from a Redfish collection.
+
+        :param data: parsed collection resource that may hold ``Members``.
+        :return: list of member ``@odata.id`` strings, empty when absent
+            or malformed.
+        """
         if not isinstance(data, dict):
             return []
         return [
@@ -72,6 +96,12 @@ class WorkloadPower(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
+        """Return the ``@odata.id`` referenced by ``data[key]``.
+
+        :param data: parsed resource that may hold a link object under ``key``.
+        :param key: name of the link property to dereference.
+        :return: the ``@odata.id`` string, or None when absent or malformed.
+        """
         value = data.get(key) if isinstance(data, dict) else None
         if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
             return value["@odata.id"]
@@ -79,6 +109,12 @@ class WorkloadPower(RedfishManagerBase,
 
     @staticmethod
     def _nested_link(data, *keys):
+        """Follow a chain of nested keys and return the final ``@odata.id``.
+
+        :param data: parsed resource to descend into.
+        :return: the ``@odata.id`` at the end of the key chain, or None when
+            any step is missing or malformed.
+        """
         value = data
         for key in keys:
             if not isinstance(value, dict):
@@ -90,15 +126,34 @@ class WorkloadPower(RedfishManagerBase,
 
     @staticmethod
     def _resource_id(uri):
+        """Derive the resource id from a Redfish URI.
+
+        :param uri: resource ``@odata.id`` path.
+        :return: the trailing path segment used as the resource id.
+        """
         return uri.rstrip("/").rsplit("/", 1)[-1]
 
     def _get(self, uri, do_async=False):
+        """Query a URI and return its data, swallowing errors.
+
+        :param uri: Redfish resource path to GET.
+        :param do_async: when True, issue the query on the async event loop.
+        :return: the response data dict, or an empty dict on any failure.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
             return {}
 
     def _workload_power_resources(self, do_async=False):
+        """Discover all GPU WorkloadPowerProfile resources across systems.
+
+        Walks every system's GPU processors and collects those exposing an
+        ``Oem/Nvidia/WorkloadPowerProfile`` link.
+
+        :param do_async: when True, issue queries on the async event loop.
+        :return: list of dicts with System, GPU, and Uri for each resource.
+        """
         resources = []
         systems = self._get(RedfishApi.Systems, do_async=do_async)
         for system_uri in self._members(systems):
@@ -127,6 +182,14 @@ class WorkloadPower(RedfishManagerBase,
         return resources
 
     def _select_workload_power(self, gpu_id, do_async=False):
+        """Select the WorkloadPowerProfile resource for a given GPU.
+
+        :param gpu_id: GPU processor id to match.
+        :param do_async: when True, issue queries on the async event loop.
+        :return: the matching resource dict with System, GPU, and Uri.
+        :raises InvalidArgument: when ``gpu_id`` is empty or has no such
+            resource.
+        """
         if not gpu_id:
             raise InvalidArgument("GPU id is required")
         for resource in self._workload_power_resources(do_async=do_async):
@@ -147,7 +210,27 @@ class WorkloadPower(RedfishManagerBase,
                 confirm: Optional[bool] = False,
                 dry_run: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Preview or POST one NVIDIA WorkloadPower profile-mask action."""
+        """Preview or POST one NVIDIA WorkloadPower profile-mask action.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this
+            command.
+        :param do_async: when True, run Redfish queries on the async event
+            loop.
+        :param do_expanded: accepted for CLI compatibility; not used by this
+            command.
+        :param gpu_id: GPU processor id whose WorkloadPowerProfile is targeted.
+        :param profile_mask: hex profile bit mask to enable or disable, such
+            as ``0x1``.
+        :param mode: ``enable`` or ``disable``, selecting the action to invoke.
+        :param confirm: when True, POST the action; otherwise only preview it.
+        :param dry_run: when True, force preview mode even when ``confirm`` is
+            set.
+        :return: CommandResult with the action outcome and target GPU context.
+        :raises InvalidArgument: when ``mode`` is not enable/disable or the GPU
+            has no WorkloadPowerProfile resource.
+        """
         if mode not in _ACTION_TYPES:
             raise InvalidArgument("mode must be 'enable' or 'disable'")
 


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/power/` (power, power-smoothing, workload-power commands), compliant with the merged docstring gate (#145).

Adds/completes reST docstrings: summary + `:param:`/`:return:` for methods with real args, `:return:` on register_subcommand, and `redfish_ctl <cmd>` module examples. CLI params that a command's `execute` never uses (e.g. filename/data_type/verbose/do_expanded on the read commands) are documented honestly as "accepted for CLI compatibility; not used by this command" — verified with an AST param-usage check, not assumed.

Docstrings only, no behavior change.

Gates: `tools/docstring_gate.py --all` 0 violations in power/; ruff no new findings; pytest green.