### PR TITLE
Document network command methods (docstring coverage)

### DIFF
--- a/redfish_ctl/network/cmd_ethernet_interfaces.py
+++ b/redfish_ctl/network/cmd_ethernet_interfaces.py
@@ -27,26 +27,39 @@ class EthernetInterfaces(RedfishManagerBase,
     """Read EthernetInterface config from every system and manager."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the ethernet-interfaces command."""
         super(EthernetInterfaces, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``ethernet-interfaces`` subcommand (read-only)."""
+        """Register the ``ethernet-interfaces`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read host and BMC EthernetInterfaces (IP/MAC/VLAN)"
         return cmd_parser, "ethernet-interfaces", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (expects a ``Members`` list).
+        :return: list of member ``@odata.id`` strings ([] if data is not a dict).
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
                 if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 
     def _get(self, uri, do_async):
-        """GET a resource body, returning {} on any failure."""
+        """GET a resource body, returning {} on any failure.
+
+        :param uri: the Redfish resource path to GET.
+        :param do_async: note async will subscribe to an event loop.
+        :return: the resource body dict, or {} on any query error.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
@@ -54,20 +67,32 @@ class EthernetInterfaces(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
-        """Return the @odata.id of a single ``{key: {@odata.id}}`` link, or None."""
+        """Return the @odata.id of a single ``{key: {@odata.id}}`` link, or None.
+
+        :param data: a Redfish resource body that may hold the link.
+        :param key: the property name whose ``{@odata.id}`` link to extract.
+        :return: the linked ``@odata.id`` string, or None if absent/malformed.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
     @staticmethod
     def _ipv4(data):
-        """First IPv4 address string on the interface, or None."""
+        """First IPv4 address string on the interface, or None.
+
+        :param data: an EthernetInterface body.
+        :return: the first IPv4 address string, or None if none present.
+        """
         addrs = (data or {}).get("IPv4Addresses")
         if isinstance(addrs, list) and addrs and isinstance(addrs[0], dict):
             return addrs[0].get("Address")
         return None
 
     def _roots(self):
-        """Every ComputerSystem + Manager URI (multi-member aware), tolerant."""
+        """Every ComputerSystem + Manager URI (multi-member aware), tolerant.
+
+        :return: list of ComputerSystem and Manager URIs (empty on discovery error).
+        """
         roots = []
         for finder in (self.discover_computer_system_ids, self.discover_manager_ids):
             try:
@@ -83,7 +108,15 @@ class EthernetInterfaces(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Walk EthernetInterfaces on every system/manager and collect config."""
+        """Walk EthernetInterfaces on every system/manager and collect config.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: note async will subscribe to an event loop.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult holding a list of per-interface config rows.
+        """
         rows = []
         for root_uri in self._roots():
             rdata = self._get(root_uri, do_async)

--- a/redfish_ctl/network/cmd_network_adapters.py
+++ b/redfish_ctl/network/cmd_network_adapters.py
@@ -29,19 +29,27 @@ class NetworkAdapters(RedfishManagerBase,
     """Read every NetworkAdapter (NIC/DPU) across all chassis."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the network-adapters command."""
         super(NetworkAdapters, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``network-adapters`` subcommand (read-only)."""
+        """Register the ``network-adapters`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read all chassis NetworkAdapters (NICs and DPUs)"
         return cmd_parser, "network-adapters", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (expects a ``Members`` list).
+        :return: list of member ``@odata.id`` strings ([] if data is not a dict).
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
@@ -53,6 +61,9 @@ class NetworkAdapters(RedfishManagerBase,
 
         BlueField is a DPU/SmartNIC; ConnectX is a NIC. Unknown models fall
         through to NIC, which is the safe default for an Ethernet adapter.
+
+        :param model: the adapter model string (may be None).
+        :return: "DPU" for a BlueField model, otherwise "NIC".
         """
         m = (model or "").lower()
         if "bluefield" in m or "bf3" in m or "bf2" in m:
@@ -72,6 +83,13 @@ class NetworkAdapters(RedfishManagerBase,
 
         Tolerant of a chassis with no NetworkAdapters link or an unreachable
         collection (skips it).
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: note async will subscribe to an event loop.
+        :param do_expanded: issue an expanded ($expand) query on the adapters collection.
+        :return: CommandResult holding a list of per-adapter rows.
         """
         rows = []
         chassis = self.base_query(REDFISH_API.Chassis, do_async=do_async)

--- a/redfish_ctl/network/cmd_network_ports.py
+++ b/redfish_ctl/network/cmd_network_ports.py
@@ -28,26 +28,39 @@ class NetworkPorts(RedfishManagerBase,
     """Read every NetworkAdapter Port's link state across all chassis."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the network-ports command."""
         super(NetworkPorts, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``network-ports`` subcommand (read-only)."""
+        """Register the ``network-ports`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read NetworkAdapter port link state (up/speed) per chassis"
         return cmd_parser, "network-ports", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (expects a ``Members`` list).
+        :return: list of member ``@odata.id`` strings ([] if data is not a dict).
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
                 if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 
     def _get(self, uri, do_async):
-        """GET a resource body, returning {} on any failure."""
+        """GET a resource body, returning {} on any failure.
+
+        :param uri: the Redfish resource path to GET.
+        :param do_async: note async will subscribe to an event loop.
+        :return: the resource body dict, or {} on any query error.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
@@ -55,7 +68,12 @@ class NetworkPorts(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
-        """Return the @odata.id of a single ``{key: {@odata.id}}`` link, or None."""
+        """Return the @odata.id of a single ``{key: {@odata.id}}`` link, or None.
+
+        :param data: a Redfish resource body that may hold the link.
+        :param key: the property name whose ``{@odata.id}`` link to extract.
+        :return: the linked ``@odata.id`` string, or None if absent/malformed.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
@@ -66,7 +84,15 @@ class NetworkPorts(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Walk every chassis adapter's Ports and collect per-port link state."""
+        """Walk every chassis adapter's Ports and collect per-port link state.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: note async will subscribe to an event loop.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult holding a list of per-port link-state rows.
+        """
         rows = []
         chassis = self.base_query(REDFISH_API.Chassis, do_async=do_async)
         for chassis_uri in self._members(chassis.data):

--- a/redfish_ctl/network/cmd_nic_firmware.py
+++ b/redfish_ctl/network/cmd_nic_firmware.py
@@ -53,6 +53,9 @@ def network_class(text: Optional[str]) -> Optional[str]:
     BlueField is a DPU/SmartNIC; ConnectX/Mellanox is a NIC; a bare ``nic`` token is
     the weak last signal. Matching is on whole alphanumeric tokens, so BMC/GPU/PCIe
     firmware and GUIDs (which may contain a fragment like ``cx8``) return None.
+
+    :param text: a firmware id or name to classify (may be None).
+    :return: "DPU", "NIC", or None when the text is not a network device.
     """
     tokens = set(_TOKEN_RE.findall((text or "").lower()))
     if tokens & _DPU_TOKENS:
@@ -69,26 +72,38 @@ class NicFirmware(RedfishManagerBase,
     """Read every NIC/DPU adapter and its firmware version across all chassis."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the nic-firmware command."""
         super(NicFirmware, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``nic-firmware`` subcommand (read-only)."""
+        """Register the ``nic-firmware`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read NIC/DPU network-adapter firmware (out-of-band)"
         return cmd_parser, "nic-firmware", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (expects a ``Members`` list).
+        :return: list of member ``@odata.id`` strings ([] if data is not a dict).
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
                 if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 
     def _adapters(self, do_async):
-        """Physical NIC/DPU cards from ``Chassis/*/NetworkAdapters/*``."""
+        """Physical NIC/DPU cards from ``Chassis/*/NetworkAdapters/*``.
+
+        :param do_async: note async will subscribe to an event loop.
+        :return: list of adapter dicts (empty if the Chassis walk is unavailable).
+        """
         rows = []
         try:
             chassis = self.base_query(REDFISH_API.Chassis, do_async=do_async)
@@ -134,6 +149,9 @@ class NicFirmware(RedfishManagerBase,
         links (identified by id/name token) to read each ``Version``. When the BMC
         honours ``$expand`` and returns members inline with a Version, that value is
         used without a second GET.
+
+        :param do_async: note async will subscribe to an event loop.
+        :return: list of network-relevant firmware component dicts (empty if unavailable).
         """
         rows = []
         fw_root = f"{RedfishApi.Version}/UpdateService/FirmwareInventory"
@@ -182,7 +200,15 @@ class NicFirmware(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Return the joined NIC/DPU adapter + firmware report (read-only)."""
+        """Return the joined NIC/DPU adapter + firmware report (read-only).
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: note async will subscribe to an event loop.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult holding {"adapters", "firmware", "summary"}.
+        """
         adapters = self._adapters(do_async)
         firmware = self._nic_firmware(do_async)
         versions = sorted({f["Version"] for f in firmware if f.get("Version")})


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/network/` (ethernet-interfaces, network-adapters/ports, nic-firmware commands), compliant with the merged docstring gate (#145).

Adds/completes reST docstrings: summary + `:param:`/`:return:` for methods with real args, `:return:` on register_subcommand, and `redfish_ctl <cmd>` module examples. CLI params that a command's `execute` never uses (e.g. filename/data_type/verbose/do_expanded on the read commands) are documented honestly as "accepted for CLI compatibility; not used by this command" — verified with an AST param-usage check, not assumed.

Docstrings only, no behavior change.

Gates: `tools/docstring_gate.py --all` 0 violations in network/; ruff no new findings; pytest green.