### PR TITLE
Document firmware command methods (docstring coverage)

### DIFF
--- a/redfish_ctl/firmware/cmd_firmware.py
+++ b/redfish_ctl/firmware/cmd_firmware.py
@@ -5,6 +5,11 @@ back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
 
+Example::
+
+    redfish_ctl firmware
+    redfish_ctl firmware --deep
+
 Author Mus spyroot@gmail.com
 """
 import argparse
@@ -27,15 +32,15 @@ class FirmwareQuery(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the firmware command."""
         super(FirmwareQuery, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """
+        """Register the firmware subcommand.
 
-        :param cls:
-        :return:
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_arg = argparse.ArgumentParser(add_help=False)
         cmd_arg.add_argument('--async', action='store_true',

--- a/redfish_ctl/firmware/cmd_firmware_inv.py
+++ b/redfish_ctl/firmware/cmd_firmware_inv.py
@@ -5,6 +5,11 @@ back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
 
+Example::
+
+    redfish_ctl firmware_inventory
+    redfish_ctl firmware_inventory --filename fw.json
+
 Author Mus spyroot@gmail.com
 """
 import argparse
@@ -26,14 +31,15 @@ class FirmwareInventoryQuery(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the firmware_inventory command."""
         super(FirmwareInventoryQuery, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register command.
-        :param cls:
-        :return:
+        """Register the firmware_inventory subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_arg = argparse.ArgumentParser(add_help=False)
         cmd_arg.add_argument('--async', action='store_true', required=False, dest="do_async",

--- a/redfish_ctl/firmware/cmd_firmware_update.py
+++ b/redfish_ctl/firmware/cmd_firmware_update.py
@@ -33,12 +33,16 @@ class FirmwareUpdate(RedfishManagerBase,
     """Flash firmware via a discovered UpdateService update endpoint."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the firmware-update command."""
         super(FirmwareUpdate, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``firmware-update`` subcommand and its safety flags."""
+        """Register the ``firmware-update`` subcommand and its safety flags.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--image_uri', required=False, dest='image_uri', type=str, default=None,
@@ -58,7 +62,12 @@ class FirmwareUpdate(RedfishManagerBase,
         return cmd_parser, "firmware-update", "command flash firmware via UpdateService (guarded)"
 
     def _update_service_uri(self, do_async):
-        """Resolve the UpdateService URI from the service root, with a fallback."""
+        """Resolve the UpdateService URI from the service root, with a fallback.
+
+        :param do_async: query the service root asynchronously.
+        :return: the UpdateService ``@odata.id``, or the default
+            ``{Version}/UpdateService`` when the root exposes no link.
+        """
         try:
             root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
         except Exception:
@@ -69,7 +78,11 @@ class FirmwareUpdate(RedfishManagerBase,
         return f"{RedfishApi.Version}/UpdateService"
 
     def _read_update_service(self, do_async):
-        """Return ``(uri, resource, error)`` for UpdateService discovery."""
+        """Return ``(uri, resource, error)`` for UpdateService discovery.
+
+        :param do_async: read the UpdateService asynchronously.
+        :return: tuple of (UpdateService URI, resource dict, error string or None).
+        """
         uri = self._update_service_uri(do_async)
         try:
             resource = self.base_query(uri, do_async=do_async).data or {}
@@ -78,7 +91,17 @@ class FirmwareUpdate(RedfishManagerBase,
         return uri, resource, None
 
     def _action_result(self, target, payload, actions, do_async, dry_run, confirm):
-        """Post the SimpleUpdate action with the same fail-safe response shape."""
+        """Post the SimpleUpdate action with the same fail-safe response shape.
+
+        :param target: the SimpleUpdate action target URI to POST to.
+        :param payload: the request body (ImageURI and optional TransferProtocol).
+        :param actions: discovered action metadata carried on the result.
+        :param do_async: POST the action asynchronously.
+        :param dry_run: when True, preview only and POST nothing.
+        :param confirm: required to run a destructive action; when False the
+            action is forced to a dry-run preview.
+        :return: CommandResult with a dry-run preview or the POST outcome.
+        """
         from ..actions.action_policy import Destructiveness, classify
 
         full = "#UpdateService.SimpleUpdate"
@@ -110,7 +133,12 @@ class FirmwareUpdate(RedfishManagerBase,
 
     @staticmethod
     def _push_target(update_service):
-        """Prefer MultipartHttpPushUri, then HttpPushUri, when present."""
+        """Prefer MultipartHttpPushUri, then HttpPushUri, when present.
+
+        :param update_service: the UpdateService resource dict to inspect.
+        :return: tuple of (push method name, push URI), or (None, None) when
+            neither push URI is present.
+        """
         for method in ("MultipartHttpPushUri", "HttpPushUri"):
             target = (update_service or {}).get(method)
             if isinstance(target, str) and target:
@@ -118,7 +146,14 @@ class FirmwareUpdate(RedfishManagerBase,
         return None, None
 
     def _post_image_file(self, target, method, image_path):
-        """Upload a local image file to the discovered push URI."""
+        """Upload a local image file to the discovered push URI.
+
+        :param target: the push URI path to upload to.
+        :param method: the push method (``MultipartHttpPushUri`` or
+            ``HttpPushUri``) selecting the upload encoding.
+        :param image_path: ``Path`` to the local firmware image to upload.
+        :return: the ``requests.Response`` from the upload POST.
+        """
         headers = {}
         auth = None
         if self.x_auth is not None:
@@ -153,7 +188,16 @@ class FirmwareUpdate(RedfishManagerBase,
             )
 
     def _push_result(self, target, method, image_file, dry_run, confirm):
-        """Preview or execute a push-URI firmware upload."""
+        """Preview or execute a push-URI firmware upload.
+
+        :param target: the push URI path to upload to.
+        :param method: the push method name being used.
+        :param image_file: path to the local firmware image file.
+        :param dry_run: when True, preview only and upload nothing.
+        :param confirm: when False, force a dry-run preview.
+        :return: CommandResult with a dry-run preview, the upload outcome, or an
+            error when the file is missing or the upload fails.
+        """
         data = {
             "method": method,
             "target": target,
@@ -205,6 +249,21 @@ class FirmwareUpdate(RedfishManagerBase,
 
         Returns a dry-run preview unless ``--confirm``; the destructiveness guard
         keeps firmware writes as previews by default.
+
+        :param image_uri: firmware image URI placed in the ImageURI payload for
+            SimpleUpdate.
+        :param image_file: local firmware image uploaded when the service exposes
+            a push URI instead of SimpleUpdate.
+        :param transfer_protocol: optional TransferProtocol added to the payload.
+        :param confirm: actually flash; without it the command stays a dry-run.
+        :param dry_run: force a dry-run preview even when confirm is set.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: run the UpdateService discovery and update request
+            asynchronously (subscribes to an event loop).
+        :return: CommandResult with a dry-run preview or the update outcome, or an
+            error when UpdateService is unreadable or exposes no update mechanism.
         """
         payload = {}
         if image_uri:

--- a/redfish_ctl/firmware/cmd_update_service.py
+++ b/redfish_ctl/firmware/cmd_update_service.py
@@ -1,4 +1,10 @@
-"""Read Redfish UpdateService capabilities and advertised actions."""
+"""Read Redfish UpdateService capabilities and advertised actions.
+
+Example::
+
+    redfish_ctl update_service
+    redfish_ctl update_service -f update_service.json
+"""
 from abc import abstractmethod
 from typing import Optional
 
@@ -16,27 +22,50 @@ class UpdateServiceQuery(RedfishManagerBase,
     """Read the service, inventory links, push URIs, and action targets."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the update_service command."""
         super(UpdateServiceQuery, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the read-only update_service subcommand."""
+        """Register the read-only update_service subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read UpdateService capabilities and actions"
         return cmd_parser, "update_service", help_text
 
     @staticmethod
     def _link(data, key):
+        """Return the ``@odata.id`` for a link entry, or None.
+
+        :param data: the resource dict to read the link from.
+        :param key: the link property name.
+        :return: the referenced ``@odata.id`` string, or None when absent or not
+            a link object.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
     @staticmethod
     def _action_name(full_name):
+        """Shorten a fully qualified action name to its trailing segment.
+
+        :param full_name: the fully qualified action name (e.g.
+            ``#UpdateService.SimpleUpdate``).
+        :return: the action name after the final dot.
+        """
         return full_name.lstrip("#").split(".")[-1]
 
     @classmethod
     def _collect_actions(cls, node):
+        """Recursively collect Redfish action entries from an Actions node.
+
+        :param node: an Actions mapping (or nested dict) to walk.
+        :return: a list of action rows with Name, FullName, Target, ActionInfo,
+            and Parameters.
+        """
         rows = []
         if not isinstance(node, dict):
             return rows
@@ -62,6 +91,12 @@ class UpdateServiceQuery(RedfishManagerBase,
         return rows
 
     def _update_service_uri(self, do_async):
+        """Resolve the UpdateService URI from the service root, with a fallback.
+
+        :param do_async: query the service root asynchronously.
+        :return: the UpdateService ``@odata.id``, or
+            ``REDFISH_API.UpdateServiceQuery`` when the root exposes no link.
+        """
         try:
             root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
         except Exception:
@@ -77,7 +112,15 @@ class UpdateServiceQuery(RedfishManagerBase,
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Read UpdateService without invoking any update action."""
+        """Read UpdateService without invoking any update action.
+
+        :param filename: if set, save the summarized response to this file.
+        :param data_type: json or xml; serialization format passed to the query.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: read UpdateService asynchronously.
+        :return: CommandResult with the summarized UpdateService (metadata,
+            inventory links, push URIs, and sorted action targets).
+        """
         service_uri = self._update_service_uri(do_async)
         result = self.base_query(service_uri, do_async=do_async, data_type=data_type)
         service = result.data or {}


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/firmware/` (firmware, firmware inventory/update, update-service commands), compliant with the merged docstring gate (#145).

Adds/completes reST docstrings: summary + `:param:`/`:return:` for methods with real args, `:return:` on register_subcommand, and `redfish_ctl <cmd>` module examples. CLI params that a command's `execute` never uses (e.g. filename/data_type/verbose/do_expanded on the read commands) are documented honestly as "accepted for CLI compatibility; not used by this command" — verified with an AST param-usage check, not assumed.

Docstrings only, no behavior change.

Gates: `tools/docstring_gate.py --all` 0 violations in firmware/; ruff no new findings; pytest green.