### PR TITLE
Document proxy module methods (docstring coverage)

### DIFF
--- a/redfish_ctl/proxy/core.py
+++ b/redfish_ctl/proxy/core.py
@@ -37,7 +37,10 @@ class NodeConfig:
     description: str | None = None
 
     def public_dict(self) -> dict[str, Any]:
-        """Return node metadata safe for API responses."""
+        """Return node metadata safe for API responses.
+
+        :return: dict of node fields excluding credentials.
+        """
         return {
             "id": self.id,
             "address": self.address,
@@ -55,6 +58,11 @@ class NodeRegistry:
     """In-memory node registry for the first read-only proxy increment."""
 
     def __init__(self, nodes: Iterable[NodeConfig]):
+        """Build the registry, indexing nodes by id.
+
+        :param nodes: node configurations to register.
+        :raises ValueError: when two nodes share the same id.
+        """
         self._nodes = {}
         for node in nodes:
             if node.id in self._nodes:
@@ -62,11 +70,19 @@ class NodeRegistry:
             self._nodes[node.id] = node
 
     def list(self) -> list[NodeConfig]:
-        """Return nodes sorted by stable id."""
+        """Return nodes sorted by stable id.
+
+        :return: list of node configurations ordered by id.
+        """
         return [self._nodes[node_id] for node_id in sorted(self._nodes)]
 
     def get(self, node_id: str) -> NodeConfig:
-        """Return one node or raise NodeNotFound."""
+        """Return one node or raise NodeNotFound.
+
+        :param node_id: id of the node to look up.
+        :return: matching node configuration.
+        :raises NodeNotFound: when no node has the given id.
+        """
         try:
             return self._nodes[node_id]
         except KeyError as exc:
@@ -74,10 +90,19 @@ class NodeRegistry:
 
 
 def _utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime.
+
+    :return: current UTC datetime.
+    """
     return datetime.now(timezone.utc)
 
 
 def _rfc3339(value: datetime) -> str:
+    """Format a datetime as an RFC 3339 UTC string with a trailing ``Z``.
+
+    :param value: datetime to format; assumed UTC when naive.
+    :return: RFC 3339 UTC timestamp string.
+    """
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     value = value.astimezone(timezone.utc)
@@ -85,6 +110,11 @@ def _rfc3339(value: datetime) -> str:
 
 
 def _as_float(value: Any) -> float | None:
+    """Coerce a value to float, returning None when it is not numeric.
+
+    :param value: value to coerce; booleans and None yield None.
+    :return: float value, or None when coercion fails.
+    """
     if value is None or isinstance(value, bool):
         return None
     try:
@@ -94,6 +124,11 @@ def _as_float(value: Any) -> float | None:
 
 
 def _temperature_summary(thermal: ThermalStatus) -> dict[str, float | int | None]:
+    """Summarize thermal readings into a count and maximum Celsius value.
+
+    :param thermal: thermal status holding temperature readings.
+    :return: dict with the reading ``count`` and ``maxCelsius`` (None when empty).
+    """
     values = [
         numeric
         for reading in thermal.temperatures
@@ -111,6 +146,14 @@ def _raw_command(
     name: str,
     **kwargs: Any,
 ) -> Any:
+    """Invoke a Redfish command and return its data or raise on error.
+
+    :param manager: synchronous invoker bound to one node.
+    :param api_call: API request type identifying the command.
+    :param name: command name key for the request type.
+    :return: command result data.
+    :raises RedfishApiError: when the command result carries an error.
+    """
     result = manager.sync_invoke(api_call, name, **kwargs)
     if result.error:
         raise RedfishApiError(str(result.error))
@@ -118,6 +161,11 @@ def _raw_command(
 
 
 def _sensor_dicts(manager: SyncInvoker) -> list[dict[str, Any]]:
+    """Read chassis sensors and normalize them into plain dict rows.
+
+    :param manager: synchronous invoker bound to one node.
+    :return: list of sensor rows with normalized keys.
+    """
     return [
         {
             "chassis": reading.chassis,
@@ -132,6 +180,11 @@ def _sensor_dicts(manager: SyncInvoker) -> list[dict[str, Any]]:
 
 
 def _address_host(address: str) -> str:
+    """Extract the bare host from an address, URL, or host:port string.
+
+    :param address: node address, which may include a scheme, credentials, or port.
+    :return: host portion of the address, or the original text on no match.
+    """
     text = str(address or "").strip()
     if "://" in text:
         parsed = urlparse(text)
@@ -143,6 +196,12 @@ def _address_host(address: str) -> str:
 
 
 def _vendor_label(manager: SyncInvoker, vendor: str | None) -> str:
+    """Resolve a vendor label, falling back to the manager's detected vendor.
+
+    :param manager: synchronous invoker whose detected vendor is used as fallback.
+    :param vendor: explicit vendor label; when set it is returned unchanged.
+    :return: vendor label, or ``"unknown"`` when none can be determined.
+    """
     if vendor:
         return vendor
     try:
@@ -158,6 +217,13 @@ def _optional_command(
     name: str,
     **kwargs: Any,
 ) -> Any:
+    """Invoke a Redfish command, returning None instead of raising on failure.
+
+    :param manager: synchronous invoker bound to one node.
+    :param api_call: API request type identifying the command.
+    :param name: command name key for the request type.
+    :return: command result data, or None on any error or exception.
+    """
     try:
         result = manager.sync_invoke(api_call, name, **kwargs)
     except Exception:
@@ -168,21 +234,42 @@ def _optional_command(
 
 
 def _list_payload(data: Any) -> list[dict[str, Any]]:
+    """Return the dict rows from a list payload, discarding non-dict items.
+
+    :param data: candidate payload; only a list of dicts yields rows.
+    :return: list of dict rows, or an empty list when data is not a list.
+    """
     if not isinstance(data, list):
         return []
     return [row for row in data if isinstance(row, dict)]
 
 
 def _dict_payload(data: Any) -> dict[str, Any]:
+    """Return a shallow dict copy of the payload, or an empty dict.
+
+    :param data: candidate payload.
+    :return: dict copy when data is a dict, otherwise an empty dict.
+    """
     return dict(data) if isinstance(data, dict) else {}
 
 
 def _dict_rows(data: Any, key: str) -> list[dict[str, Any]]:
+    """Return the dict rows stored under a key in a dict payload.
+
+    :param data: candidate dict payload.
+    :param key: key whose value holds the list of rows.
+    :return: list of dict rows, or an empty list when absent.
+    """
     rows = _dict_payload(data).get(key)
     return _list_payload(rows)
 
 
 def _sample_dict(sample: MetricSample) -> dict[str, Any]:
+    """Convert a metric sample into a JSON-safe dict.
+
+    :param sample: metric sample to serialize.
+    :return: dict with the sample metric, value, dimensions, and metadata.
+    """
     return {
         "metric": sample.metric,
         "value": sample.value,
@@ -202,20 +289,39 @@ class ReadOnlyProxy:
         manager_factory: Callable[[NodeConfig], SyncInvoker],
         clock: Callable[[], datetime] = _utc_now,
     ):
+        """Initialize the proxy with a node registry and manager factory.
+
+        :param registry: node registry backing the proxy.
+        :param manager_factory: callable that builds a synchronous invoker for a node.
+        :param clock: callable returning the current time, defaults to UTC now.
+        """
         self._registry = registry
         self._manager_factory = manager_factory
         self._clock = clock
 
     def list_nodes(self) -> dict[str, Any]:
-        """List registered nodes without exposing credentials."""
+        """List registered nodes without exposing credentials.
+
+        :return: dict with a ``nodes`` list of public node metadata.
+        """
         return {"nodes": [node.public_dict() for node in self._registry.list()]}
 
     def _node_and_manager(self, node_id: str) -> tuple[NodeConfig, SyncInvoker]:
+        """Resolve a node id to its config and a fresh invoker.
+
+        :param node_id: id of the node to resolve.
+        :return: tuple of the node configuration and its synchronous invoker.
+        :raises NodeNotFound: when no node has the given id.
+        """
         node = self._registry.get(node_id)
         return node, self._manager_factory(node)
 
     def node_status(self, node_id: str) -> dict[str, Any]:
-        """Read one node's host status and thermal summary."""
+        """Read one node's host status and thermal summary.
+
+        :param node_id: id of the node to query.
+        :return: dict with node identity, system state, and temperature summary.
+        """
         node, manager = self._node_and_manager(node_id)
         system = get_system(manager)
         thermal = get_thermal(manager)
@@ -234,7 +340,11 @@ class ReadOnlyProxy:
         }
 
     def node_sensors(self, node_id: str) -> dict[str, Any]:
-        """Read normalized chassis sensor rows for one node."""
+        """Read normalized chassis sensor rows for one node.
+
+        :param node_id: id of the node to query.
+        :return: dict with node id and a ``sensors`` list of sensor rows.
+        """
         node, manager = self._node_and_manager(node_id)
         return {
             "id": node.id,
@@ -242,7 +352,11 @@ class ReadOnlyProxy:
         }
 
     def node_gpu_metrics(self, node_id: str) -> dict[str, Any]:
-        """Read consolidated GPU metric rows for one node."""
+        """Read consolidated GPU metric rows for one node.
+
+        :param node_id: id of the node to query.
+        :return: dict with node id and ``gpuMetrics`` command data.
+        """
         node, manager = self._node_and_manager(node_id)
         return {
             "id": node.id,
@@ -259,7 +373,12 @@ class ReadOnlyProxy:
         *,
         attr_filter: str | None = None,
     ) -> dict[str, Any]:
-        """Read BIOS attributes for one node."""
+        """Read BIOS attributes for one node.
+
+        :param node_id: id of the node to query.
+        :param attr_filter: optional substring filter applied to attribute names.
+        :return: dict with node id and ``bios`` attribute command data.
+        """
         node, manager = self._node_and_manager(node_id)
         return {
             "id": node.id,
@@ -281,7 +400,17 @@ class ReadOnlyProxy:
         vendor: str | None = None,
         do_expanded: bool = False,
     ) -> tuple[MetricSample, ...]:
-        """Read one node and return exporter-compatible telemetry samples."""
+        """Read one node and return exporter-compatible telemetry samples.
+
+        :param node_id: id of the node to query.
+        :param label_bmc_ip: BMC IP used as the identity dimension label; falls
+            back to the node address host when not set.
+        :param vendor: vendor label for identity dimensions; auto-detected when
+            not set.
+        :param do_expanded: issue an expanded ($expand) Redfish query for the
+            sensor, NVLink, metric-report, network, and component-integrity reads.
+        :return: tuple of exporter metric samples built from the collected rows.
+        """
         node, manager = self._node_and_manager(node_id)
         identity = build_identity_dimensions(
             label_bmc_ip or _address_host(node.address),
@@ -367,7 +496,17 @@ class ReadOnlyProxy:
         vendor: str | None = None,
         do_expanded: bool = False,
     ) -> dict[str, Any]:
-        """Return JSON-safe exporter samples for one node."""
+        """Return JSON-safe exporter samples for one node.
+
+        :param node_id: id of the node to query.
+        :param label_bmc_ip: BMC IP used as the identity dimension label; falls
+            back to the node address host when not set.
+        :param vendor: vendor label for identity dimensions; auto-detected when
+            not set.
+        :param do_expanded: issue an expanded ($expand) Redfish query when
+            collecting the underlying samples.
+        :return: dict with node id, ``sampleCount``, and JSON-safe ``samples``.
+        """
         samples = self.node_metric_samples(
             node_id,
             label_bmc_ip=label_bmc_ip,

--- a/redfish_ctl/proxy/fastapi_app.py
+++ b/redfish_ctl/proxy/fastapi_app.py
@@ -11,7 +11,12 @@ from .core import NodeNotFound, ReadOnlyProxy
 
 
 def create_app(proxy: ReadOnlyProxy):
-    """Create a FastAPI app for read-only proxy routes."""
+    """Create a FastAPI app for read-only proxy routes.
+
+    :param proxy: read-only proxy backing the route handlers.
+    :return: configured FastAPI application.
+    :raises RuntimeError: when FastAPI is not installed.
+    """
     try:
         from fastapi import FastAPI, HTTPException
     except ImportError as exc:
@@ -22,6 +27,12 @@ def create_app(proxy: ReadOnlyProxy):
     app = FastAPI(title="redfish_ctl read-only proxy")
 
     def call(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+        """Invoke a proxy method and translate errors into HTTP responses.
+
+        :param func: proxy method to call.
+        :return: value returned by the proxy method.
+        :raises HTTPException: 404 for an unknown node, 502 for a Redfish error.
+        """
         try:
             return func(*args, **kwargs)
         except NodeNotFound as exc:
@@ -31,22 +42,47 @@ def create_app(proxy: ReadOnlyProxy):
 
     @app.get("/nodes")
     def list_nodes():
+        """List registered nodes.
+
+        :return: dict with public metadata for every registered node.
+        """
         return proxy.list_nodes()
 
     @app.get("/nodes/{node_id}")
     def node_status(node_id: str):
+        """Return host status and thermal summary for one node.
+
+        :param node_id: id of the node to query.
+        :return: dict with node identity, system state, and temperature summary.
+        """
         return call(proxy.node_status, node_id)
 
     @app.get("/nodes/{node_id}/sensors")
     def node_sensors(node_id: str):
+        """Return normalized chassis sensor rows for one node.
+
+        :param node_id: id of the node to query.
+        :return: dict with node id and a ``sensors`` list of sensor rows.
+        """
         return call(proxy.node_sensors, node_id)
 
     @app.get("/nodes/{node_id}/gpu-metrics")
     def node_gpu_metrics(node_id: str):
+        """Return consolidated GPU metric rows for one node.
+
+        :param node_id: id of the node to query.
+        :return: dict with node id and ``gpuMetrics`` command data.
+        """
         return call(proxy.node_gpu_metrics, node_id)
 
     @app.get("/nodes/{node_id}/bios")
     def node_bios(node_id: str, attr_filter: str | None = None):
+        """Return BIOS attributes for one node.
+
+        :param node_id: id of the node to query.
+        :param attr_filter: optional substring filter applied to attribute names.
+        :return: dict with node id and ``bios`` attribute command data.
+        """
         return call(proxy.node_bios, node_id, attr_filter=attr_filter)
 
     @app.get("/nodes/{node_id}/metrics")
@@ -55,6 +91,15 @@ def create_app(proxy: ReadOnlyProxy):
         label_bmc_ip: str | None = None,
         vendor: str | None = None,
     ):
+        """Return JSON-safe exporter samples for one node.
+
+        :param node_id: id of the node to query.
+        :param label_bmc_ip: BMC IP used as the identity dimension label; falls
+            back to the node address host when not set.
+        :param vendor: vendor label for identity dimensions; auto-detected when
+            not set.
+        :return: dict with node id, ``sampleCount``, and JSON-safe ``samples``.
+        """
         return call(
             proxy.node_metrics,
             node_id,


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/proxy/`, compliant with the merged docstring gate (#145).

Adds/completes reST docstrings across the proxy module(s). Not command modules (no register_subcommand / module-example rule). Recurring framework params documented per actual body usage (honest accepted-but-unused where applicable), verified with an AST param-usage check. Docstrings only, no behavior change.

Gates: `tools/docstring_gate.py --all` 0 violations in proxy/; ruff no new findings; pytest green.