### PR TITLE
Document discover module methods (docstring coverage)

### DIFF
--- a/redfish_ctl/discover/classifier.py
+++ b/redfish_ctl/discover/classifier.py
@@ -62,6 +62,10 @@ def _vendor_from_oem(service_root: Mapping[str, Any]) -> Optional[str]:
 
     The ``Oem`` value should be a mapping whose keys are vendor namespaces.
     A non-mapping ``Oem`` (malformed input) is ignored rather than raising.
+
+    :param service_root: parsed ServiceRoot mapping to read the ``Oem`` block from.
+    :return: a canonical vendor tag when an OEM namespace key is recognized, else
+        ``None``.
     """
     oem = service_root.get("Oem")
     if not isinstance(oem, Mapping):
@@ -80,6 +84,10 @@ def _vendor_from_odata_type(service_root: Mapping[str, Any]) -> Optional[str]:
 
     Example: ``#DellServiceRoot.v1_0_0.DellServiceRoot`` -> ``dell``. The leading
     ``#`` and any namespace path are stripped before matching the prefix.
+
+    :param service_root: parsed ServiceRoot mapping to read ``@odata.type`` from.
+    :return: a canonical vendor tag when the schema name starts with a known OEM
+        prefix, else ``None``.
     """
     odata_type = service_root.get("@odata.type")
     if not isinstance(odata_type, str):
@@ -94,7 +102,13 @@ def _vendor_from_odata_type(service_root: Mapping[str, Any]) -> Optional[str]:
 
 
 def _vendor_from_text(service_root: Mapping[str, Any]) -> Optional[str]:
-    """Return a vendor from ``Manufacturer``/``Vendor`` substrings, or ``None``."""
+    """Return a vendor from ``Manufacturer``/``Vendor`` substrings, or ``None``.
+
+    :param service_root: parsed ServiceRoot mapping to read ``Manufacturer`` and
+        ``Vendor`` free-text fields from.
+    :return: a canonical vendor tag when a known token is found in the combined
+        free text, else ``None``.
+    """
     parts = []
     for field in ("Manufacturer", "Vendor"):
         value = service_root.get(field)

--- a/redfish_ctl/discover/cli.py
+++ b/redfish_ctl/discover/cli.py
@@ -43,6 +43,10 @@ def _supports_rich(stream: TextIO) -> bool:
     Both conditions matter: ``rich`` styling is only worth using on an
     interactive terminal, and on a non-TTY (pipe/file/CI) we degrade to plain
     text so escape codes never pollute the output.
+
+    :param stream: output stream the table would be written to.
+    :return: ``True`` when ``stream`` is a TTY and ``rich`` imports, else
+        ``False``.
     """
     if not _stream_is_tty(stream):
         return False
@@ -54,7 +58,12 @@ def _supports_rich(stream: TextIO) -> bool:
 
 
 def _stream_is_tty(stream: TextIO) -> bool:
-    """Best-effort ``isatty`` check that tolerates odd stream objects."""
+    """Best-effort ``isatty`` check that tolerates odd stream objects.
+
+    :param stream: output stream to test for an ``isatty`` method.
+    :return: ``True`` only when ``stream.isatty()`` exists and returns truthy;
+        any missing method or error yields ``False``.
+    """
     isatty = getattr(stream, "isatty", None)
     if not callable(isatty):
         return False
@@ -65,7 +74,12 @@ def _stream_is_tty(stream: TextIO) -> bool:
 
 
 def _cell(record: Dict[str, Any], key: str) -> str:
-    """Stringify one record cell, rendering missing values as ``-``."""
+    """Stringify one record cell, rendering missing values as ``-``.
+
+    :param record: one discovered-service record dict.
+    :param key: record key to read the cell value from.
+    :return: the value as a string, or ``-`` when it is ``None``.
+    """
     value = record.get(key)
     return "-" if value is None else str(value)
 
@@ -77,6 +91,9 @@ def render_table(
 
     Uses ``rich`` when available on a TTY; otherwise writes a plain-text table.
     An empty result set prints a short notice rather than an empty frame.
+
+    :param services: discovered services to render.
+    :param stream: output stream; defaults to ``sys.stdout`` when ``None``.
     """
     out = stream if stream is not None else sys.stdout
     records = [svc.as_dict() for svc in services]
@@ -92,7 +109,11 @@ def render_table(
 
 
 def _render_rich(records: List[Dict[str, Any]], out: TextIO) -> None:
-    """Render with ``rich`` (only called when import + TTY checks passed)."""
+    """Render with ``rich`` (only called when import + TTY checks passed).
+
+    :param records: discovered-service record dicts to render as rows.
+    :param out: output stream the ``rich`` table is printed to.
+    """
     from rich.console import Console
     from rich.table import Table
 
@@ -106,7 +127,11 @@ def _render_rich(records: List[Dict[str, Any]], out: TextIO) -> None:
 
 
 def _render_plain(records: List[Dict[str, Any]], out: TextIO) -> None:
-    """Render a fixed-width plain-text table (no escape codes)."""
+    """Render a fixed-width plain-text table (no escape codes).
+
+    :param records: discovered-service record dicts to render as rows.
+    :param out: output stream the plain-text table is written to.
+    """
     headers = [header for header, _key in _COLUMNS]
     keys = [key for _header, key in _COLUMNS]
 
@@ -117,6 +142,11 @@ def _render_plain(records: List[Dict[str, Any]], out: TextIO) -> None:
     ]
 
     def _fmt(cells: Sequence[str]) -> str:
+        """Join cells into one row, left-padding each to its column width.
+
+        :param cells: cell strings for one row, in column order.
+        :return: the formatted, two-space-separated row line.
+        """
         return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(cells))
 
     out.write(_fmt(headers) + "\n")
@@ -131,6 +161,8 @@ async def _default_get(_ip: str) -> Optional[Dict[str, Any]]:
     Real discovery needs an operator-supplied transport/auth policy. The default
     deliberately performs no network call and holds no credentials, so running
     the CLI without wiring a fetcher is safe and inert.
+
+    :param _ip: host address (ignored; the default fetcher probes nothing).
     """
     return None
 
@@ -161,6 +193,8 @@ def make_http_fetcher(
         because BMCs ship self-signed certs; pass ``True`` behind a trusted CA.
     :param timeout: per-request timeout in seconds (default ``2.0``), bounding how
         long a single probe can hang.
+    :return: an :data:`~redfish_ctl.discover.scanner.AsyncGet` callable that GETs
+        one host's ServiceRoot and returns the parsed dict or ``None``.
 
     No credentials are sent — discovery reads only the unauthenticated service
     root. Building the fetcher opens no socket; I/O happens solely when the
@@ -169,9 +203,20 @@ def make_http_fetcher(
     url_template = f"{scheme}://{{host}}:{port}{REDFISH_ROOT_PATH}"
 
     async def _get(ip: str) -> Optional[Dict[str, Any]]:
+        """Fetch one host's ServiceRoot off the event loop.
+
+        :param ip: host address to probe.
+        :return: the parsed ServiceRoot dict, or ``None`` on any transport error
+            or non-usable response.
+        """
         url = url_template.format(host=ip)
 
         def _blocking_get() -> Optional[Dict[str, Any]]:
+            """Perform the blocking GET and validate the response.
+
+            :return: the parsed JSON object, or ``None`` when the status is not
+                ``200`` or the body is not a JSON object.
+            """
             response = requests.get(url, verify=verify_tls, timeout=timeout)
             if response.status_code != 200:
                 return None
@@ -190,7 +235,13 @@ def make_http_fetcher(
 
 
 def _parse_args(argv: Optional[Sequence[str]]) -> argparse.Namespace:
-    """Parse ``redfish-discover`` arguments."""
+    """Parse ``redfish-discover`` arguments.
+
+    :param argv: argument vector to parse (defaults to ``sys.argv[1:]`` when
+        ``None``).
+    :return: the parsed :class:`argparse.Namespace` (``hosts`` and
+        ``concurrency``).
+    """
     parser = argparse.ArgumentParser(
         prog="redfish-discover",
         description=(

--- a/redfish_ctl/discover/scanner.py
+++ b/redfish_ctl/discover/scanner.py
@@ -43,7 +43,11 @@ class DiscoveredService:
     redfish_version: Optional[str]
 
     def as_dict(self) -> Dict[str, Optional[str]]:
-        """Return the record as a plain dict (handy for rendering/serialization)."""
+        """Return the record as a plain dict (handy for rendering/serialization).
+
+        :return: dict with keys ``ip``, ``vendor``, ``product``, and
+            ``redfish_version``.
+        """
         return {
             "ip": self.ip,
             "vendor": self.vendor,
@@ -58,6 +62,12 @@ def _service_from_root(
 
     A falsy/non-mapping root means the host is not a usable Redfish service, so we
     return ``None`` and the caller drops it from the results.
+
+    :param ip: host address that produced this ServiceRoot.
+    :param service_root: parsed ``/redfish/v1/`` dict, or ``None`` when the host
+        did not answer with a usable Redfish document.
+    :return: a :class:`DiscoveredService` for a non-empty mapping root, else
+        ``None``.
     """
     if not isinstance(service_root, dict) or not service_root:
         return None
@@ -80,6 +90,12 @@ async def _probe_host(
     Any exception raised by the injected ``get`` (timeout, connection refused,
     bad TLS, non-JSON body) is swallowed so one unreachable host never fails the
     whole scan; that host is simply reported as not discovered (``None``).
+
+    :param ip: host address to probe.
+    :param get: async callable that fetches ``/redfish/v1/`` for one host.
+    :param semaphore: bounds the number of concurrent probes in flight.
+    :return: a :class:`DiscoveredService` when the host answers with a usable
+        ServiceRoot, else ``None``.
     """
     async with semaphore:
         try:


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/discover/`, compliant with the merged docstring gate (#145).

Adds/completes reST docstrings across the discover module(s). Not command modules (no register_subcommand / module-example rule). Recurring framework params documented per actual body usage (honest accepted-but-unused where applicable), verified with an AST param-usage check. Docstrings only, no behavior change.

Gates: `tools/docstring_gate.py --all` 0 violations in discover/; ruff no new findings; pytest green.