### PR TITLE
Document events command methods (docstring coverage)

### DIFF
--- a/redfish_ctl/events/cmd_event_service.py
+++ b/redfish_ctl/events/cmd_event_service.py
@@ -1,4 +1,7 @@
-"""Read EventService and subscription summary."""
+"""Read EventService and subscription summary.
+
+    redfish_ctl event-service
+"""
 from abc import abstractmethod
 from typing import Optional
 
@@ -14,33 +17,61 @@ class EventServiceQuery(RedfishManagerBase,
     """Read Redfish EventService, SSE, and subscription metadata."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the event-service command."""
         super(EventServiceQuery, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the read-only event-service subcommand."""
+        """Register the read-only event-service subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read EventService and subscription state"
         return cmd_parser, "event-service", help_text
 
     @staticmethod
     def _link(data, key):
+        """Return the ``@odata.id`` of the linked resource under ``key``.
+
+        :param data: the resource dict holding the link.
+        :param key: the property name of the link to resolve.
+        :return: the linked ``@odata.id``, or None when the link is absent.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
     @staticmethod
     def _status_value(data, key):
+        """Return a field from a resource's ``Status`` sub-object.
+
+        :param data: the resource dict holding the ``Status`` block.
+        :param key: the ``Status`` field to read (e.g. Health or State).
+        :return: the field value, or None when ``Status`` or the field is absent.
+        """
         status = (data or {}).get("Status")
         return status.get(key) if isinstance(status, dict) else None
 
     def _get(self, uri, do_async):
+        """Query a URI and return its data, swallowing errors as an empty dict.
+
+        :param uri: the Redfish resource URI to fetch.
+        :param do_async: issue the query over the async Redfish path when True.
+        :return: the response data dict, or an empty dict on any failure.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
             return {}
 
     def _subscriptions(self, uri, do_async):
+        """Summarize the Subscriptions collection at ``uri``.
+
+        :param uri: the Subscriptions collection URI, or falsy when unavailable.
+        :param do_async: issue the query over the async Redfish path when True.
+        :return: a dict with the collection ``uri``, member ``count``, and member URIs.
+        """
         if not uri:
             return {"uri": None, "count": None, "members": []}
 
@@ -65,7 +96,15 @@ class EventServiceQuery(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Read EventService state without opening or creating subscriptions."""
+        """Read EventService state without opening or creating subscriptions.
+
+        :param filename: if set, save the EventService response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the queries over the async Redfish path when True.
+        :param do_expanded: issue an expanded ($expand) EventService query when True.
+        :return: a CommandResult with the EventService and subscription summary.
+        """
         service = self.base_query(
             REDFISH_API.EventServiceQuery,
             filename=filename,

--- a/redfish_ctl/events/cmd_event_submit_test.py
+++ b/redfish_ctl/events/cmd_event_submit_test.py
@@ -29,12 +29,16 @@ class EventSubmitTest(RedfishManagerBase,
     """Submit a test event via EventService.SubmitTestEvent."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the event-submit-test command."""
         super(EventSubmitTest, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``event-submit-test`` subcommand."""
+        """Register the ``event-submit-test`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--message_id', required=False, dest='message_id', type=str,
@@ -49,7 +53,11 @@ class EventSubmitTest(RedfishManagerBase,
         return cmd_parser, "event-submit-test", "command submit a Redfish test event"
 
     def _event_service_uri(self, do_async):
-        """Resolve the EventService URI from the service root, with a standard fallback."""
+        """Resolve the EventService URI from the service root, with a standard fallback.
+
+        :param do_async: issue the service-root query over the async Redfish path when True.
+        :return: the EventService ``@odata.id``, or the standard fallback URI.
+        """
         try:
             root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
         except Exception:
@@ -72,6 +80,15 @@ class EventSubmitTest(RedfishManagerBase,
 
         REVERSIBLE per the action policy, so it executes by default; ``--dry_run``
         still shows the resolved target + payload without POSTing.
+
+        :param message_id: the MessageId placed in the test-event payload.
+        :param event_type: optional EventType added to the payload when set.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: resolve and POST over the async Redfish path when True.
+        :return: a CommandResult with the SubmitTestEvent outcome, or the dry-run preview.
         """
         payload = {"MessageId": message_id}
         if event_type:

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -22,6 +22,11 @@ from ..redfish_manager_shared import (
 
 
 def _as_list(values) -> list[str]:
+    """Normalize a value, list, or comma-string into trimmed non-empty strings.
+
+    :param values: a string, an iterable of strings, or None.
+    :return: a flat list of stripped, non-empty items (empty list when None).
+    """
     if values is None:
         return []
     raw_values = [values] if isinstance(values, str) else list(values)
@@ -39,6 +44,12 @@ class _SubscriptionBase(RedfishManagerBase):
 
     @staticmethod
     def _link(data, key):
+        """Return the ``@odata.id`` of the linked resource under ``key``.
+
+        :param data: the resource dict holding the link.
+        :param key: the property name of the link to resolve.
+        :return: the linked ``@odata.id``, or None when the link is absent.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
@@ -272,11 +283,15 @@ class SubscriptionCreate(_SubscriptionBase,
     """Create an EventDestination subscription after dry-run preview."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the subscription-create command."""
         super(SubscriptionCreate, self).__init__(*args, **kwargs)
 
     @staticmethod
     def register_subcommand(cls):
-        """Register the guarded subscription-create subcommand."""
+        """Register the guarded subscription-create subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             "--destination", required=True, dest="destination", metavar="URI",
@@ -420,7 +435,10 @@ class SubscriptionDelete(_SubscriptionBase,
 
     @staticmethod
     def register_subcommand(cls):
-        """Register the guarded subscription-delete subcommand."""
+        """Register the guarded subscription-delete subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             "--subscription", required=True, dest="subscription", metavar="ID_OR_URI",


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/events/` (event-service, event-submit-test, subscription lifecycle), compliant with the merged docstring gate (#145). Adds/completes reST docstrings; write commands (subscription create/delete, submit-test) documented with their real confirm/dry_run guards; recurring framework params documented per actual body usage (verified). Docstrings only, no behavior change. Gates: gate --all 0 in events/; ruff no new; pytest green.