### PR TITLE
Document core Redfish manager base classes (docstring coverage)

### DIFF
--- a/redfish_ctl/cmd_utils.py
+++ b/redfish_ctl/cmd_utils.py
@@ -15,6 +15,7 @@ import json
 def from_json_spec(from_spec: str):
     """read json from a file
     :param from_spec: a path to a file with json spec.
+    :return: the parsed JSON payload.
     """
     with open(from_spec) as user_file:
         file_contents = user_file.read()
@@ -23,10 +24,11 @@ def from_json_spec(from_spec: str):
 
 
 def _find_ids(obj, key, result):
-    """Recursively search all keys
-    :param obj:
-    :param key:
-    :return:
+    """Recursively collect values stored under ``key`` into ``result``.
+
+    :param obj: dict, list, or scalar value to search.
+    :param key: key whose values are collected.
+    :param result: accumulator list that matching values are appended to.
     """
     if obj is None:
         return
@@ -55,6 +57,14 @@ def find_ids(obj, key):
 
 
 def str2bool(v):
+    """Convert a string (or bool) to a boolean.
+
+    :param v: value to interpret; a bool passes through, while a string such as
+        ``yes``/``true``/``t``/``y``/``1`` maps to True and
+        ``no``/``false``/``f``/``n``/``0`` maps to False.
+    :return: the parsed boolean value.
+    :raise argparse.ArgumentTypeError: if the string is not a recognized boolean.
+    """
     if isinstance(v, bool):
         return v
     if v.lower() in ('yes', 'true', 't', 'y', '1'):

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -64,10 +64,13 @@ class RedfishManager:
         :param redfish_ip: redfish IP or hostname
         :param redfish_username: redfish username default is root
         :param redfish_password: redfish password.
+        :param redfish_port: redfish TCP port (default 443); accepts an int or str.
         :param insecure: when True (the default) TLS certificate verification is
             skipped. BMCs ship self-signed certificates, so verification is
             opt-in: pass ``insecure=False`` to verify the server certificate.
+        :param is_http: use plain HTTP instead of HTTPS for requests when True.
         :param x_auth: X-Authentication header.
+        :param is_debug: when True, include exception tracebacks in error logs.
         """
         self._redfish_ip = redfish_ip
         self._username = redfish_username
@@ -106,6 +109,10 @@ class RedfishManager:
 
     @property
     def redfish_ip(self) -> str:
+        """Redfish host, with the port appended when it is not the default 443.
+
+        :return: the IP or hostname, suffixed with ``:port`` for non-443 ports.
+        """
         if ":" in self._redfish_ip:
             return self._redfish_ip
         else:
@@ -116,21 +123,42 @@ class RedfishManager:
 
     @property
     def username(self) -> str:
+        """Redfish account username.
+
+        :return: the configured username.
+        """
         return self._username
 
     @property
     def password(self) -> str:
+        """Redfish account password.
+
+        :return: the configured password.
+        """
         return self._password
 
     @property
     def x_auth(self) -> str:
+        """X-Auth token used in place of basic authentication.
+
+        :return: the X-Auth token, or None when basic auth is used.
+        """
         return self._x_auth
 
     def authentication_header(self):
+        """Build the authentication header (placeholder; no-op in the base class)."""
         pass
 
     @staticmethod
     def redfish_error_handlers(status_code):
+        """Raise the matching Redfish exception for a non-success HTTP status.
+
+        :param status_code: the HTTP status code returned by the BMC.
+        :raise AuthenticationFailed: on 401.
+        :raise RedfishForbidden: on 403.
+        :raise RedfishMethodNotAllowed: on 405.
+        :raise RedfishNotAcceptable: on 406 or 409.
+        """
         if status_code == 401:
             raise AuthenticationFailed(
                 "Authentication failed."
@@ -215,6 +243,8 @@ class RedfishManager:
         ``REDFISH_HTTP_POOL`` (pool size), ``REDFISH_HTTP_RETRIES``,
         ``REDFISH_HTTP_BACKOFF`` (legacy ``IDRAC_HTTP_*`` still honored).
         Inherited by RedfishManagerBase.
+
+        :return: the cached keep-alive ``requests.Session``.
         """
         session = getattr(self, "_session_cache", None)
         if session is None:
@@ -331,6 +361,8 @@ class RedfishManager:
         Version, vendor, and the Systems path all live in this one document;
         a BMC round trip costs hundreds of milliseconds, so the identity
         properties below share a single fetch instead of each paying their own.
+
+        :return: the ServiceRoot document as a dict, or None if the query failed.
         """
         api_resp = self.base_query("/redfish/v1/")
         return api_resp.data if api_resp is not None else None
@@ -367,8 +399,10 @@ class RedfishManager:
 
     @staticmethod
     def select(select_property: Optional[str] = "") -> str:
-        """Return true if IDRAC version 6.0 i.e. a new version.
-        :return:
+        """Return a ``$select`` query-string fragment for the given property.
+
+        :param select_property: the Redfish property name to select.
+        :return: a query fragment of the form ``?$select=<property>``.
         """
         return f"?$select={select_property}"
 
@@ -472,6 +506,13 @@ class RedfishManager:
 
     @staticmethod
     def _redfish_error_from_payload(status_code: int, payload) -> RedfishError:
+        """Build a RedfishError from an error payload and HTTP status code.
+
+        :param status_code: the HTTP status code of the error response.
+        :param payload: the parsed error body; a dict is mined for ``code``,
+            ``message`` and extended-info entries, otherwise it is stringified.
+        :return: the populated RedfishError.
+        """
         if not isinstance(payload, dict):
             message = "" if payload is None else str(payload)
             return RedfishError(status_code, message=message)

--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -97,10 +97,14 @@ class RedfishManagerBase(RedfishManager):
         :param idrac_ip: idrac mgmt IP address
         :param idrac_username: idrac username default is root
         :param idrac_password: idrac password.
+        :param idrac_port: idrac TCP port (default 443); accepts an int or str.
         :param insecure: when True (the default) TLS certificate verification is
             skipped. iDRAC/BMC controllers present self-signed certificates, so
             verification is opt-in: pass ``insecure=False`` to verify the cert.
         :param x_auth: X-Authentication header.
+        :param is_http: use plain HTTP instead of HTTPS for requests when True.
+        :param is_debug: when True, include exception tracebacks in error logs.
+        :param log_level: logging level applied to this manager's logger.
         """
         super().__init__(redfish_ip=idrac_ip,
                          redfish_username=idrac_username,
@@ -208,18 +212,34 @@ class RedfishManagerBase(RedfishManager):
 
     @property
     def idrac_ip(self) -> str:
+        """iDRAC/BMC host address (delegates to :attr:`redfish_ip`).
+
+        :return: the IP or hostname, suffixed with ``:port`` for non-443 ports.
+        """
         return self.redfish_ip
 
     @property
     def username(self) -> str:
+        """iDRAC/BMC account username.
+
+        :return: the configured username.
+        """
         return self._username
 
     @property
     def password(self) -> str:
+        """iDRAC/BMC account password.
+
+        :return: the configured password.
+        """
         return self._password
 
     @property
     def x_auth(self) -> str:
+        """X-Auth token used in place of basic authentication.
+
+        :return: the X-Auth token, or None when basic auth is used.
+        """
         return self._x_auth
 
     def __init_subclass__(cls, scm_type=None, name=None, **kwargs):
@@ -837,7 +857,9 @@ class RedfishManagerBase(RedfishManager):
     @cached_property
     def version_api(self, data_type: Optional[str] = "json") -> bool:
         """Return true if IDRAC version 6.0 i.e. a new version.
-        :return:
+
+        :param data_type: content type to request; json or xml.
+        :return: True when the iDRAC firmware is 6.00.00.00 or newer, else False.
         """
         headers = {}
         if data_type == "json":
@@ -1259,6 +1281,14 @@ class RedfishManagerBase(RedfishManager):
             response: requests.models.Response,
             expected: Optional[int] = 200,
             ignore_error_code: Optional[int] = 0) -> RedfishApiRespond:
+        """Default post success handler. Map the response status or raise on failure.
+
+        :param response: HTTP response.
+        :param expected: status code the caller considers success.
+        :param ignore_error_code: HTTP status code to treat as success.
+        :return: RedfishApiRespond mapped from the response status.
+        :raise RedfishException: if the response reports a failure status.
+        """
         return self.read_api_respond(
             response, expected=expected, ignore_error_code=ignore_error_code
         )
@@ -1570,6 +1600,10 @@ class RedfishManagerBase(RedfishManager):
         off a Manager. Check every Manager first, then the host System, returning
         the first that advertises a VirtualMedia link. Falls back to the Dell
         ``{system}/VirtualMedia`` subpath so existing Dell behavior is unchanged.
+
+        :param do_async: issue the underlying queries asynchronously when True.
+        :return: the VirtualMedia collection URI.
+        :raise ResourceNotFound: if no VirtualMedia collection can be resolved.
         """
         # Managers first for iLO/Supermicro/OpenBMC; keep the historical Dell
         # System.Embedded.1 preference when both System and Manager advertise it.
@@ -1615,6 +1649,9 @@ class RedfishManagerBase(RedfishManager):
 
         Unlike the short-name discovery map, this does NOT collapse two actions
         that share a short name, so an exact full-type lookup is unambiguous.
+
+        :param resource: the parsed Redfish resource whose ``Actions`` block is read.
+        :return: a dict mapping each action full type to its target URL.
         """
         out = {}
         actions = (resource or {}).get("Actions") or {}
@@ -1633,7 +1670,16 @@ class RedfishManagerBase(RedfishManager):
     def _validate_action_payload(full_action_type: str,
                                  action: Optional[RedfishAction],
                                  payload: dict) -> list[dict]:
-        """Validate action payload keys/enum values when action metadata is available."""
+        """Validate action payload keys/enum values when action metadata is available.
+
+        :param full_action_type: the fully-qualified action type used to look up
+            parameter metadata from the CSDL when the action has no inline args.
+        :param action: the discovered RedfishAction (its inline ``args`` win over
+            CSDL metadata), or None.
+        :param payload: the action payload whose keys and values are checked.
+        :return: a list of error dicts (one per offending parameter); empty when
+            no metadata is available or every value is allowed.
+        """
         inline_args = getattr(action, "args", None) or {}
         if inline_args:
             strict_names = False
@@ -1971,6 +2017,9 @@ class RedfishManagerBase(RedfishManager):
 
         Tolerates a non-list / malformed payload (returns ``[]``) and skips
         members without a string id, so a partial response never raises.
+
+        :param members: the ``Members`` list from a Redfish collection.
+        :return: the list of ``@odata.id`` strings (empty on a malformed payload).
         """
         if not isinstance(members, list):
             return []
@@ -1986,6 +2035,8 @@ class RedfishManagerBase(RedfishManager):
         Systems collection so callers can pick the right one: e.g. a Supermicro
         GB300 exposes ``/redfish/v1/Systems/System_0`` (host) and
         ``/redfish/v1/Systems/HGX_Baseboard_0`` (NVIDIA GPU baseboard).
+
+        :return: the list of ComputerSystem ``@odata.id`` paths.
         """
         cmd_result = self.base_query(RedfishApi.Systems, key=REDFISH_JSON.Members)
         return self._member_ids(cmd_result.data)
@@ -1995,6 +2046,8 @@ class RedfishManagerBase(RedfishManager):
 
         Companion to :meth:`discover_computer_system_ids` for boxes with more
         than one BMC; ``idrac_members`` only yields a single (last) manager.
+
+        :return: the list of Manager ``@odata.id`` paths.
         """
         cmd_result = self.base_query(RedfishApi.Managers, key=REDFISH_JSON.Members)
         return self._member_ids(cmd_result.data)
@@ -2005,6 +2058,9 @@ class RedfishManagerBase(RedfishManager):
         The host exposes a ``Bios``/``Boot`` link (where boot/bios/storage live);
         on a split-topology box the others are baseboards (e.g. the NVIDIA HGX
         baseboard carries GPUs but no Bios). Returns "" if undecidable.
+
+        :param system_ids: candidate ComputerSystem ids to probe.
+        :return: the id exposing a Bios/Boot link, or "" if none qualifies.
         """
         for sid in system_ids:
             try:
@@ -2032,6 +2088,8 @@ class RedfishManagerBase(RedfishManager):
         when /redfish/v1/Systems has more than one member we prefer the host
         system -- the one exposing a Bios/Boot link. Single-system hosts (Dell)
         and hosts without a reachable Systems collection keep the original result.
+
+        :return: the managed host ComputerSystem path (empty string if unresolved).
         """
         resolved = ""
         api_resp = self.base_query(self.idrac_members, key=REDFISH_JSON.Links)
@@ -2222,7 +2280,9 @@ class RedfishManagerBase(RedfishManager):
 
        :param start_date: start date for a job YYYY-MM-DD
        :param start_time: a start time for a job HH:MM:SS
-       :param is_json_string return python string or JSON string.
+       :param is_json_string: return a JSON string when True, else a plain string.
+       :return: the future timestamp in ISO 8601 format (JSON-encoded when
+           ``is_json_string`` is True).
        :raise: MissingMandatoryArguments if mandatory args missing.
        :raise: InvalidArgumentFormat if format of the input is invalid.
        """
@@ -2261,10 +2321,12 @@ class RedfishManagerBase(RedfishManager):
         """
         The settings apply time and operation apply time annotations
         enable an operation to be performed during a maintenance window
-        :param start_date a date as string
-        :param start_time a start time for a future job
-        :param default_duration a duration
-        :param apply time auto-boot, maintenance, on-reset
+        :param apply: apply-time selector: auto-boot, maintenance, or on-reset.
+        :param start_date: a date as string
+        :param start_time: a start time for a future job
+        :param default_duration: a duration
+        :return: the settings apply-time request payload built by
+            :meth:`schedule_job_request`.
         :raise InvalidArgumentFormat will raise in case we can't parse args
         :raise ValueError if unknown apply type
         """


### PR DESCRIPTION
Docstring-coverage PR for the core base files `redfish_manager.py`, `redfish_manager_base.py`, `cmd_utils.py`, compliant with the merged docstring gate (#145). 31 members documented (property getters get summary+:return:; the two __init__ get their missing :param lines; helpers get full tags). version_api/discover_virtual_media_uri params documented per actual body usage. One copy-paste `select()` summary corrected while completing it. Docstrings only, no behavior change. Gates: gate --all 0 for the three files; ruff no new; pytest green.