### PR TITLE
Document telemetry command + tracing/otlp methods (docstring coverage)

### DIFF
--- a/redfish_ctl/telemetry/cmd_exporter.py
+++ b/redfish_ctl/telemetry/cmd_exporter.py
@@ -34,12 +34,16 @@ class Exporter(RedfishManagerBase,
     """Read BMC telemetry and expose Prometheus or SignalFx metric output."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the exporter command."""
         super(Exporter, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``exporter`` subcommand."""
+        """Register the ``exporter`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser(is_file_save=False)
         cmd_parser.add_argument(
             "--listen", default="0.0.0.0", type=str,
@@ -91,14 +95,23 @@ class Exporter(RedfishManagerBase,
 
     @staticmethod
     def _members(data):
-        """Return @odata.id strings from a Redfish collection."""
+        """Return @odata.id strings from a Redfish collection.
+
+        :param data: parsed Redfish collection resource, or any value.
+        :return: list of member @odata.id strings; empty when data is not a collection.
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
                 if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 
     def _invoke_rows(self, api_type: ApiRequestType, name: str, **kwargs) -> list:
-        """Invoke another read-only command and tolerate absent resources."""
+        """Invoke another read-only command and tolerate absent resources.
+
+        :param api_type: ApiRequestType of the command to invoke.
+        :param name: registered name of the command to invoke.
+        :return: the command's list payload, or an empty list on error or non-list data.
+        """
         try:
             result = self.sync_invoke(api_type, name, **kwargs)
         except Exception:
@@ -106,7 +119,12 @@ class Exporter(RedfishManagerBase,
         return result.data if isinstance(result.data, list) else []
 
     def _invoke_dict(self, api_type: ApiRequestType, name: str, **kwargs) -> dict:
-        """Invoke another read-only command that returns an object payload."""
+        """Invoke another read-only command that returns an object payload.
+
+        :param api_type: ApiRequestType of the command to invoke.
+        :param name: registered name of the command to invoke.
+        :return: the command's dict payload, or an empty dict on error or non-dict data.
+        """
         try:
             result = self.sync_invoke(api_type, name, **kwargs)
         except Exception:
@@ -114,7 +132,11 @@ class Exporter(RedfishManagerBase,
         return result.data if isinstance(result.data, dict) else {}
 
     def _leak_detection_rows(self, do_async: bool = False) -> list[dict]:
-        """Return LeakDetector rows from the read-only leak-detectors command."""
+        """Return LeakDetector rows from the read-only leak-detectors command.
+
+        :param do_async: when True, issue the underlying query asynchronously.
+        :return: list of leak-detector rows; empty when none are exposed.
+        """
         data = self._invoke_dict(
             ApiRequestType.LeakDetectors,
             "leak-detectors",
@@ -124,7 +146,11 @@ class Exporter(RedfishManagerBase,
         return detectors if isinstance(detectors, list) else []
 
     def _environment_rows(self, do_async: bool = False) -> list[dict]:
-        """Walk Chassis EnvironmentMetrics links and return their payloads."""
+        """Walk Chassis EnvironmentMetrics links and return their payloads.
+
+        :param do_async: when True, issue the Redfish queries asynchronously.
+        :return: list of EnvironmentMetrics payloads, one per chassis that exposes them.
+        """
         rows = []
         try:
             chassis = self.base_query(REDFISH_API.Chassis, do_async=do_async).data or {}
@@ -148,7 +174,12 @@ class Exporter(RedfishManagerBase,
         return rows
 
     def _thermal_rows(self, do_async: bool = False, do_expanded: bool = False) -> list[dict]:
-        """Return temperature readings from the read-only thermal command."""
+        """Return temperature readings from the read-only thermal command.
+
+        :param do_async: when True, issue the underlying query asynchronously.
+        :param do_expanded: when True, issue an expanded ($expand) query.
+        :return: list of temperature-reading rows; empty when none are exposed.
+        """
         try:
             result = self.sync_invoke(
                 ApiRequestType.Thermal, "thermal",
@@ -162,7 +193,14 @@ class Exporter(RedfishManagerBase,
         return [row for row in rows if isinstance(row, dict)]
 
     def _environment_command_rows(self, do_async: bool = False) -> list[dict]:
-        """Return normalized rows from the environment-metrics command."""
+        """Return normalized rows from the environment-metrics command.
+
+        Falls back to walking Chassis EnvironmentMetrics links directly when the
+        command is unavailable or returns an unexpected payload.
+
+        :param do_async: when True, issue the underlying queries asynchronously.
+        :return: list of environment-metric rows; empty when none are exposed.
+        """
         try:
             result = self.sync_invoke(
                 ApiRequestType.EnvironmentMetrics,
@@ -179,7 +217,11 @@ class Exporter(RedfishManagerBase,
         return self._environment_rows(do_async=do_async)
 
     def _vendor_label(self, vendor: Optional[str]) -> str:
-        """Return a stable lower-case vendor label."""
+        """Return a stable lower-case vendor label.
+
+        :param vendor: explicit vendor override; when falsy the vendor is auto-detected.
+        :return: the vendor label, or ``"unknown"`` when neither is available.
+        """
         if vendor:
             return vendor
         try:
@@ -193,7 +235,15 @@ class Exporter(RedfishManagerBase,
                         vendor: Optional[str] = None,
                         do_async: bool = False,
                         do_expanded: bool = False) -> list:
-        """Scrape all supported read-only telemetry paths and build samples."""
+        """Scrape all supported read-only telemetry paths and build samples.
+
+        :param label_bmc_ip: BMC IP used only for metric dimensions; defaults to the
+            configured BMC address.
+        :param vendor: vendor dimension override; auto-detected when None.
+        :param do_async: when True, issue the Redfish queries asynchronously.
+        :param do_expanded: when True, issue expanded ($expand) queries.
+        :return: list of MetricSample objects, including the scrape-health samples.
+        """
         started_at = exporter.time.monotonic()
         identity = build_identity_dimensions(
             label_bmc_ip or self.idrac_ip,
@@ -249,7 +299,32 @@ class Exporter(RedfishManagerBase,
                 otlp_endpoint: Optional[str] = None,
                 otlp_protocol: Optional[str] = None,
                 **kwargs) -> CommandResult:
-        """Scrape once, serve Prometheus, or push SignalFx/OTLP datapoints."""
+        """Scrape once, serve Prometheus, or push SignalFx/OTLP datapoints.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: when True, issue the Redfish scrape queries asynchronously.
+        :param do_expanded: when True, issue expanded ($expand) scrape queries.
+        :param listen: address for the Prometheus /metrics listener.
+        :param port: port for the Prometheus /metrics listener.
+        :param interval: scrape interval in seconds for the long-running push/serve loops.
+        :param once: scrape a single time and return the rendered output instead of serving.
+        :param exporter_output: output format — ``prometheus``, ``signalfx``, or ``otlp``.
+        :param label_bmc_ip: BMC IP used only for metric dimensions when it differs from the
+            configured address.
+        :param vendor: vendor dimension override; auto-detected when None.
+        :param push_signalfx: when True, push SignalFx datapoints instead of serving Prometheus.
+        :param signalfx_ingest_url: SignalFx ingest URL; resolved from the environment when None.
+        :param signalfx_token_env: environment variable holding the SignalFx ingest token.
+        :param otlp_endpoint: OTLP collector endpoint for ``--output otlp``; resolved from
+            OTEL_* env when None.
+        :param otlp_protocol: OTLP transport (``grpc`` or ``http/protobuf``); resolved from
+            OTEL_* env when None.
+        :return: on ``once``, a CommandResult wrapping the rendered/pushed output and a
+            sample-count summary; a CommandResult with empty payload when serving or looping
+            forever.
+        """
         if exporter_output == "otlp":
             from . import otlp
             if once:
@@ -261,6 +336,10 @@ class Exporter(RedfishManagerBase,
                     {"sample_count": len(samples), "export_result": str(result)}, None)
 
             def scrape_samples():
+                """Scrape one round of telemetry samples for the OTLP loop.
+
+                :return: list of MetricSample objects for the current scrape.
+                """
                 return self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
 
             otlp.run_otlp_loop(
@@ -294,12 +373,20 @@ class Exporter(RedfishManagerBase,
             ingest_url = resolve_signalfx_ingest_url(signalfx_ingest_url)
 
             def scrape_samples():
+                """Scrape one round of telemetry samples for the SignalFx loop.
+
+                :return: list of MetricSample objects for the current scrape.
+                """
                 return self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
 
             run_signalfx_loop(scrape_samples, token, ingest_url, float(interval or 30.0))
             return CommandResult(None, None, None, None)
 
         def scrape_text():
+            """Scrape samples and render them as Prometheus exposition text.
+
+            :return: the rendered Prometheus /metrics text for the current scrape.
+            """
             samples = self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
             return render_prometheus_text(samples)
 

--- a/redfish_ctl/telemetry/cmd_metric_definitions.py
+++ b/redfish_ctl/telemetry/cmd_metric_definitions.py
@@ -30,19 +30,27 @@ class MetricDefinitions(RedfishManagerBase,
     """Read every TelemetryService MetricReportDefinition (the report schemas)."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the metric-definitions command."""
         super(MetricDefinitions, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``metric-definitions`` subcommand (read-only)."""
+        """Register the ``metric-definitions`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read TelemetryService metric report definitions"
         return cmd_parser, "metric-definitions", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: parsed Redfish collection resource, or any value.
+        :return: list of member @odata.id strings; empty when data is not a collection.
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
@@ -60,6 +68,13 @@ class MetricDefinitions(RedfishManagerBase,
         Tolerant of a host without TelemetryService or the definitions link
         (returns an empty list). ``MetricProperties`` is the list of metric URIs
         the report publishes; its length is the report's metric count.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: when True, issue the Redfish queries asynchronously.
+        :param do_expanded: when True, issue an expanded ($expand) query for the collection.
+        :return: CommandResult wrapping the list of metric-definition summary rows.
         """
         rows = []
         defs_uri = f"{RedfishApi.Version}/TelemetryService/MetricReportDefinitions"

--- a/redfish_ctl/telemetry/cmd_metric_reports.py
+++ b/redfish_ctl/telemetry/cmd_metric_reports.py
@@ -32,12 +32,16 @@ class MetricReports(RedfishManagerBase,
     """Read every Redfish TelemetryService MetricReport (platform + accelerator OOB metrics)."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the metric-reports command."""
         super(MetricReports, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``metric-reports`` subcommand and its one optional filter."""
+        """Register the ``metric-reports`` subcommand and its one optional filter.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--report', required=False, dest="report", default=None, type=str,
@@ -47,7 +51,11 @@ class MetricReports(RedfishManagerBase,
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: parsed Redfish collection resource, or any value.
+        :return: list of member @odata.id strings; empty when data is not a collection.
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
@@ -67,6 +75,15 @@ class MetricReports(RedfishManagerBase,
         non-dict sample (each is skipped). ``report`` narrows to reports whose id
         contains that substring (case-insensitive) — e.g. ``ProcessorMetrics`` to
         scope to GPU/CPU processor telemetry on an HGX baseboard.
+
+        :param report: if set, keep only reports whose id contains this substring
+            (case-insensitive); None returns every report.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: when True, issue the Redfish queries asynchronously.
+        :param do_expanded: when True, issue an expanded ($expand) query for the collection.
+        :return: CommandResult wrapping the flattened metric-value rows.
         """
         rows = []
         reports_uri = f"{RedfishApi.Version}/TelemetryService/MetricReports"

--- a/redfish_ctl/telemetry/cmd_telemetry_triggers.py
+++ b/redfish_ctl/telemetry/cmd_telemetry_triggers.py
@@ -25,19 +25,27 @@ class TelemetryTriggers(RedfishManagerBase,
     """Read every TelemetryService Trigger (metric alert threshold)."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the telemetry-triggers command."""
         super(TelemetryTriggers, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``telemetry-triggers`` subcommand (read-only)."""
+        """Register the ``telemetry-triggers`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read TelemetryService triggers (metric alert thresholds)"
         return cmd_parser, "telemetry-triggers", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: parsed Redfish collection resource, or any value.
+        :return: list of member @odata.id strings; empty when data is not a collection.
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
@@ -50,7 +58,15 @@ class TelemetryTriggers(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Walk the Triggers collection and summarize each trigger."""
+        """Walk the Triggers collection and summarize each trigger.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: when True, issue the Redfish queries asynchronously.
+        :param do_expanded: when True, issue an expanded ($expand) query for the collection.
+        :return: CommandResult wrapping the list of trigger summary rows.
+        """
         rows = []
         triggers_uri = f"{RedfishApi.Version}/TelemetryService/Triggers"
         try:

--- a/redfish_ctl/telemetry/otlp.py
+++ b/redfish_ctl/telemetry/otlp.py
@@ -40,7 +40,11 @@ _MISSING_SDK_MSG = (
 
 
 def is_monotonic_counter(metric_name: str) -> bool:
-    """True when ``metric_name`` is a cumulative counter that should be an OTLP Sum."""
+    """True when ``metric_name`` is a cumulative counter that should be an OTLP Sum.
+
+    :param metric_name: the metric name to classify.
+    :return: True for a monotonic cumulative counter, False for a gauge.
+    """
     if metric_name in _COUNTER_EXACT:
         return True
     return any(metric_name.endswith(sfx) for sfx in _COUNTER_SUFFIXES)
@@ -53,6 +57,11 @@ def resolve_otlp_config(endpoint: Optional[str] = None,
 
     Metric-signal-specific vars win over the generic ones, matching the OTel spec
     so redfish_ctl behaves like every other OTLP producer in the pipeline.
+
+    :param endpoint: explicit OTLP endpoint; falls back to OTEL_* env when None.
+    :param protocol: explicit OTLP transport; falls back to OTEL_* env, else ``grpc``.
+    :param headers: explicit OTLP headers; falls back to OTEL_* env when None.
+    :return: tuple of (endpoint, protocol, headers) after resolution.
     """
     endpoint = (endpoint
                 or os.environ.get("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
@@ -68,7 +77,12 @@ def resolve_otlp_config(endpoint: Optional[str] = None,
 
 
 def _resource_attrs(samples, service_name: str) -> dict:
-    """Pull the shared identity dims off the samples for the OTel Resource."""
+    """Pull the shared identity dims off the samples for the OTel Resource.
+
+    :param samples: iterable of MetricSample objects to read identity dims from.
+    :param service_name: value for the ``service.name`` resource attribute.
+    :return: dict of OTel resource attributes.
+    """
     attrs = {"service.name": service_name}
     for sample in samples:
         for key in RESOURCE_DIM_KEYS:
@@ -79,7 +93,15 @@ def _resource_attrs(samples, service_name: str) -> dict:
 
 def metrics_data_from_samples(samples: Iterable, service_name: str = "redfish_ctl",
                               timestamp_ns: Optional[int] = None):
-    """Build an OTLP ``MetricsData`` from exporter ``MetricSample``s (lazy SDK import)."""
+    """Build an OTLP ``MetricsData`` from exporter ``MetricSample``s (lazy SDK import).
+
+    :param samples: iterable of exporter MetricSample objects.
+    :param service_name: value for the ``service.name`` resource attribute.
+    :param timestamp_ns: unix nanosecond timestamp for every datapoint; ``time.time_ns()``
+        when None.
+    :return: an OTLP ``MetricsData`` grouping the samples into Sum/Gauge metrics.
+    :raises RuntimeError: when the OpenTelemetry SDK is not installed.
+    """
     try:
         from opentelemetry.sdk.metrics.export import (
             AggregationTemporality,
@@ -133,7 +155,14 @@ def metrics_data_from_samples(samples: Iterable, service_name: str = "redfish_ct
 
 
 def _build_exporter(endpoint: Optional[str], protocol: str, headers: Optional[str]):
-    """Construct the grpc or http OTLP metric exporter (lazy import)."""
+    """Construct the grpc or http OTLP metric exporter (lazy import).
+
+    :param endpoint: OTLP endpoint passed to the exporter; omitted when None.
+    :param protocol: transport selector; ``http*`` picks the HTTP exporter, else grpc.
+    :param headers: OTLP headers passed to the exporter; omitted when None.
+    :return: a configured OTLPMetricExporter instance.
+    :raises RuntimeError: when the OpenTelemetry SDK/exporter is not installed.
+    """
     kwargs: dict = {}
     if endpoint:
         kwargs["endpoint"] = endpoint
@@ -156,7 +185,15 @@ def _build_exporter(endpoint: Optional[str], protocol: str, headers: Optional[st
 def push_otlp(samples: Iterable, service_name: str = "redfish_ctl",
               endpoint: Optional[str] = None, protocol: Optional[str] = None,
               headers: Optional[str] = None):
-    """Build OTLP metrics from samples and export them once. Returns the export result."""
+    """Build OTLP metrics from samples and export them once. Returns the export result.
+
+    :param samples: iterable of exporter MetricSample objects to export.
+    :param service_name: value for the ``service.name`` resource attribute.
+    :param endpoint: OTLP endpoint; resolved from OTEL_* env when None.
+    :param protocol: OTLP transport; resolved from OTEL_* env, else ``grpc``.
+    :param headers: OTLP headers; resolved from OTEL_* env when None.
+    :return: the exporter's ``MetricExportResult`` from the single export call.
+    """
     endpoint, protocol, headers = resolve_otlp_config(endpoint, protocol, headers)
     metrics_data = metrics_data_from_samples(samples, service_name)
     exporter = _build_exporter(endpoint, protocol, headers)
@@ -170,7 +207,16 @@ def run_otlp_loop(scrape_samples: Callable[[], Iterable], interval: float,
                   service_name: str = "redfish_ctl", endpoint: Optional[str] = None,
                   protocol: Optional[str] = None, headers: Optional[str] = None,
                   sleep: Callable[[float], None] = time.sleep) -> None:  # pragma: no cover
-    """Scrape and push OTLP on a fixed interval until interrupted."""
+    """Scrape and push OTLP on a fixed interval until interrupted.
+
+    :param scrape_samples: callable returning a fresh iterable of MetricSample per scrape.
+    :param interval: seconds between scrapes; clamped to a minimum of 1 second.
+    :param service_name: value for the ``service.name`` resource attribute.
+    :param endpoint: OTLP endpoint; resolved from OTEL_* env when None.
+    :param protocol: OTLP transport; resolved from OTEL_* env, else ``grpc``.
+    :param headers: OTLP headers; resolved from OTEL_* env when None.
+    :param sleep: sleep function between scrapes (injectable for testing).
+    """
     endpoint, protocol, headers = resolve_otlp_config(endpoint, protocol, headers)
     exporter = _build_exporter(endpoint, protocol, headers)
     try:

--- a/redfish_ctl/telemetry/tracing.py
+++ b/redfish_ctl/telemetry/tracing.py
@@ -33,7 +33,10 @@ BMC_PEER_SERVICE = "bmc"
 
 
 def enable_tracing(tracer: Any) -> None:
-    """Turn tracing on with a ready OpenTelemetry tracer (or off with None)."""
+    """Turn tracing on with a ready OpenTelemetry tracer (or off with None).
+
+    :param tracer: an OpenTelemetry tracer to install, or None to disable tracing.
+    """
     global _TRACER
     _TRACER = tracer
 
@@ -49,6 +52,10 @@ def setup_otlp(service_name: str = "redfish-ctl") -> None:
     Requires the OpenTelemetry SDK + OTLP exporter (the ``[otlp]`` extra);
     raises a clear error otherwise. ``service.name`` becomes the APM service
     map node.
+
+    :param service_name: value for the ``service.name`` resource attribute (the APM
+        service-map node name).
+    :raises RuntimeError: when the OpenTelemetry SDK or an OTLP exporter is not installed.
     """
     try:
         from opentelemetry.sdk.resources import Resource
@@ -85,13 +92,19 @@ def disable_tracing() -> None:
 
 
 def is_enabled() -> bool:
-    """True when a tracer is installed."""
+    """True when a tracer is installed.
+
+    :return: True when tracing is on, False when every helper no-ops.
+    """
     return _TRACER is not None
 
 
 @contextlib.contextmanager
 def operation_span(name: str) -> Iterator[Any]:
-    """Root/parent span for one command operation. No-op when tracing is off."""
+    """Root/parent span for one command operation. No-op when tracing is off.
+
+    :param name: span name, typically the command being executed.
+    """
     if _TRACER is None:
         yield None
         return
@@ -106,6 +119,9 @@ def client_span(url: str, method: str) -> Iterator[Any]:
     """CLIENT span for one BMC HTTP call. No-op when tracing is off.
 
     The BMC becomes an inferred downstream service via ``peer.service``.
+
+    :param url: BMC request URL; its hostname becomes ``server.address``.
+    :param method: HTTP method for the call (``http.request.method``).
     """
     if _TRACER is None:
         yield None
@@ -124,7 +140,11 @@ def client_span(url: str, method: str) -> Iterator[Any]:
 
 
 def record_response(span: Any, status_code: Optional[int]) -> None:
-    """Attach the HTTP status to a CLIENT span; mark ERROR on a 4xx/5xx."""
+    """Attach the HTTP status to a CLIENT span; mark ERROR on a 4xx/5xx.
+
+    :param span: the CLIENT span to annotate, or None to no-op.
+    :param status_code: HTTP response status code, or None to no-op.
+    """
     if span is None or status_code is None:
         return
     from opentelemetry.trace import Status, StatusCode
@@ -136,7 +156,11 @@ def record_response(span: Any, status_code: Optional[int]) -> None:
 
 
 def record_exception(span: Any, exc: BaseException) -> None:
-    """Mark a span failed from a transport exception (timeout, connect error)."""
+    """Mark a span failed from a transport exception (timeout, connect error).
+
+    :param span: the span to annotate, or None to no-op.
+    :param exc: the transport exception to record on the span.
+    """
     if span is None:
         return
     from opentelemetry.trace import Status, StatusCode
@@ -147,7 +171,11 @@ def record_exception(span: Any, exc: BaseException) -> None:
 
 
 def record_result(span: Any, result: Any) -> None:
-    """Mark an operation span failed when its CommandResult carries an error."""
+    """Mark an operation span failed when its CommandResult carries an error.
+
+    :param span: the operation span to annotate, or None to no-op.
+    :param result: a CommandResult whose ``error`` attribute, when set, marks the span failed.
+    """
     if span is None:
         return
     error = getattr(result, "error", None)


### PR DESCRIPTION
Docstring-coverage PR for the remaining `redfish_ctl/telemetry/` files (cmd_exporter, tracing, otlp, cmd_telemetry_triggers, cmd_metric_reports, cmd_metric_definitions), compliant with the merged docstring gate (#145). 42 members documented; recurring framework params documented per actual body usage (filename/data_type/verbose accepted-but-unused on the metric execute methods, verified). Docstrings only, no behavior change. Gates: gate --all 0 for these files; ruff no new; pytest green.