### PR TITLE
Document vendors methods (docstring coverage)

### DIFF
--- a/redfish_ctl/vendors/__init__.py
+++ b/redfish_ctl/vendors/__init__.py
@@ -27,7 +27,13 @@ from .supermicro import capabilities as _supermicro  # noqa: F401
 
 def capabilities_for_service_root(
         service_root: Optional[Mapping[str, Any]]) -> VendorCapabilities:
-    """Return the capability profile for a parsed Redfish ServiceRoot."""
+    """Return the capability profile for a parsed Redfish ServiceRoot.
+
+    :param service_root: parsed Redfish ServiceRoot mapping used to classify the
+        vendor; may be ``None``.
+    :return: the matching :class:`VendorCapabilities` profile, or the generic
+        profile when the vendor cannot be classified.
+    """
     return get_vendor(classify_vendor(service_root))
 
 

--- a/redfish_ctl/vendors/base.py
+++ b/redfish_ctl/vendors/base.py
@@ -47,10 +47,15 @@ class VendorCapabilities:
     evidence: Mapping[str, str] = field(default_factory=dict, compare=False, hash=False)
 
     def __post_init__(self):
+        """Freeze the ``evidence`` mapping into a read-only proxy."""
         object.__setattr__(self, "evidence", MappingProxyType(dict(self.evidence)))
 
     def to_dict(self) -> Dict[str, object]:
-        """Return a JSON-ready representation of the capability profile."""
+        """Return a JSON-ready representation of the capability profile.
+
+        :return: a dict mapping capability field names to their values, safe to
+            serialize as JSON.
+        """
         return {
             "vendor": self.vendor,
             "oem_prefix": self.oem_prefix,
@@ -72,20 +77,34 @@ _REGISTRY: Dict[str, VendorCapabilities] = {}
 
 
 def register(caps: VendorCapabilities) -> VendorCapabilities:
-    """Register a vendor capability profile (idempotent)."""
+    """Register a vendor capability profile (idempotent).
+
+    :param caps: the capability profile to store, keyed by ``caps.vendor``.
+    :return: the same profile that was registered.
+    """
     _REGISTRY[caps.vendor] = caps
     return caps
 
 
 def get(vendor: Optional[str]) -> VendorCapabilities:
-    """Return the profile for ``vendor``, or the generic profile if unknown."""
+    """Return the profile for ``vendor``, or the generic profile if unknown.
+
+    :param vendor: vendor name to look up (case-insensitive); ``None`` yields the
+        generic profile.
+    :return: the registered :class:`VendorCapabilities` profile, or ``GENERIC``
+        when the vendor is ``None`` or not registered.
+    """
     if vendor is None:
         return GENERIC
     return _REGISTRY.get(vendor.lower(), GENERIC)
 
 
 def all_vendors() -> Dict[str, VendorCapabilities]:
-    """A copy of the registry."""
+    """Return a copy of the registry.
+
+    :return: a new dict mapping vendor name to its :class:`VendorCapabilities`
+        profile.
+    """
     return dict(_REGISTRY)
 
 

--- a/redfish_ctl/vendors/cmd_capability_report.py
+++ b/redfish_ctl/vendors/cmd_capability_report.py
@@ -1,4 +1,10 @@
-"""Export registered vendor capability profiles."""
+"""Export registered vendor capability profiles.
+
+Emits the local vendor capability profiles as machine-readable data; needs no
+BMC access.
+
+    redfish_ctl capability-report --vendor dell
+"""
 
 from abc import abstractmethod
 from typing import Optional
@@ -17,12 +23,16 @@ class CapabilityReport(RedfishManagerBase,
     """Emit local vendor capability profiles as machine-readable data."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the capability-report command."""
         super(CapabilityReport, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the local capability-report subcommand."""
+        """Register the local capability-report subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser(is_async=False, is_expanded=False)
         cmd_parser.add_argument(
             "--vendor",
@@ -44,7 +54,17 @@ class CapabilityReport(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Return registered vendor capability profiles without BMC access."""
+        """Return registered vendor capability profiles without BMC access.
+
+        :param vendor: if set, limit the report to this one vendor profile;
+            when ``None``, include every registered vendor.
+        :param filename: if set, save the response to this file.
+        :param data_type: data format used when saving; json, yaml, xml, etc.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: a :class:`CommandResult` whose data is the capability report dict.
+        """
         data = capability_report(vendor)
         save_if_needed(filename, data, data_format=data_type)
         return CommandResult(data, None, None, None)

--- a/redfish_ctl/vendors/report.py
+++ b/redfish_ctl/vendors/report.py
@@ -8,7 +8,13 @@ REPORT_SCHEMA = "redfish_ctl.capability_report.v1"
 
 
 def capability_report(vendor: Optional[str] = None) -> dict:
-    """Return registered vendor capability profiles for IaC consumers."""
+    """Return registered vendor capability profiles for IaC consumers.
+
+    :param vendor: if set, limit the report to this one vendor profile; when
+        ``None`` or empty, include every registered vendor.
+    :return: a dict with the report ``schema``, a ``summary`` vendor count, and a
+        ``vendors`` map of vendor name to its profile dict.
+    """
     if vendor:
         caps = get(vendor)
         vendors = {caps.vendor: caps.to_dict()}


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/vendors/` (vendors (vendor capability report)), compliant with the merged docstring gate (#145). Adds/completes reST docstrings; recurring framework params documented per actual body usage (accepted-but-unused where the execute body ignores them, verified with an AST param-usage check). Docstrings only, no behavior change. Gates: gate --all 0 in vendors/; ruff no new findings; pytest green.