### PR TITLE
Document top-level Redfish infra helpers (docstring coverage)

### DIFF
--- a/redfish_ctl/fixtures_catalog.py
+++ b/redfish_ctl/fixtures_catalog.py
@@ -30,6 +30,13 @@ class FixtureSet:
 
     @classmethod
     def from_mapping(cls, data: dict[str, Any]) -> "FixtureSet":
+        """Build a :class:`FixtureSet` from a manifest mapping.
+
+        :param data: one fixture-set entry from the catalog manifest.
+        :return: the validated fixture set.
+        :raises CatalogError: if required fields are missing, the status is
+            invalid, a pending set lacks a reason, or ``oem_types`` is not a list.
+        """
         required = ("key", "vendor", "generation", "path", "status")
         missing = [field for field in required if not data.get(field)]
         if missing:
@@ -59,10 +66,22 @@ class FixtureSet:
         )
 
     def resolve_path(self, repo_root: Path | None = None) -> Path:
+        """Resolve this set's path to an absolute filesystem path.
+
+        :param repo_root: repository root to resolve against; defaults to the
+            package's repository root.
+        :return: the absolute path to the fixture-set directory.
+        """
         base = repo_root or REPO_ROOT
         return (base / self.path).resolve()
 
     def json_file_count(self, repo_root: Path | None = None) -> int:
+        """Count the JSON files under this set's resolved path.
+
+        :param repo_root: repository root to resolve against; defaults to the
+            package's repository root.
+        :return: number of ``*.json`` files found, or 0 when the path is absent.
+        """
         root = self.resolve_path(repo_root)
         if not root.exists():
             return 0
@@ -70,10 +89,18 @@ class FixtureSet:
 
     @property
     def is_active(self) -> bool:
+        """Whether this fixture set is marked active.
+
+        :return: True when the status is ``active``.
+        """
         return self.status == "active"
 
     @property
     def is_pending(self) -> bool:
+        """Whether this fixture set is marked pending.
+
+        :return: True when the status is ``pending``.
+        """
         return self.status == "pending"
 
 
@@ -85,6 +112,14 @@ class FixtureCatalog:
 
     @classmethod
     def from_manifest(cls, manifest_path: Path = DEFAULT_MANIFEST) -> "FixtureCatalog":
+        """Load and validate a fixture catalog from a manifest file.
+
+        :param manifest_path: path to the catalog manifest JSON.
+        :return: the parsed catalog.
+        :raises CatalogError: if the manifest cannot be read, is not valid JSON,
+            has an unexpected schema version, lacks a ``sets`` list, or contains
+            a duplicate fixture-set key.
+        """
         try:
             raw = json.loads(manifest_path.read_text(encoding="utf-8"))
         except OSError as exc:
@@ -112,20 +147,44 @@ class FixtureCatalog:
         )
 
     def require(self, key: str) -> FixtureSet:
+        """Return the fixture set with the given key.
+
+        :param key: fixture-set key to look up.
+        :return: the matching fixture set.
+        :raises CatalogError: if no set has that key.
+        """
         for fixture_set in self.sets:
             if fixture_set.key == key:
                 return fixture_set
         raise CatalogError(f"unknown fixture set: {key}")
 
     def active_sets(self) -> tuple[FixtureSet, ...]:
+        """Return all active fixture sets.
+
+        :return: the fixture sets whose status is ``active``.
+        """
         return tuple(fixture_set for fixture_set in self.sets if fixture_set.is_active)
 
     def pending_sets(self) -> tuple[FixtureSet, ...]:
+        """Return all pending fixture sets.
+
+        :return: the fixture sets whose status is ``pending``.
+        """
         return tuple(fixture_set for fixture_set in self.sets if fixture_set.is_pending)
 
     def by_vendor(self, vendor: str) -> tuple[FixtureSet, ...]:
+        """Return the fixture sets for one vendor.
+
+        :param vendor: vendor name to match.
+        :return: the fixture sets whose vendor equals ``vendor``.
+        """
         return tuple(fixture_set for fixture_set in self.sets if fixture_set.vendor == vendor)
 
 
 def load_catalog(manifest_path: Path = DEFAULT_MANIFEST) -> FixtureCatalog:
+    """Load the fixture catalog from a manifest file.
+
+    :param manifest_path: path to the catalog manifest JSON.
+    :return: the parsed catalog.
+    """
     return FixtureCatalog.from_manifest(manifest_path)

--- a/redfish_ctl/redfish_csdl.py
+++ b/redfish_ctl/redfish_csdl.py
@@ -24,14 +24,33 @@ class CsdlActionParameter:
 
 
 def _local_name(tag: str) -> str:
+    """Strip the XML namespace from a qualified tag.
+
+    :param tag: a possibly namespace-qualified XML tag.
+    :return: the local element name without the ``{namespace}`` prefix.
+    """
     return tag.rsplit("}", 1)[-1]
 
 
 def _namespace_family(namespace: str) -> str:
+    """Drop the versioned suffix from a CSDL namespace.
+
+    :param namespace: a CSDL namespace, e.g. ``Manager.v1_5_0``.
+    :return: the unversioned namespace family, e.g. ``Manager``.
+    """
     return _VERSION_SUFFIX.sub("", namespace or "")
 
 
 def _type_key(type_name: str) -> str:
+    """Normalize a CSDL type reference to a ``family.Type`` lookup key.
+
+    Unwraps a ``Collection(...)`` wrapper and strips the version from the
+    namespace so the key matches parsed enum definitions.
+
+    :param type_name: a CSDL type name, optionally wrapped in ``Collection(...)``.
+    :return: the normalized ``family.Type`` key, or the cleaned input when it
+        carries no namespace.
+    """
     cleaned = (type_name or "").strip()
     if cleaned.startswith("Collection(") and cleaned.endswith(")"):
         cleaned = cleaned[len("Collection("):-1]
@@ -43,6 +62,11 @@ def _type_key(type_name: str) -> str:
 
 
 def _default_schema_dir() -> Path:
+    """Return the directory holding the local CSDL schema bundle.
+
+    :return: the path from ``REDFISH_CSDL_DIR`` when set, otherwise the bundled
+        ``tools/redfish-schemas`` directory.
+    """
     configured = os.environ.get("REDFISH_CSDL_DIR")
     if configured:
         return Path(configured)
@@ -50,6 +74,12 @@ def _default_schema_dir() -> Path:
 
 
 def _iter_schema_files(schema_dir: Path) -> tuple[Path, ...]:
+    """List the CSDL schema files in a directory.
+
+    :param schema_dir: directory to search recursively.
+    :return: sorted ``*.xml`` paths, or an empty tuple when the directory does
+        not exist.
+    """
     if not schema_dir.exists():
         return ()
     return tuple(sorted(schema_dir.rglob("*.xml")))
@@ -61,6 +91,18 @@ def _parse_schema_file(
     dict[str, tuple[str, ...]],
     dict[tuple[str, str], list[CsdlActionParameter]],
 ]:
+    """Parse one CSDL schema file for enum values and action parameters.
+
+    Reads every ``Schema`` element, collecting ``EnumType`` members and
+    ``Action`` parameters (dropping the bound first parameter when the action
+    is bound). Entries are recorded under both the versioned namespace and its
+    family.
+
+    :param path: the CSDL ``*.xml`` file to parse.
+    :return: a tuple ``(enums, raw_actions)`` where ``enums`` maps a
+        ``namespace.Type`` to its member names and ``raw_actions`` maps a
+        ``(namespace, action)`` pair to its parameter list.
+    """
     root = ET.parse(path).getroot()
     enums: dict[str, tuple[str, ...]] = {}
     raw_actions: dict[tuple[str, str], list[CsdlActionParameter]] = {}
@@ -109,6 +151,15 @@ def _parse_schema_file(
 def _load_action_parameters(
     schema_dir: str,
 ) -> dict[tuple[str, str], tuple[CsdlActionParameter, ...]]:
+    """Load and cache all action parameters from a schema directory.
+
+    Merges every schema file, then resolves each parameter's allowable values
+    from the collected enum definitions. Results are cached per directory.
+
+    :param schema_dir: directory holding the CSDL schema bundle.
+    :return: a mapping of ``(namespace, action)`` to the action's resolved
+        parameters.
+    """
     enums: dict[str, tuple[str, ...]] = {}
     actions: dict[tuple[str, str], list[CsdlActionParameter]] = {}
     for path in _iter_schema_files(Path(schema_dir)):
@@ -134,7 +185,14 @@ def action_parameters_for(
     full_action_type: str,
     schema_dir: str | os.PathLike | None = None,
 ) -> Mapping[str, CsdlActionParameter]:
-    """Return CSDL parameters for a full Redfish action type, if cached locally."""
+    """Return CSDL parameters for a full Redfish action type, if cached locally.
+
+    :param full_action_type: the full action type, e.g. ``#ComputerSystem.Reset``.
+    :param schema_dir: directory holding the CSDL schema bundle; defaults to
+        :func:`_default_schema_dir`.
+    :return: a mapping of parameter name to its CSDL definition, empty when the
+        action type is malformed or absent from the local bundle.
+    """
     parts = (full_action_type or "").lstrip("#").split(".")
     if len(parts) < 2:
         return {}

--- a/redfish_ctl/redfish_query.py
+++ b/redfish_ctl/redfish_query.py
@@ -39,6 +39,16 @@ class RedfishQuery:
         top: Optional[int] = None,
         only: bool = False,
     ):
+        """Initialize a Redfish query parameter set.
+
+        :param select: property name(s) for ``$select``; a list or comma string.
+        :param filter: expression for ``$filter``.
+        :param expand: ``$expand`` mode; True expands all (``*``) or a string
+            names the expansion.
+        :param expand_levels: depth for ``$expand`` (``$levels``); defaults to 1.
+        :param top: page size for ``$top``.
+        :param only: when True, add the Redfish ``only`` parameter.
+        """
         self.select = select
         self.filter = filter
         self.expand = expand
@@ -47,10 +57,17 @@ class RedfishQuery:
         self.only = bool(only)
 
     def is_empty(self) -> bool:
-        """True when no query parameter is set."""
+        """True when no query parameter is set.
+
+        :return: True if no query parameter is active.
+        """
         return not self._active_names()
 
     def _active_names(self) -> List[str]:
+        """List the query parameters that are currently set.
+
+        :return: the names (e.g. ``$select``, ``$top``) of the active parameters.
+        """
         names = []
         if self.select:
             names.append("$select")
@@ -65,6 +82,12 @@ class RedfishQuery:
         return names
 
     def _validate(self, one_param_per_uri: bool) -> None:
+        """Validate the parameter values and cardinality.
+
+        :param one_param_per_uri: when True, allow at most one active parameter.
+        :raises ValueError: if ``$top`` or ``$expand`` levels are out of range,
+            or more than one parameter is set while ``one_param_per_uri`` is True.
+        """
         if self.top is not None and (not isinstance(self.top, int) or self.top < 0):
             raise ValueError("$top must be an integer >= 0")
         if self.expand_levels is not None and (
@@ -79,6 +102,10 @@ class RedfishQuery:
             )
 
     def _pairs(self) -> List[str]:
+        """Build the encoded ``key=value`` fragments for the active parameters.
+
+        :return: the URL-encoded query fragments in Redfish order.
+        """
         pairs: List[str] = []
         if self.select:
             value = self.select if isinstance(self.select, str) else ",".join(self.select)
@@ -95,7 +122,13 @@ class RedfishQuery:
         return pairs
 
     def to_query_string(self, one_param_per_uri: bool = False) -> str:
-        """Return the leading ``?...`` query string, or ``""`` when empty."""
+        """Return the leading ``?...`` query string, or ``""`` when empty.
+
+        :param one_param_per_uri: when True, enforce at most one query parameter.
+        :return: the ``?...`` query string, or an empty string when no parameter
+            is set.
+        :raises ValueError: if validation fails (see :meth:`_validate`).
+        """
         self._validate(one_param_per_uri)
         pairs = self._pairs()
         if not pairs:
@@ -103,5 +136,10 @@ class RedfishQuery:
         return "?" + "&".join(pairs)
 
     def apply(self, url: str, one_param_per_uri: bool = False) -> str:
-        """Append the query string to ``url`` (assumes ``url`` has no query yet)."""
+        """Append the query string to ``url`` (assumes ``url`` has no query yet).
+
+        :param url: base URL with no existing query string.
+        :param one_param_per_uri: when True, enforce at most one query parameter.
+        :return: ``url`` with the query string appended.
+        """
         return url + self.to_query_string(one_param_per_uri)

--- a/redfish_ctl/redfish_respond.py
+++ b/redfish_ctl/redfish_respond.py
@@ -73,10 +73,12 @@ class RedfishRespondMessage:
         """
         Redfish specs defines a verbose output.  THis generic respond msg.
 
+        :param http_status_code: HTTP status code the server returned.
         :param code: a string
         :param message: Displays a human-readable error message that corresponds
                         to the message in the message registry.
         :param message_extended: list of redfish that describe one or more error messages.
+        :param exception_msg: raw error text kept when JSON decoding of the error failed.
         """
         self._code = code
         self._message = message
@@ -91,7 +93,10 @@ class RedfishRespondMessage:
 
     @property
     def code(self) -> str:
-        """code from error message from redfish error"""
+        """code from error message from redfish error
+
+        :return: the error code string.
+        """
         return self._code
 
     @property
@@ -118,10 +123,18 @@ class RedfishRespondMessage:
 
     @message.setter
     def message(self, value: str) -> None:
+        """Set the top-level human-readable message.
+
+        :param value: the message text.
+        """
         self._message = value
 
     @staticmethod
     def new_msg():
+        """Return a fresh empty :class:`RedfishMessage`.
+
+        :return: a new, empty message object.
+        """
         return RedfishMessage()
 
     @staticmethod
@@ -210,5 +223,9 @@ class RedfishRespondMessage:
             self._message_extended.append(msg)
 
     def __repr__(self) -> str:
+        """Render the extended-info messages as newline-joined text.
+
+        :return: each extended message on its own line, terminated by a newline.
+        """
         msgs = [m.message for m in self._message_extended]
         return "\n".join(msgs) + "\n"

--- a/redfish_ctl/redfish_respond_error.py
+++ b/redfish_ctl/redfish_respond_error.py
@@ -107,10 +107,13 @@ class RedfishError(RedfishRespondMessage):
         """
         Redfish specs defines a verbose output. Motivation that is has more information
         about the error as possible.  It also defines multiply errors.
+        :param http_status_code: HTTP status code the server returned.
         :param code: a string
         :param message: Displays a human-readable error message that corresponds
                         to the message in the message registry.
         :param message_extended: list of redfish that describe one or more error messages.
+        :param exception_msg: raw error text for a JSON-decode failure; accepted for
+                        signature parity with the base class but not forwarded to it here.
         """
         super().__init__(
             http_status_code=http_status_code,
@@ -123,6 +126,10 @@ class RedfishError(RedfishRespondMessage):
 
     @staticmethod
     def new_msg():
+        """Return a fresh empty :class:`RedfishErrorMessage`.
+
+        :return: a new, empty error-message object.
+        """
         return RedfishErrorMessage()
 
     @property
@@ -141,6 +148,9 @@ class RedfishError(RedfishRespondMessage):
         carries only a ``MessageId`` + ``MessageArgs`` with no human-readable
         ``Message`` (e.g. iLO ``PropertyNotWritableOrUnknown``). Fall back to the
         id + args in that case so the error stays informative.
+
+        :param m: an extended-info entry, either a ``RedfishMessage`` or a raw dict.
+        :return: the rendered message string, or ``""`` when nothing is renderable.
         """
         try:
             if isinstance(m, dict):
@@ -166,6 +176,9 @@ class RedfishError(RedfishRespondMessage):
         status. Robust to ``message_extended`` being raw dicts or objects, and to
         a missing/None ``Message`` — the failure mode that previously made
         ``str(exception)`` raise and surface as ``<exception str() failed>``.
+
+        :return: the combined human-readable error text, suffixed with the HTTP
+            status when one is present.
         """
         parts = []
         top = getattr(self, "_message", None)
@@ -183,8 +196,16 @@ class RedfishError(RedfishRespondMessage):
         return f"{body} (HTTP {code})" if code else body
 
     def __repr__(self) -> str:
+        """Return the same human-readable rendering as :meth:`__str__`.
+
+        :return: the formatted error string.
+        """
         return self.__str__()
 
     @message_extended.setter
     def message_extended(self, value):
+        """Set the list of extended-info messages.
+
+        :param value: the extended-info messages to store.
+        """
         self._message_extended = value

--- a/redfish_ctl/redfish_shared.py
+++ b/redfish_ctl/redfish_shared.py
@@ -8,6 +8,10 @@ def env_first(*names: str, default: Optional[str] = None) -> Optional[str]:
 
     Used so settings honor the going-forward ``REDFISH_*`` names first and fall back
     to the legacy ``IDRAC_*`` names during the rename. Pass the REDFISH_* name first.
+
+    :param names: environment variable names to check, in priority order.
+    :param default: value returned when none of ``names`` is set.
+    :return: the first set variable's value, or ``default`` when none is set.
     """
     for name in names:
         value = os.environ.get(name)


### PR DESCRIPTION
Docstring-coverage PR for top-level infra files `fixtures_catalog.py`, `redfish_csdl.py`, `redfish_query.py`, `redfish_respond.py`, `redfish_respond_error.py`, `redfish_shared.py`, compliant with the merged docstring gate (#145). 32 members documented. Not command modules. exception_msg param on RedfishError documented honestly as accepted-but-not-forwarded. Docstrings only, no behavior change. Gates: gate --all 0 for these files; ruff no new; pytest green.