### PR TITLE
Document top-level command methods (docstring coverage)

### DIFF
--- a/redfish_ctl/cmd_boot.py
+++ b/redfish_ctl/cmd_boot.py
@@ -1,5 +1,8 @@
 """iDRAC boot query command
 
+    redfish_ctl boot
+    redfish_ctl boot --deep --filename boot.json
+
 Command provides the option to retrieve boot source from iDRAC and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command
@@ -28,6 +31,7 @@ class BootQuery(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the boot command."""
         super(BootQuery, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/cmd_current_boot.py
+++ b/redfish_ctl/cmd_current_boot.py
@@ -1,5 +1,8 @@
 """iDRAC enable boot options.
 
+    redfish_ctl current_boot
+    redfish_ctl current_boot --filename current_boot.json
+
 This cmd return Dell Boot Sources Configuration and the related
 resources.
 
@@ -30,6 +33,7 @@ class GetCurrentBoot(RedfishManagerBase,
     cmd_name = "current_boot_query"
 
     def __init__(self, *args, **kwargs):
+        """Initialize the current_boot command."""
         super(GetCurrentBoot, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/cmd_exceptions.py
+++ b/redfish_ctl/cmd_exceptions.py
@@ -1,3 +1,15 @@
+"""Exception types shared across redfish_ctl commands.
+
+These errors let a redfish_ctl command tell an expected, non-fatal condition (for
+example a 404 that is acceptable) apart from a genuinely unexpected response that
+must abort. They cover invalid arguments and JSON specs, missing or undiscoverable
+resources, uncommitted pending changes, and HTTP/JSON errors (``JsonHttpError`` and
+its POST/PATCH/DELETE subclasses).
+
+Author Mus spyroot@gmail.com
+"""
+
+
 class InvalidArgument(Exception):
     pass
 
@@ -75,6 +87,11 @@ class JsonHttpError(Exception):
     we raise.
     """
     def __init__(self, *args, **kwargs):
+        """Initialize the error and capture an optional ``json_error`` payload.
+
+        :param args: positional arguments forwarded to ``Exception``.
+        :param kwargs: keyword arguments; the ``json_error`` entry is stored on the instance.
+        """
         super(JsonHttpError, self).__init__(args, kwargs)
         self.json_error = kwargs.get('json_error')
 

--- a/redfish_ctl/cmd_get.py
+++ b/redfish_ctl/cmd_get.py
@@ -1,4 +1,8 @@
-"""Generic Redfish resource GET command."""
+"""Generic Redfish resource GET command.
+
+    redfish_ctl get /redfish/v1/Managers
+    redfish_ctl get /redfish/v1/Systems --filename systems.json
+"""
 from abc import abstractmethod
 from typing import Optional
 
@@ -16,12 +20,16 @@ class RawGet(
     """Read an arbitrary Redfish resource path."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the get command."""
         super().__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``get`` command parser."""
+        """Register the ``get`` command parser.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             "uri",
@@ -41,7 +49,16 @@ class RawGet(
             do_expanded: Optional[bool] = False,
             **kwargs,
     ) -> CommandResult:
-        """Read the caller-provided Redfish resource path."""
+        """Read the caller-provided Redfish resource path.
+
+        :param uri: Redfish resource URI to read (e.g. ``/redfish/v1/Managers``).
+        :param filename: if set, save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: note async will subscribe to an event loop.
+        :param do_expanded: issue an expanded ($expand) Redfish query.
+        :return: CommandResult with the fetched resource data.
+        """
         return self.base_query(
             uri,
             filename=filename,

--- a/redfish_ctl/cmd_query.py
+++ b/redfish_ctl/cmd_query.py
@@ -1,5 +1,8 @@
 """iDRAC query command
 
+    redfish_ctl query --resource /redfish/v1/Managers
+    redfish_ctl query --resource /redfish/v1/Systems --expanded
+
 Command provides capability raw query based URI resource,
 in case specific action might not implement yet; hence it
 is easy to query.
@@ -23,6 +26,7 @@ class QueryIDRAC(
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the query command."""
         super(QueryIDRAC, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/cmd_wait.py
+++ b/redfish_ctl/cmd_wait.py
@@ -27,6 +27,12 @@ def probe_reachable(url: str, auth, verify: bool, timeout: float) -> bool:
 
     Any HTTP response — 200, 401, or 403 — means the Redfish service answered, so
     the BMC is reachable. A connection error / timeout means it is not up yet.
+
+    :param url: ServiceRoot URL to probe.
+    :param auth: requests auth tuple ``(username, password)``, or None for anonymous.
+    :param verify: whether to verify the TLS certificate.
+    :param timeout: per-request timeout in seconds.
+    :return: True if the service answered with any HTTP status, else False.
     """
     try:
         requests.get(url, auth=auth, verify=verify, timeout=timeout)
@@ -52,9 +58,18 @@ def wait_for(predicate,
     ``invert_first`` first waits for the predicate to be False (e.g. the BMC to go
     DOWN) before waiting for it to be True — the down-then-up reboot pattern.
 
+    :param predicate: no-arg callable returning bool; polled until it is True.
+    :param description: human label for what is being awaited; echoed in the result.
+    :param timeout: max seconds to keep polling before giving up.
+    :param interval: seconds to sleep between probes.
+    :param invert_first: first wait for the predicate to be False, then for True.
     :return: ``{waiting_for, satisfied, waited_s[, precondition_met]}``
     """
     def probe() -> bool:
+        """Evaluate ``predicate`` once, treating any raised exception as False.
+
+        :return: the predicate's boolean result, or False if it raised.
+        """
         try:
             return bool(predicate())
         except Exception:
@@ -98,6 +113,14 @@ def wait_reachable(url: str, auth, verify: bool,
     A thin wrapper over :func:`wait_for` with a reachability predicate; keeps the
     ``reachable`` / ``went_down`` keys its callers (the ``wait`` command,
     ``manager-reboot --wait``) expect, and carries the ``waiting_for`` label.
+
+    :param url: ServiceRoot URL to poll.
+    :param auth: requests auth tuple ``(username, password)``, or None for anonymous.
+    :param verify: whether to verify the TLS certificate.
+    :param timeout: max seconds to wait for the service.
+    :param interval: seconds between polls.
+    :param reboot_cycle: first wait for the BMC to go DOWN, then for it to come back UP.
+    :return: ``{waiting_for, reachable, waited_s[, went_down]}``.
     """
     probe_timeout = max(1.0, min(interval or 5.0, 5.0))
     res = wait_for(lambda: probe_reachable(url, auth, verify, probe_timeout),
@@ -117,11 +140,16 @@ class WaitReady(RedfishManagerBase,
     """Poll the Redfish ServiceRoot until the BMC is reachable (bounded by a timeout)."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the wait command."""
         super(WaitReady, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
+        """Register the ``wait`` command parser and its flags.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd = cls.base_parser()
         cmd.add_argument('--timeout', required=False, type=float, dest='wait_timeout', default=300.0,
                          help="max seconds to wait for the BMC (default 300)")
@@ -137,7 +165,14 @@ class WaitReady(RedfishManagerBase,
                 wait_interval: Optional[float] = 5.0,
                 wait_reboot_cycle: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Poll the ServiceRoot until reachable (optionally after a down phase)."""
+        """Poll the ServiceRoot until reachable (optionally after a down phase).
+
+        :param wait_timeout: max seconds to wait for the BMC (default 300).
+        :param wait_interval: seconds between polls (default 5).
+        :param wait_reboot_cycle: first wait for the BMC to go DOWN, then come back UP.
+        :return: CommandResult with the reachability result (``reachable``, ``waited_s``,
+            ``target``); its error is set when the BMC is not reachable within the timeout.
+        """
         scheme = "http" if self._is_http else "https"
         url = f"{scheme}://{self.redfish_ip}:{self._port}/redfish/v1/"
         auth = (self._username, self._password) if self._username else None


### PR DESCRIPTION
Docstring-coverage PR for top-level command files `cmd_wait.py`, `cmd_get.py`, `cmd_current_boot.py`, `cmd_boot.py`, `cmd_exceptions.py`, `cmd_query.py`, compliant with the merged docstring gate (#145). 19 members + module usage examples. cmd_get data_type/verbose documented accepted-but-unused (verified). Docstrings only, no behavior change. Gates: gate --all 0 for these files; ruff no new; pytest green.