### PR TITLE
Document top-level infra modules (docstring coverage)

### DIFF
--- a/redfish_ctl/api.py
+++ b/redfish_ctl/api.py
@@ -15,6 +15,12 @@ class SyncInvoker(Protocol):
     def sync_invoke(
         self, api_call: ApiRequestType, name: str, **kwargs: Any
     ) -> CommandResult:
+        """Invoke a registered command synchronously and return its result.
+
+        :param api_call: the :class:`ApiRequestType` selecting the command family.
+        :param name: the registered command name to invoke.
+        :return: the :class:`CommandResult` produced by the command.
+        """
         ...
 
 
@@ -275,6 +281,14 @@ def _invoke(
     name: str,
     **kwargs: Any,
 ) -> Any:
+    """Invoke a command and return its data, raising on a command error.
+
+    :param manager: synchronous invoker used to run the command.
+    :param api_call: the :class:`ApiRequestType` to invoke.
+    :param name: the registered command name to invoke.
+    :return: the command result data.
+    :raises RedfishApiError: when the command returns an error.
+    """
     result = manager.sync_invoke(api_call, name, **kwargs)
     if result.error:
         raise RedfishApiError(str(result.error))
@@ -282,28 +296,54 @@ def _invoke(
 
 
 def _mapping(data: Any) -> Mapping[str, Any]:
+    """Return ``data`` when it is a mapping, else an empty mapping.
+
+    :param data: value to coerce.
+    :return: ``data`` if it is a mapping, otherwise an empty dict.
+    """
     return data if isinstance(data, Mapping) else {}
 
 
 def _rows(data: Any) -> tuple[Mapping[str, Any], ...]:
+    """Return the mapping rows from a list value.
+
+    :param data: value to coerce.
+    :return: a tuple of the mapping items; empty when ``data`` is not a list.
+    """
     if not isinstance(data, list):
         return ()
     return tuple(row for row in data if isinstance(row, Mapping))
 
 
 def _server_list(servers: str | Iterable[str]) -> list[str]:
+    """Normalize an NTP server argument to a list.
+
+    :param servers: a single server string or an iterable of server strings.
+    :return: the servers as a list (a lone string becomes a one-item list).
+    """
     if isinstance(servers, str):
         return [servers]
     return list(servers)
 
 
 def _server_tuple(data: Any, fallback: Iterable[str]) -> tuple[str, ...]:
+    """Coerce a server list, falling back when the value is not a list.
+
+    :param data: candidate server list from the command payload.
+    :param fallback: servers to use when ``data`` is not a list.
+    :return: a tuple of server strings.
+    """
     values = data if isinstance(data, list) else list(fallback)
     return tuple(str(value) for value in values)
 
 
 def get_system(manager: SyncInvoker, *, deep: bool = False) -> SystemStatus:
-    """Return typed ComputerSystem status through the existing system command."""
+    """Return typed ComputerSystem status through the existing system command.
+
+    :param manager: synchronous invoker used to run the system command.
+    :param deep: when True, request a deep ComputerSystem query.
+    :return: a :class:`SystemStatus` built from the command payload.
+    """
     data = _mapping(
         _invoke(
             manager,
@@ -326,7 +366,12 @@ def get_system(manager: SyncInvoker, *, deep: bool = False) -> SystemStatus:
 def get_sensors(
     manager: SyncInvoker, *, expanded: bool = False
 ) -> tuple[SensorReading, ...]:
-    """Return typed chassis sensor readings through the sensors command."""
+    """Return typed chassis sensor readings through the sensors command.
+
+    :param manager: synchronous invoker used to run the sensors command.
+    :param expanded: when True, issue an expanded ($expand) sensors query.
+    :return: a tuple of :class:`SensorReading` rows.
+    """
     rows = _rows(
         _invoke(
             manager,
@@ -350,7 +395,11 @@ def get_sensors(
 
 
 def get_thermal(manager: SyncInvoker) -> ThermalStatus:
-    """Return typed thermal status through the thermal command."""
+    """Return typed thermal status through the thermal command.
+
+    :param manager: synchronous invoker used to run the thermal command.
+    :return: a :class:`ThermalStatus` with temperatures, fans, and summary.
+    """
     data = _mapping(_invoke(manager, ApiRequestType.Thermal, "thermal"))
     temperature_rows = _rows(data.get("temperature_readings"))
     fan_rows = _rows(data.get("fans"))
@@ -386,7 +435,11 @@ def get_thermal(manager: SyncInvoker) -> ThermalStatus:
 
 
 def get_gpu_metrics(manager: SyncInvoker) -> GpuMetricsStatus:
-    """Return typed GPU metric rows through the gpu-metrics command."""
+    """Return typed GPU metric rows through the gpu-metrics command.
+
+    :param manager: synchronous invoker used to run the gpu-metrics command.
+    :return: a :class:`GpuMetricsStatus` with per-GPU rows and summary.
+    """
     data = _mapping(_invoke(manager, ApiRequestType.GpuMetrics, "gpu-metrics"))
     gpu_rows = tuple(
         GpuMetricRow(
@@ -427,6 +480,9 @@ def get_network_firmware(manager: SyncInvoker) -> NetworkFirmwareStatus:
     Read-only. Surfaces every network adapter (ConnectX NICs, BlueField DPUs) and
     the firmware version of each network component, plus a summary whose
     ``distinct_versions`` is the fleet firmware-drift signal.
+
+    :param manager: synchronous invoker used to run the nic-firmware command.
+    :return: a :class:`NetworkFirmwareStatus` with adapters, firmware, and summary.
     """
     data = _mapping(_invoke(manager, ApiRequestType.NicFirmware, "nic-firmware"))
     adapters = tuple(
@@ -471,7 +527,14 @@ def set_ntp(
     manager_id: str | None = None,
     confirm: bool = False,
 ) -> NtpSetResult:
-    """Preview or apply NTP servers through the guarded ntp-set command."""
+    """Preview or apply NTP servers through the guarded ntp-set command.
+
+    :param manager: synchronous invoker used to run the ntp-set command.
+    :param servers: a single server string or an iterable of NTP servers.
+    :param manager_id: restrict the change to this Manager id when set.
+    :param confirm: when False, only preview the plan; when True, apply the change.
+    :return: a typed :class:`NtpSetResult` with the plan, skipped, and applied rows.
+    """
     requested_servers = _server_list(servers)
     data = _mapping(
         _invoke(
@@ -531,7 +594,15 @@ def reboot(
     wait: bool = False,
     async_call: bool = False,
 ) -> RebootResult:
-    """Preview or execute a host ComputerSystem reset through reboot."""
+    """Preview or execute a host ComputerSystem reset through reboot.
+
+    :param manager: synchronous invoker used to run the reboot command.
+    :param reset_type: the Redfish reset type to request (default GracefulRestart).
+    :param confirm: when False, only preview the reset; when True, execute it.
+    :param wait: wait for the reset to complete (only honored when confirmed).
+    :param async_call: issue the reset as an asynchronous invocation.
+    :return: a typed :class:`RebootResult` describing the planned or executed reset.
+    """
     data = _mapping(
         _invoke(
             manager,
@@ -556,7 +627,11 @@ def reboot(
 
 
 def bios_profile_list(manager: SyncInvoker) -> tuple[BiosProfileSummary, ...]:
-    """Return typed BIOS profile summaries through bios-profile list."""
+    """Return typed BIOS profile summaries through bios-profile list.
+
+    :param manager: synchronous invoker used to run the bios-profile command.
+    :return: a tuple of :class:`BiosProfileSummary` catalog rows.
+    """
     rows = _rows(
         _invoke(
             manager,
@@ -582,7 +657,12 @@ def bios_profile_show(
     manager: SyncInvoker,
     profile_name: str,
 ) -> BiosProfileSpec:
-    """Return a typed BIOS profile specification through bios-profile show."""
+    """Return a typed BIOS profile specification through bios-profile show.
+
+    :param manager: synchronous invoker used to run the bios-profile command.
+    :param profile_name: name of the BIOS profile to show.
+    :return: a typed :class:`BiosProfileSpec` with the profile attributes.
+    """
     data = _mapping(
         _invoke(
             manager,
@@ -607,7 +687,12 @@ def bios_profile_diff(
     manager: SyncInvoker,
     profile_name: str,
 ) -> BiosProfileDiffResult:
-    """Return a typed BIOS profile diff through bios-profile diff."""
+    """Return a typed BIOS profile diff through bios-profile diff.
+
+    :param manager: synchronous invoker used to run the bios-profile command.
+    :param profile_name: name of the BIOS profile to diff against current settings.
+    :return: a typed :class:`BiosProfileDiffResult` with per-attribute rows.
+    """
     data = _mapping(
         _invoke(
             manager,
@@ -643,7 +728,14 @@ def bios_profile_apply(
     confirm: bool = False,
     dry_run: bool = False,
 ) -> BiosProfileApplyResult:
-    """Preview or stage a BIOS profile through guarded bios-profile apply."""
+    """Preview or stage a BIOS profile through guarded bios-profile apply.
+
+    :param manager: synchronous invoker used to run the bios-profile command.
+    :param profile_name: name of the BIOS profile to apply.
+    :param confirm: when True, stage the profile change instead of only previewing.
+    :param dry_run: request a dry-run apply from the underlying command.
+    :return: a typed :class:`BiosProfileApplyResult` with the staged change and rollback.
+    """
     data = _mapping(
         _invoke(
             manager,

--- a/redfish_ctl/reconcile.py
+++ b/redfish_ctl/reconcile.py
@@ -23,7 +23,11 @@ class DesiredState:
 
     @classmethod
     def from_mapping(cls, spec: Mapping[str, Any]) -> "DesiredState":
-        """Build desired state from a CRD-style or JSON-style mapping."""
+        """Build desired state from a CRD-style or JSON-style mapping.
+
+        :param spec: CRD-style or JSON-style mapping of the desired node state.
+        :return: a :class:`DesiredState` built from ``spec``.
+        """
         ntp = _mapping(spec.get("ntp"))
         boot = _mapping(spec.get("boot"))
         reboot_spec = spec.get("reboot")
@@ -84,7 +88,15 @@ def reconcile(
     wait_for_reboot: bool = False,
     async_call: bool = False,
 ) -> ReconcileResult:
-    """Plan desired state and apply only when explicitly confirmed."""
+    """Plan desired state and apply only when explicitly confirmed.
+
+    :param manager: synchronous invoker used to run the underlying commands.
+    :param desired: target state as a :class:`DesiredState` or a mapping.
+    :param confirm: when False, only build the plan; when True, apply required steps.
+    :param wait_for_reboot: wait for the host reset to finish (only when confirmed).
+    :param async_call: issue the host reset as an asynchronous invocation.
+    :return: a :class:`ReconcileResult` with the planned steps and applied changes.
+    """
     state = (
         DesiredState.from_mapping(desired)
         if isinstance(desired, Mapping)
@@ -124,6 +136,14 @@ def _reconcile_bios_profile(
     steps: list[ReconcileStep],
     applied: list[AppliedChange],
 ) -> None:
+    """Plan and optionally apply the desired BIOS profile.
+
+    :param manager: synchronous invoker used to run the bios-profile command.
+    :param state: desired state carrying the target BIOS profile name.
+    :param confirm: when True, apply the profile if the diff shows a change is required.
+    :param steps: plan list the computed step is appended to.
+    :param applied: results list an applied change is appended to.
+    """
     profile_name = state.bios_profile
     diff = _invoke_mapping(
         manager,
@@ -167,6 +187,14 @@ def _reconcile_ntp(
     steps: list[ReconcileStep],
     applied: list[AppliedChange],
 ) -> None:
+    """Plan and optionally apply the desired Manager NTP servers.
+
+    :param manager: synchronous invoker used to read and set NTP configuration.
+    :param state: desired state carrying the NTP servers and optional manager id.
+    :param confirm: when True, apply the NTP change through the guarded ntp-set command.
+    :param steps: plan list the computed step is appended to.
+    :param applied: results list an applied change is appended to.
+    """
     current = _invoke_rows(
         manager,
         ApiRequestType.ManagerNetworkProtocol,
@@ -221,6 +249,14 @@ def _reconcile_boot(
     steps: list[ReconcileStep],
     applied: list[AppliedChange],
 ) -> None:
+    """Plan and optionally apply the desired one-time boot override.
+
+    :param manager: synchronous invoker used to read and set the boot override.
+    :param state: desired state carrying the boot device, mode, and UEFI target.
+    :param confirm: when True, apply the boot override if a change is required.
+    :param steps: plan list the computed step is appended to.
+    :param applied: results list an applied change is appended to.
+    """
     current = _invoke_mapping(
         manager,
         ApiRequestType.CurrentBoot,
@@ -265,6 +301,16 @@ def _reconcile_reboot(
     steps: list[ReconcileStep],
     applied: list[AppliedChange],
 ) -> None:
+    """Plan and optionally apply the desired host reset.
+
+    :param manager: synchronous invoker used to run the reboot command.
+    :param state: desired state carrying the reset type.
+    :param confirm: when True, execute the reset; otherwise plan it as a dry run.
+    :param wait_for_reboot: wait for the reset to finish (only when confirmed).
+    :param async_call: issue the reset as an asynchronous invocation.
+    :param steps: plan list the computed step is appended to.
+    :param applied: results list an applied change is appended to.
+    """
     result = _invoke_mapping(
         manager,
         ApiRequestType.ComputerSystemReset,
@@ -294,6 +340,13 @@ def _invoke_mapping(
     name: str,
     **kwargs: Any,
 ) -> Mapping[str, Any]:
+    """Invoke a command and coerce its payload to a mapping.
+
+    :param manager: synchronous invoker used to run the command.
+    :param api_call: the :class:`ApiRequestType` to invoke.
+    :param name: the registered command name to invoke.
+    :return: the response payload as a mapping, or an empty mapping.
+    """
     return _mapping(_invoke_data(manager, api_call, name, **kwargs))
 
 
@@ -303,6 +356,13 @@ def _invoke_rows(
     name: str,
     **kwargs: Any,
 ) -> tuple[Mapping[str, Any], ...]:
+    """Invoke a command and coerce its payload to a tuple of mapping rows.
+
+    :param manager: synchronous invoker used to run the command.
+    :param api_call: the :class:`ApiRequestType` to invoke.
+    :param name: the registered command name to invoke.
+    :return: the response rows as mappings; empty when the payload is not a list.
+    """
     return _mapping_rows(_invoke_data(manager, api_call, name, **kwargs))
 
 
@@ -312,6 +372,14 @@ def _invoke_data(
     name: str,
     **kwargs: Any,
 ) -> Any:
+    """Invoke a command and return its data, raising on a command error.
+
+    :param manager: synchronous invoker used to run the command.
+    :param api_call: the :class:`ApiRequestType` to invoke.
+    :param name: the registered command name to invoke.
+    :return: the command result data.
+    :raises RedfishApiError: when the command returns an error.
+    """
     result = manager.sync_invoke(api_call, name, **kwargs)
     if result.error:
         raise RedfishApiError(str(result.error))
@@ -319,16 +387,31 @@ def _invoke_data(
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
+    """Return ``value`` when it is a mapping, else an empty mapping.
+
+    :param value: value to coerce.
+    :return: ``value`` if it is a mapping, otherwise an empty dict.
+    """
     return value if isinstance(value, Mapping) else {}
 
 
 def _mapping_rows(value: Any) -> tuple[Mapping[str, Any], ...]:
+    """Return the mapping rows from a list or tuple value.
+
+    :param value: value to coerce.
+    :return: a tuple of the mapping items; empty when ``value`` is not a list or tuple.
+    """
     if not isinstance(value, (list, tuple)):
         return ()
     return tuple(row for row in value if isinstance(row, Mapping))
 
 
 def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
+    """Return the value of the first key present in ``mapping``.
+
+    :param mapping: mapping to look keys up in.
+    :return: the value of the first matching key, or None when none is present.
+    """
     for key in keys:
         if key in mapping:
             return mapping[key]
@@ -336,6 +419,11 @@ def _first(mapping: Mapping[str, Any], *keys: str) -> Any:
 
 
 def _optional_str(value: Any) -> str | None:
+    """Coerce ``value`` to a stripped string, or None when empty.
+
+    :param value: value to coerce.
+    :return: the stripped string, or None when the value is None or blank.
+    """
     if value is None:
         return None
     text = str(value).strip()
@@ -343,6 +431,11 @@ def _optional_str(value: Any) -> str | None:
 
 
 def _str_tuple(value: Any) -> tuple[str, ...]:
+    """Coerce ``value`` to a tuple of non-empty strings.
+
+    :param value: a comma-separated string or an iterable of values.
+    :return: a tuple of stripped, non-empty strings; empty when ``value`` is None.
+    """
     if value is None:
         return ()
     if isinstance(value, str):
@@ -360,6 +453,12 @@ def _ntp_already_matches(
     rows: tuple[Mapping[str, Any], ...],
     state: DesiredState,
 ) -> bool:
+    """Return whether current NTP rows already satisfy the desired state.
+
+    :param rows: current ManagerNetworkProtocol rows.
+    :param state: desired state carrying the NTP servers and optional manager id.
+    :return: True when a comparable row matches the desired servers with NTP enabled.
+    """
     desired_servers = tuple(state.ntp_servers)
     comparable_rows = []
     for row in rows:
@@ -380,6 +479,11 @@ def _ntp_already_matches(
 
 
 def _ntp_row_is_capable(ntp: Mapping[str, Any]) -> bool:
+    """Return whether an NTP row exposes usable NTP fields.
+
+    :param ntp: the NTP sub-mapping of a ManagerNetworkProtocol row.
+    :return: True when the row reports ProtocolEnabled or any NTPServers.
+    """
     return ntp.get("ProtocolEnabled") is not None or bool(ntp.get("NTPServers"))
 
 
@@ -387,6 +491,12 @@ def _boot_already_matches(
     current: Mapping[str, Any],
     state: DesiredState,
 ) -> bool:
+    """Return whether the current boot override already matches the desired state.
+
+    :param current: current boot override fields from the ComputerSystem.
+    :param state: desired state carrying the boot device, mode, and UEFI target.
+    :return: True when the enabled state, target, mode, and UEFI target all match.
+    """
     desired_device = state.boot_device
     desired_enabled = "Disabled" if desired_device == "None" else "Once"
     if current.get("BootSourceOverrideEnabled") != desired_enabled:
@@ -407,6 +517,13 @@ def _boot_already_matches(
 
 
 def _reset_type(reboot_spec: Any, reboot: Mapping[str, Any]) -> str | None:
+    """Resolve the reset type from a reboot spec.
+
+    :param reboot_spec: the raw ``reboot`` spec value (string, bool, or mapping).
+    :param reboot: the reboot spec coerced to a mapping.
+    :return: the reset type string, or None when no reset is requested.
+    :raises ValueError: when a truthy bare reboot or a non-string resetType is given.
+    """
     if isinstance(reboot_spec, str):
         return _optional_str(reboot_spec)
     if isinstance(reboot_spec, bool):

--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -61,6 +61,9 @@ def _env(*names, default=""):
     Used to read the going-forward ``REDFISH_*`` endpoint/credential variables while
     still honoring the legacy ``IDRAC_*`` names during the rename: pass the REDFISH_
     name first, the IDRAC_ name second, so REDFISH_ wins when both are set.
+
+    :param default: value returned when none of the listed variables is set.
+    :return: the first non-empty environment variable value, or ``default``.
     """
     for name in names:
         value = os.environ.get(name)
@@ -112,6 +115,9 @@ FLEET_COMMANDS = {"fleet"}
 
 def color_printer(msg: str, tcolor: Optional[str] = TermColors.WARNING):
     """Printer error and if terminal support color print red or green etc.
+
+    :param msg: the message to print.
+    :param tcolor: terminal color escape applied when the terminal supports color.
     """
     current_term = os.getenv("TERM")
     if current_term is not None and current_term in TermList:
@@ -123,11 +129,17 @@ def color_printer(msg: str, tcolor: Optional[str] = TermColors.WARNING):
 
 def console_error_printer(msg):
     """Printer error and if terminal support color print red or green etc.
+
+    :param msg: the error message to print.
     """
     color_printer(msg, tcolor=TermColors.WARNING)
 
 
 def formatter(prog):
+    """Construct an argparse help formatter for the given program name.
+
+    :param prog: the program name passed to the help formatter.
+    """
     argparse.HelpFormatter(prog, max_help_position=100, width=200)
 
 
@@ -145,6 +157,11 @@ __version__ = IdracDetails.version
 
 
 def log_verbose(cmd_args, err):
+    """Warn about a parse failure only when verbose output is enabled.
+
+    :param cmd_args: parsed CLI arguments; ``verbose`` gates the warning.
+    :param err: the exception whose message is included in the warning.
+    """
     if cmd_args.verbose:
         err_msg = str(err)
         warnings.warn(f"Failed parse server respond. {err_msg}")
@@ -226,7 +243,12 @@ def json_printer(json_data,
 
 
 def process_respond(cmd_args, command_result):
-    """
+    """Assemble the printable payload from a command result.
+
+    :param cmd_args: parsed CLI arguments controlling which sections are emitted.
+    :param command_result: the CommandResult returned by the invoked command.
+    :return: ``command_result.data`` when ``--data_only`` is set, otherwise a dict
+        with the data, extra, and discovered-action sections that pass the output filters.
     """
     query_request = {}
     if cmd_args.data_only:
@@ -274,6 +296,9 @@ def is_network_scan(args) -> bool:
     no credentials, so they must bypass the single-host IDRAC_IP/credential gate
     and the startup ``check_api_version()`` / vendor probe (which would connect
     to a host that scan mode does not have).
+
+    :param args: parsed CLI arguments.
+    :return: True when the command is a credential-less network-segment scan.
     """
     sub = getattr(args, "subcommand", None)
     if sub == "bmc-scan":
@@ -284,7 +309,11 @@ def is_network_scan(args) -> bool:
 
 
 def is_local_command(args) -> bool:
-    """True when the command reads only local repository data."""
+    """True when the command reads only local repository data.
+
+    :param args: parsed CLI arguments.
+    :return: True when the command reads only local data and needs no BMC connection.
+    """
     subcommand = getattr(args, "subcommand", None)
     if subcommand == "bios-profile":
         return getattr(args, "action", "list") in {"list", "show"}
@@ -292,7 +321,11 @@ def is_local_command(args) -> bool:
 
 
 def _redfish_query_from_args(args: argparse.Namespace) -> RedfishQuery:
-    """Build the global Redfish query object from top-level CLI flags."""
+    """Build the global Redfish query object from top-level CLI flags.
+
+    :param args: parsed CLI arguments carrying the top-level query_* flags.
+    :return: a :class:`RedfishQuery` built from those flags.
+    """
     return RedfishQuery(
         select=getattr(args, "query_select", None),
         filter=getattr(args, "query_filter", None),
@@ -304,7 +337,12 @@ def _redfish_query_from_args(args: argparse.Namespace) -> RedfishQuery:
 
 
 def _query_flag_is_active(query: RedfishQuery, attr: str) -> bool:
-    """Return whether a RedfishQuery field should be vendor-gated."""
+    """Return whether a RedfishQuery field should be vendor-gated.
+
+    :param query: the :class:`RedfishQuery` to inspect.
+    :param attr: the query field name to test.
+    :return: True when the field is set (``top`` counts as active when not None).
+    """
     value = getattr(query, attr)
     if attr == "top":
         return value is not None
@@ -314,7 +352,12 @@ def _query_flag_is_active(query: RedfishQuery, attr: str) -> bool:
 def _validate_redfish_query_for_vendor(
         query: RedfishQuery,
         caps: VendorCapabilities) -> None:
-    """Raise when the target vendor profile does not support query flags."""
+    """Raise when the target vendor profile does not support query flags.
+
+    :param query: the :class:`RedfishQuery` to validate.
+    :param caps: the target vendor's :class:`VendorCapabilities`.
+    :raises InvalidArgument: when the vendor lacks support for a requested query flag.
+    """
     unsupported = [
         name for name, attr, enabled_attr in _QUERY_CAPABILITY_FLAGS
         if _query_flag_is_active(query, attr) and not getattr(caps, enabled_attr)
@@ -331,12 +374,19 @@ def _validate_redfish_query_for_vendor(
 
 
 def is_fleet_command(args) -> bool:
-    """True when the command manages its own per-node connections."""
+    """True when the command manages its own per-node connections.
+
+    :param args: parsed CLI arguments.
+    :return: True when the command manages its own per-node connections.
+    """
     return getattr(args, "subcommand", None) in FLEET_COMMANDS
 
 
 def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
-    """Main entry point
+    """Main entry point.
+
+    :param cmd_args: parsed CLI arguments for the selected command.
+    :param command_name_to_cmd: mapping of command name to its (type, name) tuple.
     """
     # BMCs ship self-signed certs, so verification is opt-in via --verify-ssl.
     # We skip verification by default; --insecure stays as an explicit "skip".
@@ -457,6 +507,9 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
 
 def create_cmd_tree(arg_parser, debug=False) -> Dict:
     """Create command tree structure.
+
+    :param arg_parser: the root argument parser to attach subcommand parsers to.
+    :param debug: when True, log each registered command.
     :return: a dict that store mapping for each command.
     """
     redfish_api = RedfishManagerBase()

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -203,6 +203,11 @@ class RedfishActionEncoder(JSONEncoder):
     """
 
     def default(self, obj):
+        """Serialize an object by returning its ``__dict__``.
+
+        :param obj: the object being serialized.
+        :return: the object's ``__dict__`` for JSON encoding.
+        """
         return obj.__dict__
 
 
@@ -215,6 +220,10 @@ class RedfishAction:
                  target: Optional[str] = "",
                  full_redfish_name: Optional[str] = ""):
         """Action discovered from json respond.
+
+        :param action_name: short Redfish action name.
+        :param target: the action target URI to invoke.
+        :param full_redfish_name: fully qualified Redfish action name.
         """
         super().__init__()
         self.action_name = action_name
@@ -223,6 +232,7 @@ class RedfishAction:
         self.args = None
 
     def __iter__(self):
+        """Yield the action's (key, value) pairs for dict conversion."""
         yield from {
             "action_name": self.action_name,
             "full_redfish_name": self.full_redfish_name,
@@ -242,15 +252,31 @@ class RedfishAction:
         self.args[arg_name] = allowable_value
 
     def toJSON(self):
+        """Return the action serialized as a sorted, indented JSON string.
+
+        :return: the action as a sorted, indented JSON string.
+        """
         return json.dumps(self, default=lambda o: o.__dict__, sort_keys=True, indent=4)
 
     def __repr__(self):
+        """Return the action's string representation.
+
+        :return: the JSON string form of the action.
+        """
         return self.__str__()
 
     def __str__(self):
+        """Return the action as a compact JSON string.
+
+        :return: the action encoded as a JSON string.
+        """
         return json.dumps(dict(self), ensure_ascii=False)
 
     def to_json(self):
+        """Return the action as a compact JSON string.
+
+        :return: the action encoded as a JSON string.
+        """
         return json.dumps(dict(self), ensure_ascii=False)
 
 
@@ -272,6 +298,13 @@ class Singleton(type):
 
     @staticmethod
     def _connection_key(cls, args, kwargs):
+        """Build the cache key fingerprinting a class and its BMC connection.
+
+        :param cls: the command class being instantiated.
+        :param args: positional constructor arguments.
+        :param kwargs: keyword constructor arguments carrying the connection fields.
+        :return: a tuple key; the password contributes only as a SHA-256 digest.
+        """
         password = str(kwargs.get("idrac_password", "") or "")
         return (
             cls,
@@ -286,6 +319,10 @@ class Singleton(type):
         )
 
     def __call__(cls, *args, **kwargs):
+        """Return the cached instance for this class+connection, building one once.
+
+        :return: the singleton instance for the (class, connection) key.
+        """
         key = Singleton._connection_key(cls, args, kwargs)
         inst = cls._instances.get(key)
         if inst is None:
@@ -435,9 +472,20 @@ class RestMethodMapping:
         self._api_call = {}
 
     def add_api(self, a: Rest, method: HTTPMethod):
+        """Map a REST resource to its supported HTTP method.
+
+        :param a: the REST resource key.
+        :param method: the HTTP method supported for the resource.
+        """
         self._api_call[a] = method
 
     def method(self, a):
+        """Return the HTTP method mapped to a REST resource.
+
+        :param a: the REST resource key to look up.
+        :return: the HTTP method registered for the resource.
+        :raises KeyError: when the resource has no registered method.
+        """
         return self._api_call[a]
 
 
@@ -678,6 +726,10 @@ class DellBootSource:
 
     @property
     def Id(self) -> str:
+        """The unique identifier of the boot device.
+
+        :return: the boot device id.
+        """
         return self._id
 
     @property
@@ -753,8 +805,16 @@ class TestNetworkShareReq:
 
     @property
     def success(self):
+        """The HTTP status code treated as success for this request.
+
+        :return: the success status code (200).
+        """
         return self._success
 
     @property
     def method(self):
+        """The HTTP method used for this request.
+
+        :return: the HTTP method (POST).
+        """
         return self._method


### PR DESCRIPTION
Docstring-coverage PR for top-level `reconcile.py`, `api.py`, `redfish_manager_shared.py`, `redfish_main.py`, compliant with the merged docstring gate (#145). 62 members documented. Not command modules. Similarly-named params (deep/expanded/wait/async_call) verified genuinely used. Docstrings only. Gates: gate 0; ruff no new; pytest green.