### PR TITLE
Document compute command methods (docstring coverage)

### DIFF
--- a/redfish_ctl/compute/cmd_compute_setting.py
+++ b/redfish_ctl/compute/cmd_compute_setting.py
@@ -1,5 +1,7 @@
 """iDRAC query compute settings
 
+    redfish_ctl compute-query
+
 It represents  ComputerSystem schema or system instance and
 the software-visible resources, or items within the data plane,
 such as memory, CPU, and other devices that it can access.
@@ -23,14 +25,15 @@ class QueryCompute(RedfishManagerBase,
     """Query compute
     """
     def __init__(self, *args, **kwargs):
+        """Initialize the compute-query command."""
         super(QueryCompute, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register command
-        :param cls:
-        :return:
+        """Register the compute-query subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_parser = cls.base_parser()
         help_text = "command query compute settings."
@@ -43,14 +46,17 @@ class QueryCompute(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """
+        """Query the host ComputerSystem settings resource.
+
+        On firmware 6.10+ this targets the ComputerSystem ``/Settings`` URI;
+        on older firmware it queries the ComputerSystem resource itself.
+
         :param do_expanded: will use expand output at level 1
         :param do_async: will issue asyncio request and won't block
-        :param filename:
-        :param data_type:
-        :param verbose:
-        :param kwargs:
-        :return:
+        :param filename: if set, save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult with the ComputerSystem settings query response.
         """
         idrac_version = self.idrac_manager_version
         ver_by_parts = idrac_version.split(".")

--- a/redfish_ctl/compute/cmd_power_state.py
+++ b/redfish_ctl/compute/cmd_power_state.py
@@ -1,5 +1,7 @@
 """iDRAC reset a power state for compute system command.
 
+    redfish_ctl reboot --reset_type GracefulRestart
+
 This action is used to reset the system.
 Command provides the option to reboot, and change power state.
 
@@ -40,14 +42,15 @@ class RebootHost(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the reboot command."""
         super(RebootHost, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register command
-        :param cls:
-        :return:
+        """Register the reboot subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_parser = argparse.ArgumentParser(add_help=False)
         cmd_parser.add_argument(
@@ -83,9 +86,10 @@ class RebootHost(RedfishManagerBase,
         and wait for reboot to complete. It makes sense to call this method
         only if reset already called.
 
-        :param sleep_time:
-        :param max_retry:
-        :return:
+        :param sleep_time: seconds to sleep between reboot-pending polls.
+        :param max_retry: maximum retries while waiting for the reboot job.
+        :return: the jobs-query CommandResult if that query errors; otherwise
+                 None once the reboot-pending wait loop completes.
         """
         _reboot = 1
         retry_counter = 0
@@ -159,8 +163,8 @@ class RebootHost(RedfishManagerBase,
                            GracefulShutdown, PushPowerButton, Nmi, PowerCycle"
         :param sleep_time: wait for the reboot job to start.
         :param max_retry: maximum retry while waiting for the reboot job.
-        :param filename:
-        :param data_type:
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :param kwargs:
         :return: CommandResult; on a real fire ``.data`` carries the task id/state,
                  on a dry-run it carries the resolved target + payload.

--- a/redfish_ctl/compute/cmd_system_reset.py
+++ b/redfish_ctl/compute/cmd_system_reset.py
@@ -30,12 +30,16 @@ class SystemReset(RedfishManagerBase,
     """Reset the host ComputerSystem via a discovered ComputerSystem.Reset action."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the system-reset command."""
         super(SystemReset, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``system-reset`` subcommand and its safety flags."""
+        """Register the ``system-reset`` subcommand and its safety flags.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--reset_type', required=False, dest='reset_type', type=str,
@@ -63,6 +67,17 @@ class SystemReset(RedfishManagerBase,
 
         Returns a dry-run preview (target + payload, no POST) unless ``--confirm``
         is given; the destructiveness guard lives in ``invoke_action``.
+
+        :param reset_type: the ComputerSystem ResetType to request (On, ForceOff,
+                           GracefulRestart, ForceRestart, ...).
+        :param confirm: actually perform the reset; without it this is a dry-run.
+        :param dry_run: force a dry-run preview even when ``--confirm`` is given.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the request on the asyncio path.
+        :return: CommandResult; a dry-run preview (resolved target + payload, no
+                 POST) unless ``--confirm`` is given, otherwise the reset response.
         """
         return self.invoke_action(
             self.idrac_manage_servers,

--- a/redfish_ctl/compute/cmd_update.py
+++ b/redfish_ctl/compute/cmd_update.py
@@ -1,5 +1,7 @@
 """iDRAC update compute settings
 
+    redfish_ctl compute-update
+
 TODO , this looks like overlap between 6.00.3 and 6.10.
 
 It represents  ComputerSystem schema or system instance and
@@ -25,14 +27,15 @@ class UpdateCompute(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the compute-update command."""
         super(UpdateCompute, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register command
-        :param cls:
-        :return:
+        """Register the compute-update subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_parser = cls.base_parser()
         help_text = "command update compute settings."
@@ -48,14 +51,17 @@ class UpdateCompute(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """
-        :param do_expanded:
+        """Query the host ComputerSystem settings resource for update.
+
+        On firmware 6.10+ this targets the ComputerSystem ``/Settings`` URI;
+        on older firmware it queries the ComputerSystem resource itself.
+
+        :param do_expanded: issue an expanded ($expand) Redfish query.
         :param do_async: will issue asyncio request and won't block
-        :param filename:
-        :param data_type:
-        :param verbose:
-        :param kwargs:
-        :return:
+        :param filename: if set, save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult with the ComputerSystem settings query response.
         """
 
         idrac_version = self.idrac_manager_version


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/compute/` (compute-query, reboot, compute-update, system-reset), compliant with the merged docstring gate (#145). Recurring framework params documented per body usage (verified). Docstrings only, no behavior change. Gates: gate 0; ruff no new; pytest green.