### PR TITLE
Document tasks command methods (docstring coverage)

### DIFF
--- a/redfish_ctl/tasks/cmd_task_svc.py
+++ b/redfish_ctl/tasks/cmd_task_svc.py
@@ -2,6 +2,10 @@
 
 Command provides the option to retrieve task services.
 
+Example::
+
+    redfish_ctl task-svc
+
 Author Mus spyroot@gmail.com
 """
 from abc import abstractmethod
@@ -20,14 +24,15 @@ class Manager(RedfishManagerBase,
     caller can save to a file or output to a file or pass downstream.
     """
     def __init__(self, *args, **kwargs):
+        """Initialize the task-svc command."""
         super(Manager, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Registers command args
-        :param cls:
-        :return:
+        """Register the task-svc subcommand and its arguments.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_arg = cls.base_parser()
         help_text = "command fetch task services"
@@ -39,14 +44,15 @@ class Manager(RedfishManagerBase,
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Queries task servers services from iDRAC.
-        :param do_async:
-        :param verbose:
-        :param do_deep:
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type:
-        :return:
-        :raise: AuthenticationFailed, UnexpectedResponse
+        """Query the Redfish TaskService and discover its actions.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: json or xml; json adds the JSON content-type header.
+        :param do_deep: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult wrapping the TaskService payload and discovered actions.
+        :raises AuthenticationFailed, UnexpectedResponse: on request failure.
         """
         headers = {}
         if data_type == "json":

--- a/redfish_ctl/tasks/cmd_task_watch.py
+++ b/redfish_ctl/tasks/cmd_task_watch.py
@@ -1,9 +1,13 @@
-"""iDRAC export system config command.
+"""iDRAC task watch command.
 
 Command provides the option to retrieve firmware setting from iDRAC and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
+
+Example::
+
+    redfish_ctl task-watch --task_id JID_744718373591
 
 Author Mus spyroot@gmail.com
 """
@@ -35,14 +39,15 @@ class GetTask(
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the task-watch command."""
         super(GetTask, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register command arguments.
-        :param cls:
-        :return:
+        """Register the task-watch subcommand and its arguments.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_parser = argparse.ArgumentParser(add_help=False)
         cmd_parser.add_argument('--async', action='store_true',
@@ -68,13 +73,16 @@ class GetTask(
                 do_async: Optional[bool] = False,
                 **kwargs
                 ) -> CommandResult:
-        """watch current task.
-        :param job_id:
-        :param do_async:
-        :param data_type:
-        :param verbose:
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :return:
+        """Fetch the current state of a task by its job id.
+
+        :param job_id: task/job id to fetch (e.g. JID_744718373591).
+        :param data_type: accepted for CLI compatibility; only echoed in verbose
+            logging, not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param verbose: enables verbose logging of the received arguments.
+        :param do_async: accepted for CLI compatibility; only echoed in verbose
+            logging, not used by this command.
+        :return: CommandResult wrapping the fetched task payload.
         """
 
         if verbose:

--- a/redfish_ctl/tasks/cmd_tasks_get.py
+++ b/redfish_ctl/tasks/cmd_tasks_get.py
@@ -2,6 +2,9 @@
 
 Command provides query tasks service and obtains list of task.
 
+Example::
+
+    redfish_ctl task-get
 
 Author Mus spyroot@gmail.com
 """
@@ -30,14 +33,15 @@ class TasksGet(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the task-get command."""
         super(TasksGet, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register command and all optional flags.
-        :param cls:
-        :return:
+        """Register the task-get subcommand and its arguments.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument('-t' '--task_id', required=True, dest="task_id", type=str,
@@ -54,15 +58,15 @@ class TasksGet(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = True,
                 **kwargs) -> CommandResult:
-        """Executes tasks fetch
+        """Fetch a single task by its id from the Redfish TaskService.
 
-        :param task_id:
+        :param task_id: task id to fetch (appended to the Tasks resource path).
+        :param filename: if set, save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: note async will subscribe to an event loop.
-        :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
-        :return: CommandResult and if filename provide will save to a file.
+        :param do_expanded: issue an expanded ($expand) Redfish query.
+        :return: CommandResult wrapping the task query result.
         """
         target_api = f"/redfish/v1/TaskService/Tasks/{task_id}"
         cmd_result = self.base_query(target_api,

--- a/redfish_ctl/tasks/cmd_tasks_list.py
+++ b/redfish_ctl/tasks/cmd_tasks_list.py
@@ -2,6 +2,10 @@
 
 Command provides  query tasks service and obtains list of task.
 
+Example::
+
+    redfish_ctl tasks
+
 Author Mus spyroot@gmail.com
 """
 from abc import abstractmethod
@@ -20,14 +24,15 @@ class TasksList(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the tasks command."""
         super(TasksList, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register command and all optional flags.
-        :param cls:
-        :return:
+        """Register the tasks subcommand and its arguments.
+
+        :return: tuple of (ArgumentParser, command name, command help).
         """
         cmd_parser = cls.base_parser()
         help_text = "command fetch tasks list"
@@ -40,14 +45,14 @@ class TasksList(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = True,
                 **kwargs) -> CommandResult:
-        """Executes tasks list
+        """List tasks from the Redfish TaskService and discover their actions.
 
+        :param filename: if set, save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: note async will subscribe to an event loop.
-        :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
-        :return: CommandResult and if filename provide will save to a file.
+        :param do_expanded: issue an expanded ($expand) Redfish query.
+        :return: CommandResult wrapping the tasks list and per-member discovered actions.
         """
         target_api = "/redfish/v1/TaskService/Tasks"
         cmd_result = self.base_query(target_api,


### PR DESCRIPTION
Docstring-coverage PR for `redfish_ctl/tasks/` (task-svc/watch/get/list), compliant with the merged docstring gate (#145). Recurring framework params documented per body usage (verified). Docstrings only. Gates: gate 0; ruff no new; pytest green.