### PR TITLE
Document logs/oem/serial-console/sensors/discovery methods (docstring coverage)

### DIFF
--- a/redfish_ctl/discovery/cmd_bmc_scan.py
+++ b/redfish_ctl/discovery/cmd_bmc_scan.py
@@ -31,12 +31,16 @@ class BmcScan(RedfishManagerBase,
     """Scan a CIDR for hosts exposing a Redfish ServiceRoot."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the bmc-scan command."""
         super(BmcScan, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``bmc-scan`` subcommand and its scan flags."""
+        """Register the ``bmc-scan`` subcommand and its scan flags.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--subnet', required=False, dest='subnet', type=str, default=None,
@@ -63,7 +67,21 @@ class BmcScan(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Expand the CIDR and probe each host concurrently for a Redfish BMC."""
+        """Expand the CIDR and probe each host concurrently for a Redfish BMC.
+
+        :param subnet: network segment to scan as a CIDR (e.g. 10.43.3.0/24);
+            required — a missing value returns an error result.
+        :param scan_port: HTTPS port to probe on each host.
+        :param scan_timeout: per-host probe timeout in seconds.
+        :param scan_workers: number of concurrent probes.
+        :param filename: if set, save the discovered BMC list to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult whose data is the list of discovered BMCs, or an
+            error message when --subnet is missing or invalid.
+        """
         if not subnet:
             return CommandResult(
                 [], None, None,

--- a/redfish_ctl/discovery/cmd_discovery.py
+++ b/redfish_ctl/discovery/cmd_discovery.py
@@ -2,6 +2,9 @@
 
 Command discover all idrac / redfish resources.
 
+    redfish_ctl discovery
+    redfish_ctl discovery --network 192.168.254.0/24
+
 Author Mus spyroot@gmail.com
 """
 import json

--- a/redfish_ctl/logs/cmd_logs.py
+++ b/redfish_ctl/logs/cmd_logs.py
@@ -29,12 +29,16 @@ class Logs(RedfishManagerBase,
     """Read log-service entries from every system and manager."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the logs command."""
         super(Logs, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``logs`` subcommand."""
+        """Register the ``logs`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--limit', required=False, dest='limit', type=int, default=50,
@@ -43,14 +47,23 @@ class Logs(RedfishManagerBase,
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (or any value; non-dicts yield []).
+        :return: list of member ``@odata.id`` strings.
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
                 if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 
     def _get(self, uri, do_async):
-        """GET a resource body, returning {} on any failure."""
+        """GET a resource body, returning {} on any failure.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async event loop when True.
+        :return: the parsed response body, or {} when the query fails.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
@@ -58,7 +71,12 @@ class Logs(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
-        """Return the @odata.id of a single ``{key: {@odata.id}}`` link, or None."""
+        """Return the @odata.id of a single ``{key: {@odata.id}}`` link, or None.
+
+        :param data: the resource body holding the link (may be None).
+        :param key: the property name whose ``@odata.id`` to extract.
+        :return: the link target URI, or None when absent or malformed.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
@@ -67,6 +85,8 @@ class Logs(RedfishManagerBase,
 
         Log services hang off different roots per vendor — Systems/Managers on
         iLO, Chassis on the GB300 — so all three are walked.
+
+        :return: list of root resource URIs to inspect for log services.
         """
         roots = []
         for finder in (self.discover_computer_system_ids, self.discover_manager_ids):
@@ -88,7 +108,17 @@ class Logs(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Walk LogServices on every system/manager and collect capped entries."""
+        """Walk LogServices on every system/manager and collect capped entries.
+
+        :param limit: max entries collected per log service.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries on the async event loop when True.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult whose data is a list of flattened log-entry rows
+            {Source, Service, Id, Severity, Created, Message}.
+        """
         rows = []
         for root_uri in self._roots():
             rdata = self._get(root_uri, do_async)

--- a/redfish_ctl/oem/cmd_oem_info.py
+++ b/redfish_ctl/oem/cmd_oem_info.py
@@ -27,33 +27,50 @@ class OemInfo(RedfishManagerBase,
     """Inventory the vendor OEM extensions exposed on systems/managers/chassis."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the oem-info command."""
         super(OemInfo, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``oem-info`` subcommand (read-only)."""
+        """Register the ``oem-info`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command inventory vendor OEM extensions (Dell/HPE/NVIDIA/OpenBMC)"
         return cmd_parser, "oem-info", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (or any value; non-dicts yield []).
+        :return: list of member ``@odata.id`` strings.
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
                 if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 
     def _get(self, uri, do_async):
-        """GET a resource body, returning {} on any failure."""
+        """GET a resource body, returning {} on any failure.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async event loop when True.
+        :return: the parsed response body, or {} when the query fails.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
             return {}
 
     def _roots(self, do_async):
-        """Every ComputerSystem + Manager + Chassis URI, multi-member aware."""
+        """Every ComputerSystem + Manager + Chassis URI, multi-member aware.
+
+        :param do_async: issue the Chassis query on the async event loop when True.
+        :return: list of root resource URIs to inspect for OEM extensions.
+        """
         roots = []
         for finder in (self.discover_computer_system_ids, self.discover_manager_ids):
             try:
@@ -70,7 +87,16 @@ class OemInfo(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Report each resource's OEM vendor extensions and their top-level keys."""
+        """Report each resource's OEM vendor extensions and their top-level keys.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries on the async event loop when True.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult whose data is a list of OEM rows
+            {Resource, Vendor, Type, Keys}.
+        """
         rows = []
         for root_uri in self._roots(do_async):
             oem = self._get(root_uri, do_async).get("Oem")

--- a/redfish_ctl/sensors/cmd_sensors.py
+++ b/redfish_ctl/sensors/cmd_sensors.py
@@ -24,18 +24,26 @@ class Sensors(RedfishManagerBase,
     """Read every Chassis sensor reading (temperature, power, fan, voltage…)."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the sensors command."""
         super(Sensors, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``sensors`` subcommand (read-only, no flags needed)."""
+        """Register the ``sensors`` subcommand (read-only, no flags needed).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         return cmd_parser, "sensors", "command read all chassis sensor readings"
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (or any value; non-dicts yield []).
+        :return: list of member ``@odata.id`` strings.
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
@@ -53,6 +61,15 @@ class Sensors(RedfishManagerBase,
         Tolerant of a chassis without a Sensors link or an unreachable
         collection (skips it). An ``$expand``'d Sensors member already carries
         its Reading; otherwise each member is fetched individually.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries on the async event loop when True.
+        :param do_expanded: force an expanded ($expand) Sensors query and skip the
+            per-member fallback.
+        :return: CommandResult whose data is a list of sensor rows
+            {Chassis, Name, Reading, ReadingUnits, ReadingType, Health}.
         """
         readings = []
         chassis = self.base_query(REDFISH_API.Chassis, do_async=do_async)

--- a/redfish_ctl/serial_console/cmd_serial_console.py
+++ b/redfish_ctl/serial_console/cmd_serial_console.py
@@ -45,12 +45,16 @@ class SerialConsoleConfig(RedfishManagerBase,
     """Report or enable host BIOS serial redirection together with BMC SOL."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the serial-console command."""
         super(SerialConsoleConfig, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``serial-console`` subcommand."""
+        """Register the ``serial-console`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             '--enable', action='store_true', dest='enable', default=False,
@@ -68,7 +72,12 @@ class SerialConsoleConfig(RedfishManagerBase,
         return cmd_parser, "serial-console", help_text
 
     def _get(self, uri, do_async):
-        """GET a resource body, returning {} on any failure (read is best-effort)."""
+        """GET a resource body, returning {} on any failure (read is best-effort).
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async event loop when True.
+        :return: the parsed response body, or {} when the query fails.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
@@ -81,6 +90,10 @@ class SerialConsoleConfig(RedfishManagerBase,
         Prefers an explicit override, then a known attribute name, then any
         attribute that looks like a serial-console knob. Returns ``None`` when the
         BIOS exposes nothing recognizable.
+
+        :param bios_attrs: the system's BIOS ``Attributes`` mapping.
+        :param override_attr: explicit attribute name to use, or None to auto-detect.
+        :return: the resolved BIOS attribute name, or None when none is recognizable.
         """
         if override_attr:
             return override_attr
@@ -104,7 +117,27 @@ class SerialConsoleConfig(RedfishManagerBase,
                 bios_attr: Optional[str] = None,
                 bios_value: Optional[str] = None,
                 **kwargs) -> CommandResult:
-        """Report serial-console/SOL state; with ``enable`` set both (guarded)."""
+        """Report serial-console/SOL state; with ``enable`` set both (guarded).
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries and PATCHes on the async
+            event loop when True.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :param enable: enable BIOS serial redirection and the BMC SOL service;
+            when False only the current state is reported.
+        :param confirm: actually apply the changes; without it ``enable`` only
+            previews the resolved targets and payloads (dry-run).
+        :param bios_attr: serial BIOS attribute to set; auto-discovered when omitted.
+        :param bios_value: value that enables redirection; defaults to the known
+            value for the resolved attribute.
+        :return: CommandResult whose data is the current status (report mode), a
+            dry-run preview (``enable`` without ``confirm``), or the applied result
+            (``enable`` with ``confirm``).
+        :raises InvalidArgument: when no serial BIOS attribute can be resolved, or
+            no enable value is known for it and ``--bios_value`` is not given.
+        """
         system_uri = self.idrac_manage_servers
         bios = self._get(f"{system_uri}/Bios", do_async)
         bios_attrs = bios.get("Attributes", {}) if isinstance(bios, dict) else {}


### PR DESCRIPTION
Docstring-coverage PR grouping five small read-only domains (`logs`, `oem`, `serial_console`, `sensors`, `discovery`) into one PR, compliant with the merged docstring gate (#145). 26 members. Recurring framework params documented per body usage (verified). Docstrings only. Gates: gate 0 across all five; ruff no new; pytest green.