### PR TITLE
Document ports/pci/component-integrity/boot-options/raid methods (docstring coverage)

### DIFF
--- a/redfish_ctl/boot_options/cmd_boot_option_list.py
+++ b/redfish_ctl/boot_options/cmd_boot_option_list.py
@@ -11,6 +11,8 @@ idrac9_3.36_redfishapiguide/dellbootsources?guid=guid-4803ff0e-76ad-42c5-a971-82
 
 python redfish_ctl.py --json boot_source
 
+    redfish_ctl boot-sources
+
 cmd return list of boot devices.
 
     "/redfish/v1/Systems/System.Embedded.1/BootOptions/HardDisk.List.1-1",
@@ -41,6 +43,7 @@ class BootOptionsList(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the boot-sources command."""
         super(BootOptionsList, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/boot_options/cmd_boot_options_query.py
+++ b/redfish_ctl/boot_options/cmd_boot_options_query.py
@@ -1,5 +1,7 @@
 """iDRAC query for a boot options
 
+    redfish_ctl boot-options
+
 Author Mus spyroot@gmail.com
 """
 from abc import abstractmethod
@@ -19,6 +21,7 @@ class BootOptionsQuery(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the boot-options command."""
         super(BootOptionsQuery, self).__init__(*args, **kwargs)
 
     @staticmethod

--- a/redfish_ctl/component_integrity/cmd_component_integrity.py
+++ b/redfish_ctl/component_integrity/cmd_component_integrity.py
@@ -30,19 +30,27 @@ class QueryComponentIntegrity(RedfishManagerBase,
     """Read every ComponentIntegrity (SPDM/attestation) relationship."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the component-integrity command."""
         super(QueryComponentIntegrity, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``component-integrity`` subcommand (read-only)."""
+        """Register the ``component-integrity`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read ComponentIntegrity (SPDM attestation) state"
         return cmd_parser, "component-integrity", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (dict carrying ``Members``).
+        :return: list of member ``@odata.id`` strings (empty if none/malformed).
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
@@ -54,6 +62,9 @@ class QueryComponentIntegrity(RedfishManagerBase,
 
         Layout: SPDM.IdentityAuthentication.ResponderAuthentication
         .ComponentCertificate.@odata.id. Any level may be absent.
+
+        :param spdm: the leaf's ``SPDM`` sub-dict (or any non-dict).
+        :return: the certificate ``@odata.id`` string, or None when absent.
         """
         if not isinstance(spdm, dict):
             return None
@@ -73,6 +84,14 @@ class QueryComponentIntegrity(RedfishManagerBase,
 
         Tolerant of a host without the collection (returns an empty list) or a
         leaf missing the SPDM/cert sub-structure (CertificateURI is None).
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: note async will subscribe to an event loop.
+        :param do_expanded: issue an expanded ($expand) Redfish query.
+        :return: CommandResult whose data is a list of per-leaf integrity rows
+            (empty when the host exposes no ComponentIntegrity collection).
         """
         rows = []
         coll_uri = f"{RedfishApi.Version}/ComponentIntegrity"

--- a/redfish_ctl/pci/cmd_pci.py
+++ b/redfish_ctl/pci/cmd_pci.py
@@ -5,6 +5,8 @@ back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
 
+    redfish_ctl pci PCIeDevices
+
 Author Mus spyroot@gmail.com
 """
 import asyncio
@@ -29,6 +31,7 @@ class PciDeviceQuery(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the pci command."""
         super(PciDeviceQuery, self).__init__(*args, **kwargs)
 
     @staticmethod
@@ -119,14 +122,29 @@ class PciDeviceQuery(RedfishManagerBase,
         Walks /redfish/v1/Chassis -> each chassis PCIeDevices collection -> each
         device (and, for PCIeFunctions, that device's PCIeFunctions collection).
         Skips a chassis or leaf that is missing/unreachable rather than failing.
+
+        :param pci_type: PCIeDevices or PCIeFunctions; PCIeFunctions descends one
+            level further into each device's functions collection.
+        :param do_async: forwarded to base_query so the walk can run async.
+        :return: list of PCIe device or function bodies (empty if none found).
         """
         def get(uri):
+            """Fetch the resource body at ``uri``, or {} on any error.
+
+            :param uri: Redfish resource path to GET.
+            :return: the resource body dict, or an empty dict on failure.
+            """
             try:
                 return self.base_query(uri, do_async=do_async).data or {}
             except Exception:
                 return {}
 
         def members(data):
+            """Return the ``@odata.id`` strings from a collection body.
+
+            :param data: a Redfish collection body (dict carrying ``Members``).
+            :return: list of member ``@odata.id`` strings.
+            """
             return [m["@odata.id"] for m in (data.get("Members") or [])
                     if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 

--- a/redfish_ctl/ports/cmd_nvlink_ports.py
+++ b/redfish_ctl/ports/cmd_nvlink_ports.py
@@ -32,26 +32,40 @@ class NvLinkPorts(RedfishManagerBase,
     """Read every GPU NVLink port and its traffic/error metrics."""
 
     def __init__(self, *args, **kwargs):
+        """Initialize the nvlink-ports command."""
         super(NvLinkPorts, self).__init__(*args, **kwargs)
 
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the ``nvlink-ports`` subcommand (read-only)."""
+        """Register the ``nvlink-ports`` subcommand (read-only).
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         help_text = "command read GPU NVLink ports and per-port metrics"
         return cmd_parser, "nvlink-ports", help_text
 
     @staticmethod
     def _members(data):
-        """Return the @odata.id strings from a Redfish collection, tolerantly."""
+        """Return the @odata.id strings from a Redfish collection, tolerantly.
+
+        :param data: a Redfish collection body (dict carrying ``Members``).
+        :return: list of member ``@odata.id`` strings (empty if none/malformed).
+        """
         if not isinstance(data, dict):
             return []
         return [m["@odata.id"] for m in data.get("Members", [])
                 if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
 
     def _link(self, data, key, do_async):
-        """Follow a single ``{key: {@odata.id}}`` link, returning its body or {}."""
+        """Follow a single ``{key: {@odata.id}}`` link, returning its body or {}.
+
+        :param data: the parent resource body holding the link.
+        :param key: the property name whose ``@odata.id`` link to follow.
+        :param do_async: forwarded to base_query so the fetch can run async.
+        :return: the linked resource body dict, or {} if absent/unreachable.
+        """
         link = (data or {}).get(key)
         uri = link.get("@odata.id") if isinstance(link, dict) else None
         if not uri:
@@ -73,6 +87,14 @@ class NvLinkPorts(RedfishManagerBase,
         On a multi-system host (e.g. a host System plus an HGX baseboard System)
         the GPUs live under whichever System exposes them; both are walked. A
         port whose Metrics leaf is absent still yields a row with None counters.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: note async will subscribe to an event loop.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult whose data is a list of per-port NVLink rows
+            (empty when no Systems or GPU ports are exposed).
         """
         rows = []
         try:

--- a/redfish_ctl/raid/cmd_raid_service.py
+++ b/redfish_ctl/raid/cmd_raid_service.py
@@ -11,6 +11,8 @@ In result command also store all discovered action.
 For example.
 {'AssignSpare': '/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService/Actions/DellRaidService.AssignSpare'}
 
+    redfish_ctl raid
+
 Author Mus spyroot@gmail.com
 """
 import argparse
@@ -32,6 +34,7 @@ class RaidServiceQuery(RedfishManagerBase,
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the raid command."""
         super(RaidServiceQuery, self).__init__(*args, **kwargs)
 
     @staticmethod


### PR DESCRIPTION
Docstring-coverage PR grouping five small domains (`ports`, `pci`, `component_integrity`, `boot_options`, `raid`) into one PR, compliant with the merged docstring gate (#145). 17 members + module examples. Recurring framework params documented per body usage (verified). Docstrings only. Gates: gate 0 across all five; ruff no new; pytest green.