### PR TITLE
Correct pre-existing docstring inaccuracies (honesty sweep)

### DIFF
--- a/redfish_ctl/accounts/cmd_account_svc.py
+++ b/redfish_ctl/accounts/cmd_account_svc.py
@@ -93,9 +93,9 @@ class QueryAccountService(RedfishManagerBase,
         :param schema_filter: filter account services based on schema filter key.
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         json_filter = ""

--- a/redfish_ctl/accounts/cmd_accounts.py
+++ b/redfish_ctl/accounts/cmd_accounts.py
@@ -57,9 +57,9 @@ class QueryAccounts(RedfishManagerBase,
         :param is_username_only:  filter and only output username,
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         is_expanded = False

--- a/redfish_ctl/accounts/cmd_privilage_registry.py
+++ b/redfish_ctl/accounts/cmd_privilage_registry.py
@@ -49,9 +49,9 @@ class QueryPrivilegeRegistry(RedfishManagerBase,
         :param schema_filter: filter account services based on schema filter key.
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         cmd_result = self.base_query(f"{self.idrac_members}/PrivilegeRegistry",

--- a/redfish_ctl/accounts/cmd_query_account.py
+++ b/redfish_ctl/accounts/cmd_query_account.py
@@ -58,9 +58,9 @@ class QueryAccount(RedfishManagerBase,
         :param account:  account id
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
 

--- a/redfish_ctl/bios/bios_registry.py
+++ b/redfish_ctl/bios/bios_registry.py
@@ -142,9 +142,9 @@ class BiosRegistry(RedfishManagerBase,
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
         :param is_value_only:  will only return value , choices that attribute can take.
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = self._resolve_registry_uri(do_async)

--- a/redfish_ctl/bios/cmd_bios_pending.py
+++ b/redfish_ctl/bios/cmd_bios_pending.py
@@ -1,7 +1,7 @@
-"""iDRAC query chassis services
+"""iDRAC query BIOS pending values.
 
-Command provides raw query chassis and provide
-list of supported actions.
+Command provides a raw query of the BIOS attributes that are staged as
+pending (not yet applied).
 
     redfish_ctl bios-pending
 
@@ -57,9 +57,9 @@ class BiosQueryPending(RedfishManagerBase,
         :param data_filter:
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded: will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = f"{self.idrac_manage_servers}/Bios/Settings"

--- a/redfish_ctl/bios/cmd_bios_snapshot.py
+++ b/redfish_ctl/bios/cmd_bios_snapshot.py
@@ -87,7 +87,7 @@ class BiosSnapshot(RedfishManagerBase,
         :param attr_name: comma-separated attribute names to snapshot (default: all).
         :param from_spec: bios-change spec whose attribute names scope the snapshot.
         :param filename: if set, save the response to this file.
-        :param data_type: json or xml.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded: accepted for CLI compatibility; not used by this command.

--- a/redfish_ctl/bios/cmd_change_bios.py
+++ b/redfish_ctl/bios/cmd_change_bios.py
@@ -282,11 +282,11 @@ class BiosChangeSettings(RedfishManagerBase,
         :param attr_value:  attribute value or list of values
         :param attr_name: attribute name or list of values
         :param do_async: note async will subscribe to an event loop.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param from_spec: read bios changes from a spec file
         :param commit_pending:  this command will first commit all pending changes before do new change.
         :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :param start_time:
         :param start_date:
         :return: CommandResult and if filename provide will save to a file.

--- a/redfish_ctl/bios/cmd_change_boot_order.py
+++ b/redfish_ctl/bios/cmd_change_boot_order.py
@@ -124,7 +124,7 @@ class ChangeBootOrder(
         :param boot_order:
         :param filename:
         :param do_async:
-        :param data_type:
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :param kwargs:
         :return: return cmd result
         :raise FailedDiscoverAction

--- a/redfish_ctl/boot_options/cmd_boot_option_list.py
+++ b/redfish_ctl/boot_options/cmd_boot_option_list.py
@@ -86,9 +86,9 @@ class BootOptionsList(RedfishManagerBase,
         "/redfish/v1/Systems/System.Embedded.1/BootOptions/Optical.vFlash.ISOIMG-1"
         ]
 
-        :param do_async:
-        :param verbose:
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
         :param data_type: json or xml
         :return: CommandResult and if filename provide will save to a file.
         """

--- a/redfish_ctl/boot_options/cmd_boot_options_query.py
+++ b/redfish_ctl/boot_options/cmd_boot_options_query.py
@@ -45,10 +45,10 @@ class BootOptionsQuery(RedfishManagerBase,
         """Query information for boot options.
 
         :param do_async: note async will subscribe to an event loop.
-        :param do_expanded: will issue expanded request.
-        :param verbose: enable verbose output.
-        :param data_type: json or xml
-         :param filename: if filename indicate call will save a bios setting to a file.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+         :param filename: if filename indicate call will save the response to this file.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = f"{self.idrac_manage_servers}/BootOptions"

--- a/redfish_ctl/boot_source/cmd_boot_one_shot.py
+++ b/redfish_ctl/boot_source/cmd_boot_one_shot.py
@@ -108,7 +108,7 @@ class BootOneShot(RedfishManagerBase,
         :param do_check:
         :param do_async: note async will subscribe to an event loop.
         :param verbose:
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type: json or xml
         :return: CommandResult and if filename provide will save to a file.
         """

--- a/redfish_ctl/boot_source/cmd_boot_settings.py
+++ b/redfish_ctl/boot_source/cmd_boot_settings.py
@@ -63,8 +63,8 @@ class BootSettings(RedfishManagerBase,
         """Query information for boot source settings and pending changes.
 
         :param do_async: note async will subscribe to an event loop.
-        :param verbose: enable verbose output.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type: json or xml
         :return: CommandResult and if filename provide will save to a file.
         """

--- a/redfish_ctl/boot_source/cmd_boot_source_get.py
+++ b/redfish_ctl/boot_source/cmd_boot_source_get.py
@@ -65,7 +65,7 @@ class BootSource(RedfishManagerBase,
         :param do_async: note async will subscribe to an event loop.
         :param verbose:
         :param data_type: json or xml
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :return: CommandResult and if filename provide will save to a file.
         """
         if verbose:

--- a/redfish_ctl/boot_source/cmd_boot_source_registry.py
+++ b/redfish_ctl/boot_source/cmd_boot_source_registry.py
@@ -52,9 +52,9 @@ class QueryBootSourceRegistry(
         
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         # BootSources/BootSourcesRegistry is a Dell OEM resource; degrade

--- a/redfish_ctl/boot_source/cmd_enable.py
+++ b/redfish_ctl/boot_source/cmd_enable.py
@@ -79,7 +79,7 @@ class EnableBootOptions(RedfishManagerBase,
         :param do_async: will do async call
         :param verbose: enables verbose output.
         :param data_type: json or xml
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :return: CommandResult and if filename provide will save to a file.
         """
         if verbose:

--- a/redfish_ctl/boot_source/cmd_pending.py
+++ b/redfish_ctl/boot_source/cmd_pending.py
@@ -65,9 +65,9 @@ class BootSourcePending(RedfishManagerBase,
         :param data_filter: filter applied to find specific device.
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded: will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         # DellBootSources is a Dell OEM resource; degrade gracefully off Dell.

--- a/redfish_ctl/boot_source/cmd_update.py
+++ b/redfish_ctl/boot_source/cmd_update.py
@@ -136,9 +136,9 @@ class BootSourceUpdate(RedfishManagerBase,
         :param do_reboot: will reboot a host.
         :param data_filter: filter applied to find specific device.
         :param do_async: note async will subscribe to an event loop.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: accepted for CLI compatibility; not used by this command.
         :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = f"{self.idrac_manage_servers}/Oem/Dell/DellBootSources/Settings"

--- a/redfish_ctl/chassis/cmd_chassis_query.py
+++ b/redfish_ctl/chassis/cmd_chassis_query.py
@@ -67,9 +67,9 @@ class ChassisQuery(RedfishManagerBase,
         :param data_filter: a filter on set of keys
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         # for a filter we query on level deep

--- a/redfish_ctl/cmd_boot.py
+++ b/redfish_ctl/cmd_boot.py
@@ -67,9 +67,9 @@ class BootQuery(RedfishManagerBase,
                 **kwargs) -> CommandResult:
         """Query boot source from idrac
         :param do_async: will use asyncio
-        :param verbose:
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_deep:
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type: json or xml
         :return: CommandResult and if filename provide will save to a file.
         """

--- a/redfish_ctl/cmd_current_boot.py
+++ b/redfish_ctl/cmd_current_boot.py
@@ -65,7 +65,7 @@ class GetCurrentBoot(RedfishManagerBase,
 
         :param do_async: note async will subscribe to an event loop.
         :param verbose:
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type: json or xml
         :return: CommandResult and if filename provide will save to a file.
         """

--- a/redfish_ctl/cmd_query.py
+++ b/redfish_ctl/cmd_query.py
@@ -57,9 +57,9 @@ class QueryIDRAC(
         :param resource: path to a resource
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         return self.base_query(resource,

--- a/redfish_ctl/dell_lc/cmd_dell_lc_services.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_services.py
@@ -54,7 +54,7 @@ class DellLcQuery(RedfishManagerBase,
         :param data_filter: key to filter the response on (e.g. PowerState); when set, forces an expanded query.
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param verbose: accepted for CLI compatibility; not used by this command.
         :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.

--- a/redfish_ctl/delloem/delloem_actions.py
+++ b/redfish_ctl/delloem/delloem_actions.py
@@ -43,9 +43,9 @@ class DellOemActions(RedfishManagerBase,
 
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = "/redfish/v1/Dell/Systems/System.Embedded.1/DellOSDeploymentService"

--- a/redfish_ctl/delloem/delloem_attach.py
+++ b/redfish_ctl/delloem/delloem_attach.py
@@ -65,8 +65,8 @@ class DellOemAttach(RedfishManagerBase, scm_type=ApiRequestType.OemAttach,
         :param remote_password: remote password if required for NFS or CIFS
         :param remote_workgroup:
         :param do_async: note async will subscribe to an event loop.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         cmd_result = self.sync_invoke(ApiRequestType.DellOemActions, "dell_oem_actions")

--- a/redfish_ctl/delloem/delloem_attach_status.py
+++ b/redfish_ctl/delloem/delloem_attach_status.py
@@ -51,10 +51,10 @@ class GetAttachStatus(
         }
         python redfish_ctl.py chassis
         :param do_async: note async will subscribe to an event loop.
-        :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a response to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         cmd_result = self.sync_invoke(

--- a/redfish_ctl/delloem/delloem_boot_netios.py
+++ b/redfish_ctl/delloem/delloem_boot_netios.py
@@ -73,8 +73,8 @@ class DellOemNetIsoBoot(RedfishManagerBase,
         :param remote_password: remote password if required for NFS or CIFS
         :param remote_workgroup:
         :param do_async: note async will subscribe to an event loop.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         cmd_result = self.sync_invoke(ApiRequestType.DellOemActions, "dell_oem_actions")

--- a/redfish_ctl/delloem/delloem_detach.py
+++ b/redfish_ctl/delloem/delloem_detach.py
@@ -43,8 +43,8 @@ class DellOemDetach(
                 **kwargs) -> CommandResult:
         """Executes dell oem detach cmd
         :param do_async: note async will subscribe to an event loop.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult
         """
         cmd_result = self.sync_invoke(

--- a/redfish_ctl/delloem/delloem_disconnect.py
+++ b/redfish_ctl/delloem/delloem_disconnect.py
@@ -45,8 +45,8 @@ class DellOemDisconnect(RedfishManagerBase,
         """Executes dell oem disconnect, detach network iso.
 
         :param do_async:note async will subscribe to an event loop.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         cmd_result = self.sync_invoke(ApiRequestType.DellOemActions, "dell_oem_actions")

--- a/redfish_ctl/delloem/delloem_get_networkios.py
+++ b/redfish_ctl/delloem/delloem_get_networkios.py
@@ -53,10 +53,10 @@ class GetNetworkIsoAttachStatus(RedfishManagerBase,
         python redfish_ctl.py chassis
         :param do_reboot: reboot
         :param do_async: note async will subscribe to an event loop.
-        :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         cmd_result = self.sync_invoke(ApiRequestType.DellOemActions, "dell_oem_actions")

--- a/redfish_ctl/delloem/delloem_os_deployment.py
+++ b/redfish_ctl/delloem/delloem_os_deployment.py
@@ -44,9 +44,9 @@ class DellOemTask(RedfishManagerBase,
 
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = "/redfish/v1/TaskService/Tasks/OSDeployment"

--- a/redfish_ctl/discovery/cmd_discovery.py
+++ b/redfish_ctl/discovery/cmd_discovery.py
@@ -384,9 +384,9 @@ class Discovery(RedfishManagerBase,
                members (off by default; enumerating them can overload a BMC).
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
 

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -378,11 +378,11 @@ class SubscriptionCreate(_SubscriptionBase,
                 **kwargs) -> CommandResult:
         """Preview (dry-run) or create an EventDestination subscription.
 
-        :param filename: optional path to save the result payload to.
-        :param data_type: output serialization format (``json`` or ``yaml``).
-        :param verbose: emit extra diagnostics when True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: issue the create over the async Redfish path when True.
-        :param do_expanded: request an expanded ($expand) response where supported.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
         :param destination: subscriber URL events are delivered to (required to create).
         :param protocol: the event protocol (default ``Redfish``).
         :param event_format_type: the delivered payload format, or None to omit.
@@ -460,11 +460,11 @@ class SubscriptionDelete(_SubscriptionBase,
                 **kwargs) -> CommandResult:
         """Preview (dry-run) or delete an EventDestination subscription.
 
-        :param filename: optional path to save the result payload to.
-        :param data_type: output serialization format (``json`` or ``yaml``).
-        :param verbose: emit extra diagnostics when True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: issue the delete over the async Redfish path when True.
-        :param do_expanded: request an expanded ($expand) response where supported.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
         :param subscription: the subscription id or member URI to remove (required).
         :param confirm: actually delete; without it the command only previews.
         :return: a CommandResult with the delete outcome, or the dry-run preview.

--- a/redfish_ctl/firmware/cmd_firmware_inv.py
+++ b/redfish_ctl/firmware/cmd_firmware_inv.py
@@ -63,8 +63,8 @@ class FirmwareInventoryQuery(RedfishManagerBase,
                 do_async: Optional[bool] = False, **kwargs) -> CommandResult:
         """Query firmware from idrac
         :param do_deep: will return verbose output for each pci device.
-        :param do_async: will schedule asyncio task.
-        :param verbose: verbose output.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param filename: if filename indicate call will save respond to a file.
         :param data_type: a data serialized back.
         :return: in data type json will return json

--- a/redfish_ctl/jobs/cmd_job_apply.py
+++ b/redfish_ctl/jobs/cmd_job_apply.py
@@ -72,12 +72,12 @@ class JobApply(RedfishManagerBase,
         :param default_reboot_type:  a default reset type applied in order clean all scheduled jobs
         :param sleep_time:  a default sleep time, in sync mode we wait to see task moved on
         :param do_async: note async will subscribe to an event loop.
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param setting: job we apply
         :param do_watch: will watch job progress.
         :param do_reboot: many jobs applied only after boot, watch will just block.
-        :param data_type: json or xml
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = f"{self.idrac_members}/{REDFISH_API.Jobs}"

--- a/redfish_ctl/jobs/cmd_job_del.py
+++ b/redfish_ctl/jobs/cmd_job_del.py
@@ -56,9 +56,9 @@ class JobDel(RedfishManagerBase,
 
         :param job_id: iDRAC job_id JID_744718373591
         :param do_async: note async will subscribe to an event loop.
-        :param verbose: enables verbose output
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type: json or xml
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         req = f"{self.idrac_members}/Oem/Dell/Jobs/{job_id}"

--- a/redfish_ctl/jobs/cmd_job_delete_all.py
+++ b/redfish_ctl/jobs/cmd_job_delete_all.py
@@ -62,9 +62,9 @@ class JobRmDellServices(RedfishManagerBase,
         :param do_force:
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded: will do expand query
-        :param data_type: json or xml
-        :param verbose: enables verbose output
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param filename: if filename indicate call will save the response to this file.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService"

--- a/redfish_ctl/jobs/cmd_job_dell_services.py
+++ b/redfish_ctl/jobs/cmd_job_dell_services.py
@@ -51,8 +51,8 @@ class JobDellServices(RedfishManagerBase,
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
         :param filename: if filename indicate call will save a response to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService"

--- a/redfish_ctl/jobs/cmd_job_get.py
+++ b/redfish_ctl/jobs/cmd_job_get.py
@@ -71,9 +71,9 @@ class JobGet(RedfishManagerBase,
 
         :param job_id: iDRAC job_id JID_744718373591
         :param do_async: note async will subscribe to an event loop.
-        :param verbose: enables verbose output
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type: json or xml
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param filename: if filename indicate call will save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         data = self.get_job(job_id, do_async=do_async)

--- a/redfish_ctl/jobs/cmd_job_services.py
+++ b/redfish_ctl/jobs/cmd_job_services.py
@@ -63,9 +63,9 @@ class JobServices(RedfishManagerBase,
         :param do_capability:  return service ServiceCapabilities
         :param do_async: note async will subscribe to an event loop.
         :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         cmd_result = self.base_query(REDFISH_API.JobServiceQuery,

--- a/redfish_ctl/jobs/cmd_job_watch.py
+++ b/redfish_ctl/jobs/cmd_job_watch.py
@@ -64,10 +64,10 @@ class JobWatch(RedfishManagerBase,
         python redfish_ctl job-watch --j JID_766061334802
 
         :param job_id: iDRAC job_id JID_744718373591
-        :param do_async: note async will subscribe to an event loop.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         data = self.fetch_task(job_id)

--- a/redfish_ctl/jobs/cmd_jobs.py
+++ b/redfish_ctl/jobs/cmd_jobs.py
@@ -170,11 +170,11 @@ class JobList(RedfishManagerBase,
         :param reboot_completed: retrieve completed jobs
         :param filter_scheduled: retrieve scheduled jobs
         :param filter_completed:  retrieve completed
-        :param do_async: make async request.
-        :param verbose: enable verbose
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
         :param data_type: json or xml
-        :param do_expanded: returns expanded result for API call
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
         :param job_type: filter on job_type
         :param job_ids: filter by job id only.
         :return: CommandResult and if filename provide will save to a file.

--- a/redfish_ctl/manager/cmd_manager.py
+++ b/redfish_ctl/manager/cmd_manager.py
@@ -47,10 +47,10 @@ class Manager(RedfishManagerBase,
         """Queries manager services from iDRAC.
         :param do_expanded:
         :param do_async:
-        :param verbose:
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_deep:
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type:
+        :param filename: if filename indicate call will save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return:
         :raise: AuthenticationFailed, UnexpectedResponse
         """

--- a/redfish_ctl/pci/cmd_pci.py
+++ b/redfish_ctl/pci/cmd_pci.py
@@ -59,7 +59,7 @@ class PciDeviceQuery(RedfishManagerBase,
         """Query pci device or function from idrac.
         :param verbose:
         :param do_async:
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type: a data serialized back.
         :param pci_type: PCIeDevices or  PCIeFunctions
         :return: in data type json will return json

--- a/redfish_ctl/raid/cmd_raid_service.py
+++ b/redfish_ctl/raid/cmd_raid_service.py
@@ -61,9 +61,9 @@ class RaidServiceQuery(RedfishManagerBase,
         of Command Result. The discovered named tuple store action
         and respected rest APIs.
 
-        :param do_async:
-        :param verbose:
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type:
         :return: return raid service
         """

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -434,7 +434,7 @@ class RedfishManager:
         :param do_async: sync will subscribe to an event loop and issue async request.
         :param do_expanded:  will do expand query based on spec.
         :param query_expansion:  allow to overwrite expansion, and it always appended to request.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param verbose: enables verbose output, mainly to debug if endpoint return something strange.
         :param data_type: json or xml
         :param key: Optional json key in case we want to get something from a root element only.

--- a/redfish_ctl/storage/cmd_convert_none_raid.py
+++ b/redfish_ctl/storage/cmd_convert_none_raid.py
@@ -64,10 +64,10 @@ class ConvertNoneRaid(RedfishManagerBase,
         :param exclude_filter:  excluded disk.
         :param do_expanded:
         :param controller: if empty cmd will return list of controllers.
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: will not block and return result as future.
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type:  json, xml etc.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: named tuple CommandResult
         :raise: AuthenticationFailed, UnexpectedResponse
         """

--- a/redfish_ctl/storage/cmd_convert_to_raid.py
+++ b/redfish_ctl/storage/cmd_convert_to_raid.py
@@ -68,10 +68,10 @@ class ConvertToRaid(
 
         :param exclude_filter:  excluded disk or command separate disks
         :param controller: if empty cmd will return list of controllers.
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: will not block and return result as future.
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type:  json, xml etc.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
          :param do_expanded:
         :return: named tuple CommandResult
         :raise: AuthenticationFailed, UnexpectedResponse

--- a/redfish_ctl/storage/cmd_drives.py
+++ b/redfish_ctl/storage/cmd_drives.py
@@ -60,10 +60,10 @@ class DrivesQuery(RedfishManagerBase,
         :param data_filter:
         :param do_expanded:
         :param controller: if empty cmd will return list of controllers.
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: will not block and return result as future.
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type:  json, xml etc.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: named tuple CommandResult
         :raise: AuthenticationFailed, UnexpectedResponse
         """

--- a/redfish_ctl/storage/cmd_storage_get.py
+++ b/redfish_ctl/storage/cmd_storage_get.py
@@ -95,9 +95,9 @@ class StorageView(RedfishManagerBase,
         :param data_filter:
         :param do_expanded:
         :param controller: if empty cmd will return list of controllers.
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: will not block and return result as future.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type:  json, xml etc.
         :return: named tuple CommandResult
         :raise: AuthenticationFailed, UnexpectedResponse

--- a/redfish_ctl/storage/cmd_storage_list.py
+++ b/redfish_ctl/storage/cmd_storage_list.py
@@ -49,9 +49,9 @@ class StorageListView(RedfishManagerBase,
         """Queries for storage controller list.
         :param do_expanded:
         :param do_async: will not block and return result as future.
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param data_type:  json, xml etc.
-        :param verbose: enables verbose output
+        :param filename: if filename indicate call will save the response to this file.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :return: named tuple CommandResult
         :raise: AuthenticationFailed, UnexpectedResponse
         """

--- a/redfish_ctl/system/cmd_system.py
+++ b/redfish_ctl/system/cmd_system.py
@@ -95,7 +95,7 @@ class SystemQuery(RedfishManagerBase,
         :param verbose:
         :param do_deep: if caller indicate deep, method will perform deep call
                      for each end point.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type:  what data type we use to serialize data.
         :return: json or xml and dict that host type of action and rest api end point.
         """

--- a/redfish_ctl/system/cmd_system_config.py
+++ b/redfish_ctl/system/cmd_system_config.py
@@ -84,7 +84,7 @@ class ExportSystemConfig(RedfishManagerBase,
         :param do_async:
         :param data_type:
         :param verbose:
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: accepted for CLI compatibility; not used by this command.
         :param include_in_export:
         :param target:
         :param export_format:

--- a/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
@@ -58,7 +58,7 @@ class VirtualMediaEject(RedfishManagerBase,
         :param do_strict: will raise exception if media already ejected.
                           mainly if caller need have special handler.
         :param device_id: virtual media device id. (1 or 2)
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: will not block and return result as future.
         :param data_type:  json, xml etc.
         :return: named tuple CommandResult

--- a/redfish_ctl/virtual_media/cmd_virtual_media_get.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_get.py
@@ -79,9 +79,9 @@ class VirtualMediaGet(RedfishManagerBase,
 
         :param device_id: filter based on device
         :param filter_key: filter based on key.
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: will not block and return result as future.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type:  json, xml etc.
         :return: named tuple CommandResult
         :raise: AuthenticationFailed, UnexpectedResponse

--- a/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
@@ -145,7 +145,7 @@ class VirtualMediaInsert(RedfishManagerBase,
         :param remote_username:  username for remote authentication
         :param remote_password:  password for remote authentication
         :param uri_path: URI path to image file.
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: will not block and return result as future.
         :param data_type:  json, xml etc.
         :return: named tuple CommandResult

--- a/redfish_ctl/volumes/cmd_initilize.py
+++ b/redfish_ctl/volumes/cmd_initilize.py
@@ -62,10 +62,10 @@ class VolumeInit(RedfishManagerBase,
         :param dev_id:
         :param data_filter:
         :param do_async: note async will subscribe to an event loop.
-        :param do_expanded:  will do expand query
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         vol_data = self.sync_invoke(ApiRequestType.VolumeQuery,

--- a/redfish_ctl/volumes/cmd_virtual_disk.py
+++ b/redfish_ctl/volumes/cmd_virtual_disk.py
@@ -72,10 +72,10 @@ class VirtualDiskQuery(
                 **kwargs) -> CommandResult:
         """Queries volumes from given controlled from iDRAC.
         :param device_id: a storage controller id, NonRAID.Slot.6-1
-        :param verbose: enables verbose output
+        :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_deep: do deep recursive fetch
-        :param do_async: will not block and return result as future.
-        :param filename: if filename indicate call will save a bios setting to a file.
+        :param do_async: accepted for CLI compatibility; not used by this command.
+        :param filename: if filename indicate call will save the response to this file.
         :param data_type:  json, xml etc.
         :return: named tuple CommandResult
         :raise: AuthenticationFailed, UnexpectedResponse

--- a/redfish_ctl/volumes/cmd_volumes.py
+++ b/redfish_ctl/volumes/cmd_volumes.py
@@ -53,9 +53,9 @@ class VolumeQuery(
 
         :param dev_id:
         :param do_async: note async will subscribe to an event loop.
-        :param filename: if filename indicate call will save a bios setting to a file.
-        :param verbose: enables verbose output
-        :param data_type: json or xml
+        :param filename: if filename indicate call will save the response to this file.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
         :return: CommandResult and if filename provide will save to a file.
         """
         target_api = f"{self.idrac_manage_servers}/Storage/{dev_id}/Volumes"


### PR DESCRIPTION
Follow-up cleanup after the docstring-coverage campaign. Fixes pre-existing docstring inaccuracies that were left untouched during coverage (per 'don't rewrite existing'), now corrected in one mechanical, tool-driven pass:

- **115 `:param` lines**: a recurring framework param (`filename`/`data_type`/`verbose`/`do_async`/`do_expanded`) that the command's `execute` body never references is now documented `accepted for CLI compatibility; not used by this command` instead of a functional meaning the command does not honor. Found + fixed with an AST param-usage tool (a param is only rewritten when it is genuinely unreferenced in the body).
- **35 filename copy-pastes**: `if filename indicate call will save a bios setting to a file` → `... save the response to this file` on non-BIOS commands (these save the response, not a BIOS setting).
- **1 module summary**: `bios/cmd_bios_pending.py` had a copy-pasted `iDRAC query chassis services` summary — corrected to describe the BIOS-pending query.

No `:param:`/`:return:` tags removed → docstring gate stays at **0** for redfish_ctl. Docstrings only, no behavior change. `pytest -q`: 1227 passed, 58 skipped; mutation-guard test green; ruff no new findings.