### PR TITLE
Document k8s controllers (docstring coverage)

### DIFF
--- a/k8s/controller/redfish_endpoint_controller.py
+++ b/k8s/controller/redfish_endpoint_controller.py
@@ -87,10 +87,21 @@ MANAGER_FACTORY: ManagerFactory = RedfishManagerBase
 
 
 def _utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime.
+
+    :return: current time in UTC.
+    """
     return datetime.now(timezone.utc)
 
 
 def _rfc3339(value: datetime) -> str:
+    """Format a datetime as an RFC 3339 UTC string with a ``Z`` suffix.
+
+    Naive values are assumed to be UTC.
+
+    :param value: datetime to format.
+    :return: RFC 3339 timestamp string (seconds precision, ``Z`` zone).
+    """
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     value = value.astimezone(timezone.utc).replace(microsecond=0)
@@ -98,6 +109,13 @@ def _rfc3339(value: datetime) -> str:
 
 
 def _number(value: int | float | str | None) -> float | None:
+    """Coerce a numeric-like value to ``float``, or ``None`` if it cannot.
+
+    Booleans and unparsable strings return ``None`` rather than a number.
+
+    :param value: value to coerce (int, float, numeric string, or ``None``).
+    :return: the value as a float, or ``None`` when not numeric.
+    """
     if value is None:
         return None
     if isinstance(value, bool):
@@ -111,6 +129,11 @@ def _number(value: int | float | str | None) -> float | None:
 
 
 def _temperature_summary(thermal: ThermalStatus) -> dict[str, int | float | None]:
+    """Summarize thermal readings into a count and the hottest temperature.
+
+    :param thermal: thermal read result whose ``temperatures`` are inspected.
+    :return: dict with ``count`` of valid readings and ``maxCelsius`` (or ``None``).
+    """
     values = [
         reading
         for row in thermal.temperatures
@@ -123,6 +146,11 @@ def _temperature_summary(thermal: ThermalStatus) -> dict[str, int | float | None
 
 
 def _health_from_sensors(sensors: tuple[SensorReading, ...]) -> str | None:
+    """Return the worst health across sensors, or ``None`` if none report health.
+
+    :param sensors: sensor readings to reduce.
+    :return: the most severe health string (Critical > Warning > OK), or ``None``.
+    """
     rank = {
         "OK": 0,
         "Warning": 1,
@@ -141,6 +169,10 @@ def _network_firmware_summary(
 
     ``distinctVersions`` is the fleet drift signal: one version across the fleet
     means every node's NICs run the same firmware; more than one flags drift.
+
+    :param network_firmware: typed NIC/DPU firmware read result.
+    :return: the ``status.networkFirmware`` block (counts, distinct versions,
+        and a capped list of components).
     """
     summary = network_firmware.summary
     components = [
@@ -172,7 +204,16 @@ def build_status(
     network_firmware: NetworkFirmwareStatus | None = None,
     polled_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Return the RedfishEndpoint status object from typed read results."""
+    """Return the RedfishEndpoint status object from typed read results.
+
+    :param system: typed system read result (power state, health).
+    :param sensors: sensor readings, used as a health fallback.
+    :param thermal: thermal read result for the temperature summary.
+    :param network_firmware: optional NIC/DPU firmware; adds the
+        ``networkFirmware`` block when present.
+    :param polled_at: timestamp recorded as ``lastPolled``; defaults to now.
+    :return: the ``.status`` object for the RedfishEndpoint CR.
+    """
     status: dict[str, Any] = {
         "powerState": system.power_state,
         "health": system.health or _health_from_sensors(sensors),
@@ -193,6 +234,10 @@ def parse_interval_seconds(text: Any, default: float) -> float:
 
     Returns ``default`` for missing, malformed, or non-positive values, so a bad
     CR field degrades to the base cadence rather than breaking the poll loop.
+
+    :param text: interval value (a duration string, number, or ``None``).
+    :param default: seconds to return when ``text`` is missing or invalid.
+    :return: the parsed interval in seconds, or ``default``.
     """
     if text is None:
         return default
@@ -221,6 +266,8 @@ def base_interval_seconds() -> float:
     the controller container, so an operator can retune the deployment without
     editing code. Per-CR ``spec.pollInterval`` still governs each endpoint on
     top of this floor.
+
+    :return: the base timer cadence in seconds.
     """
     return parse_interval_seconds(
         os.environ.get(POLL_INTERVAL_ENV),
@@ -229,6 +276,11 @@ def base_interval_seconds() -> float:
 
 
 def _parse_rfc3339(text: Any) -> datetime | None:
+    """Parse an RFC 3339 timestamp into a UTC-aware datetime.
+
+    :param text: timestamp string to parse; non-strings yield ``None``.
+    :return: the parsed timezone-aware datetime, or ``None`` when unparsable.
+    """
     if not isinstance(text, str) or not text:
         return None
     try:
@@ -256,6 +308,11 @@ def poll_due(
       faster than the deployment's timer is bounded by it.)
 
     A CR with no prior successful poll is always due.
+
+    :param spec: the CR spec, read for ``pollInterval``.
+    :param status: the CR ``.status``, read for ``nextPollAfter``/``lastPolled``.
+    :param now: current time used for the due/backoff comparison.
+    :return: ``True`` when the BMC should be polled this fire, else ``False``.
     """
     next_after = _parse_rfc3339(status.get("nextPollAfter"))
     if next_after is not None and now < next_after:
@@ -273,6 +330,11 @@ def backoff_seconds(failures: int, base: float, cap: float = MAX_BACKOFF_SECONDS
 
     ``failures`` is 1 for the first failure. Delay doubles each failure from the
     base cadence up to ``cap``.
+
+    :param failures: count of consecutive failures (1 for the first).
+    :param base: base delay in seconds that doubles per failure.
+    :param cap: maximum delay in seconds.
+    :return: the backoff delay in seconds, capped at ``cap``.
     """
     if failures < 1:
         return base
@@ -288,6 +350,15 @@ def _condition(
     message: str,
     changed_at: datetime,
 ) -> dict[str, str]:
+    """Build a Kubernetes-style status condition entry.
+
+    :param condition_type: the condition ``type`` value.
+    :param status: whether the condition holds, rendered as ``"True"``/``"False"``.
+    :param reason: machine-readable reason code.
+    :param message: human-readable detail; omitted when empty.
+    :param changed_at: transition time recorded as ``lastTransitionTime``.
+    :return: the condition dict.
+    """
     condition = {
         "type": condition_type,
         "status": "True" if status else "False",
@@ -300,7 +371,11 @@ def _condition(
 
 
 def _classify_poll_error(exc: BaseException) -> tuple[str, str]:
-    """Map a BMC read failure to a (reason, message) for the status condition."""
+    """Map a BMC read failure to a (reason, message) for the status condition.
+
+    :param exc: the exception raised while reading the BMC.
+    :return: tuple of (reason code, message) for the status condition.
+    """
     message = str(exc) or exc.__class__.__name__
     if isinstance(exc, (RedfishUnauthorized, RedfishForbidden, AuthenticationFailed)):
         return "AuthenticationFailed", message
@@ -331,6 +406,12 @@ def build_error_status(
     the failure and a backoff. ``lastPolled`` stays at the last *successful*
     poll, and the failure is explained by the condition + ``lastError`` rather
     than freezing silently.
+
+    :param prev_status: the current ``.status``, read for ``consecutiveFailures``.
+    :param exc: the exception raised during the failed poll.
+    :param now: current time, used for the condition and backoff deadline.
+    :param base_interval: base cadence the exponential backoff builds on.
+    :return: a partial ``.status`` merge patch recording the failure and backoff.
     """
     failures = _int(prev_status.get("consecutiveFailures")) + 1
     reason, message = _classify_poll_error(exc)
@@ -356,7 +437,12 @@ def build_success_status(
     *,
     now: datetime,
 ) -> dict[str, Any]:
-    """Merge the core readings with a healthy condition and cleared failure fields."""
+    """Merge the core readings with a healthy condition and cleared failure fields.
+
+    :param readings: the status readings from a successful poll.
+    :param now: current time recorded on the reachable condition.
+    :return: the full ``.status`` object for a successful poll.
+    """
     status = dict(readings)
     status["conditions"] = [
         _condition(
@@ -375,6 +461,11 @@ def build_success_status(
 
 
 def _int(value: Any) -> int:
+    """Coerce a value to ``int``, returning ``0`` when it cannot be parsed.
+
+    :param value: value to coerce.
+    :return: the value as an int, or ``0`` on failure.
+    """
     try:
         return int(value)
     except (TypeError, ValueError):
@@ -382,6 +473,11 @@ def _int(value: Any) -> int:
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
+    """Return ``value`` if it is a mapping, else an empty mapping.
+
+    :param value: candidate mapping.
+    :return: the mapping, or an empty dict when ``value`` is not one.
+    """
     return value if isinstance(value, Mapping) else {}
 
 
@@ -391,6 +487,8 @@ def _close_manager(manager: Any) -> None:
     ``RedfishManagerBase`` lazily caches a keep-alive ``requests.Session`` (with
     its urllib3 connection pool) in ``_session_cache``. The controller builds one
     manager per poll, so at fleet scale unclosed sessions would leak sockets/FDs.
+
+    :param manager: the per-poll manager whose cached session is closed.
     """
     session = getattr(manager, "_session_cache", None)
     if session is None:
@@ -402,6 +500,14 @@ def _close_manager(manager: Any) -> None:
 
 
 def _manager_address(spec: Mapping[str, Any]) -> tuple[str, bool]:
+    """Resolve the BMC host and HTTP flag from ``spec.address``.
+
+    Accepts either a bare host/IP (with ``spec.port``) or an ``http(s)://`` URL.
+
+    :param spec: the CR spec, read for ``address``, ``port``, and ``insecure``.
+    :return: tuple of (host address, whether to use plain HTTP).
+    :raises ValueError: when ``spec.address`` is empty.
+    """
     raw_address = str(spec.get("address") or "").strip()
     if not raw_address:
         raise ValueError("RedfishEndpoint spec.address is required")
@@ -420,6 +526,14 @@ def _make_manager(
     credentials: Mapping[str, str],
     manager_factory: ManagerFactory,
 ) -> Any:
+    """Build a Redfish manager for the endpoint from spec and credentials.
+
+    :param spec: the CR spec, read for address, port, and ``insecure``.
+    :param credentials: username/password mapping for BMC auth.
+    :param manager_factory: callable that constructs the manager (indirected
+        for tests).
+    :return: the constructed manager instance.
+    """
     address, is_http = _manager_address(spec)
     return manager_factory(
         idrac_ip=address,
@@ -440,6 +554,9 @@ def _safe_network_firmware(manager: Any) -> NetworkFirmwareStatus | None:
     The failure is logged (not silent) so a persistent NIC-firmware read problem
     is diagnosable; on failure the prior status.networkFirmware is left in place
     by the merge patch rather than being cleared.
+
+    :param manager: the BMC manager to read NIC/DPU firmware from.
+    :return: the network firmware read result, or ``None`` when unavailable.
     """
     try:
         return get_network_firmware(manager)
@@ -459,6 +576,12 @@ def poll_endpoint(
 
     Always closes the per-poll manager's pooled session, even on error, so a
     fleet of endpoints does not leak sockets one failed/slow poll at a time.
+
+    :param spec: the CR spec identifying and configuring the endpoint.
+    :param credentials: username/password mapping for BMC auth.
+    :param manager_factory: callable that constructs the manager.
+    :param polled_at: timestamp recorded as ``lastPolled``; defaults to now.
+    :return: the ``.status`` object built from the read results.
     """
     manager = _make_manager(spec, credentials or {}, manager_factory)
     try:
@@ -478,6 +601,12 @@ def poll_endpoint(
 
 
 def _decode_secret_value(data: Mapping[str, str], key: str) -> str | None:
+    """Decode a base64 Secret field, or ``None`` when the key is absent/empty.
+
+    :param data: the Secret ``data`` mapping (base64-encoded values).
+    :param key: the field name to decode.
+    :return: the decoded UTF-8 value, or ``None`` when missing.
+    """
     encoded = data.get(key)
     if not encoded:
         return None
@@ -495,6 +624,10 @@ def load_secret_credentials(
     threads. Falls back to empty credentials whenever a client is unavailable
     (kubernetes not installed, or no in-cluster/local config), matching the
     offline behaviour the test suite relies on.
+
+    :param namespace: namespace of the CR (and its Secret); empty skips the read.
+    :param secret_ref: ``spec.secretRef`` naming the Secret and its keys.
+    :return: mapping with ``username``/``password`` when found, else empty.
     """
     if not namespace or not secret_ref or not secret_ref.get("name"):
         return {}
@@ -544,6 +677,17 @@ def poll_redfish_endpoint(
     failure is caught, recorded on ``.status`` with an exponential backoff, and
     retried next cycle instead of raising forever; the last successful readings
     are preserved (merge-patch).
+
+    :param spec: the CR spec identifying and configuring the endpoint.
+    :param body: the full CR body; used to read ``.status`` when ``status`` is
+        not passed.
+    :param namespace: namespace of the CR, for the Secret read and logging.
+    :param name: name of the CR, for logging.
+    :param logger: kopf logger; poll outcomes are logged when provided.
+    :param patch: kopf patch object the new ``.status`` is written into.
+    :param status: the current ``.status`` passed by kopf; falls back to
+        ``body`` when ``None``.
+    :param force: when ``True``, poll immediately and bypass the cadence gate.
     """
     current_status = status if status is not None else _mapping(body).get("status")
     current_status = _mapping(current_status)
@@ -583,7 +727,10 @@ def poll_redfish_endpoint(
 
 
 def poll_on_change(**kwargs: Any) -> None:  # pragma: no cover - runtime kopf wiring.
-    """Create/update entrypoint: poll immediately, bypassing the cadence gate."""
+    """Create/update entrypoint: poll immediately, bypassing the cadence gate.
+
+    :return: ``None`` (delegates to :func:`poll_redfish_endpoint`).
+    """
     return poll_redfish_endpoint(force=True, **kwargs)
 
 

--- a/k8s/controller/redfish_node_profile_controller.py
+++ b/k8s/controller/redfish_node_profile_controller.py
@@ -29,10 +29,21 @@ ReconcileFunc = Callable[..., Any]
 
 
 def _utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime.
+
+    :return: current time in UTC.
+    """
     return datetime.now(timezone.utc)
 
 
 def _rfc3339(value: datetime) -> str:
+    """Format a datetime as an RFC 3339 UTC string with a ``Z`` suffix.
+
+    Naive values are assumed to be UTC.
+
+    :param value: datetime to format.
+    :return: RFC 3339 timestamp string (seconds precision, ``Z`` zone).
+    """
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     value = value.astimezone(timezone.utc).replace(microsecond=0)
@@ -40,6 +51,11 @@ def _rfc3339(value: datetime) -> str:
 
 
 def _mapping(value: Any) -> Mapping[str, Any]:
+    """Return ``value`` if it is a mapping, else an empty mapping.
+
+    :param value: candidate mapping.
+    :return: the mapping, or an empty dict when ``value`` is not one.
+    """
     return value if isinstance(value, Mapping) else {}
 
 
@@ -51,6 +67,16 @@ def _condition(
     message: str = "",
     changed_at: datetime,
 ) -> dict[str, str]:
+    """Build a Kubernetes-style status condition entry.
+
+    :param condition_type: the condition ``type`` value.
+    :param status: tri-state condition value rendered as
+        ``"True"``/``"False"``/``"Unknown"`` (``None`` means unknown).
+    :param reason: machine-readable reason code.
+    :param message: human-readable detail; omitted when empty.
+    :param changed_at: transition time recorded as ``lastTransitionTime``.
+    :return: the condition dict.
+    """
     if status is True:
         status_text = "True"
     elif status is False:
@@ -69,12 +95,23 @@ def _condition(
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
+    """Return a shallow ``dict`` copy of a mapping, else an empty dict.
+
+    :param value: candidate mapping.
+    :return: a dict copy of ``value``, or an empty dict when not a mapping.
+    """
     if isinstance(value, Mapping):
         return dict(value)
     return {}
 
 
 def _planned_step(step: Any) -> dict[str, Any]:
+    """Shape a planned reconcile step into its CR status representation.
+
+    :param step: a planned step object (kind/required/description/preview).
+    :return: dict with the step's ``kind``, ``required``, ``description``, and
+        ``preview``.
+    """
     return {
         "kind": str(getattr(step, "kind", "")),
         "required": bool(getattr(step, "required", False)),
@@ -84,6 +121,11 @@ def _planned_step(step: Any) -> dict[str, Any]:
 
 
 def _applied_change(change: Any) -> dict[str, Any]:
+    """Shape an applied reconcile change into its CR status representation.
+
+    :param change: an applied change object (kind/changed/result).
+    :return: dict with the change's ``kind``, ``changed``, and ``result``.
+    """
     return {
         "kind": str(getattr(change, "kind", "")),
         "changed": bool(getattr(change, "changed", False)),
@@ -92,6 +134,15 @@ def _applied_change(change: Any) -> dict[str, Any]:
 
 
 def plan_hash(planned_steps: list[dict[str, Any]]) -> str | None:
+    """Hash the required steps of a plan for approval matching.
+
+    Only ``required`` steps are hashed, so an unchanged plan yields a stable
+    digest an operator can approve.
+
+    :param planned_steps: the planned steps from a dry-run reconcile.
+    :return: a SHA-256 hex digest of the required steps, or ``None`` when none
+        are required.
+    """
     required_steps = [step for step in planned_steps if step.get("required")]
     if not required_steps:
         return None
@@ -110,6 +161,15 @@ def _approval_reason(
     approved_plan_hash: str | None,
     consumed_plan_hash: str | None,
 ) -> str:
+    """Classify why a plan is or is not approved, as a condition reason code.
+
+    :param approved: whether the current plan is approved to apply.
+    :param current_plan_hash: hash of the current plan's required steps.
+    :param approved_plan_hash: plan hash the spec approves, if any.
+    :param consumed_plan_hash: plan hash already applied, if any.
+    :return: a reason code (``Approved``/``ApprovalConsumed``/
+        ``ApprovalHashMismatch``/``ApprovalRequired``).
+    """
     if approved:
         return "Approved"
     if current_plan_hash and consumed_plan_hash == current_plan_hash:
@@ -128,7 +188,18 @@ def build_status(
     consumed_plan_hash: str | None = None,
     reconciled_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Return the RedfishNodeProfile status object from a reconcile result."""
+    """Return the RedfishNodeProfile status object from a reconcile result.
+
+    :param result: the reconcile result (its ``steps``/``applied``/``dry_run``).
+    :param approved: whether the plan was approved and applied.
+    :param approved_plan_hash: plan hash the spec approves, if any.
+    :param plan_hash_value: precomputed plan hash; recomputed from steps when
+        omitted.
+    :param consumed_plan_hash: plan hash already applied, if any.
+    :param reconciled_at: timestamp recorded as ``lastReconciled``; defaults to
+        now.
+    :return: the ``.status`` object for the RedfishNodeProfile CR.
+    """
     observed_at = reconciled_at or _utc_now()
     steps = tuple(getattr(result, "steps", ()))
     applied = tuple(getattr(result, "applied", ()))
@@ -190,7 +261,13 @@ def build_error_status(
     *,
     reconciled_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Return status for controller failures that occur before reconcile runs."""
+    """Return status for controller failures that occur before reconcile runs.
+
+    :param message: the failure detail recorded on the condition.
+    :param reconciled_at: timestamp recorded as ``lastReconciled``; defaults to
+        now.
+    :return: a ``.status`` object marking reconcile unavailable.
+    """
     observed_at = reconciled_at or _utc_now()
     return {
         "dryRun": True,
@@ -211,6 +288,12 @@ def build_error_status(
 
 
 def _endpoint_spec(spec: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the required ``spec.endpoint`` mapping.
+
+    :param spec: the CR spec.
+    :return: the ``endpoint`` mapping.
+    :raises ValueError: when ``spec.endpoint`` is missing or empty.
+    """
     endpoint = _mapping(spec.get("endpoint"))
     if not endpoint:
         raise ValueError("RedfishNodeProfile spec.endpoint is required")
@@ -218,6 +301,14 @@ def _endpoint_spec(spec: Mapping[str, Any]) -> Mapping[str, Any]:
 
 
 def _manager_address(endpoint: Mapping[str, Any]) -> tuple[str, int, bool]:
+    """Resolve the BMC host, port, and HTTP flag from the endpoint spec.
+
+    Accepts either a bare host/IP (with ``port``) or an ``http(s)://`` URL.
+
+    :param endpoint: the ``spec.endpoint`` mapping (address/port).
+    :return: tuple of (host, port, whether to use plain HTTP).
+    :raises ValueError: when the address is empty or a URL lacks a host.
+    """
     raw_address = str(endpoint.get("address") or "").strip()
     if not raw_address:
         raise ValueError("RedfishNodeProfile spec.endpoint.address is required")
@@ -238,6 +329,13 @@ def _make_manager(
     credentials: Mapping[str, str],
     manager_factory: ManagerFactory,
 ) -> Any:
+    """Build a Redfish manager for the endpoint from spec and credentials.
+
+    :param endpoint: the ``spec.endpoint`` mapping (address/port/insecure).
+    :param credentials: username/password mapping for BMC auth.
+    :param manager_factory: callable that constructs the manager.
+    :return: the constructed manager instance.
+    """
     address, port, is_http = _manager_address(endpoint)
     return manager_factory(
         idrac_ip=address,
@@ -251,6 +349,11 @@ def _make_manager(
 
 
 def _load_reconcile_func() -> ReconcileFunc:
+    """Import and return the reconcile function, lazily.
+
+    :return: the ``redfish_ctl.reconcile.reconcile`` callable.
+    :raises RuntimeError: when ``redfish_ctl.reconcile`` cannot be imported.
+    """
     try:
         from redfish_ctl.reconcile import reconcile
     except ImportError as exc:  # pragma: no cover - depends on merge order.
@@ -267,7 +370,22 @@ def reconcile_profile(
     reconcile_func: ReconcileFunc | None = None,
     reconciled_at: datetime | None = None,
 ) -> dict[str, Any]:
-    """Plan or apply the desired state from a RedfishNodeProfile spec."""
+    """Plan or apply the desired state from a RedfishNodeProfile spec.
+
+    Runs a dry-run plan first; applies only when the spec's approved plan hash
+    matches the current plan and has not already been consumed.
+
+    :param spec: the CR spec (endpoint, desired state, approval hash).
+    :param credentials: username/password mapping for BMC auth.
+    :param current_status: the current ``.status``, read for
+        ``consumedPlanHash``.
+    :param manager_factory: callable that constructs the manager.
+    :param reconcile_func: reconcile callable; loaded lazily when omitted.
+    :param reconciled_at: timestamp recorded as ``lastReconciled``; defaults to
+        now.
+    :return: the ``.status`` object (dry-run plan, or applied result when
+        approved).
+    """
     endpoint = _endpoint_spec(spec)
     desired_state = _mapping(spec.get("desiredState"))
     manager = _make_manager(endpoint, credentials or {}, manager_factory)
@@ -317,6 +435,12 @@ def reconcile_profile(
 
 
 def _decode_secret_value(data: Mapping[str, str], key: str) -> str | None:
+    """Decode a base64 Secret field, or ``None`` when the key is absent/empty.
+
+    :param data: the Secret ``data`` mapping (base64-encoded values).
+    :param key: the field name to decode.
+    :return: the decoded UTF-8 value, or ``None`` when missing.
+    """
     encoded = data.get(key)
     if not encoded:
         return None
@@ -332,6 +456,10 @@ def load_secret_credentials(
     Shares the process-wide client from :mod:`redfish_ctl.kube_client` with the
     endpoint controller (both run in one kopf process), so the kube config is
     loaded once for the whole process instead of on every handler thread.
+
+    :param namespace: namespace of the CR (and its Secret); empty skips the read.
+    :param secret_ref: ``spec.endpoint.secretRef`` naming the Secret and keys.
+    :return: mapping with ``username``/``password`` when found, else empty.
     """
     if not namespace or not secret_ref or not secret_ref.get("name"):
         return {}
@@ -370,6 +498,13 @@ def reconcile_redfish_node_profile(
     ``status.reconcile_redfish_node_profile``, a field the structural CRD
     schema rejects, which surfaces a "merge-patching finished with
     inconsistencies" warning on every reconcile.
+
+    :param spec: the CR spec (endpoint, desired state, approval hash).
+    :param body: the full CR body; used to read the current ``.status``.
+    :param namespace: namespace of the CR, for the Secret read and logging.
+    :param name: name of the CR, for logging.
+    :param logger: kopf logger; the reconcile is logged when provided.
+    :param patch: kopf patch object the new ``.status`` is written into.
     """
     endpoint = _mapping(spec.get("endpoint"))
     credentials = load_secret_credentials(namespace, endpoint.get("secretRef"))


### PR DESCRIPTION
Docstring-coverage PR for the two k8s controllers (`redfish_endpoint_controller.py`, `redfish_node_profile_controller.py`), extending the merged docstring gate (#145) to k8s/. 46 members; kopf-handler params (spec/body/namespace/name/logger/patch/status/force) all verified used and documented with real meaning. Docstrings only, no behavior change. Gate: 0 for both files; ruff clean; pytest green.