### PR TITLE
Enforce docstring coverage whole-tree in CI (finisher)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,17 @@ jobs:
         # The tree carries pre-existing ruff debt, so lint is reported but does
         # not fail the build. New code should still be clean.
         run: ruff check redfish_ctl || true
-      - name: Docstring hard gate (new/changed methods must document args + return)
-        # Diff-aware and BLOCKING: only functions this PR adds or changes must
-        # carry a docstring with :param: per arg and :return: (see TEAM_GUIDE.md).
-        # Pre-existing gaps are backfilled separately, not gated here.
+      - name: Docstring hard gate (diff-aware — new/changed methods)
+        # Diff-aware and BLOCKING: shows a targeted failure for the functions
+        # this PR adds or changes (each needs a docstring with :param: per arg
+        # and :return:; see TEAM_GUIDE.md). Kept for friendly per-PR messages.
         if: github.event_name == 'pull_request'
         run: |
           git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
           python tools/docstring_gate.py --base FETCH_HEAD
+      - name: Docstring hard gate (whole tree — no method anywhere may lack docs)
+        # BLOCKING on every push and PR. The whole-tree backlog (redfish_ctl and
+        # k8s) was backfilled to zero, so this keeps the entire package
+        # permanently documented: any regression — a new undocumented method OR a
+        # docstring deleted from an existing one — fails CI, not just the diff.
+        run: python tools/docstring_gate.py --all

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TWINE ?= $(CONDA_RUN) twine
 DOCKER ?= docker
 IMAGE ?= redfish-ctl
 
-.PHONY: help test lint typecheck build bench-concurrency docker-test docker-image docs-voice-check docstring-gate k8s-sandbox k8s-consumer k8s-explorer clean
+.PHONY: help test lint typecheck build bench-concurrency docker-test docker-image docs-voice-check docstring-gate docstring-gate-all k8s-sandbox k8s-consumer k8s-explorer clean
 
 DOCSTRING_BASE ?= origin/main
 
@@ -70,6 +70,9 @@ docs-voice-check: ## Reject first-person wording in public docs.
 
 docstring-gate: ## Fail if a new/changed method lacks docs (args + return). Override BASE=<ref>.
 	$(PYTHON) tools/docstring_gate.py --base $(DOCSTRING_BASE)
+
+docstring-gate-all: ## Fail if ANY method in the tree lacks docs (whole-tree gate; matches CI).
+	$(PYTHON) tools/docstring_gate.py --all
 
 k8s-sandbox: ## Run the local Kubernetes read-path sandbox when present.
 	./k8s/sandbox/run-sandbox.sh


### PR DESCRIPTION
Locks in the completed docstring-coverage work. Now that the whole-tree backlog (redfish_ctl + k8s) is backfilled to **0** under `tools/docstring_gate.py --all`, this flips the gate from diff-aware-only to **whole-tree blocking**:

- **ci.yml**: adds a blocking `python tools/docstring_gate.py --all` step that runs on every push and PR, alongside the existing diff-aware step (kept for friendly per-PR failure messages). Any regression anywhere — a newly undocumented method OR a docstring deleted from an existing one — now fails CI, not just the diff.
- **Makefile**: adds `make docstring-gate-all` (whole-tree) next to the existing `make docstring-gate` (diff-aware).

No source changes. Verified: `docstring_gate.py --all` exits 0 on this branch (whole repo documented); ci.yml is valid YAML.