### PR TITLE
Neutralize BIOS command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/bios/bios_registry.py
+++ b/redfish_ctl/bios/bios_registry.py
@@ -1,4 +1,4 @@
-"""iDRAC query bios registry
+"""BIOS attribute registry query command.
 
 Command provides raw query bios registry.
 redfish_ctl bios-registry --attr_name SystemServiceTag,OldSetupPassword

--- a/redfish_ctl/bios/cmd_bios.py
+++ b/redfish_ctl/bios/cmd_bios.py
@@ -1,6 +1,6 @@
-"""iDRAC bios command
+"""BIOS query command.
 
-Command provides the option to retrieve BIOS setting from iDRAC  and serialize
+Command provides the option to retrieve BIOS setting from a Redfish endpoint  and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
@@ -122,7 +122,7 @@ class BiosQuery(RedfishManagerBase,
                 attr_filter: Optional[str] = "",
                 attr_filter_file: Optional[str] = "",
                 **kwargs) -> CommandResult:
-        """Query bios settings from iDRAC.
+        """Query BIOS settings from a Redfish endpoint.
 
         It supports filtering via coma separate list bios attributes
         or caller can pass a json file

--- a/redfish_ctl/bios/cmd_bios_clear_pending.py
+++ b/redfish_ctl/bios/cmd_bios_clear_pending.py
@@ -1,4 +1,4 @@
-"""iDRAC command clear bios pending values.
+"""Clear pending BIOS values command.
 
 Command provides the option to clear all the BIOS
 pending values.
@@ -22,7 +22,7 @@ class BiosClearPending(RedfishManagerBase,
                        metaclass=Singleton):
     """
     This cmd action is used to clear all BIOS pending
-    values currently in iDRAC.
+    values currently staged on the Redfish endpoint.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/bios/cmd_bios_pending.py
+++ b/redfish_ctl/bios/cmd_bios_pending.py
@@ -1,4 +1,4 @@
-"""iDRAC query BIOS pending values.
+"""Query BIOS pending values.
 
 Command provides a raw query of the BIOS attributes that are staged as
 pending (not yet applied).

--- a/redfish_ctl/bios/cmd_change_bios.py
+++ b/redfish_ctl/bios/cmd_change_bios.py
@@ -1,4 +1,4 @@
-"""iDRAC query bios registry
+"""Change BIOS settings command.
 
 Command provides capability to change bios settings
 from JSON spec or via command line via --attr_name and comma separate list

--- a/redfish_ctl/bios/cmd_change_boot_order.py
+++ b/redfish_ctl/bios/cmd_change_boot_order.py
@@ -1,4 +1,4 @@
-"""iDRAC change boot order and boot options.
+"""Change BIOS boot order and boot options.
 It requires server reboot.
 
     redfish_ctl change-boot-order --from_spec specs/change_boot_order_spec.json


### PR DESCRIPTION
Vendor-neutrality doc scrub for the BIOS commands (comments/docstrings only, no behavior change).

- Reword generic-Redfish prose that said "iDRAC" to "BIOS ... command"/"a Redfish endpoint" across the BIOS command docstrings.
- Keep the functional BootOption id `Optical.iDRACVirtual.1-1` and all wire strings; argparse `help=`/`description=` runtime strings are left unchanged (out of the comments/docstrings scope).

Docstrings/comments only; no behavior change.