### PR TITLE
Neutralize boot_source command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/boot_source/cmd_boot_one_shot.py
+++ b/redfish_ctl/boot_source/cmd_boot_one_shot.py
@@ -1,9 +1,9 @@
-"""iDRAC enable boot options.
+"""Query a one-shot boot source device.
 
 This cmd return Dell Boot Sources Configuration and the related
 resources.
 
-Command provides the option to retrieve boot source from iDRAC and serialize
+Command provides the option to retrieve boot source from a Redfish endpoint and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command
 caller can save to a file and consume asynchronously or synchronously.
@@ -90,7 +90,7 @@ class BootOneShot(RedfishManagerBase,
                 dry_run: Optional[bool] = False,
                 confirm: Optional[bool] = True,
                 **kwargs) -> CommandResult:
-        """Query information for particular boot source device from idrac.
+        """Query information for particular boot source device from a Redfish endpoint.
         Example python redfish_ctl.py get_boot_source --dev "HardDisk.List.1-1"
 
         VenHw(986D1755-B9D0-4F8D-A0DA-D1DB18672045)

--- a/redfish_ctl/boot_source/cmd_boot_settings.py
+++ b/redfish_ctl/boot_source/cmd_boot_settings.py
@@ -1,4 +1,4 @@
-"""iDRAC boot settings query
+"""Boot settings query command.
 
 This resource is used to represent the Boot Sources pending configuration
 and related resources to clear pending and navigation to Jobs resource.

--- a/redfish_ctl/boot_source/cmd_boot_source_get.py
+++ b/redfish_ctl/boot_source/cmd_boot_source_get.py
@@ -1,4 +1,4 @@
-"""iDRAC query boot source device.
+"""Query a boot source device.
 
 This cmd return Dell Boot Sources configuration for
 a particular boot source.
@@ -58,7 +58,7 @@ class BootSource(RedfishManagerBase,
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Query information for particular boot source device from idrac.
+        """Query information for particular boot source device from a Redfish endpoint.
         Example python redfish_ctl.py boot-source-get --dev "HardDisk.List.1-1"
 
         :param boot_source: a device HardDisk.List.1-1

--- a/redfish_ctl/boot_source/cmd_boot_source_registry.py
+++ b/redfish_ctl/boot_source/cmd_boot_source_registry.py
@@ -1,4 +1,4 @@
-"""iDRAC query boot source registry.
+"""Query the boot source registry.
 
 And the registry defines a representation of Boot Sources instances
 
@@ -23,7 +23,7 @@ class QueryBootSourceRegistry(
     scm_type=ApiRequestType.BootSourceRegistry,
     name='boot_source_registry',
     metaclass=Singleton):
-    """A command query iDRAC resource based on a resource path.
+    """Query a Redfish endpoint resource by resource path.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/boot_source/cmd_clear_pending.py
+++ b/redfish_ctl/boot_source/cmd_clear_pending.py
@@ -1,4 +1,4 @@
-"""iDRAC command clear boot options pending values.
+"""Clear pending boot-source values command.
 
 Command provides the option to clear boot source pending values
 via dell oem.  If boot options change boot order
@@ -29,7 +29,7 @@ class BootOptionsClearPending(RedfishManagerBase,
                               metaclass=Singleton):
     """
     This cmd action is used to clear all BIOS pending
-    values currently in iDRAC.
+    values currently staged on the Redfish endpoint.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/boot_source/cmd_enable.py
+++ b/redfish_ctl/boot_source/cmd_enable.py
@@ -1,4 +1,4 @@
-"""iDRAC enable boot options.
+"""Enable a boot source option.
 
 Command provides the option to enable boot source,
 so it is used during a boot process. BootSources settings,

--- a/redfish_ctl/boot_source/cmd_pending.py
+++ b/redfish_ctl/boot_source/cmd_pending.py
@@ -1,4 +1,4 @@
-"""iDRAC query boot source pending values.
+"""Query boot source pending values.
 
 Command provides option to query boot source for
 pending values.

--- a/redfish_ctl/boot_source/cmd_update.py
+++ b/redfish_ctl/boot_source/cmd_update.py
@@ -1,4 +1,4 @@
-"""iDRAC update boot sources.
+"""Update boot sources.
 
 Command provides option to query boot source for
 pending values.


### PR DESCRIPTION
Vendor-neutrality doc scrub for the boot_source commands (comments/docstrings only, no behavior change). Generic "iDRAC" prose in the command docstrings neutralized to "Redfish endpoint" phrasing (including the "query iDRAC resource" registry docstring). Commented-out code and argparse help strings referencing real identifiers are left unchanged.