### PR TITLE
Neutralize system command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/system/cmd_system.py
+++ b/redfish_ctl/system/cmd_system.py
@@ -1,6 +1,6 @@
-"""iDRAC system command
+"""System view command.
 
-Command provides the option to retrieve system view from iDRAC and serialize
+Command provides the option to retrieve system view from a Redfish endpoint and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest of commands
 caller can save to a file and consume asynchronously or synchronously.

--- a/redfish_ctl/system/cmd_system_config.py
+++ b/redfish_ctl/system/cmd_system_config.py
@@ -1,6 +1,6 @@
-"""iDRAC export system config command.
+"""Export system configuration command.
 
-Command provides the option to retrieve firmware setting from iDRAC and serialize
+Command provides the option to retrieve firmware setting from a Redfish endpoint and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
@@ -65,7 +65,7 @@ class ExportSystemConfig(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 **kwargs
                 ) -> CommandResult:
-        """Exports system configuration from idrac
+        """Exports system configuration from a Redfish endpoint
 
         Default, Clone, Replace
         Default, IncludeReadOnly, IncludePasswordHashValues

--- a/redfish_ctl/system/cmd_system_import.py
+++ b/redfish_ctl/system/cmd_system_import.py
@@ -1,4 +1,4 @@
-"""iDRAC import system config from json file.
+"""Import system configuration from a JSON file.
 
 Command provides the option to import configuration.
 

--- a/redfish_ctl/system/cmd_system_one_time_boot.py
+++ b/redfish_ctl/system/cmd_system_one_time_boot.py
@@ -1,4 +1,4 @@
-"""iDRAC set a one-time boot device via a system-configuration import.
+"""Set a one-time boot device via a system-configuration import.
 
 Sends an ImportSystemConfiguration request whose buffer enables BootOnce and
 selects the first boot device, then optionally reboots. Distinct from the


### PR DESCRIPTION
Vendor-neutrality doc scrub for the system commands (comments/docstrings only, no behavior change). Generic "iDRAC" prose neutralized to "Redfish endpoint" phrasing; the functional SCP component `FQDD="iDRAC.Embedded.1"` string is kept.