### PR TITLE
Neutralize compute command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/compute/cmd_compute_setting.py
+++ b/redfish_ctl/compute/cmd_compute_setting.py
@@ -1,4 +1,4 @@
-"""iDRAC query compute settings
+"""Query compute system settings.
 
     redfish_ctl compute-query
 

--- a/redfish_ctl/compute/cmd_power_state.py
+++ b/redfish_ctl/compute/cmd_power_state.py
@@ -1,4 +1,4 @@
-"""iDRAC reset a power state for compute system command.
+"""Reset the power state for a compute system command.
 
     redfish_ctl reboot --reset_type GracefulRestart
 

--- a/redfish_ctl/compute/cmd_update.py
+++ b/redfish_ctl/compute/cmd_update.py
@@ -1,4 +1,4 @@
-"""iDRAC update compute settings
+"""Update compute system settings.
 
     redfish_ctl compute-update
 
@@ -23,7 +23,7 @@ class UpdateCompute(RedfishManagerBase,
                     name='update',
                     metaclass=Singleton):
     """
-    Update idrac compute
+    Update compute system settings
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Vendor-neutrality doc scrub for the compute commands (comments/docstrings only, no behavior change). Generic "iDRAC" prose neutralized to vendor-neutral phrasing.