### PR TITLE
Neutralize attribute command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/attribute/cmd_attribute.py
+++ b/redfish_ctl/attribute/cmd_attribute.py
@@ -1,8 +1,8 @@
-"""iDRAC attribute command
+"""Attribute query command.
 
     redfish_ctl attr --filter ServerPwrMon.1.PeakCurrentTime
 
-Command provides the option to retrieve the iDRAC attribute and serialize
+Command provides the option to retrieve the Redfish endpoint attribute and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
@@ -28,7 +28,7 @@ class AttributesQuery(
     scm_type=ApiRequestType.AttributesQuery,
     name='attribute_inventory',
     metaclass=Singleton):
-    """iDRAC Attribute Query Command, fetch attribute data, caller can save to a file
+    """Attribute query command, fetch attribute data, caller can save to a file
     or output to a file or pass downstream.
     """
 
@@ -82,7 +82,7 @@ class AttributesQuery(
                 attr_only: Optional[bool] = False,
                 attr_filter: Optional[str] = "",
                 **kwargs) -> CommandResult:
-        """Queries attributes from iDRAC.
+        """Queries attributes from a Redfish endpoint.
 
         :param attr_filter: filter the attributes to those matching this name.
         :param attr_only: return only the Attributes section of the resource.

--- a/redfish_ctl/attribute/cmd_attribute_clear_pending.py
+++ b/redfish_ctl/attribute/cmd_attribute_clear_pending.py
@@ -1,4 +1,4 @@
-"""iDRAC clear pending values.
+"""Clear pending attribute values.
 
     redfish_ctl attr-clear-pending
 
@@ -25,7 +25,7 @@ class AttributeClearPending(
     metaclass=Singleton):
     """
     This cmd action is used to clear all the pending
-    values currently in iDRAC.
+    values currently staged on the Redfish endpoint.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/attribute/cmd_attribute_update.py
+++ b/redfish_ctl/attribute/cmd_attribute_update.py
@@ -1,8 +1,8 @@
-"""iDRAC attribute update command
+"""Attribute update command.
 
     redfish_ctl attr-update --from_spec attribute.json
 
-Command provides the option to retrieve the iDRAC attribute and serialize
+Command provides the option to retrieve the Redfish endpoint attribute and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.
@@ -28,7 +28,7 @@ class AttributesUpdate(
     scm_type=ApiRequestType.AttributesUpdate,
     name='attribute_update',
     metaclass=Singleton):
-    """iDRAC Attribute Query Command, fetch attribute data, caller can save to a file
+    """Attribute update command, fetch attribute data, caller can save to a file
     or output to a file or pass downstream.
     """
 
@@ -67,7 +67,7 @@ class AttributesUpdate(
                 do_async: Optional[bool] = False,
                 from_spec: Optional[str] = "",
                 **kwargs) -> CommandResult:
-        """Update idrac attributes.
+        """Update Redfish endpoint attributes.
 
         :param from_spec: path to a json spec file holding the attribute
             key/value pairs to apply.


### PR DESCRIPTION
Vendor-neutrality doc scrub for the attribute commands (comments/docstrings only, no behavior change).