### PR TITLE
Neutralize chassis command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/chassis/cmd_chasis_reset.py
+++ b/redfish_ctl/chassis/cmd_chasis_reset.py
@@ -1,4 +1,4 @@
-"""iDRAC reset a chassis power state.
+"""Reset a chassis power state.
 
  redfish_ctl chassis-reset --reset_type ForceOff
 

--- a/redfish_ctl/chassis/cmd_chassis_query.py
+++ b/redfish_ctl/chassis/cmd_chassis_query.py
@@ -1,4 +1,4 @@
-"""iDRAC query chassis services
+"""Query chassis services.
 
 Command provides raw query chassis
 and provide list of supported actions.

--- a/redfish_ctl/chassis/cmd_update_chassis.py
+++ b/redfish_ctl/chassis/cmd_update_chassis.py
@@ -1,4 +1,4 @@
-"""iDRAC reset a chassis power state.
+"""Update a chassis.
 
 The Chassis schema represents the physical components of a system.
 This resource represents the sheet-metal confined spaces


### PR DESCRIPTION
Vendor-neutrality doc scrub for the chassis commands (comments/docstrings only, no behavior change). Also fixes the copy-pasted chassis-update module title (it updates a chassis via PATCH, not a power reset).