### PR TITLE
Neutralize tasks command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/tasks/cmd_task_svc.py
+++ b/redfish_ctl/tasks/cmd_task_svc.py
@@ -1,4 +1,4 @@
-"""iDRAC manager command
+"""Task service command.
 
 Command provides the option to retrieve task services.
 
@@ -20,7 +20,7 @@ class Manager(RedfishManagerBase,
               scm_type=ApiRequestType.ManagerQuery,
               name='task_svc_query',
               metaclass=Singleton):
-    """iDRAC Manager server Command, fetch manager service,
+    """Task service command, fetch the task service,
     caller can save to a file or output to a file or pass downstream.
     """
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/tasks/cmd_task_watch.py
+++ b/redfish_ctl/tasks/cmd_task_watch.py
@@ -1,6 +1,6 @@
-"""iDRAC task watch command.
+"""Task watch command.
 
-Command provides the option to retrieve firmware setting from iDRAC and serialize
+Command provides the option to retrieve firmware setting from a Redfish endpoint and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command caller can save
 to a file and consume asynchronously or synchronously.

--- a/redfish_ctl/tasks/cmd_tasks_get.py
+++ b/redfish_ctl/tasks/cmd_tasks_get.py
@@ -1,4 +1,4 @@
-"""iDRAC query tasks services
+"""Query task services.
 
 Command provides query tasks service and obtains list of task.
 

--- a/redfish_ctl/tasks/cmd_tasks_list.py
+++ b/redfish_ctl/tasks/cmd_tasks_list.py
@@ -1,4 +1,4 @@
-"""iDRAC query tasks services
+"""Query task services.
 
 Command provides  query tasks service and obtains list of task.
 


### PR DESCRIPTION
Vendor-neutrality doc scrub for the tasks (Redfish Tasks) commands (comments/docstrings only, no behavior change).