### PR TITLE
Neutralize virtual_media command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
@@ -1,6 +1,6 @@
-"""iDRAC virtual media eject command
+"""Virtual media eject command.
 
-Command provides the option to eject  virtual disk from iDRAC.
+Command provides the option to eject  virtual disk from a Redfish endpoint.
 
 Example:
     redfish_ctl eject_vm --device_id 1
@@ -23,7 +23,7 @@ class VirtualMediaEject(RedfishManagerBase,
                         scm_type=ApiRequestType.VirtualMediaEject,
                         name='virtual_disk_eject',
                         metaclass=Singleton):
-    """iDRACs cmd ejects virtual media
+    """Eject virtual media over the Redfish API.
     Virtual medial must be inserted, otherwise command throw exception.
     """
 

--- a/redfish_ctl/virtual_media/cmd_virtual_media_get.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_get.py
@@ -1,8 +1,8 @@
-"""iDRAC command return virtual media.
+"""Return virtual media.
 
 redfish_ctl get_vm
 
-Command provides the option to retrieve virtual media from iDRAC
+Command provides the option to retrieve virtual media from a Redfish endpoint
 and serialize back to caller as JSON, YAML, or XML.
 In addition, it automatically registered to the command line ctl tool.
 Similarly to the rest command caller can save to a file and
@@ -36,7 +36,7 @@ class VirtualMediaGet(RedfishManagerBase,
                       scm_type=ApiRequestType.VirtualMediaGet,
                       name='virtual_disk_query',
                       metaclass=Singleton):
-    """iDRACs REST API Virtual Disk Query Command, fetch virtual disk, caller can save
+    """Virtual media query command, fetch virtual media, caller can save
     result to a file or output stdout or pass downstream to jq etc. tools.
     """
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_insert.py
@@ -1,4 +1,4 @@
-"""iDRAC virtual media eject command
+"""Virtual media insert command.
 
 Command provides the option to insert virtual disk with ISO image.
 For example late we can set boot from virtual medial,
@@ -86,7 +86,7 @@ class VirtualMediaInsert(RedfishManagerBase,
                          scm_type=ApiRequestType.VirtualMediaInsert,
                          name='virtual_disk_insert',
                          metaclass=Singleton):
-    """iDRACs cmd insert virtual media
+    """Insert virtual media over the Redfish API.
     Virtual medial must be empty, otherwise command will throw exception.
     Called must first eject existing virtual media.
     """


### PR DESCRIPTION
Vendor-neutrality doc scrub for the virtual media commands (comments/docstrings only, no behavior change). Also fixes the copy-pasted insert-command title. Keeps the functional `Optical.iDRACVirtual.1-1` id and the example `iDRAC Virtual Media Instance` response value.