### PR TITLE
Neutralize manager command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/manager/cmd_manager.py
+++ b/redfish_ctl/manager/cmd_manager.py
@@ -1,6 +1,6 @@
-"""iDRAC manager command
+"""Manager view command.
 
-Command provides the option to retrieve iDRAC manager view.
+Command provides the option to retrieve the Redfish manager view.
 redfish_ctl manager
 
 Author Mus spyroot@gmail.com
@@ -17,7 +17,7 @@ class Manager(RedfishManagerBase,
               scm_type=ApiRequestType.ManagerQuery,
               name='manager_query',
               metaclass=Singleton):
-    """iDRAC Manager server Command, fetch manager service,
+    """Manager view command, fetch the manager service,
     caller can save to a file or output to a file or pass downstream.
     """
 
@@ -44,7 +44,7 @@ class Manager(RedfishManagerBase,
                 do_async: Optional[bool] = False,
                 do_expanded: Optional[bool] = True,
                 **kwargs) -> CommandResult:
-        """Queries manager services from iDRAC.
+        """Queries manager services from a Redfish endpoint.
         :param do_expanded:
         :param do_async:
         :param verbose: accepted for CLI compatibility; not used by this command.

--- a/redfish_ctl/manager/cmd_manager_reset.py
+++ b/redfish_ctl/manager/cmd_manager_reset.py
@@ -1,6 +1,6 @@
-"""iDRAC reset manager ,
+"""Reset the manager.
 
-command reset-reboot IDRAC manger.
+Reset/reboot the Redfish manager.
 
     redfish_ctl manager-reboot
 
@@ -19,7 +19,7 @@ class ManagerReset(RedfishManagerBase,
                    scm_type=ApiRequestType.ManagerReset,
                    name='manager_reset',
                    metaclass=Singleton):
-    """iDRAC Manager server Command, fetch manager service,
+    """Reset the manager command, targets the manager service,
     caller can save to a file or output to a file or pass downstream.
     """
 
@@ -71,7 +71,7 @@ class ManagerReset(RedfishManagerBase,
                 do_wait: Optional[bool] = False,
                 wait_timeout: Optional[float] = 300.0,
                 **kwargs) -> CommandResult:
-        """Reset IDRAC manager services.
+        """Reset the manager services.
 
         :param data_type: json or xml; ``json`` adds the JSON content-type header.
         :param do_deep: accepted for CLI compatibility; not used by this command.


### PR DESCRIPTION
Vendor-neutrality doc scrub for the manager commands (comments/docstrings only, no behavior change). The `help_text` runtime string is left unchanged (out of the comments/docstrings scope).