### PR TITLE
Neutralize boot_options command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/boot_options/cmd_boot_option_list.py
+++ b/redfish_ctl/boot_options/cmd_boot_option_list.py
@@ -1,6 +1,6 @@
-"""iDRAC boot options.
+"""List boot options.
 
-Command provides the option to retrieve boot source from iDRAC and serialize
+Command provides the option to retrieve boot source from a Redfish endpoint and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command
 caller can save to a file and consume asynchronously or synchronously.
@@ -71,7 +71,7 @@ class BootOptionsList(RedfishManagerBase,
                 data_type: Optional[str] = "json",
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False, **kwargs) -> CommandResult:
-        """List boot source from idrac.
+        """List boot source from a Redfish endpoint.
 
         The data payload contain list of all devices.
 

--- a/redfish_ctl/boot_options/cmd_boot_options_query.py
+++ b/redfish_ctl/boot_options/cmd_boot_options_query.py
@@ -1,4 +1,4 @@
-"""iDRAC query for a boot options
+"""Query boot options.
 
     redfish_ctl boot-options
 


### PR DESCRIPTION
Vendor-neutrality doc scrub for the boot_options commands (comments/docstrings only, no behavior change). Keeps the Dell iDRAC9 Redfish API guide doc URL reference.