### PR TITLE
Neutralize raid command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/raid/cmd_raid_service.py
+++ b/redfish_ctl/raid/cmd_raid_service.py
@@ -1,6 +1,6 @@
-"""iDRAC raid service query
+"""RAID service query command.
 
-Command provides the option to retrieve raid service  from iDRAC
+Command provides the option to retrieve raid service  from a Redfish endpoint
 and serialize back as caller as JSON, YAML, and XML. In addition,
 it automatically registers to the command line ctl tool. Similarly
 to the rest command caller can save to a file and consume asynchronously


### PR DESCRIPTION
Vendor-neutrality doc scrub for the raid service command (comments/docstrings only, no behavior change).