### PR TITLE
Neutralize discovery command docstring to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/discovery/cmd_discovery.py
+++ b/redfish_ctl/discovery/cmd_discovery.py
@@ -1,6 +1,6 @@
 """Redfish discovery command
 
-Command discover all idrac / redfish resources.
+Command discover all Redfish resources.
 
     redfish_ctl discovery
     redfish_ctl discovery --network 192.168.254.0/24


### PR DESCRIPTION
Vendor-neutrality doc scrub for the discovery command (comments/docstrings only, no behavior change).