### PR TITLE
Neutralize top-level command-module docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/cmd_boot.py
+++ b/redfish_ctl/cmd_boot.py
@@ -1,9 +1,9 @@
-"""iDRAC boot query command
+"""Boot query command.
 
     redfish_ctl boot
     redfish_ctl boot --deep --filename boot.json
 
-Command provides the option to retrieve boot source from iDRAC and serialize
+Command provides the option to retrieve boot source from a Redfish endpoint and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command
 caller can save to a file and consume asynchronously or synchronously.
@@ -65,7 +65,7 @@ class BootQuery(RedfishManagerBase,
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """Query boot source from idrac
+        """Query boot source from a Redfish endpoint
         :param do_async: will use asyncio
         :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_deep:

--- a/redfish_ctl/cmd_current_boot.py
+++ b/redfish_ctl/cmd_current_boot.py
@@ -1,4 +1,4 @@
-"""iDRAC enable boot options.
+"""Query the current boot configuration.
 
     redfish_ctl current_boot
     redfish_ctl current_boot --filename current_boot.json
@@ -6,7 +6,7 @@
 This cmd return Dell Boot Sources Configuration and the related
 resources.
 
-Command provides the option to retrieve boot source from iDRAC and serialize
+Command provides the option to retrieve boot source from a Redfish endpoint and serialize
 back as caller as JSON, YAML, and XML. In addition, it automatically
 registers to the command line ctl tool. Similarly to the rest command
 caller can save to a file and consume asynchronously or synchronously.

--- a/redfish_ctl/cmd_exceptions.py
+++ b/redfish_ctl/cmd_exceptions.py
@@ -40,7 +40,7 @@ class InvalidArgumentFormat(Exception):
 
 class FailedDiscoverAction(Exception):
     """Must raise if requested action failed to discover.
-    i.e. old IDRAC version for example.
+    i.e. an old BMC firmware version, for example.
     """
     pass
 

--- a/redfish_ctl/cmd_query.py
+++ b/redfish_ctl/cmd_query.py
@@ -1,4 +1,4 @@
-"""iDRAC query command
+"""Redfish query command.
 
     redfish_ctl query --resource /redfish/v1/Managers
     redfish_ctl query --resource /redfish/v1/Systems --expanded
@@ -22,7 +22,7 @@ class QueryIDRAC(
     scm_type=ApiRequestType.QueryIdrac,
     name='query_idrac',
     metaclass=Singleton):
-    """A command query iDRAC resource based on a resource path.
+    """Query a Redfish endpoint resource by resource path.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Vendor-neutrality doc scrub for the top-level command modules (cmd_boot, cmd_current_boot, cmd_query, cmd_exceptions) — comments/docstrings only, no behavior change. Engine modules (redfish_*.py) are handled separately.