### PR TITLE
Neutralize accounts command docs to vendor-neutral Redfish terms

### DIFF
--- a/redfish_ctl/accounts/cmd_account_svc.py
+++ b/redfish_ctl/accounts/cmd_account_svc.py
@@ -1,4 +1,4 @@
-"""iDRAC query account services
+"""Query account services.
 
 Command query account services.
 
@@ -19,7 +19,7 @@ class QueryAccountService(RedfishManagerBase,
                           scm_type=ApiRequestType.QueryAccountService,
                           name='query_account_svc',
                           metaclass=Singleton):
-    """A command query iDRAC account services based on a resource path.
+    """Query a Redfish endpoint's account services by resource path.
     """
     def __init__(self, *args, **kwargs):
         """Initialize the command and its CLI-filter-to-response-key map."""

--- a/redfish_ctl/accounts/cmd_accounts.py
+++ b/redfish_ctl/accounts/cmd_accounts.py
@@ -1,4 +1,4 @@
-"""iDRAC query command
+"""Account query command.
 
 Command query account.
 
@@ -21,7 +21,7 @@ class QueryAccounts(RedfishManagerBase,
                     scm_type=ApiRequestType.QueryAccounts,
                     name='query_accounts',
                     metaclass=Singleton):
-    """A command query iDRAC resource based on a resource path.
+    """Query a Redfish endpoint resource by resource path.
     """
 
     def __init__(self, *args, **kwargs):

--- a/redfish_ctl/accounts/cmd_privilage_registry.py
+++ b/redfish_ctl/accounts/cmd_privilage_registry.py
@@ -1,4 +1,4 @@
-"""iDRAC query privilege registry
+"""Query the privilege registry.
 
 Command query privilege registry.
 
@@ -18,7 +18,7 @@ class QueryPrivilegeRegistry(RedfishManagerBase,
                              scm_type=ApiRequestType.PrivilegeRegistry,
                              name='query_privilege_registry',
                              metaclass=Singleton):
-    """A command query iDRAC resource based on a resource path.
+    """Query a Redfish endpoint resource by resource path.
     """
     def __init__(self, *args, **kwargs):
         """Initialize the query_privilege_registry command."""

--- a/redfish_ctl/accounts/cmd_query_account.py
+++ b/redfish_ctl/accounts/cmd_query_account.py
@@ -1,4 +1,4 @@
-"""iDRAC query command
+"""Account query command.
 
 Command provides capability query
 particular account.
@@ -22,7 +22,7 @@ class QueryAccount(RedfishManagerBase,
                    scm_type=ApiRequestType.QueryAccount,
                    name='query_account',
                    metaclass=Singleton):
-    """A command query iDRAC resource based on a resource path.
+    """Query a Redfish endpoint resource by resource path.
     """
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Vendor-neutrality doc scrub for the accounts commands (comments/docstrings only, no behavior change).