### PR TITLE
Add JSON status map sidecar

### DIFF
--- a/docs/fixture-capture.md
+++ b/docs/fixture-capture.md
@@ -24,10 +24,11 @@ index for committed corpus tarballs and pull-all extraction commands.
 ## Path A — Full BMC crawl (whole tree → vendor corpus)
 
 `redfish_ctl` can capture its own test data. The `discovery` command does a deep crawl of a BMC and
-writes one JSON file per Redfish URI (plus `rest_api_map.npy`) under `~/.json_responses/<ip>/` —
-exactly the layout the committed corpora pack (the filtered `tests/supermicro_gb300_corpus.tar.gz`
-LFS tarball, or overlay sets like `tests/supermicro_x10_fixtures/`). To contribute coverage for a
-BMC this project has not seen:
+writes one JSON file per Redfish URI under `~/.json_responses/<ip>/`, plus `rest_api_map.npy` for
+the legacy URL/method map and `rest_api_map.status.json`, the JSON status/error sidecar written by
+`Discovery.save_url_file_mapping`. This is exactly the layout the committed corpora pack (the
+filtered `tests/supermicro_gb300_corpus.tar.gz` LFS tarball, or overlay sets like
+`tests/supermicro_x10_fixtures/`). To contribute coverage for a BMC this project has not seen:
 
 1. **Crawl an approved lab BMC** (read-only; never production, never someone else's hardware):
 

--- a/docs/full-corpus-contract.md
+++ b/docs/full-corpus-contract.md
@@ -77,6 +77,14 @@ stable IGC contract), plus two additive capture keys:
   captured non-2xx bodies. A URL is in **either** `url_file_mapping` or `error_file_mapping`,
   never both. Consumers that read only the two legacy keys are unaffected.
 
+## `rest_api_map.status.json` sidecar
+`rest_api_map.status.json`, written by `Discovery.save_url_file_mapping` next to
+`rest_api_map.npy`, contains the additive `http_status_mapping` and `error_file_mapping` keys in
+plain JSON. The mock BMC reads this sidecar first, so status/error replay does not require NumPy or
+pickle loading for new captures. If the sidecar exists but is malformed or missing either replay map,
+mock startup fails closed instead of falling back silently. Older corpora without the sidecar keep
+using the legacy `.npy` contract.
+
 ## Validation gate (fail closed)
 `pack_full_corpus.py` refuses to write unless: all JSON parse; the map loads and has the two
 required mappings; the ServiceRoot is present and mapped;

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -22,6 +22,7 @@ DEFAULT_PORT = 8080
 DEFAULT_CORPUS_DIR = Path(
     os.environ.get("MOCK_BMC_CORPUS_DIR", "/corpus/gb300")
 )
+REST_API_STATUS_MAP_JSON = "rest_api_map.status.json"
 
 
 class MockBMCServer(ThreadingHTTPServer):
@@ -40,14 +41,20 @@ def _build_fixture_index(corpus_dir: Path) -> dict[str, Path]:
 
 
 def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
-    """Load the optional ``rest_api_map.npy`` URL/status/error mapping.
+    """Load the optional Redfish URL/status/error mapping.
 
-    :param corpus_dir: directory that may contain ``rest_api_map.npy``.
+    :param corpus_dir: directory that may contain a status JSON sidecar or
+        legacy ``rest_api_map.npy``.
     :return: the decoded map, or an empty dict when the file is absent.
-    :raises ValueError: if NumPy is missing, the file fails to load, or it
-        does not decode to an object.
+    :raises ValueError: if the map fails to load or does not decode to an
+        object.
     """
-    map_path = Path(corpus_dir) / "rest_api_map.npy"
+    corpus_path = Path(corpus_dir)
+    sidecar_path = corpus_path / REST_API_STATUS_MAP_JSON
+    if sidecar_path.exists():
+        return _load_rest_api_map_json(sidecar_path)
+
+    map_path = corpus_path / "rest_api_map.npy"
     if not map_path.exists():
         return {}
     try:
@@ -62,6 +69,25 @@ def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
         raise ValueError(f"failed to load Redfish API map: {map_path}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"Redfish API map must contain an object: {map_path}")
+    _validate_rest_api_map(data, map_path)
+    return data
+
+
+def _load_rest_api_map_json(map_path: Path) -> dict[str, Any]:
+    """Load a JSON Redfish API status/error map sidecar.
+
+    :param map_path: sidecar file path to read and validate.
+    :return: decoded and validated Redfish API map data.
+    """
+    try:
+        data = json.loads(map_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"failed to load Redfish API map: {map_path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"Redfish API map must contain an object: {map_path}")
+    for key in ("http_status_mapping", "error_file_mapping"):
+        if key not in data:
+            raise ValueError(f"{key} is required in Redfish API map: {map_path}")
     _validate_rest_api_map(data, map_path)
     return data
 

--- a/redfish_ctl/discovery/cmd_discovery.py
+++ b/redfish_ctl/discovery/cmd_discovery.py
@@ -10,6 +10,7 @@ Author Mus spyroot@gmail.com
 import json
 import os
 import re
+import tempfile
 import time
 from abc import abstractmethod
 from pathlib import Path
@@ -17,9 +18,9 @@ from typing import Optional
 
 import requests
 
+from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, Singleton
-from ..redfish_manager import CommandResult
 from ..redfish_shared import env_first
 
 # Upper bound on how deep recursive_discovery will walk below a top-level
@@ -27,6 +28,35 @@ from ..redfish_shared import env_first
 # purely to guarantee termination even if normalization/dedup ever misses a
 # cyclic back-reference.
 DEFAULT_DISCOVERY_MAX_DEPTH = 32
+REST_API_STATUS_MAP_JSON = "rest_api_map.status.json"
+
+
+def _write_json_atomic(path: str, payload: dict) -> None:
+    """Write JSON by replacing the target only after serialization succeeds.
+
+    :param path: target JSON file path to replace atomically.
+    :param payload: JSON-serializable object to write.
+    :return: None.
+    """
+    target_dir = os.path.dirname(path) or "."
+    tmp_name = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=target_dir,
+            delete=False,
+        ) as file:
+            tmp_name = file.name
+            json.dump(payload, file, indent=2)
+        os.replace(tmp_name, path)
+    except Exception:
+        if tmp_name:
+            try:
+                os.unlink(tmp_name)
+            except FileNotFoundError:
+                pass
+        raise
 
 # Matches an individual *member* of any LogService's Entries collection
 # (``/LogServices/<Sel|Journal|Lclog|...>/Entries/<entry-id>``), across vendors.
@@ -353,6 +383,20 @@ class Discovery(RedfishManagerBase,
         }
         filename = os.path.join(self.json_response_dir, filename)
         np.save(filename, mappings)
+        sidecar = {
+            "http_status_mapping": {
+                path: int(status) for path, status in self._http_status.items()
+            },
+            "error_file_mapping": {
+                path: str(filename)
+                for path, filename in self._error_file_mapping.items()
+            },
+        }
+        status_filename = os.path.join(
+            self.json_response_dir,
+            REST_API_STATUS_MAP_JSON,
+        )
+        _write_json_atomic(status_filename, sidecar)
 
     def execute(self,
                 filename: Optional[str] = None,

--- a/tests/test_discovery_producer.py
+++ b/tests/test_discovery_producer.py
@@ -5,9 +5,14 @@ igc project consumes via `np.load(..., allow_pickle=True).item()`. These tests
 pin the file name and the two top-level keys so a refactor cannot silently break
 that cross-repo contract. No iDRAC, no network.
 """
+import json
+
 import numpy as np
+import pytest
 
 from redfish_ctl.discovery.cmd_discovery import Discovery
+
+STATUS_SIDECAR = "rest_api_map.status.json"
 
 
 def _new_discovery(tmp_path):
@@ -37,6 +42,71 @@ def test_save_url_file_mapping_roundtrip(tmp_path):
     assert loaded["allowed_methods_mapping"] == disc._api_allowed_methods
     assert loaded["http_status_mapping"] == disc._http_status
     assert loaded["error_file_mapping"] == disc._error_file_mapping
+
+
+def test_save_url_file_mapping_writes_status_json_sidecar(tmp_path):
+    """Captured status and error maps are available without loading pickle data."""
+    disc = _new_discovery(tmp_path)
+    disc._http_status = {"/redfish/v1/A": 200, "/redfish/v1/Ghost": 404}
+    disc._error_file_mapping = {
+        "/redfish/v1/Ghost": "_redfish_v1_Ghost.error.json"
+    }
+
+    disc.save_url_file_mapping()
+
+    sidecar = tmp_path / STATUS_SIDECAR
+    assert sidecar.exists()
+    assert json.loads(sidecar.read_text(encoding="utf-8")) == {
+        "http_status_mapping": disc._http_status,
+        "error_file_mapping": disc._error_file_mapping,
+    }
+
+
+def test_save_url_file_mapping_sidecar_uses_json_native_values(tmp_path):
+    """The sidecar remains JSON-serializable if capture maps carry scalar types."""
+    disc = _new_discovery(tmp_path)
+    disc._http_status = {"/redfish/v1/Ghost": np.int64(404)}
+    disc._error_file_mapping = {
+        "/redfish/v1/Ghost": tmp_path / "_redfish_v1_Ghost.error.json"
+    }
+
+    disc.save_url_file_mapping()
+
+    sidecar = json.loads((tmp_path / STATUS_SIDECAR).read_text(encoding="utf-8"))
+    assert sidecar == {
+        "http_status_mapping": {"/redfish/v1/Ghost": 404},
+        "error_file_mapping": {
+            "/redfish/v1/Ghost": str(tmp_path / "_redfish_v1_Ghost.error.json")
+        },
+    }
+
+
+def test_save_url_file_mapping_sidecar_write_is_atomic(tmp_path, monkeypatch):
+    """A failed sidecar write must not corrupt the previous sidecar."""
+    disc = _new_discovery(tmp_path)
+    disc._http_status = {"/redfish/v1/Ghost": 404}
+    disc._error_file_mapping = {
+        "/redfish/v1/Ghost": "_redfish_v1_Ghost.error.json"
+    }
+    sidecar = tmp_path / STATUS_SIDECAR
+    sidecar.write_text(
+        json.dumps({"http_status_mapping": {}, "error_file_mapping": {}}),
+        encoding="utf-8",
+    )
+
+    def fail_after_partial_write(payload, file_obj, indent):  # noqa: ARG001
+        file_obj.write("{")
+        raise OSError("simulated write failure")
+
+    monkeypatch.setattr(json, "dump", fail_after_partial_write)
+
+    with pytest.raises(OSError, match="simulated write failure"):
+        disc.save_url_file_mapping()
+
+    assert json.loads(sidecar.read_text(encoding="utf-8")) == {
+        "http_status_mapping": {},
+        "error_file_mapping": {},
+    }
 
 
 def test_save_url_file_mapping_keys_are_stable_for_igc(tmp_path):

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -22,6 +22,7 @@ HELM_VALUES = REPO_ROOT / "charts" / "redfish-controller" / "values.yaml"
 SIMULATION_DOC = REPO_ROOT / "docs" / "simulation-and-replay.md"
 GRACEFUL_RESTART_TRACE = REPO_ROOT / "tests" / "write_traces" / "graceful_restart.yaml"
 SUPERMICRO_RULES = REPO_ROOT / "tests" / "mutation_rules" / "supermicro_gb300.yaml"
+STATUS_SIDECAR = "rest_api_map.status.json"
 GB300_CORPUS = corpus_dir(
     REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz", "172.25.230.37"
 )
@@ -108,6 +109,33 @@ def _write_status_map_corpus(tmp_path: Path) -> Path:
                 path: filename for path, (_status, filename, _body) in error_cases.items()
             },
         },
+    )
+    return corpus
+
+
+def _write_status_sidecar_corpus(tmp_path: Path) -> Path:
+    corpus = tmp_path / "status-sidecar-corpus"
+    corpus.mkdir()
+    error_path = "/redfish/v1/Missing"
+    error_file = "_redfish_v1_Missing.error.json"
+
+    (corpus / _fixture_name("/redfish/v1")).write_text(
+        json.dumps({"@odata.id": "/redfish/v1/"}),
+        encoding="utf-8",
+    )
+    (corpus / error_file).write_text(
+        json.dumps({"error": {"code": "Base.1.17.CapturedMissing"}}),
+        encoding="utf-8",
+    )
+    (corpus / STATUS_SIDECAR).write_text(
+        json.dumps(
+            {
+                "http_status_mapping": {error_path: 404},
+                "error_file_mapping": {error_path: error_file},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
     )
     return corpus
 
@@ -215,6 +243,21 @@ def test_mock_bmc_replays_captured_error_status_map(
     assert payload == {"error": {"code": code}}
 
 
+def test_mock_bmc_replays_captured_error_status_json_sidecar(
+    tmp_path: Path,
+) -> None:
+    """Captured errors replay from JSON sidecar without requiring rest_api_map.npy."""
+    module = _load_server_module()
+    corpus = _write_status_sidecar_corpus(tmp_path)
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        observed_status, payload = _http(base, "/redfish/v1/Missing")
+
+    assert observed_status == 404
+    assert payload == {"error": {"code": "Base.1.17.CapturedMissing"}}
+
+
 def test_mock_bmc_serves_url_file_mapping_alias(tmp_path: Path) -> None:
     """URL mappings can serve fixtures whose names do not derive from the URL."""
     module = _load_server_module()
@@ -245,6 +288,29 @@ def test_rest_api_map_rejects_malformed_status_values(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="http_status_mapping"):
+        module.make_handler(corpus)
+
+
+def test_rest_api_map_rejects_incomplete_status_json_sidecar(tmp_path: Path) -> None:
+    """A sidecar must not shadow a usable legacy map without both replay maps."""
+    module = _load_server_module()
+    corpus = _write_status_sidecar_corpus(tmp_path)
+    (corpus / STATUS_SIDECAR).write_text(
+        json.dumps({"http_status_mapping": {"/redfish/v1/Missing": 404}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="error_file_mapping"):
+        module.make_handler(corpus)
+
+
+def test_rest_api_map_rejects_malformed_status_json_sidecar(tmp_path: Path) -> None:
+    """A malformed sidecar fails closed instead of falling back silently."""
+    module = _load_server_module()
+    corpus = _write_status_sidecar_corpus(tmp_path)
+    (corpus / STATUS_SIDECAR).write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="failed to load Redfish API map"):
         module.make_handler(corpus)
 
 


### PR DESCRIPTION
Summary: Adds a JSON status/error sidecar next to the legacy rest_api_map.npy output and teaches the mock BMC to read it before falling back to legacy maps. Malformed or incomplete sidecars fail closed instead of silently degrading replay, scalar/path-like values are normalized for JSON, and sidecar writes use atomic replacement. Updates the capture and corpus contract docs. Tests: conda run -n idrac_ctl pytest -q tests/test_discovery_producer.py tests/test_k8s_mock_bmc_server.py -q; conda run -n idrac_ctl ruff check redfish_ctl/discovery/cmd_discovery.py k8s/sandbox/mock_bmc_server.py tests/test_discovery_producer.py tests/test_k8s_mock_bmc_server.py; conda run -n idrac_ctl python -m pytest -q.