### PR TITLE
Preserve mock URL aliases with status sidecar

### DIFF
--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -7,6 +7,7 @@ import argparse
 import copy
 import fnmatch
 import json
+import logging
 import os
 import random
 import sys
@@ -23,6 +24,7 @@ DEFAULT_CORPUS_DIR = Path(
     os.environ.get("MOCK_BMC_CORPUS_DIR", "/corpus/gb300")
 )
 REST_API_STATUS_MAP_JSON = "rest_api_map.status.json"
+LOGGER = logging.getLogger(__name__)
 
 
 class MockBMCServer(ThreadingHTTPServer):
@@ -51,12 +53,30 @@ def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
     """
     corpus_path = Path(corpus_dir)
     sidecar_path = corpus_path / REST_API_STATUS_MAP_JSON
-    if sidecar_path.exists():
-        return _load_rest_api_map_json(sidecar_path)
-
     map_path = corpus_path / "rest_api_map.npy"
+    if sidecar_path.exists():
+        sidecar_map = _load_rest_api_map_json(sidecar_path)
+        if not map_path.exists():
+            return sidecar_map
+        legacy_map = _load_rest_api_map_npy(map_path)
+        merged = copy.deepcopy(legacy_map)
+        for key in ("http_status_mapping", "error_file_mapping"):
+            _log_status_sidecar_overrides(merged, sidecar_map, key, sidecar_path)
+            merged[key] = sidecar_map[key]
+        _validate_rest_api_map(merged, sidecar_path)
+        return merged
+
     if not map_path.exists():
         return {}
+    return _load_rest_api_map_npy(map_path)
+
+
+def _load_rest_api_map_npy(map_path: Path) -> dict[str, Any]:
+    """Load and validate a legacy NumPy Redfish API map.
+
+    :param map_path: path to ``rest_api_map.npy``.
+    :return: decoded and validated Redfish API map data.
+    """
     try:
         import numpy as np
     except ModuleNotFoundError:
@@ -71,6 +91,37 @@ def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
         raise ValueError(f"Redfish API map must contain an object: {map_path}")
     _validate_rest_api_map(data, map_path)
     return data
+
+
+def _log_status_sidecar_overrides(
+    legacy_map: dict[str, Any],
+    sidecar_map: dict[str, Any],
+    key: str,
+    sidecar_path: Path,
+) -> None:
+    """Warn when a status sidecar replaces a legacy map value.
+
+    :param legacy_map: legacy map loaded from ``rest_api_map.npy``.
+    :param sidecar_map: status/error sidecar map.
+    :param key: mapping section being overlaid.
+    :param sidecar_path: sidecar path used in log context.
+    """
+    legacy_values = _mapping_dict(legacy_map, key)
+    sidecar_values = _mapping_dict(sidecar_map, key)
+    for request_path, sidecar_value in sidecar_values.items():
+        if request_path not in legacy_values:
+            continue
+        legacy_value = legacy_values[request_path]
+        if legacy_value == sidecar_value:
+            continue
+        LOGGER.warning(
+            "%s overrides %s for %s: %r -> %r",
+            sidecar_path.name,
+            key,
+            request_path,
+            legacy_value,
+            sidecar_value,
+        )
 
 
 def _load_rest_api_map_json(map_path: Path) -> dict[str, Any]:

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -42,8 +42,26 @@ def _build_fixture_index(corpus_dir: Path) -> dict[str, Path]:
     return {path.name.lower(): path for path in root.glob("*.json")}
 
 
+def _numpy_available() -> bool:
+    """Report whether NumPy can be imported to read a legacy ``.npy`` map.
+
+    :return: True when ``import numpy`` succeeds, False otherwise.
+    """
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
     """Load the optional Redfish URL/status/error mapping.
+
+    When both a status JSON sidecar and a legacy ``rest_api_map.npy`` are
+    present (the norm for packed full corpora), the legacy map is merged
+    under the sidecar's replay keys. Without NumPy the legacy map cannot be
+    read, so the sidecar alone is served and the skip is logged loudly; a
+    malformed sidecar still fails startup.
 
     :param corpus_dir: directory that may contain a status JSON sidecar or
         legacy ``rest_api_map.npy``.
@@ -57,6 +75,15 @@ def _load_rest_api_map(corpus_dir: Path) -> dict[str, Any]:
     if sidecar_path.exists():
         sidecar_map = _load_rest_api_map_json(sidecar_path)
         if not map_path.exists():
+            return sidecar_map
+        if not _numpy_available():
+            LOGGER.warning(
+                "NumPy is unavailable; serving status/error replay from %s "
+                "only and skipping the legacy-only keys (url_file_mapping, "
+                "allowed_methods_mapping) in %s",
+                sidecar_path.name,
+                map_path.name,
+            )
             return sidecar_map
         legacy_map = _load_rest_api_map_npy(map_path)
         merged = copy.deepcopy(legacy_map)
@@ -79,7 +106,7 @@ def _load_rest_api_map_npy(map_path: Path) -> dict[str, Any]:
     """
     try:
         import numpy as np
-    except ModuleNotFoundError:
+    except ImportError:
         raise ValueError(
             f"NumPy is required to load Redfish API map: {map_path}"
         ) from None

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import logging
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -326,6 +327,36 @@ def test_status_json_sidecar_preserves_legacy_url_file_mapping_alias(
     }
     assert error_status == 404
     assert error_payload == {"error": {"code": "Base.1.17.CapturedMissing"}}
+
+
+def test_status_json_sidecar_serves_replay_without_numpy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """With both map files and no NumPy the mock serves the sidecar replay.
+
+    Packed full corpora ship ``rest_api_map.npy`` next to the JSON status
+    sidecar, and the sidecar exists so status replay works without NumPy —
+    so startup on such a corpus in a NumPy-free environment (a bare-host
+    run or slim deployment) must fall back to the sidecar loudly instead of
+    raising; only the legacy-only URL aliases degrade.
+    """
+    module = _load_server_module()
+    corpus = _write_sidecar_with_legacy_alias_corpus(tmp_path)
+    monkeypatch.setitem(sys.modules, "numpy", None)
+    caplog.set_level(logging.WARNING, logger="mock_bmc_server")
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        root_status, _ = _http(base, "/redfish/v1")
+        error_status, error_payload = _http(base, "/redfish/v1/Missing")
+
+    assert root_status == 200
+    assert error_status == 404
+    assert error_payload == {"error": {"code": "Base.1.17.CapturedMissing"}}
+    assert "NumPy is unavailable" in caplog.text
+    assert "url_file_mapping" in caplog.text
 
 
 def test_status_json_sidecar_warns_when_overriding_legacy_status(

--- a/tests/test_k8s_mock_bmc_server.py
+++ b/tests/test_k8s_mock_bmc_server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -176,6 +177,38 @@ def _write_url_map_corpus(tmp_path: Path) -> Path:
     return corpus
 
 
+def _write_sidecar_with_legacy_alias_corpus(tmp_path: Path) -> Path:
+    corpus = _write_url_map_corpus(tmp_path)
+    error_path = "/redfish/v1/Missing"
+    error_file = "_redfish_v1_Missing.error.json"
+
+    (corpus / error_file).write_text(
+        json.dumps({"error": {"code": "Base.1.17.CapturedMissing"}}),
+        encoding="utf-8",
+    )
+    (corpus / STATUS_SIDECAR).write_text(
+        json.dumps(
+            {
+                "http_status_mapping": {error_path: 404},
+                "error_file_mapping": {error_path: error_file},
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return corpus
+
+
+def _write_sidecar_with_legacy_status_conflict_corpus(tmp_path: Path) -> Path:
+    corpus = _write_sidecar_with_legacy_alias_corpus(tmp_path)
+    error_path = "/redfish/v1/Missing"
+    api_map = np.load(corpus / "rest_api_map.npy", allow_pickle=True).item()
+    api_map["http_status_mapping"][error_path] = 200
+    api_map["error_file_mapping"][error_path] = "_legacy_missing.error.json"
+    np.save(corpus / "rest_api_map.npy", api_map)
+    return corpus
+
+
 def test_mock_bmc_maps_redfish_paths_to_gb300_corpus() -> None:
     """Redfish URLs resolve to the flattened files in the GB300 corpus."""
     module = _load_server_module()
@@ -274,6 +307,48 @@ def test_mock_bmc_serves_url_file_mapping_alias(tmp_path: Path) -> None:
     }
 
 
+def test_status_json_sidecar_preserves_legacy_url_file_mapping_alias(
+    tmp_path: Path,
+) -> None:
+    """A status sidecar must not shadow non-derived URL aliases from the npy map."""
+    module = _load_server_module()
+    corpus = _write_sidecar_with_legacy_alias_corpus(tmp_path)
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        alias_status, alias_payload = _http(base, "/redfish/v1/Alias")
+        error_status, error_payload = _http(base, "/redfish/v1/Missing")
+
+    assert alias_status == 200
+    assert alias_payload == {
+        "@odata.id": "/redfish/v1/Systems/Original",
+        "Id": "Original",
+    }
+    assert error_status == 404
+    assert error_payload == {"error": {"code": "Base.1.17.CapturedMissing"}}
+
+
+def test_status_json_sidecar_warns_when_overriding_legacy_status(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Sidecar overrides of legacy replay entries are visible in logs."""
+    module = _load_server_module()
+    corpus = _write_sidecar_with_legacy_status_conflict_corpus(tmp_path)
+    caplog.set_level(logging.WARNING, logger="mock_bmc_server")
+
+    with module.run_server("127.0.0.1", 0, corpus) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, payload = _http(base, "/redfish/v1/Missing")
+
+    assert status == 404
+    assert payload == {"error": {"code": "Base.1.17.CapturedMissing"}}
+    assert (
+        "rest_api_map.status.json overrides http_status_mapping "
+        "for /redfish/v1/Missing"
+    ) in caplog.text
+
+
 def test_rest_api_map_rejects_malformed_status_values(tmp_path: Path) -> None:
     """A bad status map fails startup instead of silently dropping a status."""
     module = _load_server_module()
@@ -295,6 +370,21 @@ def test_rest_api_map_rejects_incomplete_status_json_sidecar(tmp_path: Path) -> 
     """A sidecar must not shadow a usable legacy map without both replay maps."""
     module = _load_server_module()
     corpus = _write_status_sidecar_corpus(tmp_path)
+    (corpus / STATUS_SIDECAR).write_text(
+        json.dumps({"http_status_mapping": {"/redfish/v1/Missing": 404}}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="error_file_mapping"):
+        module.make_handler(corpus)
+
+
+def test_rest_api_map_rejects_incomplete_status_json_sidecar_with_legacy_map(
+    tmp_path: Path,
+) -> None:
+    """A partial sidecar fails closed even when a legacy map is present."""
+    module = _load_server_module()
+    corpus = _write_sidecar_with_legacy_alias_corpus(tmp_path)
     (corpus / STATUS_SIDECAR).write_text(
         json.dumps({"http_status_mapping": {"/redfish/v1/Missing": 404}}),
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- Preserve legacy URL aliases and allowed methods when a status sidecar exists beside `rest_api_map.npy`.
- Overlay sidecar status/error mappings onto the legacy map and warn when sidecar entries replace legacy values.
- Add regression coverage for alias preservation, override warnings, and incomplete sidecars with a legacy map present.

## Tests
- `conda run -n idrac_ctl python -m pytest -q tests/test_k8s_mock_bmc_server.py` (35 passed)
- `conda run -n idrac_ctl ruff check k8s/sandbox/mock_bmc_server.py tests/test_k8s_mock_bmc_server.py` (All checks passed)
- `conda run -n idrac_ctl python -m pytest -q` (1241 passed, 58 skipped, 12 warnings)
