### PR TITLE
Add guarded BIOS reset command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -91,6 +91,7 @@ Safety labels:
 | `bios-pending` | Read pending BIOS values. | Read |
 | `bios-profile` | List/show committed BIOS tuning profiles, diff against current BIOS attributes, or preview/apply a profile with `--confirm`. | Guarded |
 | `bios-registry` | Read BIOS registry metadata, choices, and writable attributes. | Read |
+| `bios-reset` | Preview or perform the Redfish BIOS resource's `Bios.ResetBios` action; requires `--confirm` to execute. | Guarded |
 | `bios-snapshot` | Capture a BIOS restore point for rollback-able changes. | Read |
 | `bmc-scan` | Scan a network segment for Redfish BMCs. | Read |
 | `boot` | Read boot source data (vendor-neutral: falls back to the ComputerSystem `Boot` object). | Read |

--- a/redfish_ctl/bios/cmd_bios_reset_default.py
+++ b/redfish_ctl/bios/cmd_bios_reset_default.py
@@ -1,0 +1,101 @@
+"""Reset BIOS settings to defaults through the Redfish BIOS resource's ResetBios action.
+
+    redfish_ctl bios-reset              # dry-run preview
+    redfish_ctl bios-reset --confirm    # POST the ResetBios action
+
+The command discovers the host ComputerSystem's ``Bios`` resource and invokes
+its own ``#Bios.ResetBios`` action. Resetting BIOS settings rewrites platform
+configuration, so the shared action guard treats it as DESTRUCTIVE and previews
+by default unless ``--confirm`` is present.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_RESET_BIOS_ACTION = "#Bios.ResetBios"
+
+
+class BiosResetDefault(RedfishManagerBase,
+                       scm_type=ApiRequestType.BiosResetDefault,
+                       name="bios_reset",
+                       metaclass=Singleton):
+    """Reset the host BIOS resource through the discovered ResetBios action."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the bios-reset command."""
+        super(BiosResetDefault, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``bios-reset`` subcommand.
+
+        :param cls: the owning command class, used to build the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the ResetBios POST; without it the command only previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing",
+        )
+        return cmd_parser, "bios-reset", "command reset BIOS settings to defaults"
+
+    def _bios_uri(self, do_async: bool) -> str:
+        """Resolve the host BIOS resource URI from the ComputerSystem link.
+
+        :param do_async: issue the host-system query over the async path when True.
+        :return: the linked BIOS resource URI, or the standard ``/Bios`` fallback.
+        """
+        system_uri = self.idrac_manage_servers
+        try:
+            system = self.base_query(system_uri, do_async=do_async).data or {}
+        except Exception:
+            system = {}
+        bios_link = system.get("Bios") if isinstance(system, dict) else None
+        if isinstance(bios_link, dict) and bios_link.get("@odata.id"):
+            return bios_link["@odata.id"]
+        return f"{system_uri}{RedfishApi.Bios}"
+
+    def execute(self,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Resolve and invoke ``Bios.ResetBios`` on the host BIOS resource.
+
+        :param confirm: authorize the DESTRUCTIVE ResetBios POST to run.
+        :param dry_run: force a dry-run preview even when ``confirm`` is true.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with a dry-run preview or POST result.
+        """
+        return self.invoke_action(
+            self._bios_uri(bool(do_async)),
+            "ResetBios",
+            payload={},
+            full_action_type=_RESET_BIOS_ACTION,
+            do_async=do_async,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/bios/cmd_bios_reset_default.py
+++ b/redfish_ctl/bios/cmd_bios_reset_default.py
@@ -63,14 +63,16 @@ class BiosResetDefault(RedfishManagerBase,
         :return: the linked BIOS resource URI, or the standard ``/Bios`` fallback.
         """
         system_uri = self.idrac_manage_servers
-        try:
-            system = self.base_query(system_uri, do_async=do_async).data or {}
-        except Exception:
-            system = {}
+        system = self.base_query(system_uri, do_async=do_async).data or {}
         bios_link = system.get("Bios") if isinstance(system, dict) else None
         if isinstance(bios_link, dict) and bios_link.get("@odata.id"):
             return bios_link["@odata.id"]
-        return f"{system_uri}{RedfishApi.Bios}"
+        return self._bios_fallback_uri(system_uri)
+
+    @staticmethod
+    def _bios_fallback_uri(system_uri: str) -> str:
+        """Build the conventional BIOS URI under a ComputerSystem URI."""
+        return f"{system_uri.rstrip('/')}/{str(RedfishApi.Bios).strip('/')}"
 
     def execute(self,
                 confirm: Optional[bool] = False,

--- a/redfish_ctl/bios/cmd_bios_reset_default.py
+++ b/redfish_ctl/bios/cmd_bios_reset_default.py
@@ -71,7 +71,11 @@ class BiosResetDefault(RedfishManagerBase,
 
     @staticmethod
     def _bios_fallback_uri(system_uri: str) -> str:
-        """Build the conventional BIOS URI under a ComputerSystem URI."""
+        """Build the conventional BIOS URI under a ComputerSystem URI.
+
+        :param system_uri: the ComputerSystem resource URI to base the path on.
+        :return: the conventional ``<system_uri>/Bios`` resource URI.
+        """
         return f"{system_uri.rstrip('/')}/{str(RedfishApi.Bios).strip('/')}"
 
     def execute(self,

--- a/tests/test_bios_reset_dualmode.py
+++ b/tests/test_bios_reset_dualmode.py
@@ -1,5 +1,8 @@
 """Dual-mode-style coverage for the guarded BIOS reset command."""
 
+import pytest
+
+from redfish_ctl.bios.cmd_bios_reset_default import BiosResetDefault
 from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_shared import ApiRequestType
 
@@ -54,6 +57,28 @@ def test_bios_reset_confirm_posts_to_dell_discovered_target(
     assert posts[0].json() == {}
 
 
+def test_bios_reset_confirm_dry_run_still_does_not_post(
+    redfish_mock,
+    redfish_service,
+) -> None:
+    """--dry_run wins over --confirm so operators can preview a confirmed call."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosResetDefault,
+        "bios_reset",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == (
+        "/redfish/v1/Systems/System.Embedded.1/Bios/Settings/Actions/Bios.ResetBios"
+    )
+    assert _post_requests(redfish_service) == []
+
+
 def test_bios_reset_confirm_posts_to_hpe_discovered_target(
     redfish_mock_factory,
 ) -> None:
@@ -79,3 +104,34 @@ def test_bios_reset_confirm_posts_to_hpe_discovered_target(
         "/redfish/v1/systems/1/bios/actions/bios.resetbios/"
     )
     assert posts[0].json() == {}
+
+
+def test_bios_reset_fallback_uri_normalizes_bios_fragment() -> None:
+    """Fallback URI joining stays valid even if the API fragment shape changes."""
+    assert BiosResetDefault._bios_fallback_uri("/redfish/v1/Systems/1") == (
+        "/redfish/v1/Systems/1/Bios"
+    )
+    assert BiosResetDefault._bios_fallback_uri("/redfish/v1/Systems/1/") == (
+        "/redfish/v1/Systems/1/Bios"
+    )
+
+
+def test_bios_reset_system_query_failure_is_not_hidden(monkeypatch) -> None:
+    """Connectivity/auth/parsing failures on the ComputerSystem read propagate."""
+    command = BiosResetDefault(
+        idrac_ip="127.0.0.1",
+        idrac_username="user",
+        idrac_password="password",
+        idrac_port=443,
+        insecure=True,
+        is_http=True,
+    )
+    command.__dict__["idrac_manage_servers"] = "/redfish/v1/Systems/1"
+
+    def fail_query(*_args, **_kwargs):
+        raise RuntimeError("system read failed")
+
+    monkeypatch.setattr(command, "base_query", fail_query)
+
+    with pytest.raises(RuntimeError, match="system read failed"):
+        command._bios_uri(do_async=False)

--- a/tests/test_bios_reset_dualmode.py
+++ b/tests/test_bios_reset_dualmode.py
@@ -1,0 +1,81 @@
+"""Dual-mode-style coverage for the guarded BIOS reset command."""
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_bios_reset_without_confirm_dry_runs_and_does_not_post(
+    redfish_mock_factory,
+) -> None:
+    """bios-reset previews the discovered GB300 target unless confirmed."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(ApiRequestType.BiosResetDefault, "bios_reset")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["action"] == "#Bios.ResetBios"
+    assert result.data["target"] == (
+        "/redfish/v1/Systems/System_0/Bios/Actions/Bios.ResetBios"
+    )
+    assert _post_requests(service) == []
+
+
+def test_bios_reset_confirm_posts_to_dell_discovered_target(
+    redfish_mock,
+    redfish_service,
+) -> None:
+    """bios-reset --confirm POSTs to the Dell BIOS action target."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosResetDefault,
+        "bios_reset",
+        confirm=True,
+    )
+
+    posts = _post_requests(redfish_service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["target"] == (
+        "/redfish/v1/Systems/System.Embedded.1/Bios/Settings/Actions/Bios.ResetBios"
+    )
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/systems/system.embedded.1/bios/settings/actions/bios.resetbios"
+    )
+    assert posts[0].json() == {}
+
+
+def test_bios_reset_confirm_posts_to_hpe_discovered_target(
+    redfish_mock_factory,
+) -> None:
+    """bios-reset --confirm POSTs to the HPE BIOS action target."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BiosResetDefault,
+        "bios_reset",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["target"] == (
+        "/redfish/v1/systems/1/bios/Actions/Bios.ResetBios/"
+    )
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/systems/1/bios/actions/bios.resetbios/"
+    )
+    assert posts[0].json() == {}


### PR DESCRIPTION
## Summary
- Add `bios-reset`, which discovers the host BIOS resource and invokes its `Bios.ResetBios` action through the shared action guard.
- Keep reset execution guarded by `--confirm`, with dry-run preview by default.
- Cover Supermicro, Dell, and HPE mock paths and document the command in the command reference.

## Tests
- `conda run -n idrac_ctl python -m pytest -q tests/test_bios_reset_dualmode.py` (3 passed)
- `conda run -n idrac_ctl python -m pytest -q tests/test_bios_reset_dualmode.py tests/test_action_commands_dualmode.py tests/test_cli_subcommand_uniqueness.py` (13 passed)
- `conda run -n idrac_ctl ruff check redfish_ctl/bios/cmd_bios_reset_default.py tests/test_bios_reset_dualmode.py` (All checks passed)
- `conda run -n idrac_ctl python -m pytest -q` (1252 passed, 58 skipped, 12 warnings)
- `git diff --check` (clean)
- `conda run -n idrac_ctl python -m redfish_ctl bios-reset --help` (exit 0)
