### PR TITLE
Add CertificateService CSR command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -108,6 +108,7 @@ Safety labels:
 | `capability-report` | Export registered vendor capability profiles for IaC and inventory tooling. | Read |
 | `certificates` | Read CertificateService and linked certificate inventory metadata without certificate bodies. | Read |
 | `change-boot-order` | Change boot order and boot options. | Write |
+| `cert-gen-csr` | Generate a CertificateService CSR through the `CertificateService.GenerateCSR` action; `--dry_run` previews without POSTing. | Write |
 | `chassis` | Read chassis services. | Read |
 | `chassis-reset` | Change chassis power state. | Write |
 | `component-integrity` | Read ComponentIntegrity/SPDM attestation resources. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -111,6 +111,7 @@ from .logs.cmd_log_clear import *
 from .network.cmd_ethernet_interfaces import *
 from .security.cmd_secure_boot import *
 from .security.cmd_certificates import *
+from .security.cmd_certificate_generate_csr import *
 from .firmware.cmd_firmware_update import *
 from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -115,6 +115,7 @@ class ApiRequestType(Enum):
     EthernetInterfaces = auto()
     SecureBoot = auto()
     CertificatesQuery = auto()
+    CertificateGenerateCSR = auto()
     FirmwareUpdate = auto()
     Triggers = auto()
     NetworkPorts = auto()

--- a/redfish_ctl/security/cmd_certificate_generate_csr.py
+++ b/redfish_ctl/security/cmd_certificate_generate_csr.py
@@ -221,6 +221,21 @@ class CertificateGenerateCSR(RedfishManagerBase,
             return None
         return {"@odata.id": uri}
 
+    def _certificate_service_uri(self, do_async):
+        """Resolve the CertificateService URI from the service root, with a standard fallback.
+
+        :param do_async: issue the service-root query over the async Redfish path when True.
+        :return: the CertificateService ``@odata.id``, or the standard fallback URI.
+        """
+        try:
+            root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
+        except Exception:
+            root = {}
+        link = root.get("CertificateService")
+        if isinstance(link, dict) and link.get("@odata.id"):
+            return link["@odata.id"]
+        return f"{RedfishApi.Version}/CertificateService"
+
     def _payload(self,
                  common_name,
                  organization=None,
@@ -339,7 +354,7 @@ class CertificateGenerateCSR(RedfishManagerBase,
         :return: a CommandResult with the GenerateCSR result or dry-run preview.
         """
         return self.invoke_action(
-            f"{RedfishApi.Version}/CertificateService",
+            self._certificate_service_uri(do_async),
             "GenerateCSR",
             payload=self._payload(
                 common_name,

--- a/redfish_ctl/security/cmd_certificate_generate_csr.py
+++ b/redfish_ctl/security/cmd_certificate_generate_csr.py
@@ -1,0 +1,367 @@
+"""Generate a certificate signing request through CertificateService.GenerateCSR.
+
+    redfish_ctl cert-gen-csr --common-name bmc.example.test --dry_run
+    redfish_ctl cert-gen-csr --common-name bmc.example.test --organization Example
+
+The command resolves ``#CertificateService.GenerateCSR`` from the standard
+CertificateService resource and posts only the CSR subject/key fields provided by
+the operator. GenerateCSR is reversible in the action policy: it creates a CSR
+and may retain a private key for the eventual signed certificate, but it does not
+replace the active certificate.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_GENERATE_CSR_ACTION = "#CertificateService.GenerateCSR"
+
+
+class CertificateGenerateCSR(RedfishManagerBase,
+                             scm_type=ApiRequestType.CertificateGenerateCSR,
+                             name="cert_gen_csr",
+                             metaclass=Singleton):
+    """Generate a CSR through the Redfish CertificateService."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the cert-gen-csr command."""
+        super(CertificateGenerateCSR, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``cert-gen-csr`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--common-name",
+            required=True,
+            dest="common_name",
+            type=str,
+            help="CSR CommonName, typically the BMC DNS name",
+        )
+        cmd_parser.add_argument(
+            "--organization",
+            required=False,
+            dest="organization",
+            type=str,
+            default=None,
+            help="CSR Organization field",
+        )
+        cmd_parser.add_argument(
+            "--organizational-unit",
+            required=False,
+            dest="organizational_unit",
+            type=str,
+            default=None,
+            help="CSR OrganizationalUnit field",
+        )
+        cmd_parser.add_argument(
+            "--city",
+            required=False,
+            dest="city",
+            type=str,
+            default=None,
+            help="CSR City/locality field",
+        )
+        cmd_parser.add_argument(
+            "--state",
+            required=False,
+            dest="state",
+            type=str,
+            default=None,
+            help="CSR State or province field",
+        )
+        cmd_parser.add_argument(
+            "--country",
+            required=False,
+            dest="country",
+            type=str,
+            default=None,
+            help="CSR two-letter Country field",
+        )
+        cmd_parser.add_argument(
+            "--contact-person",
+            required=False,
+            dest="contact_person",
+            type=str,
+            default=None,
+            help="CSR ContactPerson field",
+        )
+        cmd_parser.add_argument(
+            "--email",
+            required=False,
+            dest="email",
+            type=str,
+            default=None,
+            help="CSR Email field",
+        )
+        cmd_parser.add_argument(
+            "--given-name",
+            required=False,
+            dest="given_name",
+            type=str,
+            default=None,
+            help="CSR GivenName field",
+        )
+        cmd_parser.add_argument(
+            "--initials",
+            required=False,
+            dest="initials",
+            type=str,
+            default=None,
+            help="CSR Initials field",
+        )
+        cmd_parser.add_argument(
+            "--surname",
+            required=False,
+            dest="surname",
+            type=str,
+            default=None,
+            help="CSR Surname field",
+        )
+        cmd_parser.add_argument(
+            "--unstructured-name",
+            required=False,
+            dest="unstructured_name",
+            type=str,
+            default=None,
+            help="CSR UnstructuredName field",
+        )
+        cmd_parser.add_argument(
+            "--key-pair-algorithm",
+            required=False,
+            dest="key_pair_algorithm",
+            type=str,
+            default=None,
+            help="TPM algorithm name, such as TPM_ALG_RSA",
+        )
+        cmd_parser.add_argument(
+            "--key-bit-length",
+            required=False,
+            dest="key_bit_length",
+            type=int,
+            default=None,
+            help="key size in bits when required by the key algorithm",
+        )
+        cmd_parser.add_argument(
+            "--key-curve-id",
+            required=False,
+            dest="key_curve_id",
+            type=str,
+            default=None,
+            help="TPM ECC curve id when required by the key algorithm",
+        )
+        cmd_parser.add_argument(
+            "--key-usage",
+            required=False,
+            dest="key_usage",
+            action="append",
+            default=None,
+            help="certificate KeyUsage value; repeat or comma-separate values",
+        )
+        cmd_parser.add_argument(
+            "--alternative-name",
+            required=False,
+            dest="alternative_names",
+            action="append",
+            default=None,
+            help="subjectAltName DNS/IP value; repeat or comma-separate values",
+        )
+        cmd_parser.add_argument(
+            "--certificate-collection",
+            required=False,
+            dest="certificate_collection",
+            type=str,
+            default=None,
+            help="certificate collection URI where the signed certificate installs",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the GenerateCSR target and show the payload without POSTing",
+        )
+        return cmd_parser, "cert-gen-csr", "command generate a CertificateService CSR"
+
+    @staticmethod
+    def _string_list(values):
+        """Normalize repeated and comma-separated CLI values into a list.
+
+        :param values: None, a string, or a list/tuple of strings.
+        :return: flattened list with empty values removed, or None when empty.
+        """
+        if values is None:
+            return None
+        raw_values = values if isinstance(values, (list, tuple)) else [values]
+        items = []
+        for value in raw_values:
+            if value is None:
+                continue
+            items.extend(part.strip() for part in str(value).split(","))
+        return [item for item in items if item] or None
+
+    @staticmethod
+    def _certificate_collection_link(uri):
+        """Build a Redfish link object from a certificate collection URI.
+
+        :param uri: Redfish certificate collection URI, or None.
+        :return: ``{"@odata.id": uri}`` when set, otherwise None.
+        """
+        if not uri:
+            return None
+        return {"@odata.id": uri}
+
+    def _payload(self,
+                 common_name,
+                 organization=None,
+                 organizational_unit=None,
+                 city=None,
+                 state=None,
+                 country=None,
+                 contact_person=None,
+                 email=None,
+                 given_name=None,
+                 initials=None,
+                 surname=None,
+                 unstructured_name=None,
+                 key_pair_algorithm=None,
+                 key_bit_length=None,
+                 key_curve_id=None,
+                 key_usage=None,
+                 alternative_names=None,
+                 certificate_collection=None):
+        """Build a GenerateCSR payload from the provided non-empty fields.
+
+        :param common_name: CSR CommonName value.
+        :param organization: CSR Organization value.
+        :param organizational_unit: CSR OrganizationalUnit value.
+        :param city: CSR City/locality value.
+        :param state: CSR State/province value.
+        :param country: CSR two-letter Country value.
+        :param contact_person: CSR ContactPerson value.
+        :param email: CSR Email value.
+        :param given_name: CSR GivenName value.
+        :param initials: CSR Initials value.
+        :param surname: CSR Surname value.
+        :param unstructured_name: CSR UnstructuredName value.
+        :param key_pair_algorithm: optional TPM key-pair algorithm name.
+        :param key_bit_length: optional key length in bits.
+        :param key_curve_id: optional TPM ECC curve id.
+        :param key_usage: optional KeyUsage values.
+        :param alternative_names: optional subject alternative names.
+        :param certificate_collection: optional target certificate collection URI.
+        :return: GenerateCSR payload containing only supplied fields.
+        """
+        payload = {
+            "CommonName": common_name,
+            "Organization": organization,
+            "OrganizationalUnit": organizational_unit,
+            "City": city,
+            "State": state,
+            "Country": country,
+            "ContactPerson": contact_person,
+            "Email": email,
+            "GivenName": given_name,
+            "Initials": initials,
+            "Surname": surname,
+            "UnstructuredName": unstructured_name,
+            "KeyPairAlgorithm": key_pair_algorithm,
+            "KeyBitLength": key_bit_length,
+            "KeyCurveId": key_curve_id,
+            "KeyUsage": self._string_list(key_usage),
+            "AlternativeNames": self._string_list(alternative_names),
+            "CertificateCollection": self._certificate_collection_link(
+                certificate_collection
+            ),
+        }
+        return {key: value for key, value in payload.items() if value is not None}
+
+    def execute(self,
+                common_name: Optional[str] = None,
+                organization: Optional[str] = None,
+                organizational_unit: Optional[str] = None,
+                city: Optional[str] = None,
+                state: Optional[str] = None,
+                country: Optional[str] = None,
+                contact_person: Optional[str] = None,
+                email: Optional[str] = None,
+                given_name: Optional[str] = None,
+                initials: Optional[str] = None,
+                surname: Optional[str] = None,
+                unstructured_name: Optional[str] = None,
+                key_pair_algorithm: Optional[str] = None,
+                key_bit_length: Optional[int] = None,
+                key_curve_id: Optional[str] = None,
+                key_usage=None,
+                alternative_names=None,
+                certificate_collection: Optional[str] = None,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Resolve and invoke ``CertificateService.GenerateCSR``.
+
+        :param common_name: CSR CommonName value.
+        :param organization: CSR Organization value.
+        :param organizational_unit: CSR OrganizationalUnit value.
+        :param city: CSR City/locality value.
+        :param state: CSR State/province value.
+        :param country: CSR two-letter Country value.
+        :param contact_person: CSR ContactPerson value.
+        :param email: CSR Email value.
+        :param given_name: CSR GivenName value.
+        :param initials: CSR Initials value.
+        :param surname: CSR Surname value.
+        :param unstructured_name: CSR UnstructuredName value.
+        :param key_pair_algorithm: optional TPM key-pair algorithm name.
+        :param key_bit_length: optional key length in bits.
+        :param key_curve_id: optional TPM ECC curve id.
+        :param key_usage: optional KeyUsage values.
+        :param alternative_names: optional subject alternative names.
+        :param certificate_collection: optional target certificate collection URI.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with the GenerateCSR result or dry-run preview.
+        """
+        return self.invoke_action(
+            f"{RedfishApi.Version}/CertificateService",
+            "GenerateCSR",
+            payload=self._payload(
+                common_name,
+                organization=organization,
+                organizational_unit=organizational_unit,
+                city=city,
+                state=state,
+                country=country,
+                contact_person=contact_person,
+                email=email,
+                given_name=given_name,
+                initials=initials,
+                surname=surname,
+                unstructured_name=unstructured_name,
+                key_pair_algorithm=key_pair_algorithm,
+                key_bit_length=key_bit_length,
+                key_curve_id=key_curve_id,
+                key_usage=key_usage,
+                alternative_names=alternative_names,
+                certificate_collection=certificate_collection,
+            ),
+            full_action_type=_GENERATE_CSR_ACTION,
+            do_async=do_async,
+            dry_run=bool(dry_run),
+        )

--- a/tests/test_action_commands_dualmode.py
+++ b/tests/test_action_commands_dualmode.py
@@ -1,8 +1,8 @@
 """Dual-mode-style mock tests for vendor-neutral action commands."""
 import json
 
-from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
 
 
 def _post_requests(service):
@@ -113,6 +113,11 @@ def test_action_list_returns_supermicro_action_inventory_without_posts(
     assert result.data
     assert "#ComputerSystem.Reset" in full_types
     assert "#EventService.SubmitTestEvent" in full_types
+    assert "#CertificateService.GenerateCSR" in full_types
+    assert {
+        row["FullType"]: row["Level"]
+        for row in result.data
+    }["#CertificateService.GenerateCSR"] == "reversible"
     assert all(row["Target"] for row in result.data)
     assert all(row["Level"] for row in result.data)
     assert _post_requests(service) == []

--- a/tests/test_cert_generate_csr_dualmode.py
+++ b/tests/test_cert_generate_csr_dualmode.py
@@ -1,0 +1,203 @@
+"""Dual-mode tests for the CertificateService.GenerateCSR command."""
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+
+def _post_requests(redfish_service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param redfish_service: the MockRedfishService recording requests.
+    :return: list of recorded POST requests.
+    """
+    return [request for request in redfish_service.requests if request.method == "POST"]
+
+
+def test_cert_gen_csr_posts_payload_to_generic_certificate_service(
+    redfish_mock_factory,
+):
+    """cert-gen-csr posts a reversible CSR payload to the discovered target."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.CertificateGenerateCSR,
+        "cert_gen_csr",
+        common_name="bmc.example.test",
+        organization="Example Org",
+        organizational_unit="Platform",
+        city="San Francisco",
+        state="CA",
+        country="US",
+        key_pair_algorithm="TPM_ALG_RSA",
+        key_bit_length=2048,
+        key_curve_id="TPM_ECC_NIST_P256",
+        key_usage=["DigitalSignature", "KeyEncipherment"],
+        alternative_names=["bmc-alt.example.test,192.0.2.10"],
+        certificate_collection=(
+            "/redfish/v1/Managers/BMC/NetworkProtocol/HTTPS/Certificates"
+        ),
+        contact_person="Ops Team",
+        email="ops@example.test",
+        given_name="Platform",
+        initials="PT",
+        surname="Team",
+        unstructured_name="lab-bmc",
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "reversible"
+    assert result.data["target"] == (
+        "/redfish/v1/CertificateService/Actions/CertificateService.GenerateCSR"
+    )
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/certificateservice/actions/certificateservice.generatecsr"
+    )
+    assert posts[0].json() == {
+        "CertificateCollection": {
+            "@odata.id": "/redfish/v1/Managers/BMC/NetworkProtocol/HTTPS/Certificates"
+        },
+        "City": "San Francisco",
+        "CommonName": "bmc.example.test",
+        "Country": "US",
+        "AlternativeNames": ["bmc-alt.example.test", "192.0.2.10"],
+        "ContactPerson": "Ops Team",
+        "Email": "ops@example.test",
+        "GivenName": "Platform",
+        "Initials": "PT",
+        "KeyBitLength": 2048,
+        "KeyCurveId": "TPM_ECC_NIST_P256",
+        "KeyPairAlgorithm": "TPM_ALG_RSA",
+        "KeyUsage": ["DigitalSignature", "KeyEncipherment"],
+        "Organization": "Example Org",
+        "OrganizationalUnit": "Platform",
+        "State": "CA",
+        "Surname": "Team",
+        "UnstructuredName": "lab-bmc",
+    }
+
+
+def test_cert_gen_csr_dry_run_suppresses_post(redfish_mock_factory):
+    """cert-gen-csr --dry_run resolves the action target without POSTing."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.CertificateGenerateCSR,
+        "cert_gen_csr",
+        common_name="ilo.example.test",
+        key_usage=["DigitalSignature"],
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["level"] == "reversible"
+    assert result.data["target"] == (
+        "/redfish/v1/CertificateService/Actions/CertificateService.GenerateCSR"
+    )
+    assert result.data["payload"] == {
+        "CommonName": "ilo.example.test",
+        "KeyUsage": ["DigitalSignature"],
+    }
+    assert _post_requests(service) == []
+
+
+def test_cert_gen_csr_uses_supermicro_certificate_service_target(
+    redfish_mock_factory,
+):
+    """cert-gen-csr discovers GenerateCSR on the Supermicro CertificateService."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.CertificateGenerateCSR,
+        "cert_gen_csr",
+        common_name="gb300.example.test",
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["target"] == (
+        "/redfish/v1/CertificateService/Actions/CertificateService.GenerateCSR"
+    )
+    assert len(posts) == 1
+    assert posts[0].json() == {"CommonName": "gb300.example.test"}
+
+
+def test_cert_gen_csr_reports_missing_action_without_post(redfish_mock_factory):
+    """A CertificateService without GenerateCSR reports the available actions."""
+    manager, service = redfish_mock_factory("generic")
+    service._overlay["/redfish/v1/certificateservice"] = {
+        "@odata.id": "/redfish/v1/CertificateService",
+        "Id": "CertificateService",
+        "Actions": {},
+    }
+
+    result = manager.sync_invoke(
+        ApiRequestType.CertificateGenerateCSR,
+        "cert_gen_csr",
+        common_name="bmc.example.test",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#CertificateService.GenerateCSR' not found on "
+        "/redfish/v1/CertificateService"
+    )
+    assert result.data == {
+        "action": "#CertificateService.GenerateCSR",
+        "available": [],
+    }
+    assert _post_requests(service) == []
+
+
+def test_cert_gen_csr_rejects_invalid_hpe_key_usage_without_post(
+    redfish_mock_factory,
+):
+    """HPE inline KeyUsage allowable values reject invalid payloads before POST."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.CertificateGenerateCSR,
+        "cert_gen_csr",
+        common_name="ilo.example.test",
+        key_usage=["NotAKeyUsage"],
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for CertificateService.GenerateCSR KeyUsage: "
+        "NotAKeyUsage; allowed: CRLSigning, ClientAuthentication, CodeSigning, "
+        "DataEncipherment, DecipherOnly, DigitalSignature, EmailProtection, "
+        "EncipherOnly, KeyAgreement, KeyCertSign, KeyEncipherment, "
+        "NonRepudiation, OCSPSigning, ServerAuthentication, Timestamping"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "KeyUsage",
+            "value": "NotAKeyUsage",
+            "allowed": [
+                "CRLSigning",
+                "ClientAuthentication",
+                "CodeSigning",
+                "DataEncipherment",
+                "DecipherOnly",
+                "DigitalSignature",
+                "EmailProtection",
+                "EncipherOnly",
+                "KeyAgreement",
+                "KeyCertSign",
+                "KeyEncipherment",
+                "NonRepudiation",
+                "OCSPSigning",
+                "ServerAuthentication",
+                "Timestamping",
+            ],
+        }
+    ]
+    assert _post_requests(service) == []


### PR DESCRIPTION
## Summary
- add a `cert-gen-csr` command for `CertificateService.GenerateCSR`
- register the new request type and command import
- cover POST, dry-run, missing-action, KeyUsage validation, and action inventory behavior across fixture families

## Validation
- PASS: `python3 -m pytest -q tests/test_cert_generate_csr_dualmode.py tests/test_action_commands_dualmode.py::test_action_list_discovers_dell_actions_in_dual_mode tests/test_action_commands_dualmode.py::test_action_list_returns_supermicro_action_inventory_without_posts`
- PASS: `python3 -m pytest -q tests/test_cert_generate_csr_dualmode.py tests/test_certificates_dualmode.py tests/test_action_foundation.py tests/test_action_commands_dualmode.py tests/test_action_commands.py tests/test_cli_subcommand_uniqueness.py tests/test_package_imports.py tests/test_command_import_regressions.py tests/test_invoke_action_csdl.py`
- PASS: `ruff check redfish_ctl/security/cmd_certificate_generate_csr.py redfish_ctl/redfish_manager_shared.py redfish_ctl/__init__.py tests/test_cert_generate_csr_dualmode.py tests/test_action_commands_dualmode.py`
- BLOCKED: full `python3 -m pytest -q` did not complete locally after more than 15 minutes; follow-up diagnostics showed `import pytest` hanging before the pytest header after the targeted gates had completed.
