### PR TITLE
Fix empty virtual media eject

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,6 @@
 COORDINATION.md
 
 # Bulky, run-time-only, or captured data the package does not need to run.
-tests/supermicro_fixtures/
 dumps/
 reports/
 .json_responses/

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -12,7 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-        python3 python3-pip python3-venv ca-certificates \
+        python3 python3-pip python3-venv ca-certificates make \
  && rm -rf /var/lib/apt/lists/*
 
 # Isolated venv (Ubuntu 24.04 is PEP 668 externally-managed).

--- a/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_eject.py
@@ -14,9 +14,9 @@ from abc import abstractmethod
 from typing import Optional
 
 from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, RedfishApiRespond, Singleton
-from ..redfish_manager import CommandResult
 
 
 class VirtualMediaEject(RedfishManagerBase,
@@ -85,13 +85,7 @@ class VirtualMediaEject(RedfishManagerBase,
             raise InvalidArgument(f"Invalid device id {device_id}, "
                                   f"supported device id {valid_dev_id}")
 
-        # if another image already mounted.
-        inserted = {
-            'image': m['Image'] for m
-            in members if m['Id'] == device_id and m['Inserted'] is False
-        }
-
-        if 'image' in inserted:
+        if any(m['Id'] == device_id and m.get('Inserted') is False for m in members):
             if do_strict:
                 raise InvalidArgument("Image already ejected")
             else:

--- a/tests/test_ast_conventions.py
+++ b/tests/test_ast_conventions.py
@@ -58,7 +58,7 @@ LEGACY_UNGUARDED_MUTATION_CALLS = {
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:138 execute base_post",
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:151 execute base_patch",
     "redfish_ctl/virtual_media/cmd_smc_virtual_media.py:158 execute base_post",
-    "redfish_ctl/virtual_media/cmd_virtual_media_eject.py:105 execute base_post",
+    "redfish_ctl/virtual_media/cmd_virtual_media_eject.py:99 execute base_post",
     "redfish_ctl/virtual_media/cmd_virtual_media_insert.py:208 execute base_post",
     "redfish_ctl/volumes/cmd_initilize.py:81 execute base_post",
 }

--- a/tests/test_virtual_media_dualmode.py
+++ b/tests/test_virtual_media_dualmode.py
@@ -4,9 +4,9 @@ import json
 import pytest
 
 from redfish_ctl.cmd_exceptions import ResourceNotFound
+from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType, RedfishApiRespond
-from redfish_ctl.redfish_manager import CommandResult
 
 
 def test_virtual_media_query_returns_collection(redfish_api):
@@ -300,6 +300,33 @@ def test_virtual_media_eject_skips_post_when_device_is_already_empty(
     redfish_mock, redfish_service
 ):
     """non-strict eject returns Ok without POSTing when media is not inserted."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.VirtualMediaEject,
+        "virtual_disk_eject",
+        device_id="1",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {"Status": RedfishApiRespond.Ok}
+    assert redfish_service.last_request.method == "GET"
+
+
+def test_virtual_media_eject_treats_missing_image_on_empty_slot_as_ejected(
+    redfish_mock, redfish_service
+):
+    collection_path = "/redfish/v1/Systems/System.Embedded.1/VirtualMedia"
+    collection = dict(redfish_service._state(collection_path))
+    members = [dict(member) for member in collection["Members"]]
+    target_member = next(member for member in members if member.get("Id") == "1")
+    target_member["Inserted"] = False
+    target_member.pop("Image", None)
+    target_member.pop("ImageName", None)
+    collection["Members"] = members
+    redfish_service._overlay[collection_path] = collection
+    redfish_service._overlay[collection_path.lower()] = collection
+
+    assert "Image" not in target_member
+
     result = redfish_mock.sync_invoke(
         ApiRequestType.VirtualMediaEject,
         "virtual_disk_eject",


### PR DESCRIPTION
## Summary
- avoid a KeyError when an already-empty virtual media member omits Image
- add regression coverage for the missing-Image empty-slot eject path
- simplify the empty-slot check and keep the direct-mutation convention baseline aligned
- keep the Docker test image aligned with the offline suite by including Supermicro fixtures and make

## Validation
- PASS: ./docker/run-tests.sh tests/test_virtual_media_dualmode.py -q (17 passed)
- PASS: ./docker/run-tests.sh tests/test_ast_conventions.py::test_new_direct_mutation_calls_are_guarded_or_baselined -q
- PASS: ./docker/run-tests.sh (1245 passed, 63 skipped)
- PASS: ruff check redfish_ctl/virtual_media/cmd_virtual_media_eject.py tests/test_virtual_media_dualmode.py tests/test_ast_conventions.py
- PASS: git diff --check