### PR TITLE
Skip the full CI suite on docs-only PRs; stop rebuilding the test image per code edit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,40 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
+      - name: Detect docs-only change
+        # A PR that touches ONLY docs/ and Markdown files skips the full suite
+        # below and runs just the docs-coupled tests instead. Anything else —
+        # including push events, where the base diff is not fetched — runs the
+        # full suite. Step-level (not job/workflow-level) so the required
+        # check names always report and branch protection is never left pending.
+        id: changes
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+          changed="$(git diff --name-only FETCH_HEAD...HEAD)"
+          echo "$changed"
+          if [ -n "$changed" ] && ! echo "$changed" | grep -qvE '^docs/|\.md$'; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Offline tests (no BMC, no IDRAC_IP)
+        if: steps.changes.outputs.docs_only != 'true'
         run: pytest -q
+      - name: Offline tests (docs-only fast path — docs-coupled tests)
+        # Docs edits can still break tests that read docs/ or README.md (path
+        # links, Makefile/docker doc contracts), so run exactly those instead
+        # of the whole suite. The set is discovered by grep, so a new
+        # docs-reading test is picked up automatically.
+        if: steps.changes.outputs.docs_only == 'true'
+        run: |
+          files="$(grep -rlE '\bdocs/|commands\.md|README\.md' tests/test_*.py || true)"
+          if [ -n "$files" ]; then
+            # shellcheck disable=SC2086
+            pytest -q $files
+          else
+            echo "no docs-coupled tests detected"
+          fi
       - name: Lint changed-file hygiene (informational)
         # The tree carries pre-existing ruff debt, so lint is reported but does
         # not fail the build. New code should still be clean.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,10 @@ jobs:
         id: changes
         if: github.event_name == 'pull_request'
         run: |
-          git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
-          changed="$(git diff --name-only FETCH_HEAD...HEAD)"
+          # Fail safe: if the base fetch or diff fails (e.g. merge-base beyond
+          # the shallow fetch), fall through to the full suite.
+          git fetch --no-tags --depth=200 origin "${{ github.base_ref }}" || true
+          changed="$(git diff --name-only FETCH_HEAD...HEAD 2>/dev/null || true)"
           echo "$changed"
           if [ -n "$changed" ] && ! echo "$changed" | grep -qvE '^docs/|\.md$'; then
             echo "docs_only=true" >> "$GITHUB_OUTPUT"
@@ -61,13 +63,21 @@ jobs:
         if: steps.changes.outputs.docs_only != 'true'
         run: pytest -q
       - name: Offline tests (docs-only fast path — docs-coupled tests)
-        # Docs edits can still break tests that read docs/ or README.md (path
-        # links, Makefile/docker doc contracts), so run exactly those instead
-        # of the whole suite. The set is discovered by grep, so a new
-        # docs-reading test is picked up automatically.
+        # Docs edits can still break tests that read docs/ or any Markdown
+        # file (path links, Makefile/docker doc contracts, simulator-contract
+        # references), so run exactly those instead of the whole suite. The
+        # set is discovered by grep over every test module, so a new
+        # docs-reading test is picked up automatically; if a shared fixture
+        # module (conftest or a helper) ever becomes docs-coupled, fall back
+        # to the full suite rather than guess.
         if: steps.changes.outputs.docs_only == 'true'
         run: |
-          files="$(grep -rlE '\bdocs/|commands\.md|README\.md' tests/test_*.py || true)"
+          if grep -qlE '\bdocs/|\.md\b' tests/conftest.py tests/test_utils.py tests/vendor_corpus.py 2>/dev/null; then
+            echo "shared test helper is docs-coupled; running the full suite"
+            pytest -q
+            exit 0
+          fi
+          files="$(grep -rlE '\bdocs/|\.md\b' tests/test_*.py || true)"
           if [ -n "$files" ]; then
             # shellcheck disable=SC2086
             pytest -q $files

--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -3,6 +3,11 @@
 # paths and Linux is case-SENSITIVE, so a fixture-lookup bug that macOS's
 # case-insensitive filesystem hides would surface here.
 #
+# The image holds DEPENDENCIES ONLY — the repo is mounted at /work by
+# docker/run-tests.sh at run time. Code edits therefore never invalidate a
+# layer: the image rebuilds only when setup.py/requirements change, and
+# repeated test runs stop stranding dangling images on the host.
+#
 # Build + run:  ./docker/run-tests.sh   (or see the commands at the bottom)
 FROM ubuntu:24.04
 
@@ -19,15 +24,27 @@ RUN apt-get update \
 RUN python3 -m venv /venv
 ENV PATH="/venv/bin:$PATH"
 
-WORKDIR /app
-COPY . /app
+# Resolve the package's runtime + dev dependencies from the manifests plus a
+# version stub (setup.py reads redfish_ctl/version.py and README.md, and
+# declares the idrac_ctl alias package), install them, then drop the stub
+# package — only the dependency set stays.
+WORKDIR /deps
+COPY setup.py pyproject.toml requirements.txt README.md ./
+COPY redfish_ctl/version.py redfish_ctl/version.py
+COPY idrac_ctl/__init__.py idrac_ctl/__init__.py
+RUN touch redfish_ctl/__init__.py \
+ && pip install --no-cache-dir -e ".[dev]" pytest-cov \
+ && pip uninstall -y redfish_ctl \
+ && rm -rf /deps
 
-# Install the package with its dev/test extras (pytest, ruff, requests-mock, ...).
-RUN pip install --no-cache-dir -e ".[dev]" pytest-cov
+# The suite imports the package from the mounted tree (tests/conftest.py puts
+# the repo root on sys.path; PYTHONPATH covers non-pytest invocations too).
+WORKDIR /work
+ENV PYTHONPATH=/work
 
 # Default: the offline suite (live tests auto-skip with no IDRAC_IP).
 CMD ["pytest", "-q"]
 
 # Manual equivalent of run-tests.sh:
 #   docker build -f docker/Dockerfile.test -t redfish-ctl-test .
-#   docker run --rm redfish-ctl-test
+#   docker run --rm -v "$PWD:/work" -w /work redfish-ctl-test

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -11,14 +11,22 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 echo ">> building ${IMAGE} (ubuntu:24.04, dependency layers only — cached)"
+previous_id="$(docker images -q "${IMAGE}" 2>/dev/null || true)"
 docker build -f docker/Dockerfile.test -t "${IMAGE}" .
 
-# A dependency rebuild leaves the previous image untagged; reclaim dangling
-# layers quietly so repeated runs do not accumulate images on the host.
-docker image prune -f >/dev/null
+# Only a genuine dependency rebuild changes the image id and leaves the
+# previous image untagged; reclaim dangling layers just for that case so the
+# prune cannot race an unrelated concurrent build on a shared host.
+if [ -n "${previous_id}" ] && [ "${previous_id}" != "$(docker images -q "${IMAGE}")" ]; then
+  docker image prune -f >/dev/null
+fi
 
 echo ">> running offline test suite in Linux container (repo mounted at /work)"
-# Pass extra pytest args through, e.g. ./docker/run-tests.sh -k boot
-docker run --rm -v "${REPO_ROOT}:/work" -w /work "${IMAGE}" pytest -q "$@"
+# Run as the invoking user so anything written into the mounted repo (e.g.
+# .pytest_cache) is never root-owned on a Linux host; HOME points at a
+# writable location for the non-root uid. Pass extra pytest args through,
+# e.g. ./docker/run-tests.sh -k boot
+docker run --rm -u "$(id -u):$(id -g)" -e HOME=/tmp \
+  -v "${REPO_ROOT}:/work" -w /work "${IMAGE}" pytest -q "$@"
 
 echo ">> Linux test run complete"

--- a/docker/run-tests.sh
+++ b/docker/run-tests.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Build the Ubuntu test image and run the offline redfish_ctl suite inside it.
-# Confirms Mac/Linux parity (Linux is case-sensitive; macOS is not).
+# Build the deps-only Ubuntu test image (cached — it only rebuilds when the
+# dependency manifests change) and run the offline redfish_ctl suite inside it
+# against the repo MOUNTED at /work. Confirms Mac/Linux parity (Linux is
+# case-sensitive; macOS is not) without creating a new image per code edit.
 set -euo pipefail
 
 IMAGE="${IMAGE:-redfish-ctl-test}"
@@ -8,11 +10,15 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 cd "$REPO_ROOT"
 
-echo ">> building ${IMAGE} (ubuntu:24.04)"
+echo ">> building ${IMAGE} (ubuntu:24.04, dependency layers only — cached)"
 docker build -f docker/Dockerfile.test -t "${IMAGE}" .
 
-echo ">> running offline test suite in Linux container"
-# --cov optional; pass extra pytest args through, e.g. ./docker/run-tests.sh -k boot
-docker run --rm "${IMAGE}" pytest -q "$@"
+# A dependency rebuild leaves the previous image untagged; reclaim dangling
+# layers quietly so repeated runs do not accumulate images on the host.
+docker image prune -f >/dev/null
+
+echo ">> running offline test suite in Linux container (repo mounted at /work)"
+# Pass extra pytest args through, e.g. ./docker/run-tests.sh -k boot
+docker run --rm -v "${REPO_ROOT}:/work" -w /work "${IMAGE}" pytest -q "$@"
 
 echo ">> Linux test run complete"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -72,9 +72,12 @@ read-only GB300 observation. HPE coverage comes from the HPE iLO emulator corpus
 
 ## Mac/Linux Parity
 
-`docker/run-tests.sh` builds `ubuntu:24.04`, installs `.[dev]`, and runs the offline suite. Linux is
-case-sensitive and macOS is not, so this catches fixture-path mistakes that can hide on a laptop.
-Sensitive local files are excluded from the image.
+`docker/run-tests.sh` builds a deps-only `ubuntu:24.04` image (the `.[dev]` dependency set, no source
+copy) and runs the offline suite against the repo mounted at `/work`. Linux is case-sensitive and
+macOS is not, so this catches fixture-path mistakes that can hide on a laptop. Because the image
+holds only dependencies, code edits reuse the cached image — it rebuilds only when
+`requirements.txt`/`setup.py` change, and the script prunes dangling layers after a rebuild. No
+source files are baked into the image.
 
 ## Coverage
 


### PR DESCRIPTION
Two cost cuts, no coverage loss:

## CI (GitHub)
A PR touching only `docs/` + Markdown runs just the **docs-coupled tests** (the set is discovered with grep — `tests/test_makefile_targets.py`, `test_dockerfile_contract.py`, corpus-manifest docs checks, etc. — so a new docs-reading test is picked up automatically) instead of the full suite ×3 Pythons. Everything else, and every push to main, runs the full suite unchanged. Conditions are **step-level**, so the required `test (3.x)` check names always report and branch protection is never left pending. k8s-e2e already path-filters; untouched.

## Local docker (the bigger win)
`docker/Dockerfile.test` previously did `COPY . /app` + `pip install` — every code edit invalidated the layer, re-ran a full dependency install, and stranded the previous ~394MB image as dangling. Now the image holds **dependencies only** (resolved from the manifests + a version stub) and the suite runs against the repo **mounted** at `/work`. `run-tests.sh` also prunes dangling layers after a genuine dependency rebuild.

## Evidence
- Full suite in the new flow: **1245 passed / 63 skipped** (Linux container, mounted tree).
- Cache proof: back-to-back builds → identical image id; survives `docker image prune -f`; a real code edit → **identical image id** (zero new layers).
- Docs-only detection verified on 5 cases (docs-only ⇒ true; mixed/code/empty ⇒ false).
- `actionlint` + `shellcheck` clean.