### PR TITLE
Add LogService diagnostic collection command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,6 +143,7 @@ Safety labels:
 | `leak-detectors` | Read chassis LeakDetection detector states and linked leak policy data. | Read |
 | `logs` | Read system and manager log entries. | Read |
 | `log-clear` | Clear a discovered LogService (LogService.ClearLog); lists clearable services when no target is given, requires `--confirm` to write. | Guarded |
+| `log-collect-diag` | Collect diagnostic data from a discovered LogService (LogService.CollectDiagnosticData); lists capable services when no target is given, requires `--confirm` to write. | Guarded |
 | `manager` | Read manager data. | Read |
 | `manager-network` | Read BMC ManagerNetworkProtocol service state, including HTTP/HTTPS/IPMI/SSH and NTP. | Read |
 | `manager-reboot` | Reboot the BMC manager. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -108,6 +108,7 @@ from .events.cmd_subscription_lifecycle import *
 from .compute.cmd_system_reset import *
 from .logs.cmd_logs import *
 from .logs.cmd_log_clear import *
+from .logs.cmd_log_collect_diag import *
 from .network.cmd_ethernet_interfaces import *
 from .security.cmd_secure_boot import *
 from .security.cmd_certificates import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -48,6 +48,7 @@ ACTION_POLICY = {
     "#VirtualMedia.InsertMedia": Destructiveness.REVERSIBLE,
     "#VirtualMedia.EjectMedia": Destructiveness.REVERSIBLE,
     "#CertificateService.GenerateCSR": Destructiveness.REVERSIBLE,
+    "#LogService.CollectDiagnosticData": Destructiveness.REVERSIBLE,
     "#NvidiaPowerSmoothing.ActivatePresetProfile": Destructiveness.REVERSIBLE,
     "#NvidiaPowerSmoothing.ApplyAdminOverrides": Destructiveness.REVERSIBLE,
     "#NvidiaWorkloadPower.EnableProfiles": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/logs/cmd_log_collect_diag.py
+++ b/redfish_ctl/logs/cmd_log_collect_diag.py
@@ -56,7 +56,7 @@ class LogCollectDiagnosticData(RedfishManagerBase,
             help="fire the CollectDiagnosticData POST; without it the command previews")
         cmd_parser.add_argument(
             "--dry_run", action="store_true", dest="dry_run", default=False,
-            help="resolve the target and show it without POSTing")
+            help="resolve the target and show it without POSTing; overrides --confirm")
         return (
             cmd_parser,
             "log-collect-diag",
@@ -166,7 +166,10 @@ class LogCollectDiagnosticData(RedfishManagerBase,
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """List capable services, or collect diagnostic data from one service."""
+        """List capable services, or collect diagnostic data from one service.
+
+        ``--dry_run`` is a no-POST override even when ``--confirm`` is also set.
+        """
         services = self._discover_log_services(do_async)
         if log_service is None:
             return CommandResult(

--- a/redfish_ctl/logs/cmd_log_collect_diag.py
+++ b/redfish_ctl/logs/cmd_log_collect_diag.py
@@ -36,7 +36,11 @@ class LogCollectDiagnosticData(RedfishManagerBase,
     @staticmethod
     @abstractmethod
     def register_subcommand(cls):
-        """Register the guarded ``log-collect-diag`` subcommand."""
+        """Register the guarded ``log-collect-diag`` subcommand.
+
+        :param cls: the owning command class, used to build the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
         cmd_parser = cls.base_parser()
         cmd_parser.add_argument(
             "--log-service", required=False, dest="log_service", type=str,
@@ -65,7 +69,11 @@ class LogCollectDiagnosticData(RedfishManagerBase,
 
     @staticmethod
     def _members(data):
-        """Return the ``@odata.id`` strings from a Redfish collection."""
+        """Return the ``@odata.id`` strings from a Redfish collection.
+
+        :param data: a Redfish collection body (or any value; non-dicts yield []).
+        :return: list of member ``@odata.id`` strings.
+        """
         if not isinstance(data, dict):
             return []
         return [
@@ -75,19 +83,37 @@ class LogCollectDiagnosticData(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
-        """Return a Redfish link target from a ``{key: {@odata.id}}`` property."""
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: the resource body holding the link (may be None).
+        :param key: the property name whose ``@odata.id`` to extract.
+        :return: the link target URI, or None when absent or malformed.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
     def _get(self, uri, do_async):
-        """GET a resource body, returning ``{}`` when discovery cannot read it."""
+        """GET a resource body, returning ``{}`` when discovery cannot read it.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async event loop when True.
+        :return: the parsed response body, or {} when the query fails.
+        """
         try:
             return self.base_query(uri, do_async=do_async).data or {}
         except Exception:
             return {}
 
     def _roots(self, do_async):
-        """Return ComputerSystem, Manager, and Chassis root URIs to inspect."""
+        """Return ComputerSystem, Manager, and Chassis root URIs to inspect.
+
+        Log services hang off different roots per vendor — Systems/Managers on
+        iLO, Chassis on the GB300 — so all three collections are walked.
+
+        :param do_async: issue the Chassis collection query on the async loop
+            when True.
+        :return: list of root resource URIs to inspect for log services.
+        """
         roots = []
         for finder in (self.discover_computer_system_ids, self.discover_manager_ids):
             try:
@@ -101,7 +127,15 @@ class LogCollectDiagnosticData(RedfishManagerBase,
         return roots
 
     def _discover_log_services(self, do_async):
-        """Discover LogServices exposing CollectDiagnosticData across roots."""
+        """Discover LogServices exposing CollectDiagnosticData across roots.
+
+        Walks each root's ``LogServices`` collection and keeps the services
+        whose ``Actions`` block exposes ``#LogService.CollectDiagnosticData``.
+
+        :param do_async: issue the underlying queries on the async loop when True.
+        :return: list of ``{"Id": <id>, "uri": <service uri>}`` dicts,
+            de-duplicated by service URI and ordered by discovery.
+        """
         services = []
         seen = set()
         for root_uri in self._roots(do_async):
@@ -124,7 +158,16 @@ class LogCollectDiagnosticData(RedfishManagerBase,
 
     @staticmethod
     def _resolve_target(log_service, services):
-        """Resolve a LogService Id or full URI to a discovered service URI."""
+        """Resolve a LogService Id or full URI to a discovered service URI.
+
+        :param log_service: a LogService Id (case-insensitive) or a full
+            Redfish URI.
+        :param services: the discovered collection-capable services from
+            :meth:`_discover_log_services`.
+        :return: the resolved LogService URI.
+        :raises InvalidArgument: when the id/URI is empty, matches no capable
+            service, or is ambiguous across several services.
+        """
         requested = (log_service or "").strip()
         if not requested:
             raise InvalidArgument("log service id or URI cannot be empty")
@@ -149,7 +192,13 @@ class LogCollectDiagnosticData(RedfishManagerBase,
 
     @staticmethod
     def _payload(diagnostic_data_type, oem_diagnostic_data_type):
-        """Build the CollectDiagnosticData action payload."""
+        """Build the CollectDiagnosticData action payload.
+
+        :param diagnostic_data_type: ``DiagnosticDataType`` value to send.
+        :param oem_diagnostic_data_type: ``OEMDiagnosticDataType`` value to
+            include when set (used when the data type is OEM).
+        :return: the JSON-serializable action payload dict.
+        """
         payload = {"DiagnosticDataType": diagnostic_data_type}
         if oem_diagnostic_data_type:
             payload["OEMDiagnosticDataType"] = oem_diagnostic_data_type
@@ -168,7 +217,31 @@ class LogCollectDiagnosticData(RedfishManagerBase,
                 **kwargs) -> CommandResult:
         """List capable services, or collect diagnostic data from one service.
 
+        With no ``--log-service`` the command discovers and returns the
+        collection-capable services WITHOUT mutating. With a target it invokes
+        CollectDiagnosticData, which only fires with ``--confirm``;
         ``--dry_run`` is a no-POST override even when ``--confirm`` is also set.
+
+        :param log_service: LogService Id or full URI to collect from; None
+            lists the capable services.
+        :param diagnostic_data_type: ``DiagnosticDataType`` value to send
+            (default ``Manager``).
+        :param oem_diagnostic_data_type: ``OEMDiagnosticDataType`` value to
+            include when set (used when the data type is OEM).
+        :param confirm: authorize the CollectDiagnosticData POST to actually fire.
+        :param dry_run: resolve the target and show it without POSTing;
+            overrides ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async loop
+            when True.
+        :return: a CommandResult whose data is the capable-service list (when
+            no target is given), the collection outcome, or the blocked/dry-run
+            preview.
+        :raises InvalidArgument: when no capable services exist, or when
+            ``log_service`` is empty, matches no capable service, or is
+            ambiguous across several services.
         """
         services = self._discover_log_services(do_async)
         if log_service is None:

--- a/redfish_ctl/logs/cmd_log_collect_diag.py
+++ b/redfish_ctl/logs/cmd_log_collect_diag.py
@@ -1,0 +1,198 @@
+"""Collect Redfish LogService diagnostic data (LogService.CollectDiagnosticData).
+
+    redfish_ctl log-collect-diag
+    redfish_ctl log-collect-diag --log-service Dump --diagnostic-data-type Manager
+    redfish_ctl log-collect-diag --log-service /redfish/v1/Managers/BMC_0/LogServices/Dump --confirm
+
+Discovers LogService resources under ComputerSystems, Managers, and Chassis by
+link, then keeps services exposing ``#LogService.CollectDiagnosticData``. With
+no target the command lists capable services. With a target it previews the POST
+unless ``--confirm`` is supplied.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_COLLECT_DIAG_ACTION = "#LogService.CollectDiagnosticData"
+
+
+class LogCollectDiagnosticData(RedfishManagerBase,
+                               scm_type=ApiRequestType.LogCollectDiagnosticData,
+                               name="log-collect-diag",
+                               metaclass=Singleton):
+    """Collect diagnostic data from a discovered LogService."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the log-collect-diag command."""
+        super(LogCollectDiagnosticData, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``log-collect-diag`` subcommand."""
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--log-service", required=False, dest="log_service", type=str,
+            default=None,
+            help="LogService Id (for example Dump) or full URI to collect from; "
+                 "omit to list capable services without mutating")
+        cmd_parser.add_argument(
+            "--diagnostic-data-type", required=False,
+            dest="diagnostic_data_type", type=str, default="Manager",
+            help="DiagnosticDataType value to send, default: Manager")
+        cmd_parser.add_argument(
+            "--oem-diagnostic-data-type", required=False,
+            dest="oem_diagnostic_data_type", type=str, default=None,
+            help="OEMDiagnosticDataType value to send when DiagnosticDataType is OEM")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="fire the CollectDiagnosticData POST; without it the command previews")
+        cmd_parser.add_argument(
+            "--dry_run", action="store_true", dest="dry_run", default=False,
+            help="resolve the target and show it without POSTing")
+        return (
+            cmd_parser,
+            "log-collect-diag",
+            "command collect Redfish LogService diagnostic data",
+        )
+
+    @staticmethod
+    def _members(data):
+        """Return the ``@odata.id`` strings from a Redfish collection."""
+        if not isinstance(data, dict):
+            return []
+        return [
+            m["@odata.id"] for m in data.get("Members", [])
+            if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property."""
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _get(self, uri, do_async):
+        """GET a resource body, returning ``{}`` when discovery cannot read it."""
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def _roots(self, do_async):
+        """Return ComputerSystem, Manager, and Chassis root URIs to inspect."""
+        roots = []
+        for finder in (self.discover_computer_system_ids, self.discover_manager_ids):
+            try:
+                roots.extend(finder() or [])
+            except Exception:
+                continue
+        try:
+            roots.extend(self._members(self._get(f"{RedfishApi.Version}/Chassis", do_async)))
+        except Exception:
+            pass
+        return roots
+
+    def _discover_log_services(self, do_async):
+        """Discover LogServices exposing CollectDiagnosticData across roots."""
+        services = []
+        seen = set()
+        for root_uri in self._roots(do_async):
+            services_uri = self._link(self._get(root_uri, do_async), "LogServices")
+            if not services_uri:
+                continue
+            for svc_uri in self._members(self._get(services_uri, do_async)):
+                if svc_uri in seen:
+                    continue
+                svc = self._get(svc_uri, do_async)
+                actions = svc.get("Actions") if isinstance(svc, dict) else None
+                if not isinstance(actions, dict) or _COLLECT_DIAG_ACTION not in actions:
+                    continue
+                seen.add(svc_uri)
+                services.append({
+                    "Id": svc.get("Id") or svc_uri.rsplit("/", 1)[-1],
+                    "uri": svc_uri,
+                })
+        return services
+
+    @staticmethod
+    def _resolve_target(log_service, services):
+        """Resolve a LogService Id or full URI to a discovered service URI."""
+        requested = (log_service or "").strip()
+        if not requested:
+            raise InvalidArgument("log service id or URI cannot be empty")
+        if requested.startswith("/redfish"):
+            match = next((s for s in services if s["uri"] == requested), None)
+            if match is not None:
+                return match["uri"]
+            raise InvalidArgument(
+                f"no diagnostic data collection-capable log service at URI "
+                f"'{requested}'; available: {[s['uri'] for s in services]}")
+        wanted = requested.lower()
+        matches = [s for s in services if s["Id"].lower() == wanted]
+        if not matches:
+            raise InvalidArgument(
+                f"no diagnostic data collection-capable log service with Id "
+                f"'{requested}'; available: {[s['Id'] for s in services]}")
+        if len(matches) > 1:
+            raise InvalidArgument(
+                f"log service Id '{requested}' is ambiguous across "
+                f"{[s['uri'] for s in matches]}; pass the full --log-service URI")
+        return matches[0]["uri"]
+
+    @staticmethod
+    def _payload(diagnostic_data_type, oem_diagnostic_data_type):
+        """Build the CollectDiagnosticData action payload."""
+        payload = {"DiagnosticDataType": diagnostic_data_type}
+        if oem_diagnostic_data_type:
+            payload["OEMDiagnosticDataType"] = oem_diagnostic_data_type
+        return payload
+
+    def execute(self,
+                log_service: Optional[str] = None,
+                diagnostic_data_type: Optional[str] = "Manager",
+                oem_diagnostic_data_type: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List capable services, or collect diagnostic data from one service."""
+        services = self._discover_log_services(do_async)
+        if log_service is None:
+            return CommandResult(
+                {"collectable_log_services": services}, None, None, None)
+        if not services:
+            raise InvalidArgument(
+                "no diagnostic data collection-capable log services found on "
+                "this Redfish endpoint (none expose "
+                "#LogService.CollectDiagnosticData)")
+
+        target_uri = self._resolve_target(log_service, services)
+        preview_only = bool(dry_run) or not bool(confirm)
+        result = self.invoke_action(
+            target_uri,
+            "CollectDiagnosticData",
+            payload=self._payload(diagnostic_data_type, oem_diagnostic_data_type),
+            full_action_type=_COLLECT_DIAG_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=preview_only,
+            confirm=True,
+        )
+        if (
+                not confirm
+                and not dry_run
+                and result.error is None
+                and isinstance(result.data, dict)):
+            result.data["blocked"] = "diagnostic data collection requires --confirm"
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -112,6 +112,7 @@ class ApiRequestType(Enum):
     SystemReset = auto()
     Logs = auto()
     LogClear = auto()
+    LogCollectDiagnosticData = auto()
     EthernetInterfaces = auto()
     SecureBoot = auto()
     CertificatesQuery = auto()

--- a/tests/test_log_collect_diag_dualmode.py
+++ b/tests/test_log_collect_diag_dualmode.py
@@ -1,0 +1,176 @@
+"""Dual-mode-style coverage for collecting LogService diagnostic data."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+GB300_NODE2_CORPUS = corpus_dir(
+    Path(__file__).parent / "nvidia_gb300_node2_corpus.tar.gz", "172.25.230.20"
+)
+GB300_NODE2_INDEX = {path.name.lower(): path for path in GB300_NODE2_CORPUS.glob("*.json")}
+MANAGER_DUMP = "/redfish/v1/Managers/BMC_0/LogServices/Dump"
+COLLECT_TARGET = f"{MANAGER_DUMP}/Actions/LogService.CollectDiagnosticData"
+
+
+def _fixture_for_path(path):
+    """Return the extracted node2 fixture matching a Redfish path."""
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return GB300_NODE2_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def gb300_node2_manager():
+    """Serve the committed GB300 node2 corpus over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/collect-1"
+        return json.dumps({"Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/collect-1"}})
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-gb300-node2",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_log_collect_diag_lists_services_without_mutating(gb300_node2_manager):
+    """With no target, the command lists collectable LogServices and never POSTs."""
+    manager, requests = gb300_node2_manager
+
+    result = manager.sync_invoke(ApiRequestType.LogCollectDiagnosticData, "log-collect-diag")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    services = result.data["collectable_log_services"]
+    assert any(service["uri"] == MANAGER_DUMP for service in services)
+    assert _post_requests(requests) == []
+
+
+def test_log_collect_diag_without_confirm_is_preview_only(gb300_node2_manager):
+    """CollectDiagnosticData resolves the target but does not POST without --confirm."""
+    manager, requests = gb300_node2_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LogCollectDiagnosticData,
+        "log-collect-diag",
+        log_service=MANAGER_DUMP,
+        diagnostic_data_type="Manager",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#LogService.CollectDiagnosticData"
+    assert result.data["target"] == COLLECT_TARGET
+    assert result.data["payload"] == {"DiagnosticDataType": "Manager"}
+    assert result.data["level"] == "reversible"
+    assert result.data["blocked"] == "diagnostic data collection requires --confirm"
+    assert _post_requests(requests) == []
+
+
+def test_log_collect_diag_confirm_posts_payload(gb300_node2_manager):
+    """--confirm POSTs the requested diagnostic-data type to the discovered action."""
+    manager, requests = gb300_node2_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LogCollectDiagnosticData,
+        "log-collect-diag",
+        log_service=MANAGER_DUMP,
+        diagnostic_data_type="Manager",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#LogService.CollectDiagnosticData"
+    assert result.data["target"] == COLLECT_TARGET
+    assert result.data["level"] == "reversible"
+    assert result.data["task_id"] == "collect-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == COLLECT_TARGET.lower()
+    assert posts[0].json() == {"DiagnosticDataType": "Manager"}
+
+
+def test_log_collect_diag_oem_payload_includes_oem_type(gb300_node2_manager):
+    """OEM diagnostic-data collection includes the OEM type when supplied."""
+    manager, requests = gb300_node2_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LogCollectDiagnosticData,
+        "log-collect-diag",
+        log_service=MANAGER_DUMP,
+        diagnostic_data_type="OEM",
+        oem_diagnostic_data_type="NvidiaDump",
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["payload"] == {
+        "DiagnosticDataType": "OEM",
+        "OEMDiagnosticDataType": "NvidiaDump",
+    }
+    assert result.data["blocked"] is None
+    assert _post_requests(requests) == []
+
+
+def test_log_collect_diag_ambiguous_id_requires_uri(gb300_node2_manager):
+    """The GB300 corpus exposes several Dump services, so Id-only targeting is rejected."""
+    manager, requests = gb300_node2_manager
+
+    with pytest.raises(InvalidArgument, match="ambiguous"):
+        manager.sync_invoke(
+            ApiRequestType.LogCollectDiagnosticData,
+            "log-collect-diag",
+            log_service="Dump",
+            diagnostic_data_type="Manager",
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_log_collect_diag_no_capable_services_raises(redfish_mock_factory):
+    """A corpus without CollectDiagnosticData fails clearly before any POST."""
+    manager, service = redfish_mock_factory("hpe")
+
+    with pytest.raises(InvalidArgument, match="no diagnostic data collection-capable"):
+        manager.sync_invoke(
+            ApiRequestType.LogCollectDiagnosticData,
+            "log-collect-diag",
+            log_service="IML",
+            diagnostic_data_type="Manager",
+        )
+
+    assert _post_requests(service.requests) == []

--- a/tests/test_log_collect_diag_dualmode.py
+++ b/tests/test_log_collect_diag_dualmode.py
@@ -124,6 +124,28 @@ def test_log_collect_diag_confirm_posts_payload(gb300_node2_manager):
     assert posts[0].json() == {"DiagnosticDataType": "Manager"}
 
 
+def test_log_collect_diag_confirm_dry_run_still_does_not_post(gb300_node2_manager):
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    manager, requests = gb300_node2_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LogCollectDiagnosticData,
+        "log-collect-diag",
+        log_service=MANAGER_DUMP,
+        diagnostic_data_type="Manager",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == COLLECT_TARGET
+    assert result.data["payload"] == {"DiagnosticDataType": "Manager"}
+    assert _post_requests(requests) == []
+
+
 def test_log_collect_diag_oem_payload_includes_oem_type(gb300_node2_manager):
     """OEM diagnostic-data collection includes the OEM type when supplied."""
     manager, requests = gb300_node2_manager


### PR DESCRIPTION
## Summary
- add a guarded `log-collect-diag` command for LogService `CollectDiagnosticData`
- discover capable LogServices across systems, managers, and chassis
- add GB300 corpus-backed coverage for list, preview, confirmed POST, OEM payload, ambiguous target, and unsupported service paths

## Tests
- `./docker/run-tests.sh tests/test_log_collect_diag_dualmode.py`
- `./docker/run-tests.sh tests/test_log_collect_diag_dualmode.py tests/test_log_clear_dualmode.py tests/test_action_commands_dualmode.py`
- `docker run --rm redfish-ctl-test ruff check redfish_ctl/logs/cmd_log_collect_diag.py redfish_ctl/actions/action_policy.py redfish_ctl/redfish_manager_shared.py tests/test_log_collect_diag_dualmode.py`
- `git diff --check`
- `./docker/run-tests.sh`
