### PR TITLE
Tear the sandbox kind cluster down on success; add docker-clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,15 @@ docstring-gate-all: ## Fail if ANY method in the tree lacks docs (whole-tree gat
 k8s-sandbox: ## Run the local Kubernetes read-path sandbox when present.
 	./k8s/sandbox/run-sandbox.sh
 
+k8s-sandbox-down: ## Delete the sandbox kind cluster (frees ~1.4GB RAM and steady CPU).
+	kind delete cluster --name redfish-sandbox
+
+docker-clean: ## Reclaim local docker space: sandbox cluster, exited redfish containers, dangling layers.
+	-kind delete cluster --name redfish-sandbox
+	@ids="$$(docker ps -aq --filter status=exited --filter name=redfish)"; \
+	 if [ -n "$$ids" ]; then docker rm $$ids >/dev/null; fi
+	docker image prune -f
+
 k8s-consumer: ## Build and deploy the fleet-status consumer into the sandbox.
 	./k8s/consumer/deploy.sh
 

--- a/docs/k8s-sandbox-quickstart.md
+++ b/docs/k8s-sandbox-quickstart.md
@@ -37,10 +37,16 @@ open -a Docker            # macOS; wait until `docker info` succeeds
 ## 1. Stand up the sandbox (mock BMC) in one go
 
 The sandbox target builds the images, creates the kind cluster, and deploys the
-controller plus a mock BMC that serves the committed corpus:
+controller plus a mock BMC that serves the committed corpus. On success the
+cluster is torn down automatically (a leftover kind cluster holds ~1.4GB RAM);
+set `KEEP_CLUSTER=1` to keep it up — required before `make k8s-consumer` or
+`make k8s-explorer`, which deploy into the running cluster. A failed run always
+leaves the cluster up for diagnosis.
 
 ```bash
-make k8s-sandbox         # kind up → mock-bmc → controller → sample RedfishEndpoint
+make k8s-sandbox                  # kind up → verify → kind down
+KEEP_CLUSTER=1 make k8s-sandbox   # keep the cluster for k8s-consumer / iteration
+make k8s-sandbox-down             # tear a kept cluster down when finished
 ```
 
 The active kube context becomes `kind-redfish-sandbox`. Confirm the controller

--- a/k8s/consumer/deploy.sh
+++ b/k8s/consumer/deploy.sh
@@ -11,6 +11,13 @@
 set -euo pipefail
 
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-redfish-sandbox}"
+
+# The sandbox tears itself down after a green run; deploying into a missing
+# cluster otherwise fails with an opaque kubectl context error.
+if ! kind get clusters 2>/dev/null | grep -qx "${KIND_CLUSTER_NAME}"; then
+	printf 'sandbox cluster "%s" is not running.\nStart it and keep it up first:  KEEP_CLUSTER=1 make k8s-sandbox\n' "${KIND_CLUSTER_NAME}" >&2
+	exit 1
+fi
 NAMESPACE="${NAMESPACE:-redfish-sandbox}"
 KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${KIND_CLUSTER_NAME}}"
 IMAGE="${IMAGE:-redfish-ctl-consumer:local}"

--- a/k8s/explorer/deploy.sh
+++ b/k8s/explorer/deploy.sh
@@ -9,6 +9,13 @@
 set -euo pipefail
 
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-redfish-sandbox}"
+
+# The sandbox tears itself down after a green run; deploying into a missing
+# cluster otherwise fails with an opaque kubectl context error.
+if ! kind get clusters 2>/dev/null | grep -qx "${KIND_CLUSTER_NAME}"; then
+	printf 'sandbox cluster "%s" is not running.\nStart it and keep it up first:  KEEP_CLUSTER=1 make k8s-sandbox\n' "${KIND_CLUSTER_NAME}" >&2
+	exit 1
+fi
 NAMESPACE="${NAMESPACE:-redfish-sandbox}"
 KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-kind-${KIND_CLUSTER_NAME}}"
 IMAGE="${IMAGE:-redfish-ctl-explorer:local}"

--- a/k8s/sandbox/run-sandbox.sh
+++ b/k8s/sandbox/run-sandbox.sh
@@ -342,3 +342,13 @@ fi
 if has_backend "corpus-mock"; then
 	drive_node_profile gb300-mock
 fi
+
+# Tear the throwaway cluster down on success unless the caller keeps it for
+# iteration (KEEP_CLUSTER=1 — needed before `make k8s-consumer`/`k8s-explorer`,
+# which deploy into this cluster). A failure exits earlier via `set -e`, so the
+# cluster stays up for diagnostics. On a laptop a leftover kind cluster holds
+# ~1.4GB RAM and steady CPU; in CI the teardown is a few harmless seconds.
+if [ "${KEEP_CLUSTER:-0}" != "1" ]; then
+	section "tearing down the sandbox cluster (KEEP_CLUSTER=1 to keep it)"
+	kind delete cluster --name "${KIND_CLUSTER_NAME}"
+fi

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -16,8 +16,10 @@ REQUIRED_TARGETS = {
     "build",
     "docker-test",
     "docker-image",
+    "docker-clean",
     "docs-voice-check",
     "k8s-sandbox",
+    "k8s-sandbox-down",
     "clean",
 }
 
@@ -48,8 +50,10 @@ def test_make_dry_run_uses_expected_safe_local_commands() -> None:
             "bench-concurrency",
             "docker-test",
             "docker-image",
+            "docker-clean",
             "docs-voice-check",
             "k8s-sandbox",
+            "k8s-sandbox-down",
         ],
         cwd=REPO_ROOT,
         check=False,
@@ -64,6 +68,8 @@ def test_make_dry_run_uses_expected_safe_local_commands() -> None:
     assert "twine check" in result.stdout
     assert "docker/run-tests.sh" in result.stdout
     assert "docker build" in result.stdout
+    assert "kind delete cluster --name redfish-sandbox" in result.stdout
+    assert "docker image prune -f" in result.stdout
     assert "\\b(I|me|my|mine|myself)\\b" in result.stdout
     assert "README.md docs/" in result.stdout
     assert "k8s/sandbox" in result.stdout


### PR DESCRIPTION
Laptop-stability fix: a successful `make k8s-sandbox` left the kind cluster running forever — ~1.4GB RAM + steady CPU, and it **resurrects with the docker daemon** (restart policy), so it survives even a Docker Desktop crash/restart. Combined with per-edit image rebuilds (fixed in #219) this degraded the machine and contributed to a daemon crash observed mid-test-run today.

## Changes
- `run-sandbox.sh`: on success, `kind delete cluster` — unless `KEEP_CLUSTER=1` (needed before `make k8s-consumer`/`k8s-explorer`, which deploy into the cluster). A failed run exits earlier via `set -e`, so the cluster **stays up for diagnostics** — the k8s-e2e failure path is unaffected.
- `Makefile`: `k8s-sandbox-down` (explicit teardown) and `docker-clean` (cluster + exited `redfish*` containers + dangling-layer prune; never touches other projects' tagged images).
- `tests/test_makefile_targets.py`: pins the new targets in help + dry-run.
- `docs/k8s-sandbox-quickstart.md`: documents the new default and `KEEP_CLUSTER=1`.

## Verification
This PR touches `k8s/sandbox/**`, so **kind-e2e runs here and exercises the new teardown end-to-end** (cluster up → verify → converge → teardown). The test matrix validates the Makefile pins. shellcheck: no new findings in the appended block (SC2218 at line 112 is pre-existing).