### PR TITLE
Pick the fleet image automatically with a loud base fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,26 +111,20 @@ GB300_HOSTC  = $$($(GB300_SH) host $(SLOT))
 AGENT      ?= $(shell whoami)
 REF        ?= main
 PYTEST_ARGS ?= -q
-GB300_IMAGE ?= redfish-ctl-dev
-# Same charset gb300.sh enforces for run/shell; keeps an overridden image tag
-# from reaching the remote shell strings in gb300-check/gb300-image. The value
-# is read from the environment (make exports it), never shell-parsed, so the
-# guard itself cannot be escaped.
-export GB300_IMAGE
-GB300_IMAGE_OK = case "$$GB300_IMAGE" in (*[!A-Za-z0-9._/:-]*|"") \
-	echo "invalid GB300_IMAGE"; exit 2;; esac
+# Image choice lives in scripts/gb300.sh: the credentialed agent image when a
+# node has it, the public base otherwise; pass GB300_IMAGE=<name> to pin one.
 
-gb300-check: ## Live-check every fleet slot: ssh, docker, dev image, disk.
-	@$(GB300_IMAGE_OK); \
-	printf '%-5s %-22s %-8s %-10s %-6s\n' SLOT HOST DOCKER IMAGE DISK; \
+gb300-check: ## Live-check every fleet slot: ssh, docker, base + agent images, disk.
+	@printf '%-5s %-22s %-8s %-8s %-8s %-6s\n' SLOT HOST DOCKER BASE AGENT DISK; \
 	for s in $$($(GB300_SH) list); do \
 		h=$$($(GB300_SH) host $$s); \
 		out=$$(ssh -o BatchMode=yes -o ConnectTimeout=5 $$h ' \
 			d=no; docker info >/dev/null 2>&1 && d=ok; \
-			i=absent; docker image inspect $(GB300_IMAGE) >/dev/null 2>&1 && i=present; \
+			b=absent; docker image inspect redfish-ctl-dev >/dev/null 2>&1 && b=present; \
+			a=absent; docker image inspect redfish-ctl-agent >/dev/null 2>&1 && a=present; \
 			df=$$(df -h / | awk "NR==2 {print \$$5}"); \
-			echo "$$d $$i $$df"' 2>/dev/null) || out="UNREACHABLE - -"; \
-		printf '%-5s %-22s %-8s %-10s %-6s\n' "$$s" "$$h" $$out; \
+			echo "$$d $$b $$a $$df"' 2>/dev/null) || out="UNREACHABLE - - -"; \
+		printf '%-5s %-22s %-8s %-8s %-8s %-6s\n' "$$s" "$$h" $$out; \
 	done
 
 # Both build targets stage the context in a temp file instead of piping it

--- a/scripts/gb300.sh
+++ b/scripts/gb300.sh
@@ -87,24 +87,33 @@ case "$cmd" in
         _check slot "$slot" '^[0-9]+$'
         _check agent "$agent" '^[A-Za-z0-9._-]+$'
         host="$("$0" host "$slot")"
-        image="${GB300_IMAGE:-redfish-ctl-dev}"
-        _check image "$image" '^[A-Za-z0-9._/:-]+$'
+        # Image selection: an explicit GB300_IMAGE wins; otherwise the node
+        # picks the credentialed agent image when it has been provisioned and
+        # falls back to the public base loudly, so a fresh setup works before
+        # the operator stages credentials.
+        if [ -n "${GB300_IMAGE:-}" ]; then
+            _check image "$GB300_IMAGE" '^[A-Za-z0-9._/:-]+$'
+            image_snippet="img=$GB300_IMAGE;"
+        else
+            image_snippet='img=redfish-ctl-agent;
+docker image inspect "$img" >/dev/null 2>&1 || { echo "gb300: agent image not on this node yet, using base redfish-ctl-dev" >&2; img=redfish-ctl-dev; };'
+        fi
         # The remote snippet assembles the secret mounts on the node itself so
         # a missing key file never turns into a root-owned bind-mount dir.
         remote_prefix='m="";
 [ -f "$HOME/.ssh/redfish_ctl_git" ] && m="$m -v $HOME/.ssh/redfish_ctl_git:/secrets/git_key:ro";
 [ -f "$HOME/.ssh/redfish_ctl_gh_token" ] && m="$m -v $HOME/.ssh/redfish_ctl_gh_token:/secrets/gh_token:ro";'
         if [ "$cmd" = "shell" ]; then
-            exec ssh -t "$host" "$remote_prefix docker run -it --rm \
-                --name rfctl-$agent -v rfctl-work-$agent:/work \$m $image bash"
+            exec ssh -t "$host" "$remote_prefix $image_snippet docker run -it --rm \
+                --name rfctl-$agent -v rfctl-work-$agent:/work \$m \$img bash"
         fi
         ref="${4:?usage: gb300.sh run <slot> <agent> <ref> <cmd...>}"
         _check ref "$ref" '^[A-Za-z0-9._/-]+$'
         shift 4
         [ $# -gt 0 ] || { echo "gb300.sh run: no command given" >&2; exit 2; }
         printf -v quoted '%q ' "$@"
-        exec ssh "$host" "$remote_prefix docker run --rm \
-            -v rfctl-work-$agent:/work -e RFCTL_REF=$ref \$m $image bash -lc $(printf '%q' "$quoted")"
+        exec ssh "$host" "$remote_prefix $image_snippet docker run --rm \
+            -v rfctl-work-$agent:/work -e RFCTL_REF=$ref \$m \$img bash -lc $(printf '%q' "$quoted")"
         ;;
     *)
         echo "usage: gb300.sh {host <slot>|list|run <slot> <agent> <ref> <cmd...>|shell <slot> <agent>}" >&2


### PR DESCRIPTION
Cold-start dry-run of the fleet instructions surfaced a first-contact failure: with the agent image not yet provisioned, the pinned image name made docker fail with a bare 125. Image choice now happens on the node — the credentialed agent image when present, else the public base with a printed note; an explicit GB300_IMAGE override still wins and stays charset-validated. The fleet check table now reports BASE and AGENT presence separately, and the Makefile drops its now-unused image plumbing.