### PR TITLE
Fix ApiRequestType members that break package import on Python 3.13+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/docker/Dockerfile.gb300-dev
+++ b/docker/Dockerfile.gb300-dev
@@ -50,8 +50,9 @@ ENV PATH="/opt/conda/bin:$PATH"
 # rewrites: the final "pip: -e ." line needs the full repo, which is not in
 # the build context — stripped here, the entrypoint runs "pip install -e ."
 # inside /work once the clone exists; and the open-ended python>=3.10 spec is
-# pinned to the top of the CI matrix (an unpinned solve pulls 3.14t, whose
-# enum auto() breaks ApiRequestType). nodejs comes from conda-forge so JS
+# pinned to the top of the CI matrix so the container reproduces a CI lane
+# instead of whatever python conda-forge shipped last. nodejs comes from
+# conda-forge so JS
 # tooling (node --test etc.) is available in the same env.
 WORKDIR /deps
 COPY environment.yml ./

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -25,7 +25,7 @@ class ApiRequestType(Enum):
     ComputerSystemReset = auto()
 
     ConvertToRaid = auto()
-    ConvertNoneRaid = ()
+    ConvertNoneRaid = auto()
     Drives = auto()
     VolumeInit = auto()
     VolumeQuery = auto()
@@ -137,7 +137,7 @@ class ApiRequestType(Enum):
     BootQuery = auto()
 
     GetAttachStatus = auto()
-    DellOemNetIsoBoot = ()
+    DellOemNetIsoBoot = auto()
     DellOemDetach = auto()
     TaskGet = auto()
 

--- a/tests/test_enum_auto_values.py
+++ b/tests/test_enum_auto_values.py
@@ -20,8 +20,11 @@ from redfish_ctl.redfish_manager_shared import ApiRequestType
 
 PACKAGE_DIR = Path(redfish_ctl.__file__).resolve().parent
 
-# Enum-family base-class names whose subclasses use _generate_next_value_.
-_ENUM_BASES = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag"}
+# Enum-family bases that inherit the DEFAULT int-increment
+# _generate_next_value_. StrEnum is deliberately absent: it ships its own
+# generator (lowercased member name, prior values ignored), so mixing string
+# members with auto() is legal there and must not be flagged.
+_ENUM_BASES = {"Enum", "IntEnum", "Flag", "IntFlag"}
 
 
 def _base_names(class_def: ast.ClassDef) -> set:
@@ -40,6 +43,26 @@ def _base_names(class_def: ast.ClassDef) -> set:
         elif isinstance(base, ast.Attribute):
             names.add(base.attr)
     return names
+
+
+def _member_assignment(stmt: ast.stmt) -> tuple:
+    """Extract (names, value) when a class-body statement defines a member.
+
+    Handles plain assignments and annotated assignments with a value
+    (``B: int = ()`` still creates an enum member), so an annotation cannot
+    hide a value from the audit.
+
+    :param stmt: a statement from an enum class body.
+    :return: ``(target names, value node)``, or ``([], None)`` for
+        statements that do not assign a member value.
+    """
+    if isinstance(stmt, ast.Assign):
+        names = [t.id for t in stmt.targets if isinstance(t, ast.Name)]
+        return names, stmt.value
+    if isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+        if isinstance(stmt.target, ast.Name):
+            return [stmt.target.id], stmt.value
+    return [], None
 
 
 def _is_auto_call(node: ast.AST) -> bool:
@@ -84,12 +107,10 @@ def _enum_auto_violations(tree: ast.AST, rel_path: str) -> list:
             continue
         saw_non_int_member = False
         for stmt in node.body:
-            if not isinstance(stmt, ast.Assign):
-                continue
-            targets = [t.id for t in stmt.targets if isinstance(t, ast.Name)]
+            targets, value = _member_assignment(stmt)
             if not targets or all(t.startswith("_") for t in targets):
                 continue
-            if _is_auto_call(stmt.value):
+            if _is_auto_call(value):
                 if saw_non_int_member:
                     violations.append(
                         f"{rel_path}:{stmt.lineno} {node.name}.{targets[0]} uses"
@@ -99,8 +120,8 @@ def _enum_auto_violations(tree: ast.AST, rel_path: str) -> list:
                         " _generate_next_value_."
                     )
             elif not (
-                isinstance(stmt.value, ast.Constant)
-                and isinstance(stmt.value.value, int)
+                isinstance(value, ast.Constant)
+                and isinstance(value.value, int)
             ):
                 saw_non_int_member = True
     return violations
@@ -148,6 +169,40 @@ def test_audit_flags_the_original_breakage():
     violations = _enum_auto_violations(ast.parse(source), "broken.py")
     assert len(violations) == 1
     assert "Broken.C" in violations[0]
+
+
+def test_audit_flags_annotated_member():
+    """An annotated assignment cannot hide a non-integer member value.
+
+    ``B: tuple = ()`` still creates an enum member, so the audit tracks it
+    exactly like a plain assignment; skipping AnnAssign nodes would let the
+    original breakage return behind a type annotation.
+    """
+    source = (
+        "from enum import Enum, auto\n"
+        "class Broken(Enum):\n"
+        "    B: tuple = ()\n"
+        "    C = auto()\n"
+    )
+    violations = _enum_auto_violations(ast.parse(source), "annotated.py")
+    assert len(violations) == 1
+    assert "Broken.C" in violations[0]
+
+
+def test_audit_exempts_strenum():
+    """StrEnum legally mixes string members with auto().
+
+    ``StrEnum._generate_next_value_`` returns the lowercased member name and
+    ignores prior values, so no sorting happens and the audit must not flag
+    such classes.
+    """
+    source = (
+        "from enum import StrEnum, auto\n"
+        "class Names(StrEnum):\n"
+        "    A = 'explicit'\n"
+        "    B = auto()\n"
+    )
+    assert _enum_auto_violations(ast.parse(source), "strenum.py") == []
 
 
 def test_audit_accepts_custom_generator():

--- a/tests/test_enum_auto_values.py
+++ b/tests/test_enum_auto_values.py
@@ -45,24 +45,49 @@ def _base_names(class_def: ast.ClassDef) -> set:
     return names
 
 
-def _member_assignment(stmt: ast.stmt) -> tuple:
-    """Extract (names, value) when a class-body statement defines a member.
+def _member_values(stmt: ast.stmt):
+    """Yield ``(name, value node)`` for each member a statement defines.
 
-    Handles plain assignments and annotated assignments with a value
-    (``B: int = ()`` still creates an enum member), so an annotation cannot
-    hide a value from the audit.
+    Handles plain assignments, annotated assignments with a value
+    (``B: int = ()`` still creates an enum member, so an annotation cannot
+    hide a value from the audit), and same-length tuple unpacking
+    (``A, B = "x", "y"`` creates one member per name). Statements that
+    create no member — annotation-only lines, method definitions — yield
+    nothing.
 
     :param stmt: a statement from an enum class body.
-    :return: ``(target names, value node)``, or ``([], None)`` for
-        statements that do not assign a member value.
+    :return: iterator of ``(member name, assigned-value AST node)`` pairs.
     """
     if isinstance(stmt, ast.Assign):
-        names = [t.id for t in stmt.targets if isinstance(t, ast.Name)]
-        return names, stmt.value
-    if isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
+        for target in stmt.targets:
+            if isinstance(target, ast.Name):
+                yield target.id, stmt.value
+            elif (
+                isinstance(target, ast.Tuple)
+                and isinstance(stmt.value, ast.Tuple)
+                and len(target.elts) == len(stmt.value.elts)
+            ):
+                for elt, value in zip(target.elts, stmt.value.elts):
+                    if isinstance(elt, ast.Name):
+                        yield elt.id, value
+    elif isinstance(stmt, ast.AnnAssign) and stmt.value is not None:
         if isinstance(stmt.target, ast.Name):
-            return [stmt.target.id], stmt.value
-    return [], None
+            yield stmt.target.id, stmt.value
+
+
+def _is_int_literal(node: ast.AST) -> bool:
+    """Report whether a value node is an integer literal.
+
+    Unwraps a leading unary sign so an explicit negative member such as
+    ``X = -1`` (an ``ast.UnaryOp``, not an ``ast.Constant``) is still
+    recognized as an int — ints sort fine, so a later ``auto()`` is legal.
+
+    :param node: the assigned-value AST node.
+    :return: True when the node is a plain or sign-prefixed int literal.
+    """
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
+        node = node.operand
+    return isinstance(node, ast.Constant) and isinstance(node.value, int)
 
 
 def _is_auto_call(node: ast.AST) -> bool:
@@ -107,23 +132,20 @@ def _enum_auto_violations(tree: ast.AST, rel_path: str) -> list:
             continue
         saw_non_int_member = False
         for stmt in node.body:
-            targets, value = _member_assignment(stmt)
-            if not targets or all(t.startswith("_") for t in targets):
-                continue
-            if _is_auto_call(value):
-                if saw_non_int_member:
-                    violations.append(
-                        f"{rel_path}:{stmt.lineno} {node.name}.{targets[0]} uses"
-                        " auto() after a non-integer member value; Python 3.13+"
-                        " raises 'unable to sort non-numeric values' at import."
-                        " Give members explicit values or define"
-                        " _generate_next_value_."
-                    )
-            elif not (
-                isinstance(value, ast.Constant)
-                and isinstance(value.value, int)
-            ):
-                saw_non_int_member = True
+            for name, value in _member_values(stmt):
+                if name.startswith("_"):
+                    continue
+                if _is_auto_call(value):
+                    if saw_non_int_member:
+                        violations.append(
+                            f"{rel_path}:{stmt.lineno} {node.name}.{name} uses"
+                            " auto() after a non-integer member value; Python"
+                            " 3.13+ raises 'unable to sort non-numeric values'"
+                            " at import. Give members explicit values or"
+                            " define _generate_next_value_."
+                        )
+                elif not _is_int_literal(value):
+                    saw_non_int_member = True
     return violations
 
 
@@ -185,6 +207,40 @@ def test_audit_flags_annotated_member():
         "    C = auto()\n"
     )
     violations = _enum_auto_violations(ast.parse(source), "annotated.py")
+    assert len(violations) == 1
+    assert "Broken.C" in violations[0]
+
+
+def test_audit_accepts_negative_int_members():
+    """An explicit negative int member does not poison later auto() calls.
+
+    ``X = -1`` parses as ``ast.UnaryOp``, not ``ast.Constant``; ints sort
+    fine on every interpreter, so the audit must not flag the layout
+    (reviewer-found false positive).
+    """
+    source = (
+        "from enum import Enum, auto\n"
+        "class Levels(Enum):\n"
+        "    Below = -1\n"
+        "    Above = auto()\n"
+    )
+    assert _enum_auto_violations(ast.parse(source), "levels.py") == []
+
+
+def test_audit_flags_tuple_unpacked_members():
+    """Tuple-unpacked members with non-int values are still tracked.
+
+    ``A, B = "x", "y"`` creates one member per name, so a later ``auto()``
+    breaks import on Python 3.13+ exactly as with plain assignments
+    (reviewer-found false negative).
+    """
+    source = (
+        "from enum import Enum, auto\n"
+        "class Broken(Enum):\n"
+        "    A, B = 'x', 'y'\n"
+        "    C = auto()\n"
+    )
+    violations = _enum_auto_violations(ast.parse(source), "unpacked.py")
     assert len(violations) == 1
     assert "Broken.C" in violations[0]
 

--- a/tests/test_enum_auto_values.py
+++ b/tests/test_enum_auto_values.py
@@ -1,0 +1,167 @@
+"""Guard the Python 3.13+ enum ``auto()`` contract across the package.
+
+Since Python 3.13 the default ``enum._generate_next_value_`` sorts the values
+of the already-defined members, so an ``auto()`` member that follows a member
+with a non-integer value (an accidental ``()``, a string, a tuple) raises
+``TypeError: unable to sort non-numeric values`` at class construction — and
+the whole package fails to import. That is exactly what happened on Python
+3.14 with ``ApiRequestType`` (``ConvertNoneRaid = ()`` and
+``DellOemNetIsoBoot = ()``, both typos for ``auto()``). Older interpreters
+(3.10–3.12) tolerate the mix silently, so the CI matrix never saw it; these
+tests fail on ANY interpreter if the pattern reappears.
+
+Author Mus spyroot@gmail.com
+"""
+import ast
+from pathlib import Path
+
+import redfish_ctl
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+PACKAGE_DIR = Path(redfish_ctl.__file__).resolve().parent
+
+# Enum-family base-class names whose subclasses use _generate_next_value_.
+_ENUM_BASES = {"Enum", "IntEnum", "StrEnum", "Flag", "IntFlag"}
+
+
+def _base_names(class_def: ast.ClassDef) -> set:
+    """Collect the plain names of a class definition's bases.
+
+    Both ``class X(Enum)`` and ``class X(enum.Enum)`` forms resolve to the
+    final attribute name, so the audit sees them the same way.
+
+    :param class_def: the ``ast.ClassDef`` node to inspect.
+    :return: set of base-class name strings.
+    """
+    names = set()
+    for base in class_def.bases:
+        if isinstance(base, ast.Name):
+            names.add(base.id)
+        elif isinstance(base, ast.Attribute):
+            names.add(base.attr)
+    return names
+
+
+def _is_auto_call(node: ast.AST) -> bool:
+    """Report whether an assignment value is a bare ``auto()`` call.
+
+    :param node: the assigned-value AST node.
+    :return: True when the node is ``auto()`` or ``enum.auto()``.
+    """
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "auto"
+    return isinstance(func, ast.Attribute) and func.attr == "auto"
+
+
+def _enum_auto_violations(tree: ast.AST, rel_path: str) -> list:
+    """Find ``auto()`` members preceded by non-integer member values.
+
+    Walks every Enum-family class in a parsed module and flags each
+    ``auto()`` member that appears after a member whose value is not an
+    integer literal and not itself ``auto()`` — the exact layout Python
+    3.13+ rejects at class construction. A class that defines its own
+    ``_generate_next_value_`` opts out of the default sorting and is skipped.
+
+    :param tree: parsed module AST.
+    :param rel_path: package-relative path used in violation messages.
+    :return: list of human-readable violation strings.
+    """
+    violations = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not (_base_names(node) & _ENUM_BASES):
+            continue
+        defines_generator = any(
+            isinstance(stmt, ast.FunctionDef)
+            and stmt.name == "_generate_next_value_"
+            for stmt in node.body
+        )
+        if defines_generator:
+            continue
+        saw_non_int_member = False
+        for stmt in node.body:
+            if not isinstance(stmt, ast.Assign):
+                continue
+            targets = [t.id for t in stmt.targets if isinstance(t, ast.Name)]
+            if not targets or all(t.startswith("_") for t in targets):
+                continue
+            if _is_auto_call(stmt.value):
+                if saw_non_int_member:
+                    violations.append(
+                        f"{rel_path}:{stmt.lineno} {node.name}.{targets[0]} uses"
+                        " auto() after a non-integer member value; Python 3.13+"
+                        " raises 'unable to sort non-numeric values' at import."
+                        " Give members explicit values or define"
+                        " _generate_next_value_."
+                    )
+            elif not (
+                isinstance(stmt.value, ast.Constant)
+                and isinstance(stmt.value.value, int)
+            ):
+                saw_non_int_member = True
+    return violations
+
+
+def test_no_enum_mixes_auto_with_non_integer_values():
+    """No Enum in the package may define auto() after a non-integer member.
+
+    This statically enforces the Python 3.13+ ``_generate_next_value_``
+    contract on every interpreter in the CI matrix, so the 3.14 import
+    breakage cannot silently return while CI runs older pythons.
+    """
+    violations = []
+    for py_file in sorted(PACKAGE_DIR.rglob("*.py")):
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        rel = py_file.relative_to(PACKAGE_DIR.parent).as_posix()
+        violations.extend(_enum_auto_violations(tree, rel))
+    assert not violations, "\n".join(violations)
+
+
+def test_api_request_type_values_are_all_int():
+    """Every ApiRequestType member carries an auto()-generated int value.
+
+    Regression for ``ConvertNoneRaid = ()`` / ``DellOemNetIsoBoot = ()``:
+    an accidental non-integer value poisons every later ``auto()`` on
+    Python 3.13+ and breaks package import.
+    """
+    non_int = [m.name for m in ApiRequestType if not isinstance(m.value, int)]
+    assert non_int == []
+
+
+def test_audit_flags_the_original_breakage():
+    """The AST audit detects the exact pre-fix ApiRequestType layout.
+
+    Feeds the auditor a minimal enum with the historical ``()`` typo followed
+    by ``auto()`` and expects a violation, proving the guard actually fires.
+    """
+    source = (
+        "from enum import Enum, auto\n"
+        "class Broken(Enum):\n"
+        "    A = auto()\n"
+        "    B = ()\n"
+        "    C = auto()\n"
+    )
+    violations = _enum_auto_violations(ast.parse(source), "broken.py")
+    assert len(violations) == 1
+    assert "Broken.C" in violations[0]
+
+
+def test_audit_accepts_custom_generator():
+    """An enum with its own _generate_next_value_ is exempt from the audit.
+
+    The 3.13+ sorting lives in the DEFAULT generator; a class that overrides
+    it defines its own contract and must not be flagged.
+    """
+    source = (
+        "from enum import Enum, auto\n"
+        "class Custom(Enum):\n"
+        "    def _generate_next_value_(name, start, count, last_values):\n"
+        "        return name\n"
+        "    A = 'x'\n"
+        "    B = auto()\n"
+    )
+    assert _enum_auto_violations(ast.parse(source), "custom.py") == []


### PR DESCRIPTION
## Problem

`import redfish_ctl` fails on Python 3.13/3.14 during enum class construction:

```
File "redfish_ctl/redfish_manager_shared.py", line 29, in ApiRequestType
    Drives = auto()
File ".../python3.14/enum.py", line 1251, in _generate_next_value_
    raise TypeError('unable to sort non-numeric values') from None
```

Two `ApiRequestType` members were assigned `()` instead of `auto()` — `ConvertNoneRaid` and `DellOemNetIsoBoot`. Interpreters up to 3.12 skipped the unsortable value silently; since Python 3.13 the default `_generate_next_value_` sorts all prior member values, so the first `auto()` after the typo kills the import of the whole package. Neither member's value is consumed anywhere (both are dispatch keys only; no `.value` use, no value lookup), so switching them to `auto()` is behavior-neutral.

## Changes

- `redfish_ctl/redfish_manager_shared.py`: `ConvertNoneRaid = ()` and `DellOemNetIsoBoot = ()` → `auto()`. Audit of every `Enum` in the package (only `redfish_shared.py` and `redfish_manager_shared.py` use `auto()`): no other member mixes a non-integer value into an `auto()` enum.
- `tests/test_enum_auto_values.py` (new): AST audit that fails on ANY interpreter if an Enum in the package defines `auto()` after a non-integer member value (the exact layout 3.13+ rejects), plus a direct check that every `ApiRequestType` value is an int, plus self-tests proving the auditor fires on the pre-fix layout and exempts a custom `_generate_next_value_`. The existing `tests/test_package_imports.py` already imports every module, but only a 3.13+ interpreter would catch this bug that way — the AST audit closes that gap on the 3.10–3.12 CI matrix.
- `docker/Dockerfile.gb300-dev`: the python pin comment referenced this bug as its justification; reworded to the real remaining reason (reproduce a CI lane).
- `.github/workflows/ci.yml`: matrix extended to 3.13 and 3.14 so the import sweep guards every supported interpreter — extended only after the full suite was verified green on both (below).

## Evidence (GB300 fleet, in-container)

- Repro at `main`, slot 8, conda-forge python 3.14.6: `import redfish_ctl` → `TypeError: unable to sort non-numeric values` (`enum.py:1251`, raised at `Drives = auto()`).
- This branch, slot 9, python 3.14.6: `IMPORT-OK` + full offline suite `1275 passed, 63 skipped in 67.81s`.
- This branch, slot 10, python 3.13.14: `IMPORT-OK` + full offline suite `1275 passed, 63 skipped in 70.00s`.
- Full gate, slot 8, python 3.12 (image env): `1276 passed, 62 skipped in 73.10s`, ruff `All checks passed!`, `docstring-gate: OK`.
- The one-test pass→skip delta between the image env and the ad-hoc 3.13/3.14 envs is `tests/test_redfish_schema.py` (`importorskip("referencing")` — the `schema` extra is not part of `[dev]`), not an interpreter difference.

Observed in passing on 3.14 (separate follow-up, not addressed here): `SyntaxWarning: 'return' in a 'finally' block` at `redfish_ctl/redfish_manager.py:595`.
