### PR TITLE
Handle X10 VirtualMedia 501 responses

### DIFF
--- a/redfish_ctl/virtual_media/cmd_virtual_media_get.py
+++ b/redfish_ctl/virtual_media/cmd_virtual_media_get.py
@@ -26,9 +26,9 @@ from typing import Optional
 
 from ..cmd_exceptions import ResourceNotFound
 from ..cmd_utils import save_if_needed
+from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, Singleton
-from ..redfish_manager import CommandResult
 from ..redfish_shared import RedfishJson
 
 
@@ -100,6 +100,19 @@ class VirtualMediaGet(RedfishManagerBase,
         r = f"{self._default_method}{self.idrac_ip}{vm_uri}?$expand=*($levels=1)"
 
         response = self.api_get_call(r, headers)
+        if response.status_code == 501:
+            status = "standard VirtualMedia endpoint is not implemented on this BMC"
+            return CommandResult(
+                {
+                    "error": status,
+                    "status_code": 501,
+                    "target": vm_uri,
+                    "suggested_command": "vm-mount --status",
+                },
+                None,
+                None,
+                status,
+            )
         self.default_error_handler(response)
         data = response.json()
         data["Members"] = self._hydrate_member_links(

--- a/tests/test_virtual_media_dualmode.py
+++ b/tests/test_virtual_media_dualmode.py
@@ -1,12 +1,32 @@
 """Dual-mode tests for virtual-media commands."""
+
 import json
 
 import pytest
+import requests
 
 from redfish_ctl.cmd_exceptions import ResourceNotFound
 from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType, RedfishApiRespond
+
+_X10_VM_UNSUPPORTED = "standard VirtualMedia endpoint is not implemented on this BMC"
+
+
+def _force_x10_standard_vm_501(monkeypatch):
+    """Make only the resolved X10 standard VirtualMedia collection return 501."""
+    original_get = RedfishManagerBase.api_get_call
+
+    def x10_vm_501(self, request_uri, headers=None, **kwargs):
+        if "/redfish/v1/Managers/1/VM1?" in request_uri:
+            response = requests.Response()
+            response.status_code = 501
+            response._content = b"VirtualMedia not implemented"
+            response.headers["Content-Type"] = "text/plain"
+            return response
+        return original_get(self, request_uri, headers, **kwargs)
+
+    monkeypatch.setattr(RedfishManagerBase, "api_get_call", x10_vm_501)
 
 
 def test_virtual_media_query_returns_collection(redfish_api):
@@ -125,6 +145,58 @@ def test_virtual_media_query_hydrates_manager_members(redfish_mock_factory):
         "/redfish/v1/Managers/BMC_0/VirtualMedia/USB1/"
         "Actions/VirtualMedia.InsertMedia"
     )
+
+
+def test_virtual_media_query_reports_x10_standard_vm_501(
+    redfish_mock_factory, monkeypatch
+):
+    """X10 standard VirtualMedia 501 returns a command error, not a traceback."""
+    manager, _service = redfish_mock_factory("supermicro_x10")
+    _force_x10_standard_vm_501(monkeypatch)
+
+    result = manager.sync_invoke(
+        ApiRequestType.VirtualMediaGet,
+        "virtual_disk_query",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == _X10_VM_UNSUPPORTED
+    assert result.data == {
+        "error": _X10_VM_UNSUPPORTED,
+        "status_code": 501,
+        "target": "/redfish/v1/Managers/1/VM1",
+        "suggested_command": "vm-mount --status",
+    }
+
+
+@pytest.mark.parametrize(
+    ("api_call", "name", "kwargs"),
+    [
+        (
+            ApiRequestType.VirtualMediaInsert,
+            "virtual_disk_insert",
+            {"uri_path": "http://example.test/x10.iso", "device_id": "1"},
+        ),
+        (
+            ApiRequestType.VirtualMediaEject,
+            "virtual_disk_eject",
+            {"device_id": "1"},
+        ),
+    ],
+)
+def test_virtual_media_mutations_propagate_x10_standard_vm_501(
+    redfish_mock_factory, monkeypatch, api_call, name, kwargs
+):
+    """insert_vm and eject_vm surface X10 standard VirtualMedia 501 before POST."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+    _force_x10_standard_vm_501(monkeypatch)
+
+    result = manager.sync_invoke(api_call, name, **kwargs)
+
+    assert isinstance(result, CommandResult)
+    assert result.error == _X10_VM_UNSUPPORTED
+    assert result.data["suggested_command"] == "vm-mount --status"
+    assert all(request.method == "GET" for request in service.requests)
 
 
 def test_virtual_media_discovery_reports_missing_roots(redfish_mock, monkeypatch):


### PR DESCRIPTION
## Summary

- Return a structured command error when the standard VirtualMedia collection responds with HTTP 501.
- Include the resolved target URI and a `vm-mount --status` hint for Supermicro X10-style systems that expose OEM CfgCD virtual media.
- Propagate the same result through `insert_vm` and `eject_vm` before either command attempts a write.
- Add regression coverage for X10 `get_vm`, `insert_vm`, and `eject_vm` behavior when the resolved standard VirtualMedia GET returns 501.

Fixes #223.

## Validation

- `make gb300-gate SLOT=8 REF=neroshige/get-vm-501`
  - `1291 passed, 62 skipped, 6 warnings`
  - Ruff changed-file check passed
  - Docstring gate passed