### PR TITLE
Add SPDM signed measurements command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -179,6 +179,7 @@ Safety labels:
 | `serial-console` | Report host serial redirection + BMC SOL; `--enable --confirm` sets both. | Guarded |
 | `service-api-rs-status` | Read remote service API status. | Read |
 | `service-api-status` | Read service API status. | Read |
+| `spdm-measurements` | Fetch signed measurements from SPDM ComponentIntegrity resources. | Read |
 | `storage-controllers` | Read storage controller information. | Read |
 | `storage-convert-noraid` | Convert RAID disks under a controller to non-RAID. | Write |
 | `storage-convert-raid` | Convert non-RAID disks under a controller to RAID. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -98,6 +98,7 @@ from .telemetry.cmd_metric_reports import *
 from .telemetry.cmd_metric_definitions import *
 from .telemetry.cmd_exporter import *
 from .component_integrity.cmd_component_integrity import *
+from .component_integrity.cmd_spdm_measurements import *
 from .network.cmd_network_adapters import *
 from .network.cmd_nic_firmware import *
 from .ports.cmd_nvlink_ports import *

--- a/redfish_ctl/component_integrity/cmd_spdm_measurements.py
+++ b/redfish_ctl/component_integrity/cmd_spdm_measurements.py
@@ -1,0 +1,313 @@
+"""Fetch Redfish SPDM signed measurements.
+
+    redfish_ctl spdm-measurements
+    redfish_ctl spdm-measurements --component HGX_ERoT_BMC_0 --dry_run
+    redfish_ctl spdm-measurements --component HGX_ERoT_BMC_0 --measurement-index 255
+
+ComponentIntegrity signed-measurement fetches are read-only Redfish actions:
+the BMC carries the query over POST but does not mutate host or controller state.
+Targets are discovered from each ComponentIntegrity resource's own ``Actions``
+block; component ids and action URLs are not hardcoded.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument, ResourceNotFound
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SPDM_ACTION = "#ComponentIntegrity.SPDMGetSignedMeasurements"
+
+
+class SpdmMeasurements(RedfishManagerBase,
+                       scm_type=ApiRequestType.SpdmMeasurements,
+                       name="spdm-measurements",
+                       metaclass=Singleton):
+    """Fetch signed measurements from SPDM ComponentIntegrity resources."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the spdm-measurements command."""
+        super(SpdmMeasurements, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``spdm-measurements`` subcommand.
+
+        :param cls: the owning command class, used to build the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--component", required=False, dest="component", type=str,
+            default=None,
+            help="ComponentIntegrity Id, TargetComponentURI, or full resource URI; "
+                 "omit to list SPDM measurement targets")
+        cmd_parser.add_argument(
+            "--measurement-index", action="append", dest="measurement_indices",
+            default=None,
+            help="measurement index 0..255; may be repeated or comma-separated")
+        cmd_parser.add_argument(
+            "--nonce", required=False, dest="nonce", type=str, default=None,
+            help="optional SPDM nonce to include in the signed-measurement request")
+        cmd_parser.add_argument(
+            "--slot-id", required=False, dest="slot_id", type=int, default=None,
+            help="optional SPDM slot id to include in the request payload")
+        cmd_parser.add_argument(
+            "--dry_run", action="store_true", dest="dry_run", default=False,
+            help="resolve the target and payload without POSTing")
+        return cmd_parser, "spdm-measurements", "command fetch SPDM signed measurements"
+
+    @staticmethod
+    def _members(data):
+        """Return the ``@odata.id`` strings from a Redfish collection.
+
+        :param data: a Redfish collection body (or any value; non-dicts yield []).
+        :return: list of member ``@odata.id`` strings.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [m["@odata.id"] for m in data.get("Members", [])
+                if isinstance(m, dict) and isinstance(m.get("@odata.id"), str)]
+
+    @staticmethod
+    def _action_target(data):
+        """Return the SPDMGetSignedMeasurements target from a resource body.
+
+        :param data: ComponentIntegrity resource body.
+        :return: action target URI, or None when the action is absent.
+        """
+        actions = data.get("Actions") if isinstance(data, dict) else None
+        action = actions.get(_SPDM_ACTION) if isinstance(actions, dict) else None
+        if not isinstance(action, dict):
+            return None
+        target = action.get("target")
+        return target if isinstance(target, str) and target else None
+
+    @staticmethod
+    def _action_info(data):
+        """Return the SPDM action-info link from a resource body.
+
+        :param data: ComponentIntegrity resource body.
+        :return: ActionInfo URI, or None when absent.
+        """
+        actions = data.get("Actions") if isinstance(data, dict) else None
+        action = actions.get(_SPDM_ACTION) if isinstance(actions, dict) else None
+        if not isinstance(action, dict):
+            return None
+        info = action.get("@Redfish.ActionInfo")
+        return info if isinstance(info, str) and info else None
+
+    @staticmethod
+    def _target_row(uri, data):
+        """Build a public target row from one SPDM-capable ComponentIntegrity leaf.
+
+        :param uri: ComponentIntegrity resource URI.
+        :param data: decoded ComponentIntegrity resource body.
+        :return: row describing the measurement target.
+        """
+        return {
+            "Id": data.get("Id") or uri.rsplit("/", 1)[-1],
+            "uri": uri,
+            "target": SpdmMeasurements._action_target(data),
+            "ActionInfo": SpdmMeasurements._action_info(data),
+            "TargetComponentURI": data.get("TargetComponentURI"),
+            "Type": data.get("ComponentIntegrityType"),
+            "Version": data.get("ComponentIntegrityTypeVersion"),
+            "Enabled": data.get("ComponentIntegrityEnabled"),
+        }
+
+    @staticmethod
+    def _parse_measurement_indices(values):
+        """Parse DMTF MeasurementIndices values.
+
+        :param values: repeated or comma-separated CLI values.
+        :return: list of integer measurement indices.
+        :raises InvalidArgument: when an index is not an integer in 0..255.
+        """
+        if not values:
+            return None
+        parsed = []
+        for value in values:
+            for part in str(value).split(","):
+                part = part.strip()
+                if not part:
+                    continue
+                try:
+                    index = int(part, 10)
+                except ValueError as exc:
+                    raise InvalidArgument(
+                        f"measurement index must be an integer: {part}") from exc
+                if index < 0 or index > 255:
+                    raise InvalidArgument(
+                        f"measurement index must be between 0 and 255: {index}")
+                parsed.append(index)
+        return parsed or None
+
+    def _get(self, uri, do_async, optional=False):
+        """GET a Redfish resource body.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async Redfish path when True.
+        :param optional: when True, a missing resource is treated as an empty dict.
+        :return: parsed response body, or {} for an optional missing resource.
+        :raises InvalidArgument: when a required read fails or returns non-object data.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except ResourceNotFound:
+            if optional:
+                return {}
+            raise InvalidArgument(f"resource not found: {uri}") from None
+        except Exception as exc:
+            raise InvalidArgument(f"failed to read {uri}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise InvalidArgument(f"unexpected response from {uri}: expected object")
+        return data
+
+    def _collection_members(self, collection_uri, do_async):
+        """Return collection member URIs, following Redfish pagination.
+
+        :param collection_uri: Redfish collection URI to start from.
+        :param do_async: issue the underlying queries on the async path when True.
+        :return: list of member resource URIs.
+        :raises InvalidArgument: when a pagination loop or page read failure occurs.
+        """
+        members = []
+        next_uri = collection_uri
+        seen = set()
+        while next_uri:
+            if next_uri in seen:
+                raise InvalidArgument(
+                    f"pagination loop while reading {collection_uri}: {next_uri}")
+            seen.add(next_uri)
+            page_uri = next_uri
+            page = self._get(next_uri, do_async)
+            members.extend(self._members(page))
+            next_uri = page.get("Members@odata.nextLink")
+            if next_uri is not None and not isinstance(next_uri, str):
+                raise InvalidArgument(
+                    f"invalid Members@odata.nextLink in {page_uri}: expected string")
+        return members
+
+    def _discover_targets(self, do_async):
+        """Discover SPDM signed-measurement targets.
+
+        :param do_async: issue the underlying queries on the async path when True.
+        :return: list of target rows ordered by collection discovery.
+        """
+        targets = []
+        for uri in self._collection_members(
+            f"{RedfishApi.Version}/ComponentIntegrity",
+            do_async,
+        ):
+            data = self._get(uri, do_async)
+            if not self._action_target(data):
+                continue
+            targets.append(self._target_row(uri, data))
+        return targets
+
+    @staticmethod
+    def _resolve_component(component, targets):
+        """Resolve a component selector to a ComponentIntegrity resource URI.
+
+        :param component: Id, ComponentIntegrity URI, TargetComponentURI, or action target.
+        :param targets: discovered SPDM target rows.
+        :return: ComponentIntegrity resource URI.
+        :raises InvalidArgument: when the component is unknown or ambiguous.
+        """
+        wanted = component.strip()
+        if wanted.startswith("/redfish/"):
+            matches = [
+                row for row in targets
+                if wanted in {row["uri"], row["target"], row.get("TargetComponentURI")}
+            ]
+        else:
+            folded = wanted.lower()
+            matches = [row for row in targets if str(row["Id"]).lower() == folded]
+        if not matches:
+            available = [row["Id"] for row in targets]
+            raise InvalidArgument(
+                f"no SPDM measurement target for '{component}'; available: {available}")
+        if len(matches) > 1:
+            uris = [row["uri"] for row in matches]
+            raise InvalidArgument(
+                f"SPDM measurement target '{component}' is ambiguous; pass a URI: {uris}")
+        return matches[0]["uri"]
+
+    @staticmethod
+    def _payload(measurement_indices, nonce, slot_id):
+        """Build a SPDMGetSignedMeasurements payload from optional arguments.
+
+        :param measurement_indices: parsed MeasurementIndices list, or None.
+        :param nonce: optional SPDM nonce.
+        :param slot_id: optional SPDM slot id.
+        :return: payload dict.
+        """
+        payload = {}
+        if measurement_indices is not None:
+            payload["MeasurementIndices"] = measurement_indices
+        if nonce:
+            payload["Nonce"] = nonce
+        if slot_id is not None:
+            payload["SlotId"] = slot_id
+        return payload
+
+    def execute(self,
+                component: Optional[str] = None,
+                measurement_indices: Optional[list[str]] = None,
+                nonce: Optional[str] = None,
+                slot_id: Optional[int] = None,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List SPDM targets, or fetch signed measurements from one target.
+
+        With no component selector, the command lists ComponentIntegrity leaves
+        that advertise ``#ComponentIntegrity.SPDMGetSignedMeasurements`` and does
+        not POST. With a selector, the command invokes the read-only action; use
+        ``--dry_run`` to show the resolved payload without POSTing.
+
+        :param component: Id, ComponentIntegrity URI, TargetComponentURI, or
+            action target to fetch measurements from; None lists available targets.
+        :param measurement_indices: optional repeated/comma-separated index values.
+        :param nonce: optional SPDM nonce.
+        :param slot_id: optional SPDM slot id.
+        :param dry_run: resolve the target and payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with target listing, dry-run preview, or POST outcome.
+        :raises InvalidArgument: when the component or measurement indices are invalid.
+        """
+        targets = self._discover_targets(do_async)
+        if component is None:
+            return CommandResult(
+                {"spdm_measurement_targets": targets}, None, None, None)
+        if not targets:
+            raise InvalidArgument(
+                "no SPDM measurement targets found on this Redfish endpoint")
+
+        target_uri = self._resolve_component(component, targets)
+        payload = self._payload(
+            self._parse_measurement_indices(measurement_indices),
+            nonce,
+            slot_id,
+        )
+        return self.invoke_action(
+            target_uri,
+            "SPDMGetSignedMeasurements",
+            payload=payload,
+            full_action_type=_SPDM_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -100,6 +100,7 @@ class ApiRequestType(Enum):
     MetricReports = auto()
     MetricReportDefinitions = auto()
     ComponentIntegrity = auto()
+    SpdmMeasurements = auto()
     NetworkAdapters = auto()
     NicFirmware = auto()
     NvLinkPorts = auto()

--- a/tests/test_spdm_measurements_dualmode.py
+++ b/tests/test_spdm_measurements_dualmode.py
@@ -1,0 +1,237 @@
+"""Dual-mode tests for SPDM signed measurements.
+
+The Supermicro GB300 corpus exposes ComponentIntegrity leaves with
+``#ComponentIntegrity.SPDMGetSignedMeasurements`` targets. These tests exercise
+the real mock transport and assert the command discovers those targets instead
+of hardcoding component ids.
+"""
+import json
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.component_integrity.cmd_spdm_measurements import SpdmMeasurements
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+_BMC_RESOURCE = "/redfish/v1/ComponentIntegrity/HGX_ERoT_BMC_0"
+_BMC_TARGET = (
+    "/redfish/v1/ComponentIntegrity/HGX_ERoT_BMC_0/Actions/"
+    "ComponentIntegrity.SPDMGetSignedMeasurements"
+)
+_NONCE = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+
+def _post_requests(redfish_service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in redfish_service.requests if request.method == "POST"]
+
+
+def _replace_post_response(service, status_code, body):
+    """Replace the mock POST handler with a fixed response."""
+    requests_mock = pytest.importorskip("requests_mock")
+
+    def post_cb(request, context):
+        service.requests.append(request)
+        context.status_code = status_code
+        return json.dumps(body)
+
+    service.mocker.post(requests_mock.ANY, text=post_cb)
+
+
+def test_spdm_measurements_lists_targets_without_post(redfish_mock_factory):
+    """No component argument lists SPDM-capable ComponentIntegrity resources."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.SpdmMeasurements,
+        "spdm-measurements",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    targets = result.data["spdm_measurement_targets"]
+    assert len(targets) == 14
+    bmc = next(row for row in targets if row["Id"] == "HGX_ERoT_BMC_0")
+    assert bmc["uri"] == _BMC_RESOURCE
+    assert bmc["target"] == _BMC_TARGET
+    assert bmc["TargetComponentURI"] == "/redfish/v1/Chassis/HGX_ERoT_BMC_0"
+    assert _post_requests(service) == []
+
+
+def test_spdm_measurements_follows_collection_pagination(redfish_mock_factory):
+    """Target discovery follows Members@odata.nextLink pages."""
+    manager, service = redfish_mock_factory("supermicro")
+    service._overlay["/redfish/v1/componentintegrity"] = {
+        "Members": [{"@odata.id": _BMC_RESOURCE}],
+        "Members@odata.nextLink": "/redfish/v1/ComponentIntegrity/Page2",
+    }
+    service._overlay["/redfish/v1/componentintegrity/page2"] = {
+        "Members": [
+            {"@odata.id": "/redfish/v1/ComponentIntegrity/HGX_ERoT_CPU_0"}
+        ],
+    }
+
+    result = manager.sync_invoke(
+        ApiRequestType.SpdmMeasurements,
+        "spdm-measurements",
+    )
+
+    assert result.error is None
+    assert [row["Id"] for row in result.data["spdm_measurement_targets"]] == [
+        "HGX_ERoT_BMC_0",
+        "HGX_ERoT_CPU_0",
+    ]
+    assert _post_requests(service) == []
+
+
+def test_spdm_measurements_reports_member_read_failure(redfish_mock_factory):
+    """A failed required member read reports the failing URI instead of hiding it."""
+    manager, service = redfish_mock_factory("supermicro")
+    service._overlay["/redfish/v1/componentintegrity"] = {
+        "Members": [{"@odata.id": "/redfish/v1/ComponentIntegrity/Missing"}],
+    }
+
+    with pytest.raises(InvalidArgument, match="resource not found"):
+        manager.sync_invoke(
+            ApiRequestType.SpdmMeasurements,
+            "spdm-measurements",
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_spdm_measurements_reports_missing_collection(redfish_mock_factory):
+    """A missing ComponentIntegrity collection reports the missing entry point."""
+    manager, service = redfish_mock_factory("supermicro")
+    service._overlay["/redfish/v1/componentintegrity"] = None
+
+    with pytest.raises(InvalidArgument, match="resource not found"):
+        manager.sync_invoke(
+            ApiRequestType.SpdmMeasurements,
+            "spdm-measurements",
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_spdm_measurements_dry_run_resolves_payload_without_post(
+    redfish_mock_factory,
+):
+    """--dry_run resolves the action and payload, but sends no POST."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.SpdmMeasurements,
+        "spdm-measurements",
+        component="HGX_ERoT_BMC_0",
+        measurement_indices=["0,1", "255"],
+        nonce=_NONCE,
+        slot_id=2,
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#ComponentIntegrity.SPDMGetSignedMeasurements"
+    assert result.data["level"] == "read_only"
+    assert result.data["target"] == _BMC_TARGET
+    assert result.data["payload"] == {
+        "MeasurementIndices": [0, 1, 255],
+        "Nonce": _NONCE,
+        "SlotId": 2,
+    }
+    assert _post_requests(service) == []
+
+
+def test_spdm_measurements_posts_read_only_action_by_default(
+    redfish_mock_factory,
+):
+    """SPDM signed measurements are READ_ONLY, so no confirm flag is required."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.SpdmMeasurements,
+        "spdm-measurements",
+        component=_BMC_RESOURCE,
+        measurement_indices=["255"],
+        nonce=_NONCE,
+    )
+
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "read_only"
+    assert result.data["target"] == _BMC_TARGET
+
+    posts = _post_requests(service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == _BMC_TARGET.lower()
+    assert posts[0].json() == {
+        "MeasurementIndices": [255],
+        "Nonce": _NONCE,
+    }
+
+
+def test_spdm_measurements_accepts_sync_200_action_response(
+    redfish_mock_factory,
+):
+    """A synchronous 200 action response is accepted as successful."""
+    manager, service = redfish_mock_factory("supermicro")
+    _replace_post_response(
+        service,
+        200,
+        {"SignedMeasurements": [{"MeasurementIndex": 0}]},
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.SpdmMeasurements,
+        "spdm-measurements",
+        component=_BMC_RESOURCE,
+    )
+
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#ComponentIntegrity.SPDMGetSignedMeasurements"
+    assert result.data["target"] == _BMC_TARGET
+    assert result.data["level"] == "read_only"
+
+    posts = _post_requests(service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == _BMC_TARGET.lower()
+
+
+def test_spdm_measurements_unknown_component_raises(redfish_mock_factory):
+    """Unknown component ids fail fast and do not POST."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument, match="no SPDM measurement target"):
+        manager.sync_invoke(
+            ApiRequestType.SpdmMeasurements,
+            "spdm-measurements",
+            component="missing-component",
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_spdm_measurements_rejects_invalid_measurement_index():
+    """Measurement index parsing enforces the DMTF 0..255 range."""
+    with pytest.raises(InvalidArgument, match="between 0 and 255"):
+        SpdmMeasurements._parse_measurement_indices(["0", "256"])
+
+
+def test_spdm_measurements_exposes_cli_entrypoint():
+    """The spdm-measurements command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.SpdmMeasurements]["spdm-measurements"] is (
+        SpdmMeasurements
+    )
+
+    cmd_parser, cmd_name, cmd_help = SpdmMeasurements.register_subcommand(
+        SpdmMeasurements
+    )
+
+    assert "--component" in cmd_parser.format_help()
+    assert cmd_name == "spdm-measurements"
+    assert "SPDM" in cmd_help


### PR DESCRIPTION
## Summary
- add `spdm-measurements` to discover SPDM-capable ComponentIntegrity resources and fetch signed measurements through the existing read-only action guard
- support target listing, component selection, dry-run payload previews, measurement indices, nonce, and slot id payload fields
- cover pagination, missing collection/member errors, dry-run, POST behavior, synchronous 200 responses, CLI registration, and docs command listing

## Tests
- GB300 gate slot 8: `1299 passed, 62 skipped, 6 warnings`
- changed-file Ruff passed
- docstring-gate OK
