### PR TITLE
Add BIOS reset ResetType payload support

### DIFF
--- a/redfish_ctl/bios/cmd_bios_reset_default.py
+++ b/redfish_ctl/bios/cmd_bios_reset_default.py
@@ -1,7 +1,8 @@
 """Reset BIOS settings to defaults through the Redfish BIOS resource's ResetBios action.
 
-    redfish_ctl bios-reset              # dry-run preview
-    redfish_ctl bios-reset --confirm    # POST the ResetBios action
+    redfish_ctl bios-reset                         # dry-run preview
+    redfish_ctl bios-reset --confirm               # POST the ResetBios action
+    redfish_ctl bios-reset --reset-type ResetAll   # preview with payload
 
 The command discovers the host ComputerSystem's ``Bios`` resource and invokes
 its own ``#Bios.ResetBios`` action. Resetting BIOS settings rewrites platform
@@ -54,6 +55,15 @@ class BiosResetDefault(RedfishManagerBase,
             default=False,
             help="resolve the target and show it without POSTing",
         )
+        cmd_parser.add_argument(
+            "--reset-type",
+            "--reset_type",
+            required=False,
+            dest="reset_type",
+            type=str,
+            default=None,
+            help="optional Redfish ResetType value to include in the action payload",
+        )
         return cmd_parser, "bios-reset", "command reset BIOS settings to defaults"
 
     def _bios_uri(self, do_async: bool) -> str:
@@ -81,6 +91,7 @@ class BiosResetDefault(RedfishManagerBase,
     def execute(self,
                 confirm: Optional[bool] = False,
                 dry_run: Optional[bool] = False,
+                reset_type: Optional[str] = None,
                 filename: Optional[str] = None,
                 data_type: Optional[str] = "json",
                 verbose: Optional[bool] = False,
@@ -90,16 +101,19 @@ class BiosResetDefault(RedfishManagerBase,
 
         :param confirm: authorize the DESTRUCTIVE ResetBios POST to run.
         :param dry_run: force a dry-run preview even when ``confirm`` is true.
+        :param reset_type: optional Redfish ``ResetType`` value to include in
+            the ResetBios payload for services that require one.
         :param filename: accepted for CLI compatibility; not used by this command.
         :param data_type: accepted for CLI compatibility; not used by this command.
         :param verbose: accepted for CLI compatibility; not used by this command.
         :param do_async: issue the underlying query and POST on the async path.
         :return: a CommandResult with a dry-run preview or POST result.
         """
+        payload = {"ResetType": reset_type} if reset_type else {}
         return self.invoke_action(
             self._bios_uri(bool(do_async)),
             "ResetBios",
-            payload={},
+            payload=payload,
             full_action_type=_RESET_BIOS_ACTION,
             do_async=do_async,
             dry_run=bool(dry_run),

--- a/tests/test_bios_reset_dualmode.py
+++ b/tests/test_bios_reset_dualmode.py
@@ -1,5 +1,7 @@
 """Dual-mode-style coverage for the guarded BIOS reset command."""
 
+import copy
+
 import pytest
 
 from redfish_ctl.bios.cmd_bios_reset_default import BiosResetDefault
@@ -55,6 +57,29 @@ def test_bios_reset_confirm_posts_to_dell_discovered_target(
         "/redfish/v1/systems/system.embedded.1/bios/settings/actions/bios.resetbios"
     )
     assert posts[0].json() == {}
+
+
+def test_bios_reset_confirm_posts_optional_reset_type(
+    redfish_mock,
+    redfish_service,
+) -> None:
+    """bios-reset includes ResetType only when requested."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BiosResetDefault,
+        "bios_reset",
+        confirm=True,
+        reset_type="ResetAll",
+    )
+
+    posts = _post_requests(redfish_service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/systems/system.embedded.1/bios/settings/actions/bios.resetbios"
+    )
+    assert posts[0].json() == {"ResetType": "ResetAll"}
 
 
 def test_bios_reset_confirm_dry_run_still_does_not_post(
@@ -135,3 +160,31 @@ def test_bios_reset_system_query_failure_is_not_hidden(monkeypatch) -> None:
 
     with pytest.raises(RuntimeError, match="system read failed"):
         command._bios_uri(do_async=False)
+
+
+def test_bios_reset_missing_action_reports_available_without_post(
+    redfish_mock_factory,
+) -> None:
+    """A BIOS resource without ResetBios returns an error and never POSTs."""
+    manager, service = redfish_mock_factory("supermicro")
+    bios_path = "/redfish/v1/Systems/System_0/Bios"
+    bios = copy.deepcopy(service._state(bios_path))
+    bios["Actions"].pop("#Bios.ResetBios")
+    service._overlay[bios_path] = bios
+    service._overlay[bios_path.lower()] = bios
+
+    result = manager.sync_invoke(
+        ApiRequestType.BiosResetDefault,
+        "bios_reset",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#Bios.ResetBios' not found on "
+        "/redfish/v1/Systems/System_0/Bios"
+    )
+    assert result.data["action"] == "#Bios.ResetBios"
+    assert "ResetBios" not in result.data["available"]
+    assert "#Bios.ResetBios" not in result.data["available"]
+    assert _post_requests(service) == []


### PR DESCRIPTION
## Summary
- add optional ResetType payload support to bios-reset via --reset-type/--reset_type
- keep the existing empty payload behavior when no reset type is supplied
- add regressions for payload POSTs and missing ResetBios action handling without sending a POST

## Tests
- Remote project gate: pytest 1290 passed, 62 skipped, 6 warnings
- changed-file Ruff passed
- docstring gate OK