### PR TITLE
Validate CSR certificate collection targets

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -109,7 +109,7 @@ Safety labels:
 | `capability-report` | Export registered vendor capability profiles for IaC and inventory tooling. | Read |
 | `certificates` | Read CertificateService and linked certificate inventory metadata without certificate bodies. | Read |
 | `change-boot-order` | Change boot order and boot options. | Write |
-| `cert-gen-csr` | Generate a CertificateService CSR through the `CertificateService.GenerateCSR` action; `--dry_run` previews without POSTing. | Write |
+| `cert-gen-csr` | Generate a CertificateService CSR through the `CertificateService.GenerateCSR` action; validates `--certificate-collection`; `--dry_run` previews without POSTing. | Write |
 | `chassis` | Read chassis services. | Read |
 | `chassis-reset` | Change chassis power state. | Write |
 | `component-integrity` | Read ComponentIntegrity/SPDM attestation resources. | Read |

--- a/redfish_ctl/security/cmd_certificate_generate_csr.py
+++ b/redfish_ctl/security/cmd_certificate_generate_csr.py
@@ -14,6 +14,7 @@ Author Mus spyroot@gmail.com
 from abc import abstractmethod
 from typing import Optional
 
+from ..cmd_exceptions import InvalidArgument, ResourceNotFound
 from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, Singleton
@@ -211,10 +212,90 @@ class CertificateGenerateCSR(RedfishManagerBase,
         return [item for item in items if item] or None
 
     @staticmethod
-    def _certificate_collection_link(uri):
-        """Build a Redfish link object from a certificate collection URI.
+    def _normalize_certificate_collection_uri(uri):
+        """Normalize and validate a CertificateCollection URI.
 
         :param uri: Redfish certificate collection URI, or None.
+        :return: stripped absolute Redfish URI, or None when absent.
+        :raises InvalidArgument: when the URI is not absolute under /redfish/v1.
+        """
+        if uri is None:
+            return None
+        normalized = str(uri).strip().rstrip("/")
+        if not normalized:
+            return None
+        if not normalized.startswith(f"{RedfishApi.Version}/"):
+            raise InvalidArgument(
+                "certificate collection URI must be an absolute Redfish URI "
+                f"under {RedfishApi.Version}/"
+            )
+        return normalized
+
+    @staticmethod
+    def _is_certificate_collection(data):
+        """Return whether a resource body is a certificate collection.
+
+        :param data: decoded Redfish resource.
+        :return: True when it looks like a CertificateCollection.
+        """
+        if not isinstance(data, dict):
+            return False
+        resource_type = data.get("@odata.type")
+        if isinstance(resource_type, str):
+            return resource_type.startswith("#CertificateCollection.")
+        resource_uri = data.get("@odata.id")
+        return (
+            isinstance(data.get("Members"), list)
+            and isinstance(resource_uri, str)
+            and resource_uri.rstrip("/").endswith("/Certificates")
+        )
+
+    def _validate_certificate_collection(self, uri, do_async):
+        """Validate that an optional certificate collection URI exists.
+
+        :param uri: optional CertificateCollection URI from the CLI.
+        :param do_async: issue the validation read over the async path when True.
+        :return: tuple of (normalized URI or None, CommandResult error or None).
+        """
+        normalized = self._normalize_certificate_collection_uri(uri)
+        if normalized is None:
+            return None, None
+        try:
+            data = self.base_query(normalized, do_async=do_async).data or {}
+        except ResourceNotFound:
+            return normalized, CommandResult(
+                {"CertificateCollection": {"@odata.id": normalized}},
+                None,
+                None,
+                f"certificate collection not found: {normalized}",
+            )
+        except Exception as exc:
+            return normalized, CommandResult(
+                {"CertificateCollection": {"@odata.id": normalized}},
+                None,
+                None,
+                f"failed to read certificate collection {normalized}: {exc}",
+            )
+        if not self._is_certificate_collection(data):
+            return normalized, CommandResult(
+                {
+                    "CertificateCollection": {"@odata.id": normalized},
+                    "resource_type": data.get("@odata.type")
+                    if isinstance(data, dict)
+                    else None,
+                },
+                None,
+                None,
+                "certificate collection URI is not a CertificateCollection: "
+                f"{normalized}",
+            )
+        return normalized, None
+
+    @staticmethod
+    def _certificate_collection_link(uri):
+        """Build a Redfish link object from a validated collection URI.
+
+        :param uri: normalized Redfish certificate collection URI, or None.
         :return: ``{"@odata.id": uri}`` when set, otherwise None.
         """
         if not uri:
@@ -353,6 +434,13 @@ class CertificateGenerateCSR(RedfishManagerBase,
         :param do_async: issue the underlying query and POST on the async path.
         :return: a CommandResult with the GenerateCSR result or dry-run preview.
         """
+        collection_uri, collection_error = self._validate_certificate_collection(
+            certificate_collection,
+            do_async,
+        )
+        if collection_error is not None:
+            return collection_error
+
         return self.invoke_action(
             self._certificate_service_uri(do_async),
             "GenerateCSR",
@@ -374,7 +462,7 @@ class CertificateGenerateCSR(RedfishManagerBase,
                 key_curve_id=key_curve_id,
                 key_usage=key_usage,
                 alternative_names=alternative_names,
-                certificate_collection=certificate_collection,
+                certificate_collection=collection_uri,
             ),
             full_action_type=_GENERATE_CSR_ACTION,
             do_async=do_async,

--- a/tests/test_cert_generate_csr_dualmode.py
+++ b/tests/test_cert_generate_csr_dualmode.py
@@ -1,5 +1,8 @@
 """Dual-mode tests for the CertificateService.GenerateCSR command."""
 
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
 from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_shared import ApiRequestType
 
@@ -33,9 +36,7 @@ def test_cert_gen_csr_posts_payload_to_generic_certificate_service(
         key_curve_id="TPM_ECC_NIST_P256",
         key_usage=["DigitalSignature", "KeyEncipherment"],
         alternative_names=["bmc-alt.example.test,192.0.2.10"],
-        certificate_collection=(
-            "/redfish/v1/Managers/BMC/NetworkProtocol/HTTPS/Certificates"
-        ),
+        certificate_collection="/redfish/v1/Systems/437XR1138R2/Certificates",
         contact_person="Ops Team",
         email="ops@example.test",
         given_name="Platform",
@@ -58,7 +59,7 @@ def test_cert_gen_csr_posts_payload_to_generic_certificate_service(
     )
     assert posts[0].json() == {
         "CertificateCollection": {
-            "@odata.id": "/redfish/v1/Managers/BMC/NetworkProtocol/HTTPS/Certificates"
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Certificates"
         },
         "City": "San Francisco",
         "CommonName": "bmc.example.test",
@@ -200,4 +201,78 @@ def test_cert_gen_csr_rejects_invalid_hpe_key_usage_without_post(
             ],
         }
     ]
+    assert _post_requests(service) == []
+
+
+def test_cert_gen_csr_missing_certificate_collection_stops_before_post(
+    redfish_mock_factory,
+):
+    """A missing CertificateCollection URI returns an error without POSTing."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.CertificateGenerateCSR,
+        "cert_gen_csr",
+        common_name="bmc.example.test",
+        certificate_collection="/redfish/v1/Systems/437XR1138R2/Certificates/Missing",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "certificate collection not found: "
+        "/redfish/v1/Systems/437XR1138R2/Certificates/Missing"
+    )
+    assert result.data == {
+        "CertificateCollection": {
+            "@odata.id": "/redfish/v1/Systems/437XR1138R2/Certificates/Missing"
+        }
+    }
+    assert _post_requests(service) == []
+
+
+def test_cert_gen_csr_rejects_certificate_member_uri_without_post(
+    redfish_mock_factory,
+):
+    """A Certificate member URI is not accepted as a collection target."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.CertificateGenerateCSR,
+        "cert_gen_csr",
+        common_name="bmc.example.test",
+        certificate_collection=(
+            "/redfish/v1/Systems/437XR1138R2/Certificates/contoso-root"
+        ),
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "certificate collection URI is not a CertificateCollection: "
+        "/redfish/v1/Systems/437XR1138R2/Certificates/contoso-root"
+    )
+    assert result.data == {
+        "CertificateCollection": {
+            "@odata.id": (
+                "/redfish/v1/Systems/437XR1138R2/Certificates/contoso-root"
+            )
+        },
+        "resource_type": "#Certificate.v1_8_1.Certificate",
+    }
+    assert _post_requests(service) == []
+
+
+def test_cert_gen_csr_rejects_relative_certificate_collection_uri(
+    redfish_mock_factory,
+):
+    """CertificateCollection links must be absolute Redfish resource URIs."""
+    manager, service = redfish_mock_factory("generic")
+
+    with pytest.raises(InvalidArgument, match="absolute Redfish URI"):
+        manager.sync_invoke(
+            ApiRequestType.CertificateGenerateCSR,
+            "cert_gen_csr",
+            common_name="bmc.example.test",
+            certificate_collection="Systems/437XR1138R2/Certificates",
+        )
+
     assert _post_requests(service) == []


### PR DESCRIPTION
## Summary
- validate optional CSR CertificateCollection URIs before building the GenerateCSR payload
- stop before POST when the collection is missing or points at a certificate member
- update CSR tests and command reference for the validated option

## Validation
- pytest -q: 1291 passed, 62 skipped, 6 warnings
- ruff check changed Python files: passed
- python tools/docstring_gate.py --all: passed