### PR TITLE
Add HPE iLO test-action command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,6 +132,7 @@ Safety labels:
 | `get` | Read an arbitrary Redfish resource URI. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
+| `hpe-test-actions` | List or send HPE iLO directory, SNMP, mail, and syslog test actions; dry-run by default and `--confirm` posts. | Guarded |
 | `identify-led` | Read or set a chassis/system identify LED; requires `--confirm` to write. | Guarded |
 | `insert_vm` | Insert virtual media from a URI. | Write |
 | `job` | Read one Dell job. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -117,6 +117,7 @@ from .firmware.cmd_firmware_update import *
 from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
+from .oem.cmd_hpe_test_actions import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -45,6 +45,11 @@ ACTION_POLICY = {
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,
+    "#HpeDirectoryTest.StartTest": Destructiveness.REVERSIBLE,
+    "#HpeDirectoryTest.StopTest": Destructiveness.REVERSIBLE,
+    "#HpeiLOSnmpService.SendSNMPTestAlert": Destructiveness.REVERSIBLE,
+    "#HpeiLOManagerNetworkService.SendTestAlertMail": Destructiveness.REVERSIBLE,
+    "#HpeiLOManagerNetworkService.SendTestSyslog": Destructiveness.REVERSIBLE,
     "#VirtualMedia.InsertMedia": Destructiveness.REVERSIBLE,
     "#VirtualMedia.EjectMedia": Destructiveness.REVERSIBLE,
     "#CertificateService.GenerateCSR": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/oem/cmd_hpe_test_actions.py
+++ b/redfish_ctl/oem/cmd_hpe_test_actions.py
@@ -1,0 +1,334 @@
+"""Preview or fire HPE iLO diagnostic/test Redfish actions.
+
+    redfish_ctl hpe-test-actions
+    redfish_ctl hpe-test-actions --action snmp-alert
+    redfish_ctl hpe-test-actions --action syslog-alert --confirm
+
+The command discovers HPE OEM test-action targets from the live Redfish tree and
+dry-runs by default, because these actions can send test SNMP, mail, syslog, or
+directory-auth traffic outside the BMC. Use ``--confirm`` to send one selected
+test action. No target URL is hardcoded.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+
+@dataclass(frozen=True)
+class _HpeTestActionSpec:
+    """Static selector metadata for one HPE test action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+    resource_kind: str
+
+
+_ACTION_SPECS = {
+    "directory-start": _HpeTestActionSpec(
+        selector="directory-start",
+        full_type="#HpeDirectoryTest.StartTest",
+        action_name="StartTest",
+        description="start the configured directory authentication test",
+        resource_kind="directory-test",
+    ),
+    "directory-stop": _HpeTestActionSpec(
+        selector="directory-stop",
+        full_type="#HpeDirectoryTest.StopTest",
+        action_name="StopTest",
+        description="stop the configured directory authentication test",
+        resource_kind="directory-test",
+    ),
+    "snmp-alert": _HpeTestActionSpec(
+        selector="snmp-alert",
+        full_type="#HpeiLOSnmpService.SendSNMPTestAlert",
+        action_name="SendSNMPTestAlert",
+        description="send an SNMP test alert through the configured SNMP service",
+        resource_kind="snmp-service",
+    ),
+    "mail-alert": _HpeTestActionSpec(
+        selector="mail-alert",
+        full_type="#HpeiLOManagerNetworkService.SendTestAlertMail",
+        action_name="SendTestAlertMail",
+        description="send a test alert-mail message through ManagerNetworkProtocol",
+        resource_kind="manager-network",
+    ),
+    "syslog-alert": _HpeTestActionSpec(
+        selector="syslog-alert",
+        full_type="#HpeiLOManagerNetworkService.SendTestSyslog",
+        action_name="SendTestSyslog",
+        description="send a test syslog message through ManagerNetworkProtocol",
+        resource_kind="manager-network",
+    ),
+}
+
+
+class HpeTestActions(RedfishManagerBase,
+                     scm_type=ApiRequestType.HpeTestActions,
+                     name="hpe-test-actions",
+                     metaclass=Singleton):
+    """Discover and invoke HPE iLO diagnostic/test actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the hpe-test-actions command."""
+        super(HpeTestActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``hpe-test-actions`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="HPE test action to preview or send; omit to list available targets",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific resource URI when more than one target advertises the action",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="send the selected test action instead of dry-running it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return cmd_parser, "hpe-test-actions", "command run HPE iLO test actions"
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _hpe(data):
+        """Return the ``Oem.Hpe`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: HPE OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        hpe = oem.get("Hpe") if isinstance(oem, dict) else None
+        return hpe if isinstance(hpe, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _account_service_uri(self, do_async):
+        """Resolve AccountService, with the standard path as fallback.
+
+        :param do_async: run the service-root query asynchronously when True.
+        :return: AccountService URI.
+        """
+        root = self._get(RedfishApi.Version, do_async)
+        return self._link(root, "AccountService") or f"{RedfishApi.Version}/AccountService"
+
+    def _directory_test_uris(self, do_async):
+        """Return HPE DirectoryTest resource URIs.
+
+        :param do_async: run the AccountService query asynchronously when True.
+        :return: list of directory-test resource URIs.
+        """
+        account_uri = self._account_service_uri(do_async)
+        account = self._get(account_uri, do_async)
+        hpe = self._hpe(account)
+        directory_settings = hpe.get("DirectorySettings")
+        directory_uri = self._link(hpe, "DirectoryTest")
+        if not directory_uri and isinstance(directory_settings, dict):
+            directory_uri = self._link(directory_settings, "DirectoryTest")
+        if not directory_uri:
+            directory_uri = f"{account_uri.rstrip('/')}/DirectoryTest"
+        return [directory_uri]
+
+    def _network_protocol_uris(self, do_async):
+        """Return ManagerNetworkProtocol resource URIs for every manager.
+
+        :param do_async: run manager queries asynchronously when True.
+        :return: list of ManagerNetworkProtocol URIs.
+        """
+        uris = []
+        for manager_uri in self.discover_manager_ids() or []:
+            manager = self._get(manager_uri, do_async)
+            network_uri = self._link(manager, "NetworkProtocol")
+            if network_uri:
+                uris.append(network_uri)
+        return uris
+
+    def _snmp_service_uris(self, do_async):
+        """Return HPE SNMP service URIs from ManagerNetworkProtocol links.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of SNMP service URIs.
+        """
+        uris = []
+        for network_uri in self._network_protocol_uris(do_async):
+            network = self._get(network_uri, do_async)
+            hpe = self._hpe(network)
+            links = hpe.get("Links") if isinstance(hpe, dict) else None
+            snmp_uri = self._link(links or {}, "SNMPService")
+            if not snmp_uri:
+                manager_uri = network_uri.rsplit("/NetworkProtocol", 1)[0]
+                snmp_uri = f"{manager_uri}/SnmpService"
+            uris.append(snmp_uri)
+        return uris
+
+    def _resource_uris_for(self, spec, do_async):
+        """Return candidate resource URIs for an HPE test-action selector.
+
+        :param spec: HPE test-action selector metadata.
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of candidate resource URIs.
+        """
+        if spec.resource_kind == "directory-test":
+            return self._directory_test_uris(do_async)
+        if spec.resource_kind == "snmp-service":
+            return self._snmp_service_uris(do_async)
+        if spec.resource_kind == "manager-network":
+            return self._network_protocol_uris(do_async)
+        return []
+
+    def _target_for(self, resource_uri, spec, do_async):
+        """Return the advertised target URI for a test action on a resource.
+
+        :param resource_uri: candidate resource URI.
+        :param spec: HPE test-action selector metadata.
+        :param do_async: run the resource query asynchronously when True.
+        :return: action target URI, or None when the resource lacks that action.
+        """
+        resource = self._get(resource_uri, do_async)
+        targets = self._flatten_action_targets(resource)
+        return targets.get(spec.full_type)
+
+    def _discover_rows(self, do_async):
+        """Discover available HPE test actions from linked resources.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of available test-action rows.
+        """
+        rows = []
+        for spec in _ACTION_SPECS.values():
+            for resource_uri in self._resource_uris_for(spec, do_async):
+                target = self._target_for(resource_uri, spec, do_async)
+                if target:
+                    rows.append({
+                        "Action": spec.selector,
+                        "FullType": spec.full_type,
+                        "Resource": resource_uri,
+                        "Target": target,
+                        "Description": spec.description,
+                    })
+        return rows
+
+    @staticmethod
+    def _matches(rows, action, resource_uri):
+        """Filter discovered rows by action selector and optional resource URI.
+
+        :param rows: discovered HPE test-action rows.
+        :param action: selected action name.
+        :param resource_uri: optional resource URI selector.
+        :return: matching rows.
+        """
+        matches = [row for row in rows if row["Action"] == action]
+        if resource_uri:
+            normalized = resource_uri.rstrip("/")
+            matches = [
+                row for row in matches
+                if row["Resource"].rstrip("/") == normalized
+            ]
+        return matches
+
+    def execute(self,
+                action: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or send HPE iLO diagnostic/test actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param resource_uri: optional resource URI to disambiguate multiple targets.
+        :param confirm: send the selected test action when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if action is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = self._matches(rows, action, resource_uri)
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"HPE test action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                "multiple HPE test-action targets found; pass --resource-uri",
+            )
+
+        row = matches[0]
+        spec = _ACTION_SPECS[action]
+        result = self.invoke_action(
+            row["Resource"],
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        if not confirm and isinstance(result.data, dict):
+            result.data["requires_confirm"] = True
+            result.data["blocked"] = "HPE test action requires --confirm"
+        return result

--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -1664,6 +1664,17 @@ class RedfishManagerBase(RedfishManager):
                         out[ok] = ov["target"]
             elif isinstance(val, dict) and val.get("target"):
                 out[key] = val["target"]
+        oem = (resource or {}).get("Oem") or {}
+        if isinstance(oem, dict):
+            for vendor_ext in oem.values():
+                vendor_actions = (
+                    vendor_ext.get("Actions") if isinstance(vendor_ext, dict) else None
+                )
+                if not isinstance(vendor_actions, dict):
+                    continue
+                for key, val in vendor_actions.items():
+                    if isinstance(val, dict) and val.get("target"):
+                        out[key] = val["target"]
         return out
 
     @staticmethod

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -106,6 +106,7 @@ class ApiRequestType(Enum):
     Exporter = auto()
     ActionList = auto()
     EventSubmitTest = auto()
+    HpeTestActions = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()
     SubscriptionDelete = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -19,6 +19,15 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComputerSystem.Reset") is Destructiveness.DESTRUCTIVE
     assert classify("#Drive.SecureErase") is Destructiveness.IRREVERSIBLE
     assert classify("#EventService.SubmitTestEvent") is Destructiveness.REVERSIBLE
+    hpe_reversible_actions = (
+        "#HpeDirectoryTest.StartTest",
+        "#HpeDirectoryTest.StopTest",
+        "#HpeiLOSnmpService.SendSNMPTestAlert",
+        "#HpeiLOManagerNetworkService.SendTestAlertMail",
+        "#HpeiLOManagerNetworkService.SendTestSyslog",
+    )
+    for action in hpe_reversible_actions:
+        assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE

--- a/tests/test_hpe_test_actions_dualmode.py
+++ b/tests/test_hpe_test_actions_dualmode.py
@@ -1,0 +1,164 @@
+"""Dual-mode tests for HPE iLO diagnostic/test actions."""
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.oem.cmd_hpe_test_actions import HpeTestActions
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HPE_CORPUS = corpus_dir(REPO_ROOT / "tests" / "hpe_dl360_corpus.tar.gz", "10.43.3.209")
+
+
+@pytest.fixture
+def hpe_corpus_mock():
+    """Return a manager and mock service backed by the full HPE DL360 corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-hpe-dl360",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_hpe_test_actions_list_corpus_targets_without_post(hpe_corpus_mock):
+    """Listing discovers HPE DirectoryTest, SNMP, mail, and syslog actions."""
+    manager, service = hpe_corpus_mock
+
+    result = manager.sync_invoke(ApiRequestType.HpeTestActions, "hpe-test-actions")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    actions = {row["Action"]: row for row in result.data}
+    assert set(actions) == {
+        "directory-start",
+        "directory-stop",
+        "snmp-alert",
+        "mail-alert",
+        "syslog-alert",
+    }
+    assert actions["directory-start"]["Resource"] == (
+        "/redfish/v1/AccountService/DirectoryTest"
+    )
+    assert actions["snmp-alert"]["Target"] == (
+        "/redfish/v1/Managers/1/SnmpService/Actions/"
+        "HpeiLOSnmpService.SendSNMPTestAlert"
+    )
+    assert actions["mail-alert"]["Target"] == (
+        "/redfish/v1/Managers/1/NetworkProtocol/Actions/Oem/Hpe/"
+        "HpeiLOManagerNetworkService.SendTestAlertMail"
+    )
+    assert actions["syslog-alert"]["Target"] == (
+        "/redfish/v1/Managers/1/NetworkProtocol/Actions/Oem/Hpe/"
+        "HpeiLOManagerNetworkService.SendTestSyslog"
+    )
+    assert _post_requests(service) == []
+
+
+def test_hpe_test_action_dry_runs_by_default(hpe_corpus_mock):
+    """A selected HPE test action resolves the target but does not POST by default."""
+    manager, service = hpe_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeTestActions,
+        "hpe-test-actions",
+        action="snmp-alert",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["requires_confirm"] is True
+    assert result.data["blocked"] == "HPE test action requires --confirm"
+    assert result.data["level"] == "reversible"
+    assert result.data["payload"] == {}
+    assert result.data["target"] == (
+        "/redfish/v1/Managers/1/SnmpService/Actions/"
+        "HpeiLOSnmpService.SendSNMPTestAlert"
+    )
+    assert _post_requests(service) == []
+
+
+def test_hpe_test_action_confirm_posts_selected_target(hpe_corpus_mock):
+    """--confirm posts exactly one selected HPE test action."""
+    manager, service = hpe_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeTestActions,
+        "hpe-test-actions",
+        action="syslog-alert",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "reversible"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/managers/1/networkprotocol/actions/oem/hpe/"
+        "hpeilomanagernetworkservice.sendtestsyslog"
+    )
+    assert posts[0].json() == {}
+
+
+def test_hpe_test_action_missing_target_reports_without_post(redfish_mock_factory):
+    """A fixture without HPE test-action resources reports an error and no POST."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeTestActions,
+        "hpe-test-actions",
+        action="snmp-alert",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "HPE test action not found: snmp-alert"
+    assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_hpe_test_actions_exposes_cli_entrypoint():
+    """The hpe-test-actions command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.HpeTestActions]["hpe-test-actions"] is (
+        HpeTestActions
+    )
+
+    cmd_parser, cmd_name, cmd_help = HpeTestActions.register_subcommand(
+        HpeTestActions
+    )
+
+    assert "--action" in cmd_parser.format_help()
+    assert cmd_name == "hpe-test-actions"
+    assert "HPE" in cmd_help


### PR DESCRIPTION
Summary:
- Add hpe-test-actions to list HPE iLO DirectoryTest, SNMP, mail, and syslog test-action targets.
- Keep the command dry-run by default and require --confirm before any POST.
- Teach action discovery to read nested Oem.<Vendor>.Actions targets and cover the path with HPE corpus-backed tests.

Tests:
- Project gate passed: pytest -q (1294 passed, 62 skipped), changed-file Ruff, and docstring gate.