### PR TITLE
Handle X10 one-shot boot payloads

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -307,6 +307,11 @@ redfish_ctl get_vm
 redfish_ctl boot-one-shot --device Cd --dry_run
 ```
 
+On older Supermicro X10 Redfish endpoints, `boot-one-shot` maps `Cd` to the
+advertised `CD/DVD` target and uses that generation's top-level boot override
+fields. Optional power-on or `-r` follow-up failures are returned as command
+errors instead of being hidden.
+
 After approval for live media and next-boot changes:
 
 ```bash

--- a/redfish_ctl/boot_source/cmd_boot_one_shot.py
+++ b/redfish_ctl/boot_source/cmd_boot_one_shot.py
@@ -17,10 +17,42 @@ Author Mus spyroot@gmail.com
 from abc import abstractmethod
 from typing import Optional
 
-from ..cmd_exceptions import InvalidArgument
-from ..redfish_manager_base import RedfishManagerBase
-from ..redfish_manager_shared import ApiRequestType, BootSourceOverrideMode, RedfishApiRespond, Singleton
+import requests
+
+from ..cmd_exceptions import (
+    FailedDiscoverAction,
+    InvalidArgument,
+    UnexpectedResponse,
+    UnsupportedAction,
+)
+from ..redfish_exceptions import RedfishException
 from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import (
+    ApiRequestType,
+    BootSourceOverrideMode,
+    RedfishApiRespond,
+    Singleton,
+)
+
+_BOOT_TARGET_ALIASES = {
+    "Cd": ("Cd", "CD/DVD", "UsbCd", "UefiCd", "UefiUsbCd"),
+}
+_LEGACY_FLAT_BOOT_TARGETS = {
+    "CD/DVD",
+    "FloppyRemovableMedia",
+    "UsbKey",
+    "UsbHdd",
+    "UsbFloppy",
+}
+_RESET_ERRORS = (
+    FailedDiscoverAction,
+    InvalidArgument,
+    RedfishException,
+    requests.exceptions.RequestException,
+    UnexpectedResponse,
+    UnsupportedAction,
+)
 
 
 class BootOneShot(RedfishManagerBase,
@@ -34,6 +66,112 @@ class BootOneShot(RedfishManagerBase,
     def __init__(self, *args, **kwargs):
         """Initialize the boot-one-shot command."""
         super(BootOneShot, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def _resolve_boot_device(device: str, boot_devices: list[str]) -> str:
+        """Resolve a requested boot target against live-advertised values.
+
+        :param device: requested BootSourceOverrideTarget value.
+        :param boot_devices: values advertised by the ComputerSystem Boot object.
+        :return: the target value to send to the BMC.
+        :raises InvalidArgument: when the target is unsupported.
+        """
+        if device in boot_devices:
+            return device
+        for candidate in _BOOT_TARGET_ALIASES.get(device, ()):
+            if candidate in boot_devices:
+                return candidate
+        raise InvalidArgument(
+            f"Invalid boot device {device}, "
+            f"supported device {boot_devices}"
+        )
+
+    @staticmethod
+    def _computer_system_version_at_most(
+        system: Optional[dict],
+        major: int,
+        minor: int,
+    ) -> bool:
+        """Return whether a ComputerSystem @odata.type is at or below a version.
+
+        :param system: full ComputerSystem resource body.
+        :param major: maximum Redfish ComputerSystem major version.
+        :param minor: maximum Redfish ComputerSystem minor version.
+        :return: True when ``system`` declares a version at or below the limit.
+        """
+        if not isinstance(system, dict):
+            return False
+        type_name = str(system.get("@odata.type", ""))
+        marker = "#ComputerSystem.v"
+        if marker not in type_name:
+            return False
+        version = type_name.split(marker, 1)[1].split(".", 1)[0]
+        parts = version.split("_")
+        if len(parts) < 2:
+            return False
+        try:
+            parsed = (int(parts[0]), int(parts[1]))
+        except ValueError:
+            return False
+        return parsed <= (major, minor)
+
+    @staticmethod
+    def _use_legacy_flat_payload(
+        boot_devices: list[str],
+        system: Optional[dict],
+    ) -> bool:
+        """Return whether the endpoint expects top-level Boot fields.
+
+        Older Supermicro X10 Redfish 1.0.1 systems advertise legacy-only boot
+        target names such as ``CD/DVD`` and reject the newer nested
+        ``{"Boot": ...}`` PATCH shape. Standard UEFI target names alone are not
+        enough to identify this older shape.
+
+        :param boot_devices: values advertised by the ComputerSystem Boot object.
+        :param system: full ComputerSystem resource body.
+        :return: True when the flat legacy PATCH shape should be used.
+        """
+        if not bool(set(boot_devices) & _LEGACY_FLAT_BOOT_TARGETS):
+            return False
+        if not isinstance(system, dict):
+            return False
+        manufacturer = str(system.get("Manufacturer", "")).lower()
+        if "supermicro" not in manufacturer:
+            return False
+        return BootOneShot._computer_system_version_at_most(system, 1, 3)
+
+    @staticmethod
+    def _boot_payload(
+        device: str,
+        mode: Optional[str],
+        uefi_target: Optional[str],
+        boot_devices: list[str],
+        system: Optional[dict],
+    ) -> dict:
+        """Build the one-shot boot PATCH payload for the endpoint generation.
+
+        :param device: resolved BootSourceOverrideTarget value.
+        :param mode: optional BootSourceOverrideMode value.
+        :param uefi_target: optional UefiTargetBootSourceOverride value.
+        :param boot_devices: live-advertised target values.
+        :param system: full ComputerSystem resource body.
+        :return: PATCH payload accepted by the endpoint generation.
+        """
+        override_enabled = "Disabled" if device == "None" else "Once"
+        boot = {
+            "BootSourceOverrideEnabled": override_enabled,
+            "BootSourceOverrideTarget": device,
+            "BootSourceOverrideMode": mode,
+            "UefiTargetBootSourceOverride": uefi_target
+        }
+        for key, value in dict(boot).items():
+            if value is None:
+                del boot[key]
+        if BootOneShot._use_legacy_flat_payload(boot_devices, system):
+            boot.pop("BootSourceOverrideMode", None)
+            boot.pop("UefiTargetBootSourceOverride", None)
+            return boot
+        return {"Boot": boot}
 
     @staticmethod
     @abstractmethod
@@ -121,19 +259,18 @@ class BootOneShot(RedfishManagerBase,
         if data_type == "json":
             headers.update(self.json_content_type)
 
-        # query for a power state
-        current_boot = self.sync_invoke(
-            ApiRequestType.CurrentBoot,
-            "current_boot_query"
+        system_result = self.base_query(
+            self.idrac_manage_servers,
+            data_type=data_type,
+            do_async=do_async,
+            verbose=verbose,
         )
-        boot_device = current_boot.data[
+        system = system_result.data if isinstance(system_result.data, dict) else {}
+        boot = system.get("Boot", system)
+        boot_device = boot[
             'BootSourceOverrideTarget@Redfish.AllowableValues'
         ]
-        if device not in boot_device:
-            raise InvalidArgument(
-                f"Invalid boot device {device}, "
-                f"supported device {boot_device}"
-            )
+        device = self._resolve_boot_device(device, boot_device)
 
         # validate the requested boot mode (UEFI vs Legacy) before mutating
         valid_modes = [m.value for m in BootSourceOverrideMode]
@@ -162,24 +299,13 @@ class BootOneShot(RedfishManagerBase,
             uefi_target if uefi_target is not None else "(none)",
         )
 
-        # One-time boot must ARM the override, not just name a target: Redfish
-        # ignores BootSourceOverrideTarget unless BootSourceOverrideEnabled is set.
-        # "None" clears the override (Disabled); any real device arms it once.
-        override_enabled = "Disabled" if device == "None" else "Once"
-
-        payload = {
-            "Boot": {
-                "BootSourceOverrideEnabled": override_enabled,
-                "BootSourceOverrideTarget": device,
-                "BootSourceOverrideMode": mode,
-                "UefiTargetBootSourceOverride": uefi_target
-            }
-        }
-
-        # r = f"{self._default_method}{self.idrac_ip}/{self.idrac_manage_servers}"
-        for key, value in dict(payload['Boot']).items():
-            if value is None:
-                del payload['Boot'][key]
+        payload = self._boot_payload(
+            device,
+            mode,
+            uefi_target,
+            boot_device,
+            system,
+        )
 
         if dry_run or not confirm:
             return CommandResult(
@@ -196,10 +322,20 @@ class BootOneShot(RedfishManagerBase,
 
         # power on first if a client requested and this is a confirmed write.
         if do_power_on:
-            self.sync_invoke(
-                ApiRequestType.ChassisReset, "reboot",
-                reset_type="On"
-            )
+            try:
+                power_result = self.sync_invoke(
+                    ApiRequestType.ChassisReset, "reboot",
+                    reset_type="On"
+                )
+            except _RESET_ERRORS as exc:
+                return CommandResult(
+                    {"target": self.idrac_manage_servers, "payload": payload},
+                    None,
+                    None,
+                    f"power-on pre-step failed: {exc}",
+                )
+            if power_result.error is not None:
+                return power_result
 
         cmd_result, api_resp = self.base_patch(
             self.idrac_manage_servers, payload=payload,
@@ -213,7 +349,26 @@ class BootOneShot(RedfishManagerBase,
             cmd_result.data['task_state'] = task_state
 
         if do_reboot:
-            reboot_result = self.reboot(do_watch=True)
+            try:
+                reboot_result = self.reboot(do_watch=True)
+            except _RESET_ERRORS as exc:
+                data = cmd_result.data if isinstance(cmd_result.data, dict) else {}
+                data["reboot_error"] = str(exc)
+                return CommandResult(
+                    data,
+                    cmd_result.discovered,
+                    cmd_result.extra,
+                    f"reboot post-step failed: {exc}",
+                )
+            if reboot_result.error is not None:
+                data = cmd_result.data if isinstance(cmd_result.data, dict) else {}
+                data["reboot"] = reboot_result.data
+                return CommandResult(
+                    data,
+                    cmd_result.discovered,
+                    cmd_result.extra,
+                    reboot_result.error,
+                )
             cmd_result.data["reboot"] = reboot_result.data
 
         return cmd_result

--- a/tests/test_cmd_boot_dualmode.py
+++ b/tests/test_cmd_boot_dualmode.py
@@ -7,14 +7,16 @@ through sync_invoke and assert the CommandResult shape.
 
 Author Mus spyroot@gmail.com
 """
+import copy
 import json
 
 import pytest
 
+from redfish_ctl.boot_source.cmd_boot_one_shot import BootOneShot
 from redfish_ctl.cmd_exceptions import InvalidArgument
 from redfish_ctl.compute.cmd_power_state import RebootHost
-from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
 
 
 def test_boot_query(redfish_api):
@@ -265,6 +267,207 @@ def test_boot_one_shot_rejects_invalid_target_before_patch_in_mock_mode(
         )
 
     assert all(request.method != "PATCH" for request in redfish_service.requests)
+
+
+def test_boot_one_shot_maps_cd_to_x10_advertised_target(redfish_mock_factory):
+    """boot_one_shot maps generic Cd to X10 CD/DVD and sends a flat payload."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="Cd",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["Status"] == "ok"
+    request = service.last_request
+    assert request.method == "PATCH"
+    assert request.path.lower() == "/redfish/v1/systems/1"
+    assert request.json() == {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "CD/DVD",
+    }
+
+
+def test_boot_one_shot_x10_uefi_cd_uses_flat_payload_without_mode(
+    redfish_mock_factory,
+):
+    """boot_one_shot sends X10 UefiCd without nested Boot or override mode."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="UefiCd",
+        mode="UEFI",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "target": "/redfish/v1/Systems/1",
+        "payload": {
+            "BootSourceOverrideEnabled": "Once",
+            "BootSourceOverrideTarget": "UefiCd",
+        },
+        "blocked": None,
+    }
+    assert all(request.method != "PATCH" for request in service.requests)
+
+
+def test_boot_one_shot_legacy_payload_strips_unsupported_uefi_fields():
+    """X10 flat payloads omit fields unsupported by the legacy shape."""
+    payload = BootOneShot._boot_payload(
+        "UefiCd",
+        "UEFI",
+        "Boot0001",
+        ["None", "CD/DVD", "UefiCd"],
+        {
+            "@odata.type": "#ComputerSystem.v1_3_0.ComputerSystem",
+            "Manufacturer": "Supermicro",
+        },
+    )
+
+    assert payload == {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "UefiCd",
+    }
+
+
+def test_boot_one_shot_non_legacy_cd_dvd_keeps_nested_payload(
+    redfish_mock,
+    redfish_service,
+):
+    """boot_one_shot keeps nested payloads when CD/DVD is not legacy X10."""
+    system_path = "/redfish/v1/systems/system.embedded.1"
+    system = copy.deepcopy(redfish_service._state(system_path))
+    system["@odata.type"] = "#ComputerSystem.v1_18_0.ComputerSystem"
+    system["Manufacturer"] = "Example Systems"
+    system["Boot"]["BootSourceOverrideTarget@Redfish.AllowableValues"].append(
+        "CD/DVD"
+    )
+    redfish_service._overlay[system_path] = system
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="CD/DVD",
+        mode="UEFI",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["Status"] == "ok"
+    assert redfish_service.last_request.json() == {
+        "Boot": {
+            "BootSourceOverrideEnabled": "Once",
+            "BootSourceOverrideTarget": "CD/DVD",
+            "BootSourceOverrideMode": "UEFI",
+        }
+    }
+
+
+def test_boot_one_shot_modern_uefi_cd_keeps_nested_payload(
+    redfish_mock,
+    redfish_service,
+):
+    """boot_one_shot keeps nested Boot payloads for modern UefiCd targets."""
+    system_path = "/redfish/v1/systems/system.embedded.1"
+    system = copy.deepcopy(redfish_service._state(system_path))
+    system["Boot"]["BootSourceOverrideTarget@Redfish.AllowableValues"].append(
+        "UefiCd"
+    )
+    redfish_service._overlay[system_path] = system
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="UefiCd",
+        mode="UEFI",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["Status"] == "ok"
+    request = redfish_service.last_request
+    assert request.method == "PATCH"
+    assert request.path.lower() == "/redfish/v1/systems/system.embedded.1"
+    assert request.json() == {
+        "Boot": {
+            "BootSourceOverrideEnabled": "Once",
+            "BootSourceOverrideTarget": "UefiCd",
+            "BootSourceOverrideMode": "UEFI",
+        }
+    }
+
+
+def test_boot_one_shot_x10_power_on_failure_returns_error_before_patch(
+    redfish_mock_factory,
+):
+    """boot_one_shot reports missing X10 chassis reset action before PATCHing."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="UefiCd",
+        do_power_on=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "power-on pre-step failed: Failed to discover the reset chassis action"
+    )
+    assert result.data == {
+        "target": "/redfish/v1/Systems/1",
+        "payload": {
+            "BootSourceOverrideEnabled": "Once",
+            "BootSourceOverrideTarget": "UefiCd",
+        },
+    }
+    assert all(request.method != "PATCH" for request in service.requests)
+
+
+def test_boot_one_shot_x10_reboot_501_returns_error_after_patch(
+    redfish_mock_factory,
+):
+    """boot_one_shot -r reports a chassis read failure instead of tracebacks."""
+    requests_mock = pytest.importorskip("requests_mock")
+    manager, service = redfish_mock_factory("supermicro_x10")
+    original_get = service.get_cb
+
+    def get_cb(request, context):
+        if request.path.lower() == "/redfish/v1/chassis":
+            service.requests.append(request)
+            context.status_code = 501
+            return "{}"
+        return original_get(request, context)
+
+    service.mocker.get(requests_mock.ANY, text=get_cb)
+
+    result = manager.sync_invoke(
+        ApiRequestType.BootOneShot,
+        "boot_one_shot",
+        device="UefiCd",
+        do_reboot=True,
+    )
+
+    patches = [request for request in service.requests if request.method == "PATCH"]
+    posts = [request for request in service.requests if request.method == "POST"]
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "reboot post-step failed: Failed acquire result. Status code 501"
+    )
+    assert result.data["Status"] == "ok"
+    assert result.data["reboot_error"] == "Failed acquire result. Status code 501"
+    assert len(patches) == 1
+    assert patches[0].path.lower() == "/redfish/v1/systems/1"
+    assert patches[0].json() == {
+        "BootSourceOverrideEnabled": "Once",
+        "BootSourceOverrideTarget": "UefiCd",
+    }
+    assert posts == []
 
 
 def test_boot_one_shot_none_disarms_override_in_mock_mode(


### PR DESCRIPTION
Summary:
- Map generic CD boot requests to X10-advertised targets before PATCHing.
- Use the flat Redfish 1.0.1 boot payload shape only for older Supermicro ComputerSystem resources that advertise legacy target names.
- Preserve nested Boot payloads for modern targets and return structured errors for optional power-on or reboot follow-up failures.

Validation:
- GB300 gate on slot 13: 1295 passed, 62 skipped; ruff passed; docstring-gate passed.