### PR TITLE
Support Supermicro X10 NTP resources

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -155,7 +155,7 @@ Safety labels:
 | `metric-reports` | Read TelemetryService metric reports; `--report` filters by id substring. | Read |
 | `network-adapters` | Read chassis NetworkAdapters such as NICs and DPUs. | Read |
 | `network-ports` | Read NetworkAdapter port link state and speed. | Read |
-| `ntp-set` | Set or clear ManagerNetworkProtocol NTP servers; dry-run by default and `--confirm` applies an NTP-only PATCH. | Guarded |
+| `ntp-set` | Set or clear Manager NTP servers through standard ManagerNetworkProtocol or legacy Manager NTP resources; dry-run by default and `--confirm` applies an NTP-only PATCH. | Guarded |
 | `nvlink-ports` | Read GPU NVLink port resources where the BMC exposes them. | Read |
 | `oem-actions` | Read supported Dell OEM OS deployment actions. | Read |
 | `oem-attach` | Attach a network ISO through a Dell OEM action. | Write |

--- a/redfish_ctl/manager/cmd_ntp_set.py
+++ b/redfish_ctl/manager/cmd_ntp_set.py
@@ -9,11 +9,15 @@ from abc import abstractmethod
 from typing import Optional
 
 from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, Singleton
-from ..redfish_manager import CommandResult
 
 _MAX_NTP_SERVERS = 4
+_MAX_LEGACY_NTP_SERVERS = 2
+_LEGACY_NTP_SERVER_LIMIT_REASON = (
+    "legacy Manager NTP resources support at most 2 servers"
+)
 _HOST_LABEL = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
 
 
@@ -121,6 +125,78 @@ class NtpSet(RedfishManagerBase,
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
+    @staticmethod
+    def _nested_link(data, *keys):
+        """Return the ``@odata.id`` below a nested mapping path.
+
+        :param data: the resource body to read the link from.
+        :param keys: mapping keys that lead to the linked resource.
+        :return: the linked resource URI, or None when the path is absent.
+        """
+        current = data or {}
+        for key in keys:
+            if not isinstance(current, dict):
+                return None
+            current = current.get(key)
+        return current.get("@odata.id") if isinstance(current, dict) else None
+
+    @staticmethod
+    def _legacy_ntp_payload(servers):
+        """Build a legacy Manager ``NTP`` resource PATCH body.
+
+        :param servers: normalized NTP server list from the command arguments.
+        :return: PATCH payload for ``NTPEnable`` and primary/secondary servers.
+        :raises InvalidArgument: when more servers are provided than the legacy
+            resource shape can represent.
+        """
+        if len(servers) > _MAX_LEGACY_NTP_SERVERS:
+            raise InvalidArgument(_LEGACY_NTP_SERVER_LIMIT_REASON)
+        return {
+            "NTPEnable": bool(servers),
+            "PrimaryNTPServer": servers[0] if servers else "",
+            "SecondaryNTPServer": servers[1] if len(servers) > 1 else "",
+        }
+
+    @staticmethod
+    def _legacy_ntp_skip_reason(servers):
+        """Return why a legacy Manager ``NTP`` resource cannot be patched.
+
+        :param servers: normalized NTP server list from the command arguments.
+        :return: skip reason string, or None when the resource can be patched.
+        """
+        if len(servers) > _MAX_LEGACY_NTP_SERVERS:
+            return _LEGACY_NTP_SERVER_LIMIT_REASON
+        return None
+
+    @staticmethod
+    def _is_legacy_ntp_resource(data):
+        """Return whether a payload looks like a legacy Manager ``NTP`` resource.
+
+        :param data: parsed resource payload from a candidate Manager NTP URI.
+        :return: True when the payload exposes legacy NTP fields.
+        """
+        if not isinstance(data, dict):
+            return False
+        return any(
+            key in data
+            for key in ("NTPEnable", "PrimaryNTPServer", "SecondaryNTPServer")
+        )
+
+    def _legacy_ntp_uri(self, manager, manager_uri):
+        """Discover the legacy Manager ``NTP`` resource URI for a manager.
+
+        :param manager: parsed Manager resource payload.
+        :param manager_uri: Manager resource URI.
+        :return: discovered or conventional Supermicro NTP URI, or None.
+        """
+        supermicro_ntp_uri = self._nested_link(manager, "Oem", "Supermicro", "NTP")
+        if supermicro_ntp_uri:
+            return supermicro_ntp_uri
+        oem = (manager or {}).get("Oem")
+        if isinstance(oem, dict) and "Supermicro" in oem:
+            return f"{manager_uri.rstrip('/')}/NTP"
+        return None
+
     def _get(self, uri, do_async):
         """GET a resource body, returning {} on any failure.
 
@@ -128,10 +204,22 @@ class NtpSet(RedfishManagerBase,
         :param do_async: run the query asynchronously (subscribes to the event loop).
         :return: the resource body dict, or {} on any failure.
         """
+        data, _readable = self._try_get(uri, do_async)
+        return data
+
+    def _try_get(self, uri, do_async):
+        """GET a resource body and report whether the read succeeded.
+
+        :param uri: Redfish resource URI to query.
+        :param do_async: run the query asynchronously (subscribes to the event loop).
+        :return: tuple of (resource body dict or {}, True when the GET succeeded).
+        """
+        if not uri:
+            return {}, False
         try:
-            return self.base_query(uri, do_async=do_async).data or {}
+            return self.base_query(uri, do_async=do_async).data or {}, True
         except Exception:
-            return {}
+            return {}, False
 
     def _ntp_plan(self, servers, manager_id, do_async):
         """Build the per-manager PATCH plan for the requested NTP servers.
@@ -156,31 +244,71 @@ class NtpSet(RedfishManagerBase,
             network_uri = self._link(manager, "NetworkProtocol")
             if manager_id and current_manager_id != manager_id:
                 continue
-            if not network_uri:
+            network, network_readable = (
+                self._try_get(network_uri, do_async)
+                if network_uri else ({}, False)
+            )
+            if network_uri and not network_readable:
                 skipped.append({
                     "Manager": current_manager_id,
-                    "target": None,
-                    "reason": "NetworkProtocol link is not available",
+                    "target": network_uri,
+                    "reason": "NetworkProtocol resource is not readable",
                 })
                 continue
-            network = self._get(network_uri, do_async)
-            if not isinstance(network.get("NTP"), dict):
+            if isinstance(network.get("NTP"), dict):
+                plan.append({
+                    "Manager": current_manager_id,
+                    "target": network_uri,
+                    "payload": payload,
+                })
+                continue
+
+            legacy_uri = self._legacy_ntp_uri(manager, manager_uri)
+            legacy = self._get(legacy_uri, do_async) if legacy_uri else {}
+            if self._is_legacy_ntp_resource(legacy):
+                legacy_skip_reason = self._legacy_ntp_skip_reason(servers)
+                if legacy_skip_reason:
+                    skipped.append({
+                        "Manager": current_manager_id,
+                        "target": legacy_uri,
+                        "reason": legacy_skip_reason,
+                    })
+                    continue
+                plan.append({
+                    "Manager": current_manager_id,
+                    "target": legacy_uri,
+                    "payload": self._legacy_ntp_payload(servers),
+                })
+                continue
+
+            if network_uri:
                 skipped.append({
                     "Manager": current_manager_id,
                     "target": network_uri,
                     "reason": "NTP block is not available",
                 })
                 continue
-            plan.append({
+
+            skipped.append({
                 "Manager": current_manager_id,
-                "target": network_uri,
-                "payload": payload,
+                "target": legacy_uri,
+                "reason": "NTP resource is not available",
             })
 
         if manager_id and not plan:
-            raise InvalidArgument(f"Manager {manager_id!r} has no NTP-capable NetworkProtocol")
+            raise InvalidArgument(f"Manager {manager_id!r} has no NTP-capable resource")
         if not plan:
-            raise InvalidArgument("no NTP-capable ManagerNetworkProtocol resources found")
+            legacy_limit_reason = next(
+                (
+                    item["reason"]
+                    for item in skipped
+                    if item.get("reason") == _LEGACY_NTP_SERVER_LIMIT_REASON
+                ),
+                None,
+            )
+            if legacy_limit_reason:
+                raise InvalidArgument(legacy_limit_reason)
+            raise InvalidArgument("no NTP-capable Manager resources found")
         return plan, skipped
 
     def execute(self,

--- a/tests/test_ntp_set_dualmode.py
+++ b/tests/test_ntp_set_dualmode.py
@@ -3,8 +3,8 @@
 import pytest
 
 from redfish_ctl.cmd_exceptions import InvalidArgument
-from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
 
 
 def _mutating_requests(service):
@@ -12,6 +12,10 @@ def _mutating_requests(service):
         request for request in service.requests
         if request.method in {"POST", "PATCH", "DELETE"}
     ]
+
+
+def _patch_requests(service):
+    return [request for request in service.requests if request.method == "PATCH"]
 
 
 def test_ntp_set_dry_run_builds_gb300_patch_plan_without_writing(
@@ -47,6 +51,33 @@ def test_ntp_set_dry_run_builds_gb300_patch_plan_without_writing(
     assert _mutating_requests(service) == []
 
 
+def test_ntp_set_dry_run_builds_x10_legacy_ntp_patch_plan(redfish_mock_factory):
+    """ntp-set previews Supermicro X10 Manager NTP PATCHes by default."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org", "1.pool.ntp.org"],
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["servers"] == ["0.pool.ntp.org", "1.pool.ntp.org"]
+    assert result.data["skipped"] == []
+    assert result.data["plan"] == [{
+        "Manager": "1",
+        "target": "/redfish/v1/Managers/1/NTP",
+        "payload": {
+            "NTPEnable": True,
+            "PrimaryNTPServer": "0.pool.ntp.org",
+            "SecondaryNTPServer": "1.pool.ntp.org",
+        },
+    }]
+    assert _mutating_requests(service) == []
+
+
 def test_ntp_set_confirm_patches_only_the_ntp_block(redfish_mock_factory):
     """ntp-set --confirm PATCHes NTP servers without changing other protocols."""
     manager, service = redfish_mock_factory("supermicro")
@@ -73,6 +104,231 @@ def test_ntp_set_confirm_patches_only_the_ntp_block(redfish_mock_factory):
         "target": "/redfish/v1/Managers/BMC_0/NetworkProtocol",
         "status": "RedfishApiRespond.Ok",
         "error": None,
+    }]
+
+
+def test_ntp_set_confirm_patches_x10_legacy_ntp_resource(redfish_mock_factory):
+    """ntp-set --confirm PATCHes Supermicro X10 Manager NTP fields."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org"],
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/1/ntp"
+    assert patches[0].json() == {
+        "NTPEnable": True,
+        "PrimaryNTPServer": "0.pool.ntp.org",
+        "SecondaryNTPServer": "",
+    }
+    assert result.data["applied"] == [{
+        "Manager": "1",
+        "target": "/redfish/v1/Managers/1/NTP",
+        "status": "RedfishApiRespond.Ok",
+        "error": None,
+    }]
+
+
+def test_ntp_set_clear_patches_x10_legacy_ntp_resource(redfish_mock_factory):
+    """ntp-set --clear PATCHes empty Supermicro X10 Manager NTP fields."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        clear=True,
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/1/ntp"
+    assert patches[0].json() == {
+        "NTPEnable": False,
+        "PrimaryNTPServer": "",
+        "SecondaryNTPServer": "",
+    }
+    assert result.data["servers"] == []
+    assert result.data["applied"] == [{
+        "Manager": "1",
+        "target": "/redfish/v1/Managers/1/NTP",
+        "status": "RedfishApiRespond.Ok",
+        "error": None,
+    }]
+
+
+def test_ntp_set_skips_x10_legacy_target_when_server_list_too_long(
+        redfish_mock_factory):
+    """ntp-set still patches standard managers when legacy targets cannot fit."""
+    manager, service = redfish_mock_factory("supermicro")
+    service._overlay["/redfish/v1/managers"] = {
+        "@odata.id": "/redfish/v1/Managers",
+        "Members": [
+            {"@odata.id": "/redfish/v1/Managers/BMC_0"},
+            {"@odata.id": "/redfish/v1/Managers/legacy"},
+        ],
+        "Members@odata.count": 2,
+    }
+    service._overlay["/redfish/v1/managers/legacy"] = {
+        "@odata.id": "/redfish/v1/Managers/legacy",
+        "Id": "legacy",
+        "Oem": {
+            "Supermicro": {
+                "NTP": {"@odata.id": "/redfish/v1/Managers/legacy/NTP"},
+            },
+        },
+    }
+    service._overlay["/redfish/v1/managers/legacy/ntp"] = {
+        "@odata.id": "/redfish/v1/Managers/legacy/NTP",
+        "Id": "NTP",
+        "NTPEnable": False,
+        "PrimaryNTPServer": "",
+        "SecondaryNTPServer": "",
+    }
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"],
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/bmc_0/networkprotocol"
+    assert patches[0].json() == {
+        "NTP": {
+            "NTPServers": [
+                "0.pool.ntp.org",
+                "1.pool.ntp.org",
+                "2.pool.ntp.org",
+            ],
+            "ProtocolEnabled": True,
+        },
+    }
+    assert result.data["applied"] == [{
+        "Manager": "BMC_0",
+        "target": "/redfish/v1/Managers/BMC_0/NetworkProtocol",
+        "status": "RedfishApiRespond.Ok",
+        "error": None,
+    }]
+    assert result.data["skipped"] == [{
+        "Manager": "legacy",
+        "target": "/redfish/v1/Managers/legacy/NTP",
+        "reason": "legacy Manager NTP resources support at most 2 servers",
+    }]
+
+
+def test_ntp_set_ignores_conventional_ntp_path_for_non_supermicro_manager(
+        redfish_mock_factory):
+    """ntp-set only uses the conventional Manager NTP path for Supermicro OEMs."""
+    manager, service = redfish_mock_factory("supermicro")
+    service._overlay["/redfish/v1/managers"] = {
+        "@odata.id": "/redfish/v1/Managers",
+        "Members": [
+            {"@odata.id": "/redfish/v1/Managers/BMC_0"},
+            {"@odata.id": "/redfish/v1/Managers/vendor"},
+        ],
+        "Members@odata.count": 2,
+    }
+    service._overlay["/redfish/v1/managers/vendor"] = {
+        "@odata.id": "/redfish/v1/Managers/vendor",
+        "Id": "vendor",
+        "NetworkProtocol": {
+            "@odata.id": "/redfish/v1/Managers/vendor/NetworkProtocol",
+        },
+        "Oem": {
+            "OtherVendor": {
+                "NTP": {"@odata.id": "/redfish/v1/Managers/vendor/NTP"},
+            },
+        },
+    }
+    service._overlay["/redfish/v1/managers/vendor/networkprotocol"] = {
+        "@odata.id": "/redfish/v1/Managers/vendor/NetworkProtocol",
+        "Id": "NetworkProtocol",
+    }
+    service._overlay["/redfish/v1/managers/vendor/ntp"] = {
+        "@odata.id": "/redfish/v1/Managers/vendor/NTP",
+        "Id": "NTP",
+        "NTPEnable": False,
+        "PrimaryNTPServer": "",
+        "SecondaryNTPServer": "",
+    }
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org"],
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/bmc_0/networkprotocol"
+    assert "/redfish/v1/managers/vendor/ntp" not in {
+        request.path for request in service.requests
+    }
+    assert result.data["skipped"] == [{
+        "Manager": "vendor",
+        "target": "/redfish/v1/Managers/vendor/NetworkProtocol",
+        "reason": "NTP block is not available",
+    }]
+
+
+def test_ntp_set_does_not_fallback_when_network_protocol_is_unreadable(
+        redfish_mock_factory):
+    """ntp-set skips legacy fallback when standard NetworkProtocol cannot be read."""
+    manager, service = redfish_mock_factory("supermicro")
+    service._overlay["/redfish/v1/managers"] = {
+        "@odata.id": "/redfish/v1/Managers",
+        "Members": [
+            {"@odata.id": "/redfish/v1/Managers/BMC_0"},
+            {"@odata.id": "/redfish/v1/Managers/broken"},
+        ],
+        "Members@odata.count": 2,
+    }
+    service._overlay["/redfish/v1/managers/broken"] = {
+        "@odata.id": "/redfish/v1/Managers/broken",
+        "Id": "broken",
+        "NetworkProtocol": {
+            "@odata.id": "/redfish/v1/Managers/broken/NetworkProtocol",
+        },
+        "Oem": {
+            "Supermicro": {
+                "NTP": {"@odata.id": "/redfish/v1/Managers/broken/NTP"},
+            },
+        },
+    }
+    service._overlay["/redfish/v1/managers/broken/ntp"] = {
+        "@odata.id": "/redfish/v1/Managers/broken/NTP",
+        "Id": "NTP",
+        "NTPEnable": False,
+        "PrimaryNTPServer": "",
+        "SecondaryNTPServer": "",
+    }
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org"],
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/bmc_0/networkprotocol"
+    assert "/redfish/v1/managers/broken/ntp" not in {
+        request.path for request in service.requests
+    }
+    assert result.data["skipped"] == [{
+        "Manager": "broken",
+        "target": "/redfish/v1/Managers/broken/NetworkProtocol",
+        "reason": "NetworkProtocol resource is not readable",
     }]
 
 
@@ -110,6 +366,22 @@ def test_ntp_set_clear_rejects_explicit_servers(redfish_mock_factory):
             "ntp-set",
             servers=["0.pool.ntp.org"],
             clear=True,
+            confirm=True,
+        )
+
+    assert _mutating_requests(service) == []
+
+
+def test_ntp_set_rejects_too_many_x10_legacy_servers_before_patch(
+        redfish_mock_factory):
+    """Supermicro X10 legacy NTP resources reject a third server."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    with pytest.raises(InvalidArgument, match="legacy Manager NTP"):
+        manager.sync_invoke(
+            ApiRequestType.NtpSet,
+            "ntp-set",
+            servers=["0.pool.ntp.org", "1.pool.ntp.org", "2.pool.ntp.org"],
             confirm=True,
         )
 


### PR DESCRIPTION
## Summary
- Add an `ntp-set` fallback for legacy Manager NTP resources that expose `NTPEnable`, `PrimaryNTPServer`, and `SecondaryNTPServer`.
- Preserve the standard `ManagerNetworkProtocol.NTP` payload for modern Redfish managers.
- Restrict the conventional legacy Manager NTP path to Supermicro OEM managers and avoid legacy fallback when the standard NetworkProtocol resource is unreadable.
- Cover X10 dry-run, confirmed PATCH, clear, legacy two-server handling, mixed-manager skip behavior, non-Supermicro fallback guarding, and unreadable standard-resource handling in dual-mode tests.

## Tests
- `pytest -q` -> 1295 passed, 62 skipped, 6 warnings
- `ruff check` on changed Python files -> passed
- `python tools/docstring_gate.py --all` -> passed
