### PR TITLE
Add TelemetryService test metric command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -200,6 +200,7 @@ Safety labels:
 | `task-watch` | Watch task progress. | Read |
 | `tasks` | Read the task collection. | Read |
 | `telemetry-clear-reports` | Clear generated TelemetryService MetricReports; dry-run by default and `--confirm` posts. | Guarded |
+| `telemetry-submit-test` | Preview or submit TelemetryService.SubmitTestMetricReport; dry-run by default and `--confirm` sends it. | Guarded |
 | `telemetry-triggers` | Read TelemetryService triggers and thresholds. | Read |
 | `thermal` | Read Chassis `ThermalSubsystem` links, ThermalMetrics temperature readings, and fan collection counts from `redfish_ctl/thermal/cmd_thermal.py`. | Read |
 | `update-start` | Start updates staged for `UpdateService.StartUpdate`, the action advertised by UpdateService; previews unless `--confirm` is given. | Guarded |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -98,6 +98,7 @@ from .metrics.cmd_gpu_metrics import *
 from .telemetry.cmd_metric_reports import *
 from .telemetry.cmd_metric_definitions import *
 from .telemetry.cmd_telemetry_clear_reports import *
+from .telemetry.cmd_telemetry_submit_test import *
 from .telemetry.cmd_exporter import *
 from .component_integrity.cmd_component_integrity import *
 from .component_integrity.cmd_spdm_measurements import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -50,6 +50,7 @@ ACTION_POLICY = {
     "#HpeiLOSnmpService.SendSNMPTestAlert": Destructiveness.REVERSIBLE,
     "#HpeiLOManagerNetworkService.SendTestAlertMail": Destructiveness.REVERSIBLE,
     "#HpeiLOManagerNetworkService.SendTestSyslog": Destructiveness.REVERSIBLE,
+    "#TelemetryService.SubmitTestMetricReport": Destructiveness.REVERSIBLE,
     "#VirtualMedia.InsertMedia": Destructiveness.REVERSIBLE,
     "#VirtualMedia.EjectMedia": Destructiveness.REVERSIBLE,
     "#CertificateService.GenerateCSR": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -103,6 +103,7 @@ class ApiRequestType(Enum):
     MetricReports = auto()
     MetricReportDefinitions = auto()
     TelemetryClearReports = auto()
+    TelemetrySubmitTest = auto()
     ComponentIntegrity = auto()
     SpdmMeasurements = auto()
     NetworkAdapters = auto()

--- a/redfish_ctl/telemetry/cmd_telemetry_submit_test.py
+++ b/redfish_ctl/telemetry/cmd_telemetry_submit_test.py
@@ -1,0 +1,161 @@
+"""Submit a Redfish telemetry test metric report.
+
+    redfish_ctl telemetry-submit-test
+    redfish_ctl telemetry-submit-test --confirm
+
+Discovers TelemetryService.SubmitTestMetricReport from the service's Actions
+block and builds the current TelemetryService payload shape. The command is
+preview-only unless ``--confirm`` is supplied.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SUBMIT_TEST_ACTION = "#TelemetryService.SubmitTestMetricReport"
+
+
+class TelemetrySubmitTest(RedfishManagerBase,
+                          scm_type=ApiRequestType.TelemetrySubmitTest,
+                          name="telemetry-submit-test",
+                          metaclass=Singleton):
+    """Submit a TelemetryService test metric report."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the telemetry-submit-test command."""
+        super(TelemetrySubmitTest, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``telemetry-submit-test`` subcommand.
+
+        :param cls: the owning command class, used to build the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--metric-report-name", required=False, dest="metric_report_name",
+            type=str, default="redfish_ctl_test_metric_report",
+            help="MetricReportName parameter for the generated test report")
+        cmd_parser.add_argument(
+            "--metric-id", required=False, dest="metric_id", type=str,
+            default="redfish_ctl_test_metric",
+            help="MetricId field for the generated test metric value")
+        cmd_parser.add_argument(
+            "--metric-value", required=False, dest="metric_value", type=str,
+            default="1",
+            help="MetricValue field for the generated test metric value")
+        cmd_parser.add_argument(
+            "--metric-property", required=False, dest="metric_property", type=str,
+            default=None,
+            help="optional MetricProperty URI for the generated test metric value")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="fire the SubmitTestMetricReport POST; without it the command previews")
+        cmd_parser.add_argument(
+            "--dry_run", action="store_true", dest="dry_run", default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm")
+        return (
+            cmd_parser,
+            "telemetry-submit-test",
+            "command submit a Redfish telemetry test metric report",
+        )
+
+    def _telemetry_service_uri(self, do_async):
+        """Resolve the TelemetryService URI from the service root.
+
+        :param do_async: issue the service-root query on the async path when True.
+        :return: the TelemetryService ``@odata.id``, or the standard fallback URI.
+        """
+        try:
+            root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
+        except Exception:
+            root = {}
+        link = root.get("TelemetryService")
+        if isinstance(link, dict) and link.get("@odata.id"):
+            return link["@odata.id"]
+        return f"{RedfishApi.Version}/TelemetryService"
+
+    @staticmethod
+    def _payload(metric_report_name, metric_id, metric_value, metric_property):
+        """Build the SubmitTestMetricReport payload.
+
+        GeneratedMetricReportValues and MetricReportName are the parameters
+        defined by the TelemetryService.SubmitTestMetricReport action. Each
+        generated metric item uses MetricId, MetricValue, and optional
+        MetricProperty fields from the MetricValue schema.
+
+        :param metric_report_name: generated report name to send.
+        :param metric_id: generated metric identifier to send.
+        :param metric_value: generated metric value to send as a string.
+        :param metric_property: optional Redfish property URI for the metric.
+        :return: the JSON-serializable action payload dict.
+        """
+        metric = {
+            "MetricId": str(metric_id),
+            "MetricValue": str(metric_value),
+        }
+        if metric_property:
+            metric["MetricProperty"] = metric_property
+        return {
+            "MetricReportName": metric_report_name,
+            "GeneratedMetricReportValues": [metric],
+        }
+
+    def execute(self,
+                metric_report_name: Optional[str] = "redfish_ctl_test_metric_report",
+                metric_id: Optional[str] = "redfish_ctl_test_metric",
+                metric_value: Optional[str] = "1",
+                metric_property: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or fire TelemetryService.SubmitTestMetricReport.
+
+        The action is reversible, but synthetic metric reports may reach event
+        destinations, so this command previews by default. ``--dry_run`` remains
+        a no-POST override even when ``--confirm`` is also set.
+
+        :param metric_report_name: ``MetricReportName`` value to send.
+        :param metric_id: ``MetricId`` value for the generated metric.
+        :param metric_value: ``MetricValue`` value for the generated metric.
+        :param metric_property: optional ``MetricProperty`` URI for the metric.
+        :param confirm: authorize the SubmitTestMetricReport POST to fire.
+        :param dry_run: resolve the target and show it without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: a CommandResult with the POST outcome or dry-run preview.
+        """
+        preview_only = bool(dry_run) or not bool(confirm)
+        result = self.invoke_action(
+            self._telemetry_service_uri(do_async),
+            "SubmitTestMetricReport",
+            payload=self._payload(
+                metric_report_name,
+                metric_id,
+                metric_value,
+                metric_property,
+            ),
+            full_action_type=_SUBMIT_TEST_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=preview_only,
+            confirm=True,
+        )
+        if (
+                not confirm
+                and not dry_run
+                and result.error is None
+                and isinstance(result.data, dict)):
+            result.data["blocked"] = "test metric report submission requires --confirm"
+        return result

--- a/tests/test_telemetry_submit_test_dualmode.py
+++ b/tests/test_telemetry_submit_test_dualmode.py
@@ -1,0 +1,190 @@
+"""Dual-mode-style coverage for TelemetryService.SubmitTestMetricReport."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_XR8620T_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_XR8620T_INDEX = {
+    path.name.lower(): path for path in DELL_XR8620T_CORPUS.glob("*.json")
+}
+TELEMETRY_SERVICE = "/redfish/v1/TelemetryService"
+SUBMIT_TARGET = (
+    "/redfish/v1/TelemetryService/Actions/"
+    "TelemetryService.SubmitTestMetricReport"
+)
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell XR8620t fixture matching a Redfish path."""
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_XR8620T_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_xr8620t_telemetry_manager():
+    """Serve the committed Dell XR8620t corpus over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/telemetry-test-1"
+        return json.dumps({
+            "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/telemetry-test-1"},
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-xr8620t",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def _submit(manager, **kwargs):
+    """Invoke the telemetry test metric command with concise defaults."""
+    return manager.sync_invoke(
+        ApiRequestType.TelemetrySubmitTest,
+        "telemetry-submit-test",
+        metric_report_name="SyntheticReport",
+        metric_id="SyntheticMetric",
+        metric_value="42",
+        **kwargs,
+    )
+
+
+def test_telemetry_submit_test_without_confirm_is_preview_only(
+        dell_xr8620t_telemetry_manager):
+    """SubmitTestMetricReport resolves the target but does not POST by default."""
+    manager, requests = dell_xr8620t_telemetry_manager
+
+    result = _submit(manager)
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#TelemetryService.SubmitTestMetricReport"
+    assert result.data["target"] == SUBMIT_TARGET
+    assert result.data["payload"] == {
+        "MetricReportName": "SyntheticReport",
+        "GeneratedMetricReportValues": [
+            {
+                "MetricId": "SyntheticMetric",
+                "MetricValue": "42",
+            },
+        ],
+    }
+    assert result.data["level"] == "reversible"
+    assert result.data["blocked"] == "test metric report submission requires --confirm"
+    assert _post_requests(requests) == []
+
+
+def test_telemetry_submit_test_confirm_posts_payload(
+        dell_xr8620t_telemetry_manager):
+    """--confirm POSTs the generated metric report to the discovered action."""
+    manager, requests = dell_xr8620t_telemetry_manager
+
+    result = _submit(manager, confirm=True)
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#TelemetryService.SubmitTestMetricReport"
+    assert result.data["target"] == SUBMIT_TARGET
+    assert result.data["level"] == "reversible"
+    assert result.data["task_id"] == "telemetry-test-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SUBMIT_TARGET.lower()
+    assert posts[0].json() == {
+        "MetricReportName": "SyntheticReport",
+        "GeneratedMetricReportValues": [
+            {
+                "MetricId": "SyntheticMetric",
+                "MetricValue": "42",
+            },
+        ],
+    }
+
+
+def test_telemetry_submit_test_confirm_dry_run_still_does_not_post(
+        dell_xr8620t_telemetry_manager):
+    """--dry_run remains a no-POST preview even when --confirm is also set."""
+    manager, requests = dell_xr8620t_telemetry_manager
+
+    result = _submit(manager, confirm=True, dry_run=True)
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == SUBMIT_TARGET
+    assert result.data["payload"]["MetricReportName"] == "SyntheticReport"
+    assert _post_requests(requests) == []
+
+
+def test_telemetry_submit_test_metric_property_is_optional(
+        dell_xr8620t_telemetry_manager):
+    """MetricProperty is included only when supplied by the caller."""
+    manager, requests = dell_xr8620t_telemetry_manager
+
+    result = _submit(
+        manager,
+        metric_property="/redfish/v1/TelemetryService#/ServiceEnabled",
+        dry_run=True,
+    )
+
+    assert result.error is None
+    [metric] = result.data["payload"]["GeneratedMetricReportValues"]
+    assert metric == {
+        "MetricId": "SyntheticMetric",
+        "MetricValue": "42",
+        "MetricProperty": "/redfish/v1/TelemetryService#/ServiceEnabled",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_telemetry_submit_test_no_action_reports_clear_error(redfish_mock_factory):
+    """A corpus without SubmitTestMetricReport fails clearly before any POST."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetrySubmitTest,
+        "telemetry-submit-test",
+        confirm=True,
+    )
+
+    assert result.error == (
+        "action '#TelemetryService.SubmitTestMetricReport' "
+        f"not found on {TELEMETRY_SERVICE}"
+    )
+    assert result.data["action"] == "#TelemetryService.SubmitTestMetricReport"
+    assert _post_requests(service.requests) == []


### PR DESCRIPTION
## Summary
- Add guarded `telemetry-submit-test` for the standard TelemetryService.SubmitTestMetricReport action.
- Build the current `GeneratedMetricReportValues` payload shape and preview by default unless `--confirm` is supplied.
- Cover the command with Dell XR8620t corpus-backed dual-mode tests and document it in the command table.

## Validation
- Remote gate passed: pytest 1294 passed, 62 skipped; changed-file ruff passed; docstring gate passed.