### PR TITLE
Add volume consistency check command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -198,6 +198,7 @@ Safety labels:
 | `thermal` | Read Chassis `ThermalSubsystem` links, ThermalMetrics temperature readings, and fan collection counts from `redfish_ctl/thermal/cmd_thermal.py`. | Read |
 | `update_service` | Read UpdateService inventory links, push URIs, and advertised actions. | Read |
 | `vm-mount` | Mount/unmount an ISO via Supermicro OEM virtual media (CfgCD). | Write |
+| `volume-check-consistency` | Start a Redfish Volume.CheckConsistency action; previews unless `--confirm` is given. | Guarded |
 | `volume-create` | Create a Redfish volume; previews unless `--confirm` is given. | Guarded |
 | `volume-delete` | Delete a Redfish volume; requires `--confirm` and `--confirm_volume_id`. | Guarded |
 | `volume-get` | Read one volume from a storage device. | Read |

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -69,6 +69,7 @@ ACTION_POLICY = {
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
+    "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -31,6 +31,7 @@ class ApiRequestType(Enum):
     VolumeQuery = auto()
     VolumeCreate = auto()
     VolumeDelete = auto()
+    VolumeCheckConsistency = auto()
     ImportOneTimeBoot = auto()
 
     # dell oem

--- a/redfish_ctl/volumes/cmd_volume_manage.py
+++ b/redfish_ctl/volumes/cmd_volume_manage.py
@@ -4,14 +4,17 @@ Both commands preview by default and require ``--confirm`` to mutate.
 
     redfish_ctl volume-create --controller RAID.Integrated.1-1 --name vol0 --raid_type RAID1 --drive Disk.Bay.0 --drive Disk.Bay.1 --confirm
     redfish_ctl volume-delete --controller RAID.Integrated.1-1 --volume_id Volume-1 --confirm --confirm_volume_id Volume-1
+    redfish_ctl volume-check-consistency --controller RAID.Integrated.1-1 --volume_id Volume-1 --confirm
 """
 from abc import abstractmethod
 from typing import Iterable, Optional
 
 from ..cmd_exceptions import InvalidArgument, UnsupportedAction
+from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, Singleton
-from ..redfish_manager import CommandResult
+
+_CHECK_CONSISTENCY_ACTION = "#Volume.CheckConsistency"
 
 
 def _last_segment(uri: str) -> str:
@@ -388,4 +391,77 @@ class VolumeDelete(
             None,
             None,
             result.error,
+        )
+
+
+class VolumeCheckConsistency(
+    _VolumeMutationBase,
+    scm_type=ApiRequestType.VolumeCheckConsistency,
+    name="volume-check-consistency",
+    metaclass=Singleton,
+):
+    """Run a guarded Redfish Volume.CheckConsistency action."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the volume-check-consistency command."""
+        super(VolumeCheckConsistency, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the volume-check-consistency command and its flags.
+
+        :param cls: the CLI manager class providing the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--controller", required=True, type=str,
+            help="Storage controller id, for example RAID.Integrated.1-1")
+        cmd_parser.add_argument(
+            "--volume_id", required=True, type=str,
+            help="Volume id or Redfish Volume URI")
+        cmd_parser.add_argument(
+            "--confirm", action="store_true", dest="confirm", default=False,
+            help="actually start the consistency check; otherwise preview only")
+        cmd_parser.add_argument(
+            "--dry_run", action="store_true", dest="dry_run", default=False,
+            help="force a preview even when --confirm is present")
+        return (
+            cmd_parser,
+            "volume-check-consistency",
+            "run a Redfish volume consistency check (guarded)",
+        )
+
+    def execute(self,
+                controller: str,
+                volume_id: str,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Run Volume.CheckConsistency, previewing unless explicitly confirmed.
+
+        :param controller: storage controller id owning the volume.
+        :param volume_id: volume id or Redfish Volume URI to check.
+        :param confirm: if set (and not dry_run), actually start the check.
+        :param dry_run: force a preview even when confirm is present.
+        :param do_async: note async will subscribe to an event loop.
+        :return: CommandResult with the preview or the action result.
+        :raises InvalidArgument: if volume_id is empty or not found.
+        """
+        uri, _, _ = self._resolve_volume_uri(
+            controller,
+            volume_id,
+            do_async=bool(do_async),
+        )
+        return self.invoke_action(
+            uri,
+            "CheckConsistency",
+            payload={},
+            full_action_type=_CHECK_CONSISTENCY_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
         )

--- a/tests/test_volume_manage_dualmode.py
+++ b/tests/test_volume_manage_dualmode.py
@@ -4,8 +4,8 @@ import json
 import pytest
 
 from redfish_ctl.cmd_exceptions import InvalidArgument, UnsupportedAction
-from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
 
 _CONTROLLER = "RAID.Integrated.1-1"
 _STORAGE_PATH = f"/redfish/v1/Systems/System.Embedded.1/Storage/{_CONTROLLER}"
@@ -13,6 +13,7 @@ _VOLUMES_PATH = f"{_STORAGE_PATH}/Volumes"
 _DRIVE_PATH = f"{_STORAGE_PATH}/Drives/Disk.Bay.0"
 _VOLUME_ID = f"Disk.Virtual.0:{_CONTROLLER}"
 _VOLUME_PATH = f"{_VOLUMES_PATH}/{_VOLUME_ID}"
+_CHECK_CONSISTENCY_PATH = f"{_VOLUME_PATH}/Actions/Volume.CheckConsistency"
 
 
 def _post_requests(service):
@@ -60,6 +61,35 @@ def _invoke_delete(redfish_mock, **kwargs):
         "volume-delete",
         **params,
     )
+
+
+def _invoke_check(redfish_mock, **kwargs):
+    """Invoke volume-check-consistency with default controller and volume."""
+    params = {
+        "controller": _CONTROLLER,
+        "volume_id": _VOLUME_ID,
+    }
+    params.update(kwargs)
+    return redfish_mock.sync_invoke(
+        ApiRequestType.VolumeCheckConsistency,
+        "volume-check-consistency",
+        **params,
+    )
+
+
+def _seed_check_consistency_action(service):
+    """Seed a Volume resource that advertises CheckConsistency metadata."""
+    service._overlay[_VOLUME_PATH.lower()] = {
+        "@odata.id": _VOLUME_PATH,
+        "@odata.type": "#Volume.v1_9_0.Volume",
+        "Id": _VOLUME_ID,
+        "Name": "Mock RAID volume",
+        "Actions": {
+            "#Volume.CheckConsistency": {
+                "target": _CHECK_CONSISTENCY_PATH,
+            }
+        },
+    }
 
 
 def test_volume_create_dry_run_resolves_payload_without_post(
@@ -185,6 +215,67 @@ def test_volume_delete_unknown_volume_lists_available_ids(redfish_mock):
     """volume-delete rejects unknown ids and reports the available Volumes."""
     with pytest.raises(InvalidArgument, match=_VOLUME_ID):
         _invoke_delete(redfish_mock, volume_id="missing-volume")
+
+
+def test_volume_check_consistency_dry_run_resolves_action_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """volume-check-consistency previews the action and writes nothing by default."""
+    _seed_check_consistency_action(redfish_service)
+
+    result = _invoke_check(redfish_mock)
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#Volume.CheckConsistency",
+        "target": _CHECK_CONSISTENCY_PATH,
+        "payload": {},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(redfish_service) == []
+
+
+def test_volume_check_consistency_confirm_posts_empty_payload(
+    redfish_mock,
+    redfish_service,
+):
+    """volume-check-consistency --confirm posts the discovered action target."""
+    _seed_check_consistency_action(redfish_service)
+
+    result = _invoke_check(redfish_mock, confirm=True)
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#Volume.CheckConsistency"
+    posts = _post_requests(redfish_service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == _CHECK_CONSISTENCY_PATH.lower()
+    assert posts[0].json() == {}
+
+
+def test_volume_check_consistency_rejects_missing_action_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """volume-check-consistency fails closed when the Volume lacks the action."""
+    redfish_service._overlay[_VOLUME_PATH.lower()] = {
+        "@odata.id": _VOLUME_PATH,
+        "Id": _VOLUME_ID,
+        "Name": "Mock RAID volume",
+        "Actions": {},
+    }
+
+    result = _invoke_check(redfish_mock, confirm=True)
+
+    assert result.error == (
+        f"action '#Volume.CheckConsistency' not found on {_VOLUME_PATH}"
+    )
+    assert _post_requests(redfish_service) == []
 
 
 @pytest.mark.live


### PR DESCRIPTION
## Summary
- Add `volume-check-consistency` for Redfish `Volume.CheckConsistency` actions.
- Resolve the target Volume from the Storage controller's Volumes collection, then use the Volume resource's advertised action target.
- Default to preview behavior and require `--confirm` before starting the consistency check.

## Validation
- `pytest -q` — 1291 passed, 62 skipped
- Changed-file `ruff check`
- `python tools/docstring_gate.py --all`