### PR TITLE
Add Supermicro Node Manager clear policies command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -186,6 +186,7 @@ Safety labels:
 | `spdm-measurements` | Fetch signed measurements from SPDM ComponentIntegrity resources. | Read |
 | `storage-controllers` | Read storage controller information. | Read |
 | `storage-convert-noraid` | Convert RAID disks under a controller to non-RAID. | Write |
+| `smc-clear-policies` | Clear all Supermicro X10 Node Manager policies; previews unless `--confirm` is given. | Guarded |
 | `storage-convert-raid` | Convert non-RAID disks under a controller to RAID. | Write |
 | `storage-drives` | Read storage drive members. | Read |
 | `storage-get` | Read one storage controller with optional `--filter Drives,Volumes`. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_smc_node_manager import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -82,6 +82,7 @@ ACTION_POLICY = {
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,
     "#UpdateService.SimpleUpdate": Destructiveness.DESTRUCTIVE,
     "#UpdateService.StartUpdate": Destructiveness.DESTRUCTIVE,
+    "#SmcNodeManager.ClearAllPolicies": Destructiveness.DESTRUCTIVE,
 
     # irreversible: data loss or one-way security change — needs the extra token
     "#Drive.SecureErase": Destructiveness.IRREVERSIBLE,

--- a/redfish_ctl/oem/cmd_smc_node_manager.py
+++ b/redfish_ctl/oem/cmd_smc_node_manager.py
@@ -1,0 +1,231 @@
+"""Supermicro Node Manager policy actions.
+
+    redfish_ctl smc-clear-policies
+    redfish_ctl smc-clear-policies --node-manager "Node Manager"
+    redfish_ctl smc-clear-policies --node-manager /redfish/v1/Systems/1/SmcNodeManager --confirm
+
+The command discovers the Supermicro OEM ``SmcNodeManager`` link from each
+ComputerSystem resource and keeps only Node Manager resources that advertise
+``#SmcNodeManager.ClearAllPolicies``. Clearing policies rewrites BMC policy
+configuration, so the action is guarded: without ``--confirm`` it resolves and
+previews the POST target but does not mutate.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_CLEAR_POLICIES_ACTION = "#SmcNodeManager.ClearAllPolicies"
+
+
+class SmcNodeManagerClearPolicies(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.SmcNodeManagerClearPolicies,
+    name="smc-clear-policies",
+    metaclass=Singleton,
+):
+    """Clear Supermicro Node Manager policies through the advertised action."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the smc-clear-policies command."""
+        super(SmcNodeManagerClearPolicies, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``smc-clear-policies`` subcommand.
+
+        :param cls: the owning command class, used to build the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--node-manager",
+            required=False,
+            dest="node_manager",
+            type=str,
+            default=None,
+            help=(
+                "Node Manager Id or full URI to clear; omit to list capable "
+                "Node Manager resources without mutating"
+            ),
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the ClearAllPolicies POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing",
+        )
+        return (
+            cmd_parser,
+            "smc-clear-policies",
+            "command clear Supermicro Node Manager policies",
+        )
+
+    @staticmethod
+    def _odata_id(data):
+        """Return the Redfish link URI from a string or link object.
+
+        :param data: candidate Redfish link value.
+        :return: linked ``@odata.id`` URI, or None when absent.
+        """
+        if isinstance(data, str):
+            return data
+        if isinstance(data, dict) and isinstance(data.get("@odata.id"), str):
+            return data["@odata.id"]
+        return None
+
+    @staticmethod
+    def _node_manager_link(system):
+        """Find the OEM ``SmcNodeManager`` link on a ComputerSystem resource.
+
+        :param system: a ComputerSystem payload.
+        :return: the linked Node Manager URI, or None when absent.
+        """
+        if not isinstance(system, dict):
+            return None
+        direct = SmcNodeManagerClearPolicies._odata_id(system.get("SmcNodeManager"))
+        if direct:
+            return direct
+        oem = system.get("Oem")
+        if not isinstance(oem, dict):
+            return None
+        for vendor_payload in oem.values():
+            if not isinstance(vendor_payload, dict):
+                continue
+            link = SmcNodeManagerClearPolicies._odata_id(
+                vendor_payload.get("SmcNodeManager")
+            )
+            if link:
+                return link
+        return None
+
+    def _get(self, uri, do_async):
+        """GET a resource body for discovery.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async event loop when True.
+        :return: the parsed response body, or {} for empty responses.
+        """
+        return self.base_query(uri, do_async=do_async).data or {}
+
+    def _discover_node_managers(self, do_async):
+        """Discover Node Managers that expose ClearAllPolicies.
+
+        :param do_async: issue the underlying queries on the async loop when True.
+        :return: list of ``{"Id", "uri", "system"}`` records.
+        :raises Exception: when Redfish discovery reads fail.
+        """
+        managers = []
+        seen = set()
+        system_uris = self.discover_computer_system_ids() or []
+        for system_uri in system_uris:
+            node_manager_uri = self._node_manager_link(self._get(system_uri, do_async))
+            if not node_manager_uri or node_manager_uri in seen:
+                continue
+            node_manager = self._get(node_manager_uri, do_async)
+            actions = (
+                node_manager.get("Actions")
+                if isinstance(node_manager, dict)
+                else None
+            )
+            if not isinstance(actions, dict) or _CLEAR_POLICIES_ACTION not in actions:
+                continue
+            seen.add(node_manager_uri)
+            managers.append({
+                "Id": node_manager.get("Id") or node_manager_uri.rsplit("/", 1)[-1],
+                "uri": node_manager_uri,
+                "system": system_uri,
+            })
+        return managers
+
+    @staticmethod
+    def _resolve_target(node_manager, managers):
+        """Resolve a Node Manager Id or full URI to a discovered resource URI.
+
+        :param node_manager: requested Node Manager Id or full Redfish URI.
+        :param managers: records returned by :meth:`_discover_node_managers`.
+        :return: the resolved Node Manager URI.
+        :raises InvalidArgument: when empty, unknown, or ambiguous.
+        """
+        requested = (node_manager or "").strip()
+        if not requested:
+            raise InvalidArgument("node manager id or URI cannot be empty")
+        if requested.startswith("/redfish"):
+            match = next((m for m in managers if m["uri"] == requested), None)
+            if match is not None:
+                return match["uri"]
+            raise InvalidArgument(
+                f"no ClearAllPolicies-capable Node Manager at URI '{requested}'; "
+                f"available: {[m['uri'] for m in managers]}"
+            )
+        wanted = requested.lower()
+        matches = [m for m in managers if m["Id"].lower() == wanted]
+        if not matches:
+            raise InvalidArgument(
+                f"no ClearAllPolicies-capable Node Manager with Id '{requested}'; "
+                f"available: {[m['Id'] for m in managers]}"
+            )
+        if len(matches) > 1:
+            raise InvalidArgument(
+                f"Node Manager Id '{requested}' is ambiguous across "
+                f"{[m['uri'] for m in matches]}; pass the full --node-manager URI"
+            )
+        return matches[0]["uri"]
+
+    def execute(self,
+                node_manager: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or clear Supermicro Node Manager policies.
+
+        :param node_manager: Node Manager Id or full URI to clear; None lists
+            capable resources.
+        :param confirm: authorize the destructive ClearAllPolicies POST.
+        :param dry_run: resolve the target and show it without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async loop
+            when True.
+        :return: CommandResult carrying the capable list, preview, or POST result.
+        """
+        managers = self._discover_node_managers(do_async)
+        if node_manager is None:
+            return CommandResult(
+                {"node_managers": managers}, None, None, None
+            )
+        if not managers:
+            raise InvalidArgument(
+                "no ClearAllPolicies-capable Supermicro Node Manager resources "
+                "found on this Redfish endpoint"
+            )
+
+        target_uri = self._resolve_target(node_manager, managers)
+        return self.invoke_action(
+            target_uri,
+            "ClearAllPolicies",
+            payload={},
+            full_action_type=_CLEAR_POLICIES_ACTION,
+            do_async=do_async,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -129,6 +129,7 @@ class ApiRequestType(Enum):
     Triggers = auto()
     NetworkPorts = auto()
     OemInfo = auto()
+    SmcNodeManagerClearPolicies = auto()
     ConsoleInfo = auto()
     SerialConsoleConfig = auto()
     BiosSnapshot = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -32,6 +32,7 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
+    assert classify("#SmcNodeManager.ClearAllPolicies") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE

--- a/tests/test_smc_node_manager_dualmode.py
+++ b/tests/test_smc_node_manager_dualmode.py
@@ -1,0 +1,137 @@
+"""Offline X10 coverage for Supermicro Node Manager policy actions."""
+
+from copy import deepcopy
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+NODE_MANAGER = "/redfish/v1/Systems/1/SmcNodeManager"
+CLEAR_TARGET = f"{NODE_MANAGER}/Actions/SmcNodeManager.ClearAllPolicies"
+
+
+def _post_requests(service):
+    """Return POST requests captured by the mock Redfish transport."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_smc_clear_policies_lists_x10_node_manager_without_post(redfish_mock_factory):
+    """With no target, the command lists capable Node Managers and never POSTs."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.SmcNodeManagerClearPolicies,
+        "smc-clear-policies",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "node_managers": [{
+            "Id": "Node Manager",
+            "uri": NODE_MANAGER,
+            "system": "/redfish/v1/Systems/1",
+        }]
+    }
+    assert _post_requests(service) == []
+
+
+def test_smc_clear_policies_accepts_string_oem_link(redfish_mock_factory):
+    """Discovery accepts ``SmcNodeManager`` links encoded as plain URI strings."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+    system = deepcopy(service._state("/redfish/v1/Systems/1"))
+    system["Oem"]["Supermicro"]["SmcNodeManager"] = NODE_MANAGER
+    service._overlay["/redfish/v1/Systems/1"] = system
+
+    result = manager.sync_invoke(
+        ApiRequestType.SmcNodeManagerClearPolicies,
+        "smc-clear-policies",
+    )
+
+    assert result.error is None
+    assert result.data == {
+        "node_managers": [{
+            "Id": "Node Manager",
+            "uri": NODE_MANAGER,
+            "system": "/redfish/v1/Systems/1",
+        }]
+    }
+
+
+def test_smc_clear_policies_without_confirm_is_preview_only(redfish_mock_factory):
+    """ClearAllPolicies resolves the action but does not POST without --confirm."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.SmcNodeManagerClearPolicies,
+        "smc-clear-policies",
+        node_manager="Node Manager",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#SmcNodeManager.ClearAllPolicies"
+    assert result.data["target"] == CLEAR_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(service) == []
+
+
+def test_smc_clear_policies_confirm_posts_to_discovered_target(redfish_mock_factory):
+    """--confirm POSTs to the action target advertised by the Node Manager."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.SmcNodeManagerClearPolicies,
+        "smc-clear-policies",
+        node_manager=NODE_MANAGER,
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#SmcNodeManager.ClearAllPolicies"
+    assert result.data["target"] == CLEAR_TARGET
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == CLEAR_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_smc_clear_policies_confirm_dry_run_still_does_not_post(redfish_mock_factory):
+    """--dry_run remains a no-POST preview even when --confirm is supplied."""
+    manager, service = redfish_mock_factory("supermicro_x10")
+
+    result = manager.sync_invoke(
+        ApiRequestType.SmcNodeManagerClearPolicies,
+        "smc-clear-policies",
+        node_manager=NODE_MANAGER,
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == CLEAR_TARGET
+    assert _post_requests(service) == []
+
+
+def test_smc_clear_policies_no_capable_node_manager_raises(redfish_mock_factory):
+    """A non-X10 corpus fails clearly before any POST is attempted."""
+    manager, service = redfish_mock_factory("hpe")
+
+    with pytest.raises(InvalidArgument, match="no ClearAllPolicies-capable"):
+        manager.sync_invoke(
+            ApiRequestType.SmcNodeManagerClearPolicies,
+            "smc-clear-policies",
+            node_manager="Node Manager",
+        )
+
+    assert _post_requests(service) == []


### PR DESCRIPTION
## Summary
- Add guarded `smc-clear-policies` for Supermicro X10 Node Manager ClearAllPolicies actions.
- Discover the OEM SmcNodeManager link from ComputerSystem resources and preview by default unless `--confirm` is supplied.
- Classify the action as destructive and cover list, preview, confirm, and unavailable-target behavior with X10 fixture tests.

## Validation
- Project gate passed: 1294 passed, 62 skipped, 6 warnings.
- Changed-file Ruff passed.
- Docstring gate passed.
