### PR TITLE
Export health, state, and link-down-reason enums as gauges

### DIFF
--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -110,6 +110,15 @@ SECRET_ARG_NAMES = {"--idrac_password", "--idrac-password"}
 DIM_VALUE_OK = re.compile(r"[^A-Za-z0-9_.\-/]")
 # push_signalfx POSTs the ingest URL as-is, so it must be the full SignalFx
 # datapoint endpoint (…/v2/datapoint), never a bare host.
+# Redfish enum -> numeric mappings so state/health strings become alertable
+# gauges instead of being dropped (P0: health was previously 100% unexported).
+# Status.Health per DMTF is exactly OK/Warning/Critical.
+HEALTH_VALUES = {"ok": 1.0, "warning": 0.5, "critical": 0.0}
+
+# Power-integrity readings where anything but a clear/normal state is an
+# event worth a 1.0 sample (same fail-visible posture as hw.leak.state).
+POWER_STATE_CLEAR_VALUES = {"normal", "ok", "none", "disabled", "notapplicable", "na"}
+
 SIGNALFX_DATAPOINT_PATH = "/v2/datapoint"
 POLL_JITTER_FRACTION = 0.10
 
@@ -419,9 +428,13 @@ def samples_from_metric_report_rows(
     """Map every TelemetryService MetricReport row into a metric sample.
 
     Fabric properties get curated ``hw.fabric.*`` names and fabric dimensions;
-    every other property (GPU FP16/FP32 activity, thermal, power, memory, …) is
-    emitted under a generic ``hw.gb300.*`` name so the FULL telemetry surface
-    reaches OTel/Prometheus, not just the fabric subset.
+    every other numeric property (GPU FP16/FP32 activity, thermal, power,
+    memory, …) is emitted under a generic ``hw.gb300.*`` name so the FULL
+    telemetry surface reaches OTel/Prometheus, not just the fabric subset.
+    Known state/health enum strings (Health, HealthRollup, State,
+    LinkDownReasonCode, EDPViolationState, PowerBreakPerformanceState) are
+    mapped to numeric gauges by :func:`_state_enum_sample` instead of being
+    dropped.
 
     :param rows: TelemetryService MetricReport rows to map.
     :param identity: fixed join dimensions applied to every sample.
@@ -441,6 +454,9 @@ def samples_from_metric_report_rows(
 
         value = _as_float(row.get("MetricValue"))
         if value is None:
+            state_sample = _state_enum_sample(prop_info, row, identity)
+            if state_sample is not None:
+                samples.append(state_sample)
             continue
         if prop_name in FABRIC_PROPERTY_METRICS:
             metric = FABRIC_PROPERTY_METRICS[prop_name]
@@ -457,6 +473,69 @@ def samples_from_metric_report_rows(
         dims["report"] = str(row.get("Report") or "unknown")
         samples.append(_sample(metric, value, dims, _unit_for_metric(metric), row.get("Timestamp")))
     return samples
+
+
+def _state_enum_sample(
+        prop_info: Mapping[str, str],
+        row: Mapping,
+        identity: Mapping[str, str]) -> Optional[MetricSample]:
+    """Map a non-numeric state/health MetricReport row to a gauge sample.
+
+    Covers the enum-string rows the numeric path drops: ``Health`` and
+    ``HealthRollup`` become ``hw.health`` / ``hw.health_rollup`` (OK=1,
+    Warning=0.5, Critical=0, raw string kept in the ``health_state``
+    dimension); ``State`` becomes ``hw.state.enabled`` (1 only for Enabled,
+    raw string in the ``state`` dimension); ``LinkDownReasonCode`` becomes a
+    constant-1 ``hw.fabric.link_down_reason`` sample whose ``reason``
+    dimension carries the cause (count by reason answers WHY links dropped);
+    ``EDPViolationState`` / ``PowerBreakPerformanceState`` become 0/1
+    ``hw.power.edp_violation`` / ``hw.power.break_state`` events.
+
+    :param prop_info: parsed MetricProperty fields (property, system, gpu, port, …).
+    :param row: the raw MetricReport row.
+    :param identity: fixed join dimensions applied to the sample.
+    :return: the mapped MetricSample, or None when the row is not a known
+        state/health enum (unknown enum text stays unexported rather than
+        guessing a value).
+    """
+    prop_name = prop_info["property"]
+    text = str(row.get("MetricValue") or "").strip()
+    if not text:
+        return None
+    lowered = text.lower()
+    dims = _with_dims(identity, source="metric-report",
+                      property=_dim_value(prop_name))
+    for key in ("system", "gpu", "port", "chassis", "memory", "index"):
+        if prop_info.get(key):
+            dims[key] = str(prop_info[key])
+    dims["report"] = str(row.get("Report") or "unknown")
+
+    metric = None
+    value = None
+    if prop_name in ("Health", "HealthRollup"):
+        value = HEALTH_VALUES.get(lowered)
+        if value is None:
+            return None
+        metric = "hw.health" if prop_name == "Health" else "hw.health_rollup"
+        dims["health_state"] = _dim_value(text)
+    elif prop_name == "State":
+        metric = "hw.state.enabled"
+        value = 1.0 if lowered == "enabled" else 0.0
+        dims["state"] = _dim_value(text)
+    elif prop_name == "LinkDownReasonCode":
+        metric = "hw.fabric.link_down_reason"
+        value = 1.0
+        dims["reason"] = _dim_value(text)
+        dims["fabric"] = ("ib" if str(prop_info.get("port", "")).lower().startswith("ib")
+                          else "nvlink")
+    elif prop_name in ("EDPViolationState", "PowerBreakPerformanceState"):
+        metric = ("hw.power.edp_violation" if prop_name == "EDPViolationState"
+                  else "hw.power.break_state")
+        value = 0.0 if lowered in POWER_STATE_CLEAR_VALUES else 1.0
+        dims["state"] = _dim_value(text)
+    if metric is None:
+        return None
+    return _sample(metric, value, dims, None, row.get("Timestamp"))
 
 
 def _gpu_metric_report_sample(

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -715,3 +715,120 @@ def test_resolve_signalfx_ingest_url_validates_full_datapoint_endpoint(monkeypat
     monkeypatch.delenv("SPLUNK_INGEST_URL", raising=False)
     with pytest.raises(ValueError, match="SPLUNK_INGEST_URL is not set"):
         resolve_signalfx_ingest_url()
+
+
+def test_metric_report_mapper_exports_health_and_rollup_enums():
+    """Health/HealthRollup enum rows become hw.health gauges (P0: were dropped).
+
+    This edge exists because HGX_HealthMetrics rows carry Status.Health enum
+    strings, which the numeric-only path silently skipped — leaving no
+    component-health signal to alert on.
+    """
+    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
+    base = "/redfish/v1/Chassis/HGX_GPU_0#/Status"
+    samples = build_metric_samples(
+        identity=dims,
+        environment_rows=[],
+        sensor_rows=[],
+        nvlink_rows=[],
+        metric_report_rows=[
+            {"Report": "HGX_HealthMetrics_0",
+             "MetricProperty": f"{base}/Health", "MetricValue": "OK"},
+            {"Report": "HGX_HealthMetrics_0",
+             "MetricProperty": f"{base}/HealthRollup", "MetricValue": "Warning"},
+            {"Report": "HGX_HealthMetrics_0",
+             "MetricProperty": f"{base}/Health", "MetricValue": "Critical"},
+        ],
+    )
+    health = [s for s in samples if s.metric == "hw.health"]
+    rollup = [s for s in samples if s.metric == "hw.health_rollup"]
+    assert sorted(s.value for s in health) == [0.0, 1.0]
+    assert rollup[0].value == 0.5
+    assert rollup[0].dimensions["health_state"] == "Warning"
+    assert health[0].dimensions["report"] == "HGX_HealthMetrics_0"
+
+
+def test_metric_report_mapper_exports_link_down_reason():
+    """LinkDownReasonCode becomes a constant-1 sample with the reason dimension.
+
+    The exporter already counted link_down events but never WHY — the reason
+    enum row was dropped by the numeric path.
+    """
+    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
+    samples = build_metric_samples(
+        identity=dims,
+        environment_rows=[],
+        sensor_rows=[],
+        nvlink_rows=[],
+        metric_report_rows=[{
+            "Report": "HGX_ProcessorPortMetrics_0",
+            "MetricProperty": (
+                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/"
+                "Ports/NVLink_3/Metrics#/Oem/Nvidia/LinkDownReasonCode"
+            ),
+            "MetricValue": "PeerResetEvent",
+        }],
+    )
+    reason = [s for s in samples if s.metric == "hw.fabric.link_down_reason"]
+    assert len(reason) == 1
+    assert reason[0].value == 1.0
+    assert reason[0].dimensions["reason"] == "PeerResetEvent"
+    assert reason[0].dimensions["fabric"] == "nvlink"
+    assert reason[0].dimensions["port"] == "NVLink_3"
+
+
+def test_metric_report_mapper_exports_state_and_power_integrity_enums():
+    """State and EDP/PowerBreak enum rows become 0/1 gauges with raw-state dims."""
+    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
+    base = "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0"
+    samples = build_metric_samples(
+        identity=dims,
+        environment_rows=[],
+        sensor_rows=[],
+        nvlink_rows=[],
+        metric_report_rows=[
+            {"Report": "HGX_CpuProcessorMetrics_0",
+             "MetricProperty": f"{base}#/Status/State", "MetricValue": "Enabled"},
+            {"Report": "HGX_CpuProcessorMetrics_0",
+             "MetricProperty": f"{base}#/Status/State", "MetricValue": "Absent"},
+            {"Report": "HGX_CpuProcessorMetrics_0",
+             "MetricProperty": f"{base}#/Oem/Nvidia/EDPViolationState",
+             "MetricValue": "Normal"},
+            {"Report": "HGX_CpuProcessorMetrics_0",
+             "MetricProperty": f"{base}#/Oem/Nvidia/PowerBreakPerformanceState",
+             "MetricValue": "Throttled"},
+        ],
+    )
+    states = [s for s in samples if s.metric == "hw.state.enabled"]
+    assert sorted(s.value for s in states) == [0.0, 1.0]
+    assert {s.dimensions["state"] for s in states} == {"Enabled", "Absent"}
+    edp = [s for s in samples if s.metric == "hw.power.edp_violation"]
+    assert edp[0].value == 0.0
+    brk = [s for s in samples if s.metric == "hw.power.break_state"]
+    assert brk[0].value == 1.0
+    assert brk[0].dimensions["state"] == "Throttled"
+
+
+def test_metric_report_mapper_skips_unknown_enum_strings():
+    """Unknown enum text stays unexported instead of guessing a numeric value.
+
+    A vendor could ship a new Health value; exporting a made-up number would
+    corrupt alerts, so the fail-safe is to drop only that row.
+    """
+    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
+    samples = build_metric_samples(
+        identity=dims,
+        environment_rows=[],
+        sensor_rows=[],
+        nvlink_rows=[],
+        metric_report_rows=[
+            {"Report": "HGX_HealthMetrics_0",
+             "MetricProperty": "/redfish/v1/Chassis/HGX_GPU_0#/Status/Health",
+             "MetricValue": "SomethingNew"},
+            {"Report": "HGX_CpuProcessorMetrics_0",
+             "MetricProperty": "/redfish/v1/Chassis/HGX_GPU_0#/PCIeType",
+             "MetricValue": "Gen5"},
+        ],
+    )
+    assert [s for s in samples if s.metric.startswith("hw.health")] == []
+    assert all(s.metric.startswith("hw.scrape") for s in samples)


### PR DESCRIPTION
P0: the exporter dropped every non-numeric MetricReport row, so component health (Status.Health/HealthRollup), port/CPU State, NVLink LinkDownReasonCode, and the EDP/power-break integrity states were invisible — operators could count link_down events but never see why, and could not alert on health at all.

- `Health`/`HealthRollup` → `hw.health`/`hw.health_rollup` gauges (OK=1, Warning=0.5, Critical=0; raw string kept in the `health_state` dimension)
- `State` → `hw.state.enabled` (1 only for Enabled; raw value in the `state` dimension)
- `LinkDownReasonCode` → constant-1 `hw.fabric.link_down_reason` with the cause in the `reason` dimension (count by reason answers why links dropped)
- `EDPViolationState`/`PowerBreakPerformanceState` → 0/1 `hw.power.edp_violation`/`hw.power.break_state` event gauges
- Unknown enum text stays unexported (fail-safe: no guessed values corrupting alerts)

Regression tests cover each enum class, dimension contents, and the unknown-string fail-safe. All new names classify as OTLP Gauges (no counter-suffix collisions). Follow-up hard gate: live visibility check in Splunk via the ingest pipeline.