### PR TITLE
Add guarded license install command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -143,6 +143,7 @@ Safety labels:
 | `jobs-dell-service` | Read Dell JobService. | Read |
 | `jobs-service` | Read standard Redfish JobService. | Read |
 | `leak-detectors` | Read chassis LeakDetection detector states and linked leak policy data. | Read |
+| `license-install` | Install a license file through `LicenseService.Install`; lists the discovered action target when no URI is given, requires `--confirm` to write. | Guarded |
 | `logs` | Read system and manager log entries. | Read |
 | `log-clear` | Clear a discovered LogService (LogService.ClearLog); lists clearable services when no target is given, requires `--confirm` to write. | Guarded |
 | `log-collect-diag` | Collect diagnostic data from a discovered LogService (LogService.CollectDiagnosticData); lists capable services when no target is given, requires `--confirm` to write. | Guarded |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -109,6 +109,7 @@ from .compute.cmd_system_reset import *
 from .logs.cmd_logs import *
 from .logs.cmd_log_clear import *
 from .logs.cmd_log_collect_diag import *
+from .licenses.cmd_license_install import *
 from .network.cmd_ethernet_interfaces import *
 from .security.cmd_secure_boot import *
 from .security.cmd_certificates import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -64,6 +64,7 @@ ACTION_POLICY = {
     "#Control.ResetToDefaults": Destructiveness.DESTRUCTIVE,
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
+    "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/licenses/__init__.py
+++ b/redfish_ctl/licenses/__init__.py
@@ -1,0 +1,1 @@
+"""LicenseService command modules."""

--- a/redfish_ctl/licenses/cmd_license_install.py
+++ b/redfish_ctl/licenses/cmd_license_install.py
@@ -1,0 +1,267 @@
+"""Install a Redfish license through LicenseService.Install.
+
+    redfish_ctl license-install
+    redfish_ctl license-install --license-file-uri https://repo.example.test/license.xml --dry_run
+    redfish_ctl license-install --license-file-uri https://repo.example.test/license.xml --confirm
+
+The command resolves ``#LicenseService.Install`` from the service root's
+LicenseService link. Installing a license changes BMC entitlement state, so the
+action is DESTRUCTIVE: without ``--confirm`` the command only previews the POST.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_LICENSE_INSTALL_ACTION = "#LicenseService.Install"
+
+
+class LicenseInstall(RedfishManagerBase,
+                     scm_type=ApiRequestType.LicenseInstall,
+                     name="license-install",
+                     metaclass=Singleton):
+    """Install a license file through the Redfish LicenseService."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the license-install command."""
+        super(LicenseInstall, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``license-install`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--license-file-uri",
+            required=False,
+            dest="license_file_uri",
+            type=str,
+            default=None,
+            help="URI of the license file for LicenseService.Install; omit to "
+                 "list the discovered action target without mutating",
+        )
+        cmd_parser.add_argument(
+            "--transfer-protocol",
+            required=False,
+            dest="transfer_protocol",
+            type=str,
+            default=None,
+            help="transfer protocol for the license file, such as HTTP or HTTPS",
+        )
+        cmd_parser.add_argument(
+            "--username",
+            required=False,
+            dest="license_username",
+            type=str,
+            default=None,
+            help="optional username for the license file URI",
+        )
+        cmd_parser.add_argument(
+            "--password",
+            required=False,
+            dest="license_password",
+            type=str,
+            default=None,
+            help="optional password for the license file URI",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the LicenseService.Install POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "license-install",
+            "command install a Redfish license file",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: the resource body holding the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the link target URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _license_service_uri(self, do_async):
+        """Resolve the LicenseService URI from the service root.
+
+        :param do_async: issue the service-root query over the async Redfish path.
+        :return: the LicenseService ``@odata.id``, or the standard fallback URI.
+        """
+        try:
+            root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
+        except Exception:
+            root = {}
+        return self._link(root, "LicenseService") or f"{RedfishApi.Version}/LicenseService"
+
+    def _license_service(self, do_async):
+        """Read the LicenseService resource.
+
+        :param do_async: issue the query over the async Redfish path.
+        :return: tuple of ``(uri, body)``.
+        """
+        uri = self._license_service_uri(do_async)
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return uri, CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+        return uri, data
+
+    def _install_metadata(self, do_async):
+        """Return discovered LicenseService.Install target metadata.
+
+        :param do_async: issue the LicenseService query over the async Redfish path.
+        :return: CommandResult with target metadata, or an error if absent.
+        """
+        uri, service = self._license_service(do_async)
+        if isinstance(service, CommandResult):
+            return service
+        actions = self.discover_redfish_actions(self, service)
+        target = self._flatten_action_targets(service).get(_LICENSE_INSTALL_ACTION)
+        action = actions.get("Install")
+        transfer_protocols = sorted((getattr(action, "args", {}) or {}).get(
+            "TransferProtocol", []
+        ))
+        if target is None:
+            available = sorted(set(list(actions.keys())
+                                   + list(self._flatten_action_targets(service).keys())))
+            return CommandResult(
+                {
+                    "license_service": uri,
+                    "action": _LICENSE_INSTALL_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_LICENSE_INSTALL_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "license_service": uri,
+                "action": _LICENSE_INSTALL_ACTION,
+                "target": target,
+                "transfer_protocols": transfer_protocols,
+            },
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _payload(license_file_uri,
+                 transfer_protocol=None,
+                 license_username=None,
+                 license_password=None):
+        """Build a LicenseService.Install payload.
+
+        :param license_file_uri: URI of the license file to install.
+        :param transfer_protocol: optional TransferProtocol value.
+        :param license_username: optional username for the URI.
+        :param license_password: optional password for the URI.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when ``license_file_uri`` is empty.
+        """
+        uri = (license_file_uri or "").strip()
+        if not uri:
+            raise InvalidArgument("license file URI cannot be empty")
+        payload = {
+            "LicenseFileURI": uri,
+            "TransferProtocol": transfer_protocol,
+            "Username": license_username,
+            "Password": license_password,
+        }
+        return {key: value for key, value in payload.items() if value is not None}
+
+    @staticmethod
+    def _redact_password(result):
+        """Mask Password in dry-run payloads before returning to callers.
+
+        :param result: CommandResult from ``invoke_action``.
+        :return: CommandResult with any dry-run password masked.
+        """
+        if not isinstance(result.data, dict):
+            return result
+        payload = result.data.get("payload")
+        if isinstance(payload, dict) and "Password" in payload:
+            payload = dict(payload)
+            payload["Password"] = "********"
+            result.data["payload"] = payload
+        return result
+
+    def execute(self,
+                license_file_uri: Optional[str] = None,
+                transfer_protocol: Optional[str] = None,
+                license_username: Optional[str] = None,
+                license_password: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List the install action target, or install a license file.
+
+        With no ``--license-file-uri`` the command returns the discovered
+        LicenseService.Install target WITHOUT mutating. With a URI it resolves
+        and invokes the action; because the action is DESTRUCTIVE, the POST only
+        fires with ``--confirm``. ``--dry_run`` remains a no-POST override even
+        when ``--confirm`` is also set.
+
+        :param license_file_uri: URI of the license file to install; None lists
+            target metadata.
+        :param transfer_protocol: optional TransferProtocol value.
+        :param license_username: optional username for the license file URI.
+        :param license_password: optional password for the license file URI.
+        :param confirm: authorize the LicenseService.Install POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with target metadata, the install outcome, or a
+            blocked/dry-run preview.
+        :raises InvalidArgument: when ``license_file_uri`` is empty after trimming.
+        """
+        if license_file_uri is None:
+            return self._install_metadata(do_async)
+
+        result = self.invoke_action(
+            self._license_service_uri(do_async),
+            "Install",
+            payload=self._payload(
+                license_file_uri,
+                transfer_protocol=transfer_protocol,
+                license_username=license_username,
+                license_password=license_password,
+            ),
+            full_action_type=_LICENSE_INSTALL_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        return self._redact_password(result)

--- a/redfish_ctl/licenses/cmd_license_install.py
+++ b/redfish_ctl/licenses/cmd_license_install.py
@@ -10,7 +10,9 @@ action is DESTRUCTIVE: without ``--confirm`` the command only previews the POST.
 
 Author Mus spyroot@gmail.com
 """
+import os
 from abc import abstractmethod
+from pathlib import Path
 from typing import Optional
 
 from ..cmd_exceptions import InvalidArgument
@@ -66,13 +68,22 @@ class LicenseInstall(RedfishManagerBase,
             default=None,
             help="optional username for the license file URI",
         )
-        cmd_parser.add_argument(
-            "--password",
+        password_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        password_group.add_argument(
+            "--password-env",
             required=False,
-            dest="license_password",
+            dest="license_password_env",
             type=str,
             default=None,
-            help="optional password for the license file URI",
+            help="environment variable containing the license file URI password",
+        )
+        password_group.add_argument(
+            "--password-file",
+            required=False,
+            dest="license_password_file",
+            type=str,
+            default=None,
+            help="file containing the license file URI password",
         )
         cmd_parser.add_argument(
             "--confirm",
@@ -171,6 +182,37 @@ class LicenseInstall(RedfishManagerBase,
         )
 
     @staticmethod
+    def _password_from_source(password_env=None, password_file=None):
+        """Read a license URI password from a named environment variable or file.
+
+        :param password_env: name of the environment variable to read.
+        :param password_file: path to a file containing the password.
+        :return: the password string, or None when no source was provided.
+        :raises InvalidArgument: when both sources are provided, a source name is
+            empty, the environment variable is absent, or the file cannot be read.
+        """
+        if password_env and password_file:
+            raise InvalidArgument(
+                "use only one of --password-env or --password-file"
+            )
+        if password_env is not None:
+            env_name = password_env.strip()
+            if not env_name:
+                raise InvalidArgument("password environment variable name cannot be empty")
+            if env_name not in os.environ:
+                raise InvalidArgument(f"password environment variable '{env_name}' is not set")
+            return os.environ[env_name]
+        if password_file is not None:
+            path = Path(password_file).expanduser()
+            try:
+                return path.read_text(encoding="utf-8").rstrip("\r\n")
+            except OSError as exc:
+                raise InvalidArgument(
+                    f"failed to read password file '{path}': {exc}"
+                ) from exc
+        return None
+
+    @staticmethod
     def _payload(license_file_uri,
                  transfer_protocol=None,
                  license_username=None,
@@ -180,7 +222,7 @@ class LicenseInstall(RedfishManagerBase,
         :param license_file_uri: URI of the license file to install.
         :param transfer_protocol: optional TransferProtocol value.
         :param license_username: optional username for the URI.
-        :param license_password: optional password for the URI.
+        :param license_password: optional password read from an env var or file.
         :return: JSON-serializable action payload.
         :raises InvalidArgument: when ``license_file_uri`` is empty.
         """
@@ -215,7 +257,8 @@ class LicenseInstall(RedfishManagerBase,
                 license_file_uri: Optional[str] = None,
                 transfer_protocol: Optional[str] = None,
                 license_username: Optional[str] = None,
-                license_password: Optional[str] = None,
+                license_password_env: Optional[str] = None,
+                license_password_file: Optional[str] = None,
                 confirm: Optional[bool] = False,
                 dry_run: Optional[bool] = False,
                 filename: Optional[str] = None,
@@ -235,7 +278,10 @@ class LicenseInstall(RedfishManagerBase,
             target metadata.
         :param transfer_protocol: optional TransferProtocol value.
         :param license_username: optional username for the license file URI.
-        :param license_password: optional password for the license file URI.
+        :param license_password_env: environment variable containing the optional
+            password for the license file URI.
+        :param license_password_file: file containing the optional password for
+            the license file URI.
         :param confirm: authorize the LicenseService.Install POST to actually fire.
         :param dry_run: resolve the target and show the payload without POSTing.
         :param filename: accepted for CLI compatibility; not used by this command.
@@ -256,7 +302,10 @@ class LicenseInstall(RedfishManagerBase,
                 license_file_uri,
                 transfer_protocol=transfer_protocol,
                 license_username=license_username,
-                license_password=license_password,
+                license_password=self._password_from_source(
+                    license_password_env,
+                    license_password_file,
+                ),
             ),
             full_action_type=_LICENSE_INSTALL_ACTION,
             do_async=do_async,

--- a/redfish_ctl/licenses/cmd_license_install.py
+++ b/redfish_ctl/licenses/cmd_license_install.py
@@ -213,6 +213,18 @@ class LicenseInstall(RedfishManagerBase,
         return None
 
     @staticmethod
+    def _optional_payload_value(value):
+        """Strip optional string payload values and drop empty values.
+
+        :param value: optional Redfish action payload value.
+        :return: stripped string, original non-string value, or None.
+        """
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    @staticmethod
     def _payload(license_file_uri,
                  transfer_protocol=None,
                  license_username=None,
@@ -231,9 +243,9 @@ class LicenseInstall(RedfishManagerBase,
             raise InvalidArgument("license file URI cannot be empty")
         payload = {
             "LicenseFileURI": uri,
-            "TransferProtocol": transfer_protocol,
-            "Username": license_username,
-            "Password": license_password,
+            "TransferProtocol": LicenseInstall._optional_payload_value(transfer_protocol),
+            "Username": LicenseInstall._optional_payload_value(license_username),
+            "Password": LicenseInstall._optional_payload_value(license_password),
         }
         return {key: value for key, value in payload.items() if value is not None}
 

--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -1366,6 +1366,31 @@ class RedfishManagerBase(RedfishManager):
         """
         return f"?$expand=*($levels={level})"
 
+    @staticmethod
+    def _redact_sensitive_payload(payload):
+        """Return a copy of a request payload with secret-like fields masked.
+
+        :param payload: JSON-compatible request payload.
+        :return: payload copy safe for debug logging.
+        """
+        sensitive = {"apikey", "api_key", "secret", "token"}
+
+        if isinstance(payload, dict):
+            redacted = {}
+            for key, value in payload.items():
+                key_text = str(key).lower()
+                if key_text.endswith("password") or key_text in sensitive:
+                    redacted[key] = "********"
+                else:
+                    redacted[key] = RedfishManagerBase._redact_sensitive_payload(value)
+            return redacted
+        if isinstance(payload, list):
+            return [
+                RedfishManagerBase._redact_sensitive_payload(value)
+                for value in payload
+            ]
+        return payload
+
     def base_request_respond(
             self,
             resource: str,
@@ -1396,10 +1421,11 @@ class RedfishManagerBase(RedfishManager):
             headers.update(self.json_content_type)
 
         pd = payload if payload is not None else {}
+        log_payload = self._redact_sensitive_payload(pd)
 
         self.logger.debug(f"Issuing {method} request to "
                           f"resource: {resource}, "
-                          f"payload: {json.dumps(pd)}")
+                          f"payload: {json.dumps(log_payload)}")
 
         err = None
         response = None

--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -1373,13 +1373,14 @@ class RedfishManagerBase(RedfishManager):
         :param payload: JSON-compatible request payload.
         :return: payload copy safe for debug logging.
         """
-        sensitive = {"apikey", "api_key", "secret", "token"}
+        sensitive_exact = {"apikey", "api_key", "accesskey", "access_key"}
+        sensitive_suffixes = ("password", "secret", "token")
 
         if isinstance(payload, dict):
             redacted = {}
             for key, value in payload.items():
                 key_text = str(key).lower()
-                if key_text.endswith("password") or key_text in sensitive:
+                if key_text in sensitive_exact or key_text.endswith(sensitive_suffixes):
                     redacted[key] = "********"
                 else:
                     redacted[key] = RedfishManagerBase._redact_sensitive_payload(value)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -113,6 +113,7 @@ class ApiRequestType(Enum):
     Logs = auto()
     LogClear = auto()
     LogCollectDiagnosticData = auto()
+    LicenseInstall = auto()
     EthernetInterfaces = auto()
     SecureBoot = auto()
     CertificatesQuery = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -20,6 +20,7 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#Drive.SecureErase") is Destructiveness.IRREVERSIBLE
     assert classify("#EventService.SubmitTestEvent") is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
+    assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -35,10 +35,14 @@ def test_request_log_payload_redacts_sensitive_fields():
         "Nested": {
             "OldPassword": "old-secret",
             "NewPassword": "new-secret",
+            "ClientSecret": "client-secret",
+            "RefreshToken": "refresh-token",
             "PasswordName": "Administrator",
         },
         "Links": [
             {"token": "bearer-value"},
+            {"ApiKey": "api-key-value"},
+            {"AccessKey": "access-key-value"},
             {"Label": "public"},
         ],
     }
@@ -48,9 +52,13 @@ def test_request_log_payload_redacts_sensitive_fields():
     assert redacted["Password"] == "********"
     assert redacted["Nested"]["OldPassword"] == "********"
     assert redacted["Nested"]["NewPassword"] == "********"
+    assert redacted["Nested"]["ClientSecret"] == "********"
+    assert redacted["Nested"]["RefreshToken"] == "********"
     assert redacted["Nested"]["PasswordName"] == "Administrator"
     assert redacted["Links"][0]["token"] == "********"
-    assert redacted["Links"][1]["Label"] == "public"
+    assert redacted["Links"][1]["ApiKey"] == "********"
+    assert redacted["Links"][2]["AccessKey"] == "********"
+    assert redacted["Links"][3]["Label"] == "public"
     assert payload["Password"] == "secret-value"
     assert payload["Nested"]["OldPassword"] == "old-secret"
 

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -7,6 +7,7 @@ against tests/supermicro_fixtures/ through the real requests path; the mock
 records every POST so we can assert exactly what did (or did not) fire.
 """
 from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
 
 
 def _post_count(svc):
@@ -24,6 +25,34 @@ def test_policy_classifies_known_and_unknown():
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE
+
+
+def test_request_log_payload_redacts_sensitive_fields():
+    """Debug request logging masks secrets without mutating the real payload."""
+    payload = {
+        "UserName": "root",
+        "Password": "secret-value",
+        "Nested": {
+            "OldPassword": "old-secret",
+            "NewPassword": "new-secret",
+            "PasswordName": "Administrator",
+        },
+        "Links": [
+            {"token": "bearer-value"},
+            {"Label": "public"},
+        ],
+    }
+
+    redacted = RedfishManagerBase._redact_sensitive_payload(payload)
+
+    assert redacted["Password"] == "********"
+    assert redacted["Nested"]["OldPassword"] == "********"
+    assert redacted["Nested"]["NewPassword"] == "********"
+    assert redacted["Nested"]["PasswordName"] == "Administrator"
+    assert redacted["Links"][0]["token"] == "********"
+    assert redacted["Links"][1]["Label"] == "public"
+    assert payload["Password"] == "secret-value"
+    assert payload["Nested"]["OldPassword"] == "old-secret"
 
 
 def test_invoke_resolves_target_from_actions_block(redfish_mock_factory):

--- a/tests/test_license_install_dualmode.py
+++ b/tests/test_license_install_dualmode.py
@@ -193,16 +193,20 @@ def test_license_install_rejects_invalid_transfer_protocol(dell_license_manager)
     assert _post_requests(requests) == []
 
 
-def test_license_install_masks_password_in_dry_run(dell_license_manager):
-    """Dry-run output does not echo a URI credential password."""
+def test_license_install_masks_password_from_env_in_dry_run(
+    dell_license_manager,
+    monkeypatch,
+):
+    """Dry-run output does not echo a URI credential password read from env."""
     manager, requests = dell_license_manager
+    monkeypatch.setenv("LICENSE_INSTALL_PASSWORD", "placeholder-value")
 
     result = manager.sync_invoke(
         ApiRequestType.LicenseInstall,
         "license-install",
         license_file_uri="https://repo.example.test/license.xml",
         license_username="license-reader",
-        license_password="placeholder-value",
+        license_password_env="LICENSE_INSTALL_PASSWORD",
         dry_run=True,
     )
 
@@ -210,6 +214,48 @@ def test_license_install_masks_password_in_dry_run(dell_license_manager):
     assert result.error is None
     assert result.data["payload"]["Username"] == "license-reader"
     assert result.data["payload"]["Password"] == "********"
+    assert _post_requests(requests) == []
+
+
+def test_license_install_reads_password_file_and_redacts_dry_run(
+    dell_license_manager,
+    tmp_path,
+):
+    """A password file source is supported without echoing the file content."""
+    manager, requests = dell_license_manager
+    password_file = tmp_path / "license-password"
+    password_file.write_text("placeholder-value\n", encoding="utf-8")
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+        license_password_file=str(password_file),
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["payload"]["Password"] == "********"
+    assert _post_requests(requests) == []
+
+
+def test_license_install_rejects_missing_password_env(dell_license_manager):
+    """Missing password environment variables fail before any POST."""
+    manager, requests = dell_license_manager
+
+    with pytest.raises(
+        InvalidArgument,
+        match="environment variable 'MISSING_LICENSE_PASSWORD'",
+    ):
+        manager.sync_invoke(
+            ApiRequestType.LicenseInstall,
+            "license-install",
+            license_file_uri="https://repo.example.test/license.xml",
+            license_password_env="MISSING_LICENSE_PASSWORD",
+            confirm=True,
+        )
+
     assert _post_requests(requests) == []
 
 

--- a/tests/test_license_install_dualmode.py
+++ b/tests/test_license_install_dualmode.py
@@ -193,6 +193,28 @@ def test_license_install_rejects_invalid_transfer_protocol(dell_license_manager)
     assert _post_requests(requests) == []
 
 
+def test_license_install_strips_and_omits_empty_optional_fields(dell_license_manager):
+    """Optional strings are stripped, and blank values are omitted from payloads."""
+    manager, requests = dell_license_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+        transfer_protocol=" HTTPS ",
+        license_username="  ",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["payload"] == {
+        "LicenseFileURI": "https://repo.example.test/license.xml",
+        "TransferProtocol": "HTTPS",
+    }
+    assert _post_requests(requests) == []
+
+
 def test_license_install_masks_password_from_env_in_dry_run(
     dell_license_manager,
     monkeypatch,

--- a/tests/test_license_install_dualmode.py
+++ b/tests/test_license_install_dualmode.py
@@ -1,0 +1,249 @@
+"""Dual-mode-style coverage for LicenseService.Install."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+LICENSE_SERVICE = "/redfish/v1/LicenseService"
+INSTALL_TARGET = f"{LICENSE_SERVICE}/Actions/LicenseService.Install"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_license_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase and recorded requests list.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/license-1"
+        return json.dumps({"Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/license-1"}})
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-license",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_license_install_lists_target_without_mutating(dell_license_manager):
+    """With no license URI, the command lists the Install target and never POSTs."""
+    manager, requests = dell_license_manager
+
+    result = manager.sync_invoke(ApiRequestType.LicenseInstall, "license-install")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "license_service": LICENSE_SERVICE,
+        "action": "#LicenseService.Install",
+        "target": INSTALL_TARGET,
+        "transfer_protocols": ["CIFS", "HTTP", "HTTPS", "NFS"],
+    }
+    assert _post_requests(requests) == []
+
+
+def test_license_install_without_confirm_is_preview_only(dell_license_manager):
+    """LicenseService.Install resolves the target but does not POST without --confirm."""
+    manager, requests = dell_license_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+        transfer_protocol="HTTPS",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#LicenseService.Install"
+    assert result.data["target"] == INSTALL_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {
+        "LicenseFileURI": "https://repo.example.test/license.xml",
+        "TransferProtocol": "HTTPS",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_license_install_confirm_posts_payload(dell_license_manager):
+    """--confirm POSTs the license URI payload to the discovered action target."""
+    manager, requests = dell_license_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+        transfer_protocol="HTTPS",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#LicenseService.Install"
+    assert result.data["target"] == INSTALL_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "license-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == INSTALL_TARGET.lower()
+    assert posts[0].json() == {
+        "LicenseFileURI": "https://repo.example.test/license.xml",
+        "TransferProtocol": "HTTPS",
+    }
+
+
+def test_license_install_confirm_dry_run_still_does_not_post(dell_license_manager):
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    manager, requests = dell_license_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+        transfer_protocol="HTTPS",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == INSTALL_TARGET
+    assert _post_requests(requests) == []
+
+
+def test_license_install_rejects_invalid_transfer_protocol(dell_license_manager):
+    """Inline allowable values reject an unsupported TransferProtocol before POST."""
+    manager, requests = dell_license_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+        transfer_protocol="FTP",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for LicenseService.Install TransferProtocol: FTP; "
+        "allowed: CIFS, HTTP, HTTPS, NFS"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "TransferProtocol",
+            "value": "FTP",
+            "allowed": ["CIFS", "HTTP", "HTTPS", "NFS"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_license_install_masks_password_in_dry_run(dell_license_manager):
+    """Dry-run output does not echo a URI credential password."""
+    manager, requests = dell_license_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+        license_username="license-reader",
+        license_password="placeholder-value",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["payload"]["Username"] == "license-reader"
+    assert result.data["payload"]["Password"] == "********"
+    assert _post_requests(requests) == []
+
+
+def test_license_install_rejects_empty_license_uri(dell_license_manager):
+    """A blank URI is rejected before any action POST can fire."""
+    manager, requests = dell_license_manager
+
+    with pytest.raises(InvalidArgument, match="license file URI cannot be empty"):
+        manager.sync_invoke(
+            ApiRequestType.LicenseInstall,
+            "license-install",
+            license_file_uri="   ",
+            confirm=True,
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_license_install_reports_missing_action_without_post(redfish_mock_factory):
+    """A LicenseService without Install reports the available actions."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.LicenseInstall,
+        "license-install",
+        license_file_uri="https://repo.example.test/license.xml",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#LicenseService.Install' not found on /redfish/v1/LicenseService"
+    )
+    assert result.data == {
+        "action": "#LicenseService.Install",
+        "available": [],
+    }
+    assert _post_requests(service.requests) == []


### PR DESCRIPTION
## Summary
- Add a guarded `license-install` command for `LicenseService.Install`.
- List the discovered install target when no license URI is provided, and require `--confirm` before posting an install payload.
- Read optional license URI passwords from an environment variable or file, mask password fields in dry-run output, and redact sensitive request payload fields from debug logs.
- Add Dell corpus-backed coverage for preview, confirm, validation, password-source, logging-redaction, and missing-action paths.

## Validation
- GB300 offline gate completed for `neroshige/license-install`.
- Result: `1302 passed, 62 skipped, 6 warnings in 75.12s`; changed-file `ruff check` passed; `python tools/docstring_gate.py --all` passed.
