### PR TITLE
Export Splunk ingest credentials in the fleet container entrypoint

### DIFF
--- a/docker/gb300/entrypoint.sh
+++ b/docker/gb300/entrypoint.sh
@@ -26,6 +26,20 @@ if [ -f /secrets/gh_token ]; then
     GH_TOKEN="$(tr -d '[:space:]' < /secrets/gh_token)"
     export GH_TOKEN
 fi
+# Observability ingest credentials (optional): the telemetry exporter reads
+# SPLUNK_ACCESS_TOKEN / SPLUNK_INGEST_URL, so a container can push and
+# live-verify metrics without any per-run token plumbing. An explicit
+# SPLUNK_INGEST_URL from the caller wins over the realm-derived default.
+if [ -f /secrets/splunk_token ]; then
+    SPLUNK_ACCESS_TOKEN="$(tr -d '[:space:]' < /secrets/splunk_token)"
+    export SPLUNK_ACCESS_TOKEN
+fi
+if [ -f /secrets/splunk_realm ] && [ -z "${SPLUNK_INGEST_URL:-}" ]; then
+    _realm="$(tr -d '[:space:]' < /secrets/splunk_realm)"
+    if [ -n "$_realm" ]; then
+        export SPLUNK_INGEST_URL="https://ingest.${_realm}.signalfx.com/v2/datapoint"
+    fi
+fi
 
 source /opt/conda/etc/profile.d/conda.sh
 conda activate redfish_ctl


### PR DESCRIPTION
Optional `/secrets/splunk_token` and `/secrets/splunk_realm` (staged by the operator into the internal agent image, same pattern as the git key and gh token) are exported as `SPLUNK_ACCESS_TOKEN` and a realm-derived `SPLUNK_INGEST_URL`, so any fleet container can push telemetry and run the live observability gate without per-run token plumbing. Both files are optional — the base image and key-less nodes behave exactly as before; an explicit `SPLUNK_INGEST_URL` from the caller wins over the realm default. No secrets in the repo or image layers of the public base.