### PR TITLE
Keep SignalFx push loop alive after transient failures

### DIFF
--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -7,6 +7,7 @@ import math
 import os
 import random
 import re
+import sys
 import time
 import urllib.request
 from dataclasses import dataclass
@@ -881,6 +882,14 @@ def push_signalfx(body: Mapping, token: str, ingest_url: str, timeout: float = 2
         return response.status
 
 
+def _report_signalfx_loop_error(exc: Exception) -> None:
+    """Report a failed SignalFx push without stopping the exporter loop.
+
+    :param exc: exception raised while scraping or pushing a SignalFx datapoint batch.
+    """
+    print(f"SignalFx push failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+
 def serve_prometheus(
         scrape: Callable[[], str],
         bind: str = "0.0.0.0",
@@ -929,7 +938,8 @@ def run_signalfx_loop(
         token: str,
         ingest_url: str,
         interval: float,
-        timeout: float = 20.0) -> None:
+        timeout: float = 20.0,
+        on_error: Optional[Callable[[Exception], None]] = None) -> None:
     """Push SignalFx datapoints forever at ``interval`` seconds.
 
     :param scrape_samples: callable returning the samples to push each cycle.
@@ -937,10 +947,20 @@ def run_signalfx_loop(
     :param ingest_url: full SignalFx datapoint endpoint.
     :param interval: base seconds between pushes (jittered per cycle).
     :param timeout: per-push request timeout in seconds.
+    :param on_error: optional callback for transient scrape or push failures.
     """
+    report_error = on_error or _report_signalfx_loop_error
     while True:
         start = time.monotonic()
-        push_signalfx(to_signalfx_body(scrape_samples()), token, ingest_url, timeout=timeout)
+        try:
+            push_signalfx(
+                to_signalfx_body(scrape_samples()),
+                token,
+                ingest_url,
+                timeout=timeout,
+            )
+        except Exception as exc:  # noqa: BLE001 - exporter must survive transient push failures
+            report_error(exc)
         elapsed = time.monotonic() - start
         time.sleep(max(1.0, jittered_interval(interval) - elapsed))
 

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -579,6 +579,54 @@ def test_signalfx_push_loop_jitters_sleep(monkeypatch):
     assert sleep_calls == [pytest.approx(28.0)]
 
 
+def test_signalfx_push_loop_continues_after_transient_push_error(monkeypatch):
+    """A transient SignalFx push failure is reported but does not kill the loop."""
+    samples = [
+        MetricSample(
+            metric="hw.scrape.ok",
+            value=1,
+            dimensions=build_identity_dimensions("172.25.230.29", vendor="supermicro")
+            | {"source": "exporter"},
+        )
+    ]
+    push_calls = []
+
+    def fake_push(body, token, ingest_url, timeout=20.0):
+        push_calls.append((body, token, ingest_url, timeout))
+        if len(push_calls) == 1:
+            raise TimeoutError("temporary ingest timeout")
+        return 200
+
+    sleep_calls = []
+
+    def fake_sleep(seconds):
+        sleep_calls.append(seconds)
+        if len(sleep_calls) == 2:
+            raise RuntimeError("stop loop")
+
+    errors = []
+    monotonic_values = iter([100.0, 101.0, 130.0, 132.0])
+    monkeypatch.setattr(exporter_mod, "push_signalfx", fake_push)
+    monkeypatch.setattr(exporter_mod.random, "random", lambda: 0.5)
+    monkeypatch.setattr(exporter_mod.time, "monotonic", lambda: next(monotonic_values))
+    monkeypatch.setattr(exporter_mod.time, "sleep", fake_sleep)
+
+    with pytest.raises(RuntimeError, match="stop loop"):
+        exporter_mod.run_signalfx_loop(
+            lambda: samples,
+            "token",
+            "https://ingest.us1.signalfx.com/v2/datapoint",
+            interval=30.0,
+            timeout=1.0,
+            on_error=errors.append,
+        )
+
+    assert len(push_calls) == 2
+    assert len(errors) == 1
+    assert isinstance(errors[0], TimeoutError)
+    assert sleep_calls == [pytest.approx(29.0), pytest.approx(28.0)]
+
+
 def test_exporter_uses_environment_metrics_command_rollups(gb300_exporter_manager):
     """Exporter output includes EnvironmentMetrics rows for every GB300 resource."""
     manager, requests = gb300_exporter_manager


### PR DESCRIPTION
## Summary
- Keep long-running SignalFx push mode running when a scrape or ingest POST raises a transient exception.
- Report transient loop errors before sleeping and retrying on the next interval.
- Add regression coverage that a second push still runs after the first push times out.

## Validation
- Project gate passed: 1302 passed, 62 skipped, 6 warnings in 72.92s.
- Changed-file Ruff passed.
- Docstring gate passed.
