### PR TITLE
Add exporter SignalFx config plumbing

### DIFF
--- a/docs/telemetry-exporter.md
+++ b/docs/telemetry-exporter.md
@@ -168,6 +168,14 @@ series as `host.name=gb300-poc1-slot9`, `node=slot9`, and `server.address=192.0.
 Use `--label-bmc-ip` only when the connection address is not the BMC address you want in the metric
 labels.
 
+Override the identity math with `--identity-host-prefix`, `--identity-bmc-octet-base`,
+`--identity-server-octet-base`, and `--identity-server-subnet`. The same settings can come from
+`REDFISH_EXPORTER_HOST_PREFIX`, `REDFISH_EXPORTER_BMC_OCTET_BASE`,
+`REDFISH_EXPORTER_SERVER_OCTET_BASE`, and `REDFISH_EXPORTER_SERVER_SUBNET`, which the exporter reads
+from the process environment. A config spec can also carry them; the sample
+`specs/exporter_signalfx_spec.json`, defined in this repository's `specs/` directory, uses the
+`identity` object for these fields.
+
 ThermalSubsystem temperature samples set `source=thermal-subsystem` and include `chassis`, `sensor`,
 and `zone` dimensions. The `zone` dimension comes from Redfish `PhysicalContext` when present, or
 falls back to the reported sensor name.
@@ -181,11 +189,18 @@ full SignalFx datapoint endpoint ending in `/v2/datapoint` (for example
 as `https://ingest.us1.observability.splunkcloud.com` is rejected because it would accept the request
 but silently drop every datapoint. Override the default with `--signalfx-ingest-url`.
 
+For non-environment token sources, use `--signalfx-token-file` or `--signalfx-token`. The
+`--signalfx-token-file` option reads the token from a local file created by the deployment step. A
+config spec passed with `--exporter-config` can set `signalfx.ingest_url`, `signalfx.token_env`,
+`signalfx.token_file`, or `signalfx.token`; explicit CLI values win over the spec, and the spec wins
+over the default environment fallback.
+
 Without `--once`, push mode scrapes and pushes on a loop every `--interval` seconds:
 
 ```bash
 redfish_ctl exporter \
   --credential-file .internal/idrac_exporter.env \
+  --exporter-config specs/exporter_signalfx_spec.json \
   --vendor supermicro \
   --output signalfx \
   --push-signalfx

--- a/redfish_ctl/telemetry/cmd_exporter.py
+++ b/redfish_ctl/telemetry/cmd_exporter.py
@@ -11,9 +11,9 @@ observability demo.
 from abc import abstractmethod
 from typing import Optional
 
+from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
-from ..redfish_manager import CommandResult
 from . import exporter
 from .exporter import (
     build_identity_dimensions,
@@ -72,14 +72,42 @@ class Exporter(RedfishManagerBase,
             help="gitignored KEY=VALUE runtime file for "
                  "REDFISH_IP/USERNAME/PASSWORD/PORT (legacy IDRAC_* also accepted)")
         cmd_parser.add_argument(
+            "--exporter-config", dest="exporter_config_file", default=None, type=str,
+            help="JSON exporter config spec for SignalFx ingest/token source and "
+                 "identity dimension overrides")
+        cmd_parser.add_argument(
             "--push-signalfx", action="store_true", default=False,
             help="push SignalFx datapoints instead of returning/serving Prometheus output")
         cmd_parser.add_argument(
             "--signalfx-ingest-url", dest="signalfx_ingest_url", default=None, type=str,
             help="SignalFx ingest URL; defaults to SPLUNK_INGEST_URL when pushing")
         cmd_parser.add_argument(
-            "--signalfx-token-env", dest="signalfx_token_env", default="SPLUNK_ACCESS_TOKEN",
+            "--signalfx-token-env", dest="signalfx_token_env", default=None,
             type=str, help="environment variable that holds the SignalFx ingest token")
+        token_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        token_group.add_argument(
+            "--signalfx-token", dest="signalfx_token", default=None, type=str,
+            help="SignalFx ingest token value; prefer --signalfx-token-file or env "
+                 "for unattended runs")
+        token_group.add_argument(
+            "--signalfx-token-file", dest="signalfx_token_file", default=None, type=str,
+            help="file containing the SignalFx ingest token")
+        cmd_parser.add_argument(
+            "--identity-host-prefix", dest="identity_host_prefix",
+            default=None, type=str,
+            help="host.name prefix for derived exporter identity dimensions")
+        cmd_parser.add_argument(
+            "--identity-bmc-octet-base", dest="identity_bmc_octet_base",
+            default=None, type=int,
+            help="BMC last-octet base subtracted to derive the node slot")
+        cmd_parser.add_argument(
+            "--identity-server-octet-base", dest="identity_server_octet_base",
+            default=None, type=int,
+            help="server last-octet base added to the derived node slot")
+        cmd_parser.add_argument(
+            "--identity-server-subnet", dest="identity_server_subnet",
+            default=None, type=str,
+            help="server.address subnet override for derived identity dimensions")
         cmd_parser.add_argument(
             "--otlp-endpoint", dest="otlp_endpoint", default=None, type=str,
             help="OTLP collector endpoint for --output otlp; defaults to "
@@ -234,7 +262,11 @@ class Exporter(RedfishManagerBase,
                         label_bmc_ip: Optional[str] = None,
                         vendor: Optional[str] = None,
                         do_async: bool = False,
-                        do_expanded: bool = False) -> list:
+                        do_expanded: bool = False,
+                        identity_host_prefix: Optional[str] = None,
+                        identity_bmc_octet_base: Optional[int] = None,
+                        identity_server_octet_base: Optional[int] = None,
+                        identity_server_subnet: Optional[str] = None) -> list:
         """Scrape all supported read-only telemetry paths and build samples.
 
         :param label_bmc_ip: BMC IP used only for metric dimensions; defaults to the
@@ -242,12 +274,23 @@ class Exporter(RedfishManagerBase,
         :param vendor: vendor dimension override; auto-detected when None.
         :param do_async: when True, issue the Redfish queries asynchronously.
         :param do_expanded: when True, issue expanded ($expand) queries.
+        :param identity_host_prefix: host.name prefix override.
+        :param identity_bmc_octet_base: BMC last-octet base override for slot math.
+        :param identity_server_octet_base: server last-octet base override.
+        :param identity_server_subnet: server.address subnet override.
         :return: list of MetricSample objects, including the scrape-health samples.
         """
         started_at = exporter.time.monotonic()
+        identity_options = exporter.resolve_identity_options(
+            host_prefix=identity_host_prefix,
+            bmc_octet_base=identity_bmc_octet_base,
+            server_octet_base=identity_server_octet_base,
+            server_subnet=identity_server_subnet,
+        )
         identity = build_identity_dimensions(
             label_bmc_ip or self.idrac_ip,
             vendor=self._vendor_label(vendor),
+            **identity_options,
         )
         environment_rows = self._environment_command_rows(do_async=do_async)
         thermal_rows = self._thermal_rows(do_async=do_async, do_expanded=do_expanded)
@@ -293,9 +336,16 @@ class Exporter(RedfishManagerBase,
                 exporter_output: Optional[str] = "prometheus",
                 label_bmc_ip: Optional[str] = None,
                 vendor: Optional[str] = None,
+                exporter_config_file: Optional[str] = None,
                 push_signalfx: Optional[bool] = False,
                 signalfx_ingest_url: Optional[str] = None,
-                signalfx_token_env: Optional[str] = "SPLUNK_ACCESS_TOKEN",
+                signalfx_token_env: Optional[str] = None,
+                signalfx_token: Optional[str] = None,
+                signalfx_token_file: Optional[str] = None,
+                identity_host_prefix: Optional[str] = None,
+                identity_bmc_octet_base: Optional[int] = None,
+                identity_server_octet_base: Optional[int] = None,
+                identity_server_subnet: Optional[str] = None,
                 otlp_endpoint: Optional[str] = None,
                 otlp_protocol: Optional[str] = None,
                 **kwargs) -> CommandResult:
@@ -314,9 +364,16 @@ class Exporter(RedfishManagerBase,
         :param label_bmc_ip: BMC IP used only for metric dimensions when it differs from the
             configured address.
         :param vendor: vendor dimension override; auto-detected when None.
+        :param exporter_config_file: JSON config spec for SignalFx and identity settings.
         :param push_signalfx: when True, push SignalFx datapoints instead of serving Prometheus.
         :param signalfx_ingest_url: SignalFx ingest URL; resolved from the environment when None.
         :param signalfx_token_env: environment variable holding the SignalFx ingest token.
+        :param signalfx_token: direct SignalFx ingest token value.
+        :param signalfx_token_file: file containing the SignalFx ingest token.
+        :param identity_host_prefix: host.name prefix override.
+        :param identity_bmc_octet_base: BMC last-octet base override for slot math.
+        :param identity_server_octet_base: server last-octet base override.
+        :param identity_server_subnet: server.address subnet override.
         :param otlp_endpoint: OTLP collector endpoint for ``--output otlp``; resolved from
             OTEL_* env when None.
         :param otlp_protocol: OTLP transport (``grpc`` or ``http/protobuf``); resolved from
@@ -325,10 +382,49 @@ class Exporter(RedfishManagerBase,
             sample-count summary; a CommandResult with empty payload when serving or looping
             forever.
         """
+        config_options = exporter.exporter_config_options(exporter_config_file)
+
+        def option(name, value):
+            """Return the explicit value or the config value for ``name``.
+
+            :param name: flattened exporter config option name.
+            :param value: explicit CLI or programmatic value.
+            :return: explicit value when set, else the config value.
+            """
+            return value if value not in (None, "") else config_options.get(name)
+
+        signalfx_ingest_url = option("signalfx_ingest_url", signalfx_ingest_url)
+        signalfx_token_env = option("signalfx_token_env", signalfx_token_env)
+        signalfx_token = option("signalfx_token", signalfx_token)
+        signalfx_token_file = option("signalfx_token_file", signalfx_token_file)
+        identity_host_prefix = option("identity_host_prefix", identity_host_prefix)
+        identity_bmc_octet_base = option(
+            "identity_bmc_octet_base", identity_bmc_octet_base)
+        identity_server_octet_base = option(
+            "identity_server_octet_base", identity_server_octet_base)
+        identity_server_subnet = option(
+            "identity_server_subnet", identity_server_subnet)
+
+        def collect_current_samples():
+            """Collect samples with the resolved exporter identity options.
+
+            :return: list of MetricSample objects for the current scrape.
+            """
+            return self.collect_samples(
+                label_bmc_ip,
+                vendor,
+                do_async,
+                do_expanded,
+                identity_host_prefix=identity_host_prefix,
+                identity_bmc_octet_base=identity_bmc_octet_base,
+                identity_server_octet_base=identity_server_octet_base,
+                identity_server_subnet=identity_server_subnet,
+            )
+
         if exporter_output == "otlp":
             from . import otlp
             if once:
-                samples = self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
+                samples = collect_current_samples()
                 result = otlp.push_otlp(
                     samples, endpoint=otlp_endpoint, protocol=otlp_protocol)
                 return CommandResult(
@@ -340,7 +436,7 @@ class Exporter(RedfishManagerBase,
 
                 :return: list of MetricSample objects for the current scrape.
                 """
-                return self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
+                return collect_current_samples()
 
             otlp.run_otlp_loop(
                 scrape_samples, float(interval or 30.0),
@@ -351,9 +447,13 @@ class Exporter(RedfishManagerBase,
             # Resolve and validate the push target BEFORE scraping so a missing
             # token or a bare (non-/v2/datapoint) ingest URL fails fast.
             if exporter_output == "signalfx" and push_signalfx:
-                token = resolve_signalfx_token(signalfx_token_env)
+                token = resolve_signalfx_token(
+                    signalfx_token_env,
+                    token=signalfx_token,
+                    token_file=signalfx_token_file,
+                )
                 ingest_url = resolve_signalfx_ingest_url(signalfx_ingest_url)
-                samples = self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
+                samples = collect_current_samples()
                 body = to_signalfx_body(samples)
                 status = exporter.push_signalfx(body, token, ingest_url)
                 return CommandResult(
@@ -363,13 +463,17 @@ class Exporter(RedfishManagerBase,
                      "ingest_url": ingest_url},
                     None,
                 )
-            samples = self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
+            samples = collect_current_samples()
             data = (to_signalfx_body(samples) if exporter_output == "signalfx"
                     else render_prometheus_text(samples))
             return CommandResult(data, None, {"sample_count": len(samples)}, None)
 
         if push_signalfx or exporter_output == "signalfx":
-            token = resolve_signalfx_token(signalfx_token_env)
+            token = resolve_signalfx_token(
+                signalfx_token_env,
+                token=signalfx_token,
+                token_file=signalfx_token_file,
+            )
             ingest_url = resolve_signalfx_ingest_url(signalfx_ingest_url)
 
             def scrape_samples():
@@ -377,7 +481,7 @@ class Exporter(RedfishManagerBase,
 
                 :return: list of MetricSample objects for the current scrape.
                 """
-                return self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
+                return collect_current_samples()
 
             run_signalfx_loop(scrape_samples, token, ingest_url, float(interval or 30.0))
             return CommandResult(None, None, None, None)
@@ -387,7 +491,7 @@ class Exporter(RedfishManagerBase,
 
             :return: the rendered Prometheus /metrics text for the current scrape.
             """
-            samples = self.collect_samples(label_bmc_ip, vendor, do_async, do_expanded)
+            samples = collect_current_samples()
             return render_prometheus_text(samples)
 
         serve_prometheus(scrape_text, listen or "0.0.0.0", int(port or 9109))

--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -181,6 +181,25 @@ _EXPORTER_CRED_KEYS = frozenset({
     "REDFISH_IP", "REDFISH_USERNAME", "REDFISH_PASSWORD", "REDFISH_PORT",
     "IDRAC_IP", "IDRAC_USERNAME", "IDRAC_PASSWORD", "IDRAC_PORT",
 })
+_EXPORTER_CONFIG_FILE_ENVS = (
+    "REDFISH_EXPORTER_CONFIG_FILE",
+    "IDRAC_EXPORTER_CONFIG_FILE",
+)
+_IDENTITY_ENV_KEYS = {
+    "host_prefix": ("REDFISH_EXPORTER_HOST_PREFIX", "IDRAC_EXPORTER_HOST_PREFIX"),
+    "bmc_octet_base": (
+        "REDFISH_EXPORTER_BMC_OCTET_BASE",
+        "IDRAC_EXPORTER_BMC_OCTET_BASE",
+    ),
+    "server_octet_base": (
+        "REDFISH_EXPORTER_SERVER_OCTET_BASE",
+        "IDRAC_EXPORTER_SERVER_OCTET_BASE",
+    ),
+    "server_subnet": (
+        "REDFISH_EXPORTER_SERVER_SUBNET",
+        "IDRAC_EXPORTER_SERVER_SUBNET",
+    ),
+}
 
 
 def load_exporter_env_file(path: os.PathLike[str] | str) -> dict[str, str]:
@@ -201,6 +220,136 @@ def load_exporter_env_file(path: os.PathLike[str] | str) -> dict[str, str]:
         if key in _EXPORTER_CRED_KEYS:
             values[key] = value.strip().strip("'\"")
     return values
+
+
+def _non_empty(value):
+    """Return ``value`` with blank strings collapsed to None.
+
+    :param value: candidate config value.
+    :return: stripped value, original non-string value, or None.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
+
+
+def _first_non_empty(*values):
+    """Return the first non-empty value from ``values``.
+
+    :param values: candidate values in precedence order.
+    :return: the first non-empty value, or None.
+    """
+    for value in values:
+        cleaned = _non_empty(value)
+        if cleaned is not None:
+            return cleaned
+    return None
+
+
+def _coerce_int(value, field_name: str) -> int:
+    """Coerce an integer config field with a targeted error message.
+
+    :param value: value to coerce.
+    :param field_name: field name included in validation errors.
+    :return: coerced integer value.
+    :raises ValueError: when the value cannot be parsed as an integer.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer; got {value!r}") from exc
+
+
+def _config_path(path: Optional[str] = None) -> Optional[str]:
+    """Return the explicit or environment-provided exporter config path.
+
+    :param path: explicit config path.
+    :return: config path from argument or environment, or None.
+    """
+    return _first_non_empty(
+        path,
+        *(os.environ.get(name) for name in _EXPORTER_CONFIG_FILE_ENVS),
+    )
+
+
+def load_exporter_config_file(path: os.PathLike[str] | str) -> dict:
+    """Read an exporter JSON config spec.
+
+    :param path: JSON config file path.
+    :return: parsed config mapping.
+    :raises ValueError: when the config root is not a JSON object.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("exporter config root must be a JSON object")
+    return data
+
+
+def _section(config: Mapping, key: str) -> Mapping:
+    """Return a nested config section mapping, or an empty mapping.
+
+    :param config: exporter config mapping.
+    :param key: nested section name.
+    :return: nested section mapping, or an empty mapping.
+    """
+    value = config.get(key)
+    return value if isinstance(value, Mapping) else {}
+
+
+def _config_value(config: Mapping, section: str, top_key: str, section_key: str):
+    """Return a top-level or nested config value.
+
+    :param config: exporter config mapping.
+    :param section: nested section name to inspect first.
+    :param top_key: top-level fallback key.
+    :param section_key: key inside the nested section.
+    :return: configured value, or None.
+    """
+    nested = _section(config, section)
+    if section_key in nested:
+        return nested[section_key]
+    return config.get(top_key)
+
+
+def exporter_config_options(path: Optional[str] = None) -> dict:
+    """Return flattened exporter options from an optional JSON spec file.
+
+    The spec may use nested ``signalfx`` and ``identity`` objects or the flat
+    CLI-style keys used by tests and programmatic callers.
+
+    :param path: explicit config file path; falls back to exporter config env vars.
+    :return: flattened option names understood by ``Exporter.execute``.
+    """
+    file_path = _config_path(path)
+    if not file_path:
+        return {}
+    config = load_exporter_config_file(file_path)
+    candidates = {
+        "signalfx_ingest_url": _config_value(
+            config, "signalfx", "signalfx_ingest_url", "ingest_url"),
+        "signalfx_token_env": _config_value(
+            config, "signalfx", "signalfx_token_env", "token_env"),
+        "signalfx_token_file": _config_value(
+            config, "signalfx", "signalfx_token_file", "token_file"),
+        "signalfx_token": _config_value(
+            config, "signalfx", "signalfx_token", "token"),
+        "identity_host_prefix": _config_value(
+            config, "identity", "identity_host_prefix", "host_prefix"),
+        "identity_bmc_octet_base": _config_value(
+            config, "identity", "identity_bmc_octet_base", "bmc_octet_base"),
+        "identity_server_octet_base": _config_value(
+            config, "identity", "identity_server_octet_base", "server_octet_base"),
+        "identity_server_subnet": _config_value(
+            config, "identity", "identity_server_subnet", "server_subnet"),
+    }
+    return {
+        key: value
+        for key, value in candidates.items()
+        if _non_empty(value) is not None
+    }
 
 
 def exporter_argv_uses_secret(argv: Iterable[str]) -> bool:
@@ -249,6 +398,51 @@ def apply_exporter_env_file(args, path: Optional[str] = None) -> None:
         if current in ("", None, "root") or is_password:
             value = values[key]
             setattr(args, attr, int(value) if attr == "idrac_port" else value)
+
+
+def resolve_identity_options(
+        host_prefix: Optional[str] = None,
+        bmc_octet_base: Optional[int] = None,
+        server_octet_base: Optional[int] = None,
+        server_subnet: Optional[str] = None) -> dict:
+    """Resolve exporter identity dimension options from args, env, and defaults.
+
+    :param host_prefix: explicit ``host.name`` prefix override.
+    :param bmc_octet_base: explicit BMC last-octet base used to derive slot.
+    :param server_octet_base: explicit server last-octet base used to derive host IP.
+    :param server_subnet: explicit server subnet for ``server.address``.
+    :return: keyword arguments for :func:`build_identity_dimensions`.
+    """
+    resolved_host_prefix = _first_non_empty(
+        host_prefix,
+        *(os.environ.get(name) for name in _IDENTITY_ENV_KEYS["host_prefix"]),
+        "gb300-poc1",
+    )
+    resolved_bmc_octet_base = _first_non_empty(
+        bmc_octet_base,
+        *(os.environ.get(name) for name in _IDENTITY_ENV_KEYS["bmc_octet_base"]),
+        20,
+    )
+    resolved_server_octet_base = _first_non_empty(
+        server_octet_base,
+        *(os.environ.get(name) for name in _IDENTITY_ENV_KEYS["server_octet_base"]),
+        40,
+    )
+    resolved_server_subnet = _first_non_empty(
+        server_subnet,
+        *(os.environ.get(name) for name in _IDENTITY_ENV_KEYS["server_subnet"]),
+    )
+    return {
+        "host_prefix": str(resolved_host_prefix),
+        "bmc_octet_base": _coerce_int(resolved_bmc_octet_base, "bmc_octet_base"),
+        "server_octet_base": _coerce_int(
+            resolved_server_octet_base, "server_octet_base"),
+        "server_subnet": (
+            str(resolved_server_subnet)
+            if resolved_server_subnet is not None
+            else None
+        ),
+    }
 
 
 def build_metric_samples(
@@ -825,13 +1019,27 @@ def _require_datapoint_url(ingest_url: str) -> str:
     return ingest_url
 
 
-def resolve_signalfx_token(token_env: Optional[str] = None) -> str:
-    """Return the SignalFx ingest token from ``token_env`` (default SPLUNK_ACCESS_TOKEN).
+def resolve_signalfx_token(
+        token_env: Optional[str] = None,
+        token: Optional[str] = None,
+        token_file: Optional[str] = None) -> str:
+    """Return the SignalFx ingest token from direct, file, or env source.
 
     :param token_env: env var name to read the token from; defaults to ``SPLUNK_ACCESS_TOKEN``.
+    :param token: direct token value.
+    :param token_file: path to a file containing the token.
     :return: the ingest token value.
-    :raises ValueError: if the environment variable is unset or empty.
+    :raises ValueError: if the chosen source is unset or empty.
     """
+    direct_token = _non_empty(token)
+    if direct_token is not None:
+        return str(direct_token)
+    file_path = _non_empty(token_file)
+    if file_path is not None:
+        value = Path(str(file_path)).expanduser().read_text(encoding="utf-8").strip()
+        if not value:
+            raise ValueError(f"{file_path} is empty")
+        return value
     name = token_env or "SPLUNK_ACCESS_TOKEN"
     token = os.environ.get(name, "")
     if not token:

--- a/specs/README.md
+++ b/specs/README.md
@@ -32,6 +32,7 @@ Use these files with the command's `--from_spec` option unless the table says ot
 | `change_boot_order_spec02.json` | `change-boot-order` | Dell/iDRAC | Write | Move virtual media earlier. |
 | `change_boot_order_spec03.json` | `change-boot-order` | Dell/iDRAC | Write | Put NIC entries first. |
 | `change_boot_source_spec01.json` | `boot-source-update` | Dell/iDRAC | Write | Enable/disable Dell boot entries. |
+| `exporter_signalfx_spec.json` | `exporter --exporter-config` | generic/vendor-neutral | Read | Sample SignalFx ingest URL, token-file path, and identity label math. |
 | `fastboot.spec.json` | `bios-change` | CPU/platform | Write | Faster POST BIOS attributes. |
 | `realtime.opt.spec.json` | `bios-change` | CPU/platform | Write | Low-latency BIOS attributes. |
 | `set_profile_example.json` | `bios-change` | Dell/iDRAC, CPU/platform | Write | Select a Dell `WorkloadProfile`. |

--- a/specs/exporter_signalfx_spec.json
+++ b/specs/exporter_signalfx_spec.json
@@ -1,0 +1,12 @@
+{
+  "signalfx": {
+    "ingest_url": "https://ingest.example.signalfx.com/v2/datapoint",
+    "token_file": "/etc/redfish-exporter/signalfx-token"
+  },
+  "identity": {
+    "host_prefix": "rack-a",
+    "bmc_octet_base": 20,
+    "server_octet_base": 40,
+    "server_subnet": "192.0.2"
+  }
+}

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -19,6 +19,7 @@ from redfish_ctl.telemetry.exporter import (
     load_exporter_env_file,
     render_prometheus_text,
     resolve_signalfx_ingest_url,
+    resolve_signalfx_token,
     to_signalfx_body,
 )
 
@@ -71,6 +72,28 @@ def test_identity_dimensions_follow_nv72_slot_contract():
         "server.address": "172.25.230.49",
         "bmc.ip": "172.25.230.29",
         "vendor": "supermicro",
+    }
+
+
+def test_identity_options_resolve_from_environment(monkeypatch):
+    """Exporter identity math can be moved out of the GB300 default contract."""
+    monkeypatch.setenv("REDFISH_EXPORTER_HOST_PREFIX", "rack-a")
+    monkeypatch.setenv("REDFISH_EXPORTER_BMC_OCTET_BASE", "10")
+    monkeypatch.setenv("REDFISH_EXPORTER_SERVER_OCTET_BASE", "100")
+    monkeypatch.setenv("REDFISH_EXPORTER_SERVER_SUBNET", "198.51.100")
+
+    dims = build_identity_dimensions(
+        "203.0.113.29",
+        vendor="dell",
+        **exporter_mod.resolve_identity_options(),
+    )
+
+    assert dims == {
+        "host.name": "rack-a-slot19",
+        "node": "slot19",
+        "server.address": "198.51.100.119",
+        "bmc.ip": "203.0.113.29",
+        "vendor": "dell",
     }
 
 
@@ -481,6 +504,44 @@ def test_exporter_env_file_prefers_redfish_over_idrac(tmp_path):
     assert args2.idrac_ip == "198.51.100.5"  # legacy fallback still honored
 
 
+def test_exporter_config_file_flattens_signalfx_and_identity(tmp_path):
+    """The exporter config spec carries SignalFx and identity settings."""
+    token_file = tmp_path / "token"
+    spec = tmp_path / "exporter.json"
+    spec.write_text(json.dumps({
+        "signalfx": {
+            "ingest_url": "https://ingest.example.test/v2/datapoint",
+            "token_file": str(token_file),
+        },
+        "identity": {
+            "host_prefix": "rack-a",
+            "bmc_octet_base": 20,
+            "server_octet_base": 100,
+            "server_subnet": "198.51.100",
+        },
+    }), encoding="utf-8")
+
+    assert exporter_mod.exporter_config_options(str(spec)) == {
+        "signalfx_ingest_url": "https://ingest.example.test/v2/datapoint",
+        "signalfx_token_file": str(token_file),
+        "identity_host_prefix": "rack-a",
+        "identity_bmc_octet_base": 20,
+        "identity_server_octet_base": 100,
+        "identity_server_subnet": "198.51.100",
+    }
+
+
+def test_signalfx_token_resolves_direct_file_and_env(tmp_path, monkeypatch):
+    """SignalFx token plumbing supports direct, file, and env sources."""
+    token_file = tmp_path / "token"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    monkeypatch.setenv("SPLUNK_ACCESS_TOKEN", "env-token")
+
+    assert resolve_signalfx_token(token="direct-token") == "direct-token"
+    assert resolve_signalfx_token(token_file=str(token_file)) == "file-token"
+    assert resolve_signalfx_token() == "env-token"
+
+
 def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_factory):
     """The exporter scrapes the GB300 corpus offline and emits SignalFx datapoints."""
     mgr, service = redfish_mock_factory("supermicro")
@@ -536,6 +597,58 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
     assert thermal_points
     assert {"chassis", "sensor", "zone"} <= set(thermal_points[0]["dimensions"])
     assert all(recorded.method != "POST" for recorded in service.requests)
+
+
+def test_exporter_command_uses_config_file_for_signalfx_and_identity(
+    redfish_mock_factory,
+    tmp_path,
+    monkeypatch,
+):
+    """A config spec supplies SignalFx token source and identity overrides."""
+    mgr, _service = redfish_mock_factory("supermicro")
+    token_file = tmp_path / "signalfx-token"
+    token_file.write_text("file-token\n", encoding="utf-8")
+    spec = tmp_path / "exporter.json"
+    spec.write_text(json.dumps({
+        "signalfx": {
+            "ingest_url": "https://ingest.example.test/v2/datapoint",
+            "token_file": str(token_file),
+        },
+        "identity": {
+            "host_prefix": "rack-a",
+            "bmc_octet_base": 20,
+            "server_octet_base": 100,
+            "server_subnet": "198.51.100",
+        },
+    }), encoding="utf-8")
+
+    calls = []
+
+    def fake_push(body, token, ingest_url, timeout=20.0):
+        calls.append({"body": body, "token": token, "ingest_url": ingest_url})
+        return 202
+
+    monkeypatch.delenv("SPLUNK_ACCESS_TOKEN", raising=False)
+    monkeypatch.delenv("SPLUNK_INGEST_URL", raising=False)
+    monkeypatch.setattr(exporter_mod, "push_signalfx", fake_push)
+
+    result = mgr.sync_invoke(
+        ApiRequestType.Exporter,
+        "exporter",
+        once=True,
+        exporter_output="signalfx",
+        push_signalfx=True,
+        exporter_config_file=str(spec),
+        label_bmc_ip="172.25.230.29",
+        vendor="supermicro",
+    )
+
+    assert result.extra["push_status"] == 202
+    assert calls[0]["token"] == "file-token"
+    assert calls[0]["ingest_url"] == "https://ingest.example.test/v2/datapoint"
+    first_dims = calls[0]["body"]["gauge"][0]["dimensions"]
+    assert first_dims["host.name"] == "rack-a-slot9"
+    assert first_dims["server.address"] == "198.51.100.109"
 
 
 def test_signalfx_push_loop_jitters_sleep(monkeypatch):


### PR DESCRIPTION
## Summary
- Add exporter config specs for SignalFx ingest URL, token source, and identity label math
- Add CLI/programmatic token sources for direct values and token files while keeping the existing environment fallback
- Add identity override flags/env handling plus offline coverage and a sample spec

## Tests
- Project gate: 1305 passed, 62 skipped, 6 warnings
- Changed-file Ruff: passed
- Docstring gate: passed