### PR TITLE
Reshape categorical exports to one-hot state metrics

### DIFF
--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -110,14 +110,19 @@ SECRET_ARG_NAMES = {"--idrac_password", "--idrac-password"}
 DIM_VALUE_OK = re.compile(r"[^A-Za-z0-9_.\-/]")
 # push_signalfx POSTs the ingest URL as-is, so it must be the full SignalFx
 # datapoint endpoint (…/v2/datapoint), never a bare host.
-# Redfish enum -> numeric mappings so state/health strings become alertable
-# gauges instead of being dropped (P0: health was previously 100% unexported).
-# Status.Health per DMTF is exactly OK/Warning/Critical.
-HEALTH_VALUES = {"ok": 1.0, "warning": 0.5, "critical": 0.0}
-
-# Power-integrity readings where anything but a clear/normal state is an
-# event worth a 1.0 sample (same fail-visible posture as hw.leak.state).
-POWER_STATE_CLEAR_VALUES = {"normal", "ok", "none", "disabled", "notapplicable", "na"}
+# One-hot state-metric label allowlists (specs/telemetry/gates.md, M1): each
+# categorical row emits value 1 with a normalized lowercase label; values
+# outside the allowlist map to "unknown" (health/state) or "other"
+# (reason/reset_type) — never dropped, never free-form. A contract test
+# asserts these sets match specs/telemetry/expected_signals.yaml.
+HEALTH_LABELS = {"ok", "warning", "critical"}
+STATE_LABELS = {"enabled", "disabled", "standby_offline", "standby_spare",
+                "in_test", "starting", "absent", "unavailable_offline",
+                "deferring", "quiesced", "updating", "qualified"}
+LINK_DOWN_REASONS = {"peer_reset_event"}
+RESET_TYPES = {"pf_flr", "conventional", "fundamental"}
+EDP_STATES = {"normal", "asserted"}
+POWER_BREAK_STATES = {"normal", "active"}
 
 SIGNALFX_DATAPOINT_PATH = "/v2/datapoint"
 POLL_JITTER_FRACTION = 0.10
@@ -431,10 +436,10 @@ def samples_from_metric_report_rows(
     every other numeric property (GPU FP16/FP32 activity, thermal, power,
     memory, …) is emitted under a generic ``hw.gb300.*`` name so the FULL
     telemetry surface reaches OTel/Prometheus, not just the fabric subset.
-    Known state/health enum strings (Health, HealthRollup, State,
-    LinkDownReasonCode, EDPViolationState, PowerBreakPerformanceState) are
-    mapped to numeric gauges by :func:`_state_enum_sample` instead of being
-    dropped.
+    Categorical rows (Health, HealthRollup, State, LinkDownReasonCode,
+    EDPViolationState, PowerBreakPerformanceState, LastResetType) are mapped
+    to one-hot state samples by :func:`_state_enum_sample` per the M1 model
+    in ``specs/telemetry/gates.md`` instead of being dropped.
 
     :param rows: TelemetryService MetricReport rows to map.
     :param identity: fixed join dimensions applied to every sample.
@@ -475,34 +480,48 @@ def samples_from_metric_report_rows(
     return samples
 
 
+def _state_label(text: str) -> str:
+    """Normalize an enum string to a lowercase snake_case label value.
+
+    :param text: raw vendor enum text (for example ``PeerResetEvent``).
+    :return: normalized label (for example ``peer_reset_event``).
+    """
+    snake = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", text)
+    snake = re.sub(r"[^A-Za-z0-9]+", "_", snake).strip("_").lower()
+    return snake or "unknown"
+
+
 def _state_enum_sample(
         prop_info: Mapping[str, str],
         row: Mapping,
         identity: Mapping[str, str]) -> Optional[MetricSample]:
-    """Map a non-numeric state/health MetricReport row to a gauge sample.
+    """Map a categorical MetricReport row to a one-hot state sample.
 
-    Covers the enum-string rows the numeric path drops: ``Health`` and
-    ``HealthRollup`` become ``hw.health`` / ``hw.health_rollup`` (OK=1,
-    Warning=0.5, Critical=0, raw string kept in the ``health_state``
-    dimension); ``State`` becomes ``hw.state.enabled`` (1 only for Enabled,
-    raw string in the ``state`` dimension); ``LinkDownReasonCode`` becomes a
-    constant-1 ``hw.fabric.link_down_reason`` sample whose ``reason``
-    dimension carries the cause (count by reason answers WHY links dropped);
-    ``EDPViolationState`` / ``PowerBreakPerformanceState`` become 0/1
-    ``hw.power.edp_violation`` / ``hw.power.break_state`` events.
+    Implements the M1 model from ``specs/telemetry/gates.md``: every known
+    state/health enum row emits value 1 with a normalized, allowlisted
+    lowercase label — ``Health``/``HealthRollup`` → ``hw.component.health`` /
+    ``hw.component.health_rollup`` (``health`` label), ``State`` →
+    ``hw.component.state`` (``state`` label), ``LinkDownReasonCode`` →
+    ``hw.fabric.link_down_reason`` (``reason`` label — the WHY behind
+    link-down counters), ``EDPViolationState`` →
+    ``hw.power.edp_violation_state``, ``PowerBreakPerformanceState`` →
+    ``hw.power.break_performance_state``, ``LastResetType`` →
+    ``hw.component.last_reset_type`` (``reset_type`` label). Values outside
+    an allowlist map to ``unknown`` (health/state) or ``other``
+    (reason/reset_type/power states) so no vendor string is ever dropped and
+    no free-form text ever becomes a label.
 
     :param prop_info: parsed MetricProperty fields (property, system, gpu, port, …).
     :param row: the raw MetricReport row.
     :param identity: fixed join dimensions applied to the sample.
     :return: the mapped MetricSample, or None when the row is not a known
-        state/health enum (unknown enum text stays unexported rather than
-        guessing a value).
+        categorical property (or its value is empty).
     """
     prop_name = prop_info["property"]
     text = str(row.get("MetricValue") or "").strip()
     if not text:
         return None
-    lowered = text.lower()
+    label = _state_label(text)
     dims = _with_dims(identity, source="metric-report",
                       property=_dim_value(prop_name))
     for key in ("system", "gpu", "port", "chassis", "memory", "index"):
@@ -510,32 +529,30 @@ def _state_enum_sample(
             dims[key] = str(prop_info[key])
     dims["report"] = str(row.get("Report") or "unknown")
 
-    metric = None
-    value = None
     if prop_name in ("Health", "HealthRollup"):
-        value = HEALTH_VALUES.get(lowered)
-        if value is None:
-            return None
-        metric = "hw.health" if prop_name == "Health" else "hw.health_rollup"
-        dims["health_state"] = _dim_value(text)
+        metric = ("hw.component.health" if prop_name == "Health"
+                  else "hw.component.health_rollup")
+        dims["health"] = label if label in HEALTH_LABELS else "unknown"
     elif prop_name == "State":
-        metric = "hw.state.enabled"
-        value = 1.0 if lowered == "enabled" else 0.0
-        dims["state"] = _dim_value(text)
+        metric = "hw.component.state"
+        dims["state"] = label if label in STATE_LABELS else "unknown"
     elif prop_name == "LinkDownReasonCode":
         metric = "hw.fabric.link_down_reason"
-        value = 1.0
-        dims["reason"] = _dim_value(text)
+        dims["reason"] = label if label in LINK_DOWN_REASONS else "other"
         dims["fabric"] = ("ib" if str(prop_info.get("port", "")).lower().startswith("ib")
                           else "nvlink")
-    elif prop_name in ("EDPViolationState", "PowerBreakPerformanceState"):
-        metric = ("hw.power.edp_violation" if prop_name == "EDPViolationState"
-                  else "hw.power.break_state")
-        value = 0.0 if lowered in POWER_STATE_CLEAR_VALUES else 1.0
-        dims["state"] = _dim_value(text)
-    if metric is None:
+    elif prop_name == "EDPViolationState":
+        metric = "hw.power.edp_violation_state"
+        dims["state"] = label if label in EDP_STATES else "other"
+    elif prop_name == "PowerBreakPerformanceState":
+        metric = "hw.power.break_performance_state"
+        dims["state"] = label if label in POWER_BREAK_STATES else "other"
+    elif prop_name == "LastResetType":
+        metric = "hw.component.last_reset_type"
+        dims["reset_type"] = label if label in RESET_TYPES else "other"
+    else:
         return None
-    return _sample(metric, value, dims, None, row.get("Timestamp"))
+    return _sample(metric, 1.0, dims, None, row.get("Timestamp"))
 
 
 def _gpu_metric_report_sample(

--- a/tests/test_splunk_metric_gate.py
+++ b/tests/test_splunk_metric_gate.py
@@ -123,7 +123,8 @@ def test_metrics_file_loading(tmp_path, monkeypatch, capsys):
 
 def test_default_metric_set_includes_p0_signals(monkeypatch):
     """The built-in list carries the P0 health/state and link-down-reason names."""
-    for name in ("hw.health", "hw.fabric.link_down_reason", "hw.power.edp_violation"):
+    for name in ("hw.component.health", "hw.fabric.link_down_reason",
+                 "hw.power.edp_violation_state"):
         assert name in gate.DEFAULT_METRICS
 
 

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -717,118 +717,102 @@ def test_resolve_signalfx_ingest_url_validates_full_datapoint_endpoint(monkeypat
         resolve_signalfx_ingest_url()
 
 
-def test_metric_report_mapper_exports_health_and_rollup_enums():
-    """Health/HealthRollup enum rows become hw.health gauges (P0: were dropped).
+def _report_row(source_property, value, report="HGX_HealthMetrics_0"):
+    """Build a MetricReport row whose property path ends in source_property.
 
-    This edge exists because HGX_HealthMetrics rows carry Status.Health enum
-    strings, which the numeric-only path silently skipped — leaving no
-    component-health signal to alert on.
+    :param source_property: dotted property (for example ``Status.Health``).
+    :param value: the MetricValue string to carry.
+    :param report: report name for the ``report`` dimension.
+    :return: a MetricReport row dict.
+    """
+    suffix = source_property.replace(".", "/")
+    return {"Report": report,
+            "MetricProperty": f"/redfish/v1/Chassis/HGX_GPU_0#/{suffix}",
+            "MetricValue": value}
+
+
+def _enum_samples(rows):
+    """Run MetricReport rows through the mapper with a fixed identity.
+
+    :param rows: MetricReport rows to map.
+    :return: the emitted MetricSample list.
     """
     dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
-    base = "/redfish/v1/Chassis/HGX_GPU_0#/Status"
-    samples = build_metric_samples(
-        identity=dims,
-        environment_rows=[],
-        sensor_rows=[],
-        nvlink_rows=[],
-        metric_report_rows=[
-            {"Report": "HGX_HealthMetrics_0",
-             "MetricProperty": f"{base}/Health", "MetricValue": "OK"},
-            {"Report": "HGX_HealthMetrics_0",
-             "MetricProperty": f"{base}/HealthRollup", "MetricValue": "Warning"},
-            {"Report": "HGX_HealthMetrics_0",
-             "MetricProperty": f"{base}/Health", "MetricValue": "Critical"},
-        ],
-    )
-    health = [s for s in samples if s.metric == "hw.health"]
-    rollup = [s for s in samples if s.metric == "hw.health_rollup"]
-    assert sorted(s.value for s in health) == [0.0, 1.0]
-    assert rollup[0].value == 0.5
-    assert rollup[0].dimensions["health_state"] == "Warning"
-    assert health[0].dimensions["report"] == "HGX_HealthMetrics_0"
+    return build_metric_samples(identity=dims, environment_rows=[], sensor_rows=[],
+                                nvlink_rows=[], metric_report_rows=rows)
 
 
-def test_metric_report_mapper_exports_link_down_reason():
-    """LinkDownReasonCode becomes a constant-1 sample with the reason dimension.
+def test_expected_signals_contract():
+    """Every fixture row in specs/telemetry/expected_signals.yaml is emitted.
 
-    The exporter already counted link_down events but never WHY — the reason
-    enum row was dropped by the numeric path.
+    This is the M2 gap-closure gate: expected signals minus emitted signals
+    must be empty, so the code can never silently drift from the contract.
     """
-    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
-    samples = build_metric_samples(
-        identity=dims,
-        environment_rows=[],
-        sensor_rows=[],
-        nvlink_rows=[],
-        metric_report_rows=[{
-            "Report": "HGX_ProcessorPortMetrics_0",
-            "MetricProperty": (
-                "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/"
-                "Ports/NVLink_3/Metrics#/Oem/Nvidia/LinkDownReasonCode"
-            ),
-            "MetricValue": "PeerResetEvent",
-        }],
-    )
-    reason = [s for s in samples if s.metric == "hw.fabric.link_down_reason"]
-    assert len(reason) == 1
-    assert reason[0].value == 1.0
-    assert reason[0].dimensions["reason"] == "PeerResetEvent"
-    assert reason[0].dimensions["fabric"] == "nvlink"
-    assert reason[0].dimensions["port"] == "NVLink_3"
+    import yaml
+    spec = yaml.safe_load(
+        (Path(__file__).parent.parent / "specs/telemetry/expected_signals.yaml")
+        .read_text(encoding="utf-8"))
+    missing = []
+    for row in spec["signals"]:
+        samples = _enum_samples([_report_row(row["source_property"], row["input"])])
+        want = row["expected"]
+        hit = [s for s in samples
+               if s.metric == want["metric"] and s.value == float(want["value"])
+               and all(s.dimensions.get(k) == v for k, v in want["labels"].items())]
+        if not hit:
+            missing.append(f'{row["source_property"]}={row["input"]} -> {want["metric"]}')
+    assert missing == []
 
 
-def test_metric_report_mapper_exports_state_and_power_integrity_enums():
-    """State and EDP/PowerBreak enum rows become 0/1 gauges with raw-state dims."""
-    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
-    base = "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0"
-    samples = build_metric_samples(
-        identity=dims,
-        environment_rows=[],
-        sensor_rows=[],
-        nvlink_rows=[],
-        metric_report_rows=[
-            {"Report": "HGX_CpuProcessorMetrics_0",
-             "MetricProperty": f"{base}#/Status/State", "MetricValue": "Enabled"},
-            {"Report": "HGX_CpuProcessorMetrics_0",
-             "MetricProperty": f"{base}#/Status/State", "MetricValue": "Absent"},
-            {"Report": "HGX_CpuProcessorMetrics_0",
-             "MetricProperty": f"{base}#/Oem/Nvidia/EDPViolationState",
-             "MetricValue": "Normal"},
-            {"Report": "HGX_CpuProcessorMetrics_0",
-             "MetricProperty": f"{base}#/Oem/Nvidia/PowerBreakPerformanceState",
-             "MetricValue": "Throttled"},
-        ],
-    )
-    states = [s for s in samples if s.metric == "hw.state.enabled"]
-    assert sorted(s.value for s in states) == [0.0, 1.0]
-    assert {s.dimensions["state"] for s in states} == {"Enabled", "Absent"}
-    edp = [s for s in samples if s.metric == "hw.power.edp_violation"]
-    assert edp[0].value == 0.0
-    brk = [s for s in samples if s.metric == "hw.power.break_state"]
-    assert brk[0].value == 1.0
-    assert brk[0].dimensions["state"] == "Throttled"
+def test_state_allowlists_match_contract_spec():
+    """Code allowlists equal the spec allowlists (G0 documentation truth)."""
+    import yaml
+    spec = yaml.safe_load(
+        (Path(__file__).parent.parent / "specs/telemetry/expected_signals.yaml")
+        .read_text(encoding="utf-8"))
+    allow = spec["allowlists"]
+    assert set(allow["health"]) == exporter_mod.HEALTH_LABELS | {"unknown"}
+    assert set(allow["state"]) == exporter_mod.STATE_LABELS | {"unknown"}
+    assert set(allow["reason"]) == exporter_mod.LINK_DOWN_REASONS | {"other"}
+    assert set(allow["reset_type"]) == exporter_mod.RESET_TYPES | {"other"}
 
 
-def test_metric_report_mapper_skips_unknown_enum_strings():
-    """Unknown enum text stays unexported instead of guessing a numeric value.
+def test_one_hot_state_samples_shape():
+    """State rows emit value 1 with normalized labels and full join dims."""
+    samples = _enum_samples([
+        _report_row("Status.Health", "Warning"),
+        _report_row("Status.State", "StandbyOffline"),
+        _report_row("Oem.Nvidia.LinkDownReasonCode", "PeerResetEvent",
+                    report="HGX_ProcessorPortMetrics_0"),
+    ])
+    by_metric = {s.metric: s for s in samples if s.metric.startswith(("hw.component", "hw.fabric"))}
+    health = by_metric["hw.component.health"]
+    assert health.value == 1.0
+    assert health.dimensions["health"] == "warning"
+    assert health.dimensions["report"] == "HGX_HealthMetrics_0"
+    state = by_metric["hw.component.state"]
+    assert state.value == 1.0
+    assert state.dimensions["state"] == "standby_offline"
+    reason = by_metric["hw.fabric.link_down_reason"]
+    assert reason.value == 1.0
+    assert reason.dimensions["reason"] == "peer_reset_event"
+    assert reason.dimensions["fabric"] == "nvlink"
 
-    A vendor could ship a new Health value; exporting a made-up number would
-    corrupt alerts, so the fail-safe is to drop only that row.
+
+def test_unknown_enum_values_map_to_unknown_or_other():
+    """Vendor surprises become bounded labels — never dropped, never free-form.
+
+    This edge occurs whenever a firmware update introduces a new enum value;
+    the M1 gate requires it to surface as unknown/other so dashboards see the
+    component instead of losing it.
     """
-    dims = build_identity_dimensions("172.25.230.29", vendor="supermicro")
-    samples = build_metric_samples(
-        identity=dims,
-        environment_rows=[],
-        sensor_rows=[],
-        nvlink_rows=[],
-        metric_report_rows=[
-            {"Report": "HGX_HealthMetrics_0",
-             "MetricProperty": "/redfish/v1/Chassis/HGX_GPU_0#/Status/Health",
-             "MetricValue": "SomethingNew"},
-            {"Report": "HGX_CpuProcessorMetrics_0",
-             "MetricProperty": "/redfish/v1/Chassis/HGX_GPU_0#/PCIeType",
-             "MetricValue": "Gen5"},
-        ],
-    )
-    assert [s for s in samples if s.metric.startswith("hw.health")] == []
-    assert all(s.metric.startswith("hw.scrape") for s in samples)
+    samples = _enum_samples([
+        _report_row("Status.Health", "VendorSpecialState"),
+        _report_row("Oem.Nvidia.LinkDownReasonCode", "BrandNewReason!!"),
+        _report_row("Oem.Nvidia.LastResetType", "WeirdReset"),
+    ])
+    by_metric = {s.metric: s for s in samples if not s.metric.startswith("hw.scrape")}
+    assert by_metric["hw.component.health"].dimensions["health"] == "unknown"
+    assert by_metric["hw.fabric.link_down_reason"].dimensions["reason"] == "other"
+    assert by_metric["hw.component.last_reset_type"].dimensions["reset_type"] == "other"
+    assert all(s.value == 1.0 for s in by_metric.values())

--- a/tools/splunk_metric_gate.py
+++ b/tools/splunk_metric_gate.py
@@ -35,12 +35,12 @@ import urllib.request
 # The P0 telemetry set: health/state enums plus a core signal from each
 # long-standing family, so a green gate means the whole pipeline is live.
 DEFAULT_METRICS = [
-    "hw.health",
-    "hw.health_rollup",
-    "hw.state.enabled",
+    "hw.component.health",
+    "hw.component.health_rollup",
+    "hw.component.state",
     "hw.fabric.link_down_reason",
-    "hw.power.edp_violation",
-    "hw.power.break_state",
+    "hw.power.edp_violation_state",
+    "hw.power.break_performance_state",
     "hw.temperature",
     "hw.power",
     "hw.scrape.ok",


### PR DESCRIPTION
Implements the M1 state-metric model from `specs/telemetry/gates.md`, replacing the numeric health mapping before anything reaches a backend: Health/HealthRollup → `hw.component.health(:_rollup){health}`, State → `hw.component.state{state}`, LinkDownReasonCode → `hw.fabric.link_down_reason{reason}`, EDPViolationState → `hw.power.edp_violation_state{state}`, PowerBreakPerformanceState → `hw.power.break_performance_state{state}`, and newly covered LastResetType → `hw.component.last_reset_type{reset_type}` — every sample value 1 with a normalized lowercase snake_case label from an explicit allowlist; unknown vendor values map to `unknown`/`other` (never dropped, never free-form).

The M2 gate lands with it: `test_expected_signals_contract` drives every fixture row of `specs/telemetry/expected_signals.yaml` through the mapper and requires expected−emitted to be empty, and `test_state_allowlists_match_contract_spec` keeps code allowlists byte-equal to the spec (G0 documentation truth). The Splunk gate tool's default metric set is updated to the contract names. Fleet gate green: 1301 passed / 62 skipped, ruff, docstring gate.