### PR TITLE
Trace Redfish mutating requests

### DIFF
--- a/redfish_ctl/firmware/cmd_firmware_update.py
+++ b/redfish_ctl/firmware/cmd_firmware_update.py
@@ -20,10 +20,11 @@ from typing import Optional
 
 import requests
 
+from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, RedfishApiRespond, Singleton
-from ..redfish_manager import CommandResult
 from ..redfish_shared import RedfishApi
+from ..telemetry import tracing
 
 
 class FirmwareUpdate(RedfishManagerBase,
@@ -162,6 +163,12 @@ class FirmwareUpdate(RedfishManagerBase,
             auth = (self._username, self._password)
 
         url = f"{self._default_method}{self.redfish_ip}{target}"
+        span_attributes = {
+            "redfish.action.name": "FirmwareUpload",
+            "redfish.action.type": method,
+            "redfish.action.target": target,
+            "redfish.action.level": "destructive",
+        }
         with image_path.open("rb") as image:
             if method == "MultipartHttpPushUri":
                 files = {
@@ -171,20 +178,30 @@ class FirmwareUpdate(RedfishManagerBase,
                         "application/octet-stream",
                     )
                 }
-                return requests.post(
+                return tracing.traced_request(
                     url,
-                    files=files,
+                    "POST",
+                    lambda: requests.post(
+                        url,
+                        files=files,
+                        verify=self._is_verify_cert,
+                        headers=headers,
+                        auth=auth,
+                    ),
+                    attributes=span_attributes,
+                )
+            headers["Content-Type"] = "application/octet-stream"
+            return tracing.traced_request(
+                url,
+                "POST",
+                lambda: requests.post(
+                    url,
+                    data=image,
                     verify=self._is_verify_cert,
                     headers=headers,
                     auth=auth,
-                )
-            headers["Content-Type"] = "application/octet-stream"
-            return requests.post(
-                url,
-                data=image,
-                verify=self._is_verify_cert,
-                headers=headers,
-                auth=auth,
+                ),
+                attributes=span_attributes,
             )
 
     def _push_result(self, target, method, image_file, dry_run, confirm):

--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -956,16 +956,21 @@ class RedfishManagerBase(RedfishManager):
 
         if self.x_auth is not None:
             headers.update({'X-Auth-Token': self.x_auth})
-            return requests.delete(
-                req, verify=self._is_verify_cert,
-                headers=headers
+            request_call = functools.partial(
+                requests.delete,
+                req,
+                verify=self._is_verify_cert,
+                headers=headers,
             )
         else:
-            return requests.delete(
-                req, verify=self._is_verify_cert,
+            request_call = functools.partial(
+                requests.delete,
+                req,
+                verify=self._is_verify_cert,
                 auth=(self._username, self._password),
-                headers=headers
+                headers=headers,
             )
+        return tracing.traced_request(req, "DELETE", request_call)
 
     def api_post_call(
             self, req: str, payload: str, hdr: dict) -> requests.models.Response:
@@ -982,19 +987,23 @@ class RedfishManagerBase(RedfishManager):
 
         if self.x_auth is not None:
             headers.update({'X-Auth-Token': self.x_auth})
-            return requests.post(
+            request_call = functools.partial(
+                requests.post,
                 req,
                 data=payload,
                 verify=self._is_verify_cert,
-                headers=headers
+                headers=headers,
             )
         else:
-            return requests.post(
-                req, data=payload,
+            request_call = functools.partial(
+                requests.post,
+                req,
+                data=payload,
                 verify=self._is_verify_cert,
                 headers=headers,
-                auth=(self._username, self._password)
+                auth=(self._username, self._password),
             )
+        return tracing.traced_request(req, "POST", request_call)
 
     async def api_async_post_call(
             self, loop, req: str, payload: str, hdr: Dict):
@@ -1011,24 +1020,26 @@ class RedfishManagerBase(RedfishManager):
             headers.update(hdr)
 
         if self.x_auth is not None:
-            return loop.run_in_executor(
-                None, functools.partial(
-                    requests.post, req,
-                    data=payload,
-                    verify=self._is_verify_cert,
-                    headers=headers
-                )
+            request_call = functools.partial(
+                requests.post,
+                req,
+                data=payload,
+                verify=self._is_verify_cert,
+                headers=headers,
             )
         else:
-            return loop.run_in_executor(
-                None, functools.partial(
-                    requests.post, req,
-                    data=payload,
-                    headers=headers,
-                    verify=self._is_verify_cert,
-                    auth=(self._username, self._password)
-                )
+            request_call = functools.partial(
+                requests.post,
+                req,
+                data=payload,
+                headers=headers,
+                verify=self._is_verify_cert,
+                auth=(self._username, self._password),
             )
+        return loop.run_in_executor(
+            None,
+            tracing.traced_request_callable(req, "POST", request_call),
+        )
 
     async def api_async_patch_until_complete(
             self, r: str,
@@ -1124,18 +1135,23 @@ class RedfishManagerBase(RedfishManager):
 
         if self.x_auth is not None:
             headers.update({'X-Auth-Token': self.x_auth})
-            return requests.patch(
-                req, data=payload,
-                verify=self._is_verify_cert,
-                headers=headers
-            )
-        else:
-            return requests.patch(
-                req, data=payload,
+            request_call = functools.partial(
+                requests.patch,
+                req,
+                data=payload,
                 verify=self._is_verify_cert,
                 headers=headers,
-                auth=(self._username, self._password)
             )
+        else:
+            request_call = functools.partial(
+                requests.patch,
+                req,
+                data=payload,
+                verify=self._is_verify_cert,
+                headers=headers,
+                auth=(self._username, self._password),
+            )
+        return tracing.traced_request(req, "PATCH", request_call)
 
     async def api_async_patch_call(
             self, loop, req, payload: str, hdr: Dict):
@@ -1154,20 +1170,26 @@ class RedfishManagerBase(RedfishManager):
             headers.update(hdr)
 
         if self.x_auth is not None:
-            return loop.run_in_executor(
-                None, functools.partial(requests.patch, req,
-                                        data=payload,
-                                        verify=self._is_verify_cert,
-                                        headers=headers)
+            request_call = functools.partial(
+                requests.patch,
+                req,
+                data=payload,
+                verify=self._is_verify_cert,
+                headers=headers,
             )
         else:
-            return loop.run_in_executor(
-                None, functools.partial(
-                    requests.patch, req, data=payload,
-                    verify=self._is_verify_cert, headers=headers,
-                    auth=(self._username, self._password)
-                )
+            request_call = functools.partial(
+                requests.patch,
+                req,
+                data=payload,
+                verify=self._is_verify_cert,
+                headers=headers,
+                auth=(self._username, self._password),
             )
+        return loop.run_in_executor(
+            None,
+            tracing.traced_request_callable(req, "PATCH", request_call),
+        )
 
     async def api_async_delete_call(
             self, loop, req, payload: str, hdr: Dict):
@@ -1186,21 +1208,26 @@ class RedfishManagerBase(RedfishManager):
             headers.update(hdr)
 
         if self.x_auth is not None:
-            return loop.run_in_executor(
-                None, functools.partial(
-                    requests.delete, req, data=payload,
-                    verify=self._is_verify_cert,
-                    headers=headers)
+            request_call = functools.partial(
+                requests.delete,
+                req,
+                data=payload,
+                verify=self._is_verify_cert,
+                headers=headers,
             )
         else:
-            return loop.run_in_executor(
-                None, functools.partial(
-                    requests.delete, req, data=payload,
-                    verify=self._is_verify_cert,
-                    headers=headers,
-                    auth=(self._username, self._password)
-                )
+            request_call = functools.partial(
+                requests.delete,
+                req,
+                data=payload,
+                verify=self._is_verify_cert,
+                headers=headers,
+                auth=(self._username, self._password),
             )
+        return loop.run_in_executor(
+            None,
+            tracing.traced_request_callable(req, "DELETE", request_call),
+        )
 
     def read_api_respond(
             self,
@@ -1838,8 +1865,15 @@ class RedfishManagerBase(RedfishManager):
                 "blocked": blocked_reason,
             }, actions, None, None)
 
-        result, _ = self.base_post(target, payload=body, do_async=do_async,
-                                   expected_status=expected_status)
+        span_attributes = {
+            "redfish.action.name": action_name,
+            "redfish.action.type": full,
+            "redfish.action.target": target,
+            "redfish.action.level": level.value,
+        }
+        with tracing.client_span_attributes(span_attributes):
+            result, _ = self.base_post(target, payload=body, do_async=do_async,
+                                       expected_status=expected_status)
         data = result.data if isinstance(result.data, dict) else {"result": result.data}
         data.setdefault("executed", True)
         data.setdefault("action", full)

--- a/redfish_ctl/telemetry/tracing.py
+++ b/redfish_ctl/telemetry/tracing.py
@@ -20,7 +20,8 @@ Author Mus <spyroot@gmail.com>
 from __future__ import annotations
 
 import contextlib
-from typing import Any, Iterator, Optional
+from contextvars import ContextVar
+from typing import Any, Callable, Iterator, Optional
 from urllib.parse import urlsplit
 
 # Set by enable_tracing(); None means tracing is off and every helper no-ops.
@@ -30,6 +31,9 @@ _TRACER: Any = None
 # server.address) is what makes an APM backend render one inferred "bmc" node
 # instead of one node per BMC IP.
 BMC_PEER_SERVICE = "bmc"
+_CLIENT_ATTRIBUTES: ContextVar[dict[str, Any]] = ContextVar(
+    "redfish_client_span_attributes", default={}
+)
 
 
 def enable_tracing(tracer: Any) -> None:
@@ -115,13 +119,18 @@ def operation_span(name: str) -> Iterator[Any]:
 
 
 @contextlib.contextmanager
-def client_span(url: str, method: str) -> Iterator[Any]:
+def client_span(
+    url: str,
+    method: str,
+    attributes: Optional[dict[str, Any]] = None,
+) -> Iterator[Any]:
     """CLIENT span for one BMC HTTP call. No-op when tracing is off.
 
     The BMC becomes an inferred downstream service via ``peer.service``.
 
     :param url: BMC request URL; its hostname becomes ``server.address``.
     :param method: HTTP method for the call (``http.request.method``).
+    :param attributes: optional extra attributes to add to the client span.
     """
     if _TRACER is None:
         yield None
@@ -129,6 +138,9 @@ def client_span(url: str, method: str) -> Iterator[Any]:
     from opentelemetry.trace import SpanKind
 
     host = urlsplit(url).hostname or ""
+    span_attributes = dict(_CLIENT_ATTRIBUTES.get())
+    if attributes:
+        span_attributes.update(attributes)
     with _TRACER.start_as_current_span(
         "redfish.bmc.request", kind=SpanKind.CLIENT
     ) as span:
@@ -136,7 +148,93 @@ def client_span(url: str, method: str) -> Iterator[Any]:
         if host:
             span.set_attribute("server.address", host)
         span.set_attribute("http.request.method", method)
+        for key, value in span_attributes.items():
+            if value is not None:
+                span.set_attribute(key, value)
         yield span
+
+
+@contextlib.contextmanager
+def client_span_attributes(attributes: dict[str, Any]) -> Iterator[None]:
+    """Temporarily attach extra attributes to nested BMC client spans.
+
+    :param attributes: attributes to merge into each nested ``client_span``.
+    :return: context manager yielding None.
+    """
+    current = dict(_CLIENT_ATTRIBUTES.get())
+    current.update(attributes)
+    token = _CLIENT_ATTRIBUTES.set(current)
+    try:
+        yield None
+    finally:
+        _CLIENT_ATTRIBUTES.reset(token)
+
+
+def traced_request(
+    url: str,
+    method: str,
+    request_call: Callable[[], Any],
+    attributes: Optional[dict[str, Any]] = None,
+) -> Any:
+    """Run a request callable inside a BMC client span.
+
+    :param url: BMC request URL used for span attributes.
+    :param method: HTTP method name.
+    :param request_call: zero-argument callable that performs the request.
+    :param attributes: optional extra attributes for the span.
+    :return: the response returned by ``request_call``.
+    """
+    with client_span(url, method, attributes=attributes) as span:
+        try:
+            response = request_call()
+        except Exception as exc:
+            record_exception(span, exc)
+            raise
+        record_response(span, getattr(response, "status_code", None))
+        return response
+
+
+def traced_request_callable(
+    url: str,
+    method: str,
+    request_call: Callable[[], Any],
+    attributes: Optional[dict[str, Any]] = None,
+) -> Callable[[], Any]:
+    """Wrap a request callable for executor use while preserving trace context.
+
+    :param url: BMC request URL used for span attributes.
+    :param method: HTTP method name.
+    :param request_call: zero-argument callable that performs the request.
+    :param attributes: optional extra attributes for the span.
+    :return: callable suitable for ``run_in_executor``.
+    """
+    span_attributes = dict(_CLIENT_ATTRIBUTES.get())
+    if attributes:
+        span_attributes.update(attributes)
+    if _TRACER is None:
+        return request_call
+
+    from opentelemetry import context
+
+    parent_context = context.get_current()
+
+    def _wrapped() -> Any:
+        """Run the request with the parent trace context attached.
+
+        :return: the response returned by ``request_call``.
+        """
+        token = context.attach(parent_context)
+        try:
+            return traced_request(
+                url,
+                method,
+                request_call,
+                attributes=span_attributes,
+            )
+        finally:
+            context.detach(token)
+
+    return _wrapped
 
 
 def record_response(span: Any, status_code: Optional[int]) -> None:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -3,18 +3,24 @@
 A command run through ``sync_invoke`` should, when tracing is enabled, emit an
 operation root span named by the command plus a ``SpanKind.CLIENT`` span per BMC
 HTTP call. The CLIENT span carries ``peer.service="bmc"`` so an APM backend
-renders the BMC as one inferred downstream node. With tracing disabled (the
-default) commands must behave exactly as before and emit nothing.
+renders the BMC as one inferred downstream node. Mutating calls also produce
+CLIENT spans and action metadata when routed through the action primitive. With
+tracing disabled (the default) commands must behave exactly as before and emit
+nothing.
 
 These use an in-memory span exporter — no collector, no network — and skip
 cleanly when the OpenTelemetry SDK (the ``[otlp]`` extra) is not installed.
 
 Author Mus <spyroot@gmail.com>
 """
+import asyncio
+import json
+
 import pytest
 
-from redfish_ctl.redfish_manager_shared import ApiRequestType
+from redfish_ctl.firmware.cmd_firmware_update import FirmwareUpdate
 from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.telemetry import tracing
 
 
@@ -36,6 +42,16 @@ def span_exporter():
         yield exporter
     finally:
         tracing.disable_tracing()
+
+
+def _client_span_attrs(spans, method):
+    """Return attributes for BMC client spans matching one HTTP method."""
+    return [
+        dict(span.attributes)
+        for span in spans
+        if span.name == "redfish.bmc.request"
+        and span.attributes.get("http.request.method") == method
+    ]
 
 
 def test_command_emits_operation_root_and_client_bmc_spans(span_exporter, redfish_mock):
@@ -64,6 +80,150 @@ def test_command_emits_operation_root_and_client_bmc_spans(span_exporter, redfis
     assert attrs.get("peer.service") == "bmc"
     assert attrs.get("http.request.method") == "GET"
     assert "server.address" in attrs
+
+
+def test_mutating_verbs_emit_client_bmc_spans(span_exporter, redfish_mock):
+    """POST/PATCH/DELETE calls emit CLIENT spans with method and status."""
+    redfish_mock.api_post_call(
+        "https://mock-idrac/redfish/v1/Systems/System.Embedded.1/"
+        "Actions/ComputerSystem.Reset",
+        json.dumps({"ResetType": "On"}),
+        {},
+    )
+    redfish_mock.api_patch_call(
+        "https://mock-idrac/redfish/v1/Systems/System.Embedded.1/Bios/Settings",
+        json.dumps({"Attributes": {"BootMode": "Uefi"}}),
+        {},
+    )
+    redfish_mock.api_delete_call(
+        "https://mock-idrac/redfish/v1/Systems/System.Embedded.1/"
+        "Storage/Volumes/Disk.Virtual.0",
+        {},
+    )
+
+    spans = span_exporter.get_finished_spans()
+    post = _client_span_attrs(spans, "POST")[0]
+    patch = _client_span_attrs(spans, "PATCH")[0]
+    delete = _client_span_attrs(spans, "DELETE")[0]
+
+    assert post["peer.service"] == "bmc"
+    assert post["http.response.status_code"] == 202
+    assert patch["http.response.status_code"] == 200
+    assert delete["http.response.status_code"] == 200
+
+
+def test_async_mutating_verbs_emit_client_bmc_spans(span_exporter, redfish_mock):
+    """Async POST/PATCH/DELETE wrappers preserve BMC client spans."""
+    loop = asyncio.new_event_loop()
+    try:
+        post_future = loop.run_until_complete(
+            redfish_mock.api_async_post_call(
+                loop,
+                "https://mock-idrac/redfish/v1/Systems/System.Embedded.1/"
+                "Actions/ComputerSystem.Reset",
+                json.dumps({"ResetType": "On"}),
+                {},
+            )
+        )
+        patch_future = loop.run_until_complete(
+            redfish_mock.api_async_patch_call(
+                loop,
+                "https://mock-idrac/redfish/v1/Systems/System.Embedded.1/Bios/Settings",
+                json.dumps({"Attributes": {"BootMode": "Uefi"}}),
+                {},
+            )
+        )
+        delete_future = loop.run_until_complete(
+            redfish_mock.api_async_delete_call(
+                loop,
+                "https://mock-idrac/redfish/v1/Systems/System.Embedded.1/"
+                "Storage/Volumes/Disk.Virtual.0",
+                "{}",
+                {},
+            )
+        )
+
+        assert loop.run_until_complete(post_future).status_code == 202
+        assert loop.run_until_complete(patch_future).status_code == 200
+        assert loop.run_until_complete(delete_future).status_code == 200
+    finally:
+        loop.close()
+
+    spans = span_exporter.get_finished_spans()
+    assert _client_span_attrs(spans, "POST")
+    assert _client_span_attrs(spans, "PATCH")
+    assert _client_span_attrs(spans, "DELETE")
+
+
+def test_invoke_action_adds_action_metadata_to_post_span(
+    span_exporter,
+    redfish_mock_factory,
+):
+    """Action POST spans carry action/type/target/level attributes."""
+    mgr, _svc = redfish_mock_factory("supermicro")
+    result = mgr.invoke_action(
+        "/redfish/v1/EventService",
+        "SubmitTestEvent",
+        payload={"MessageId": "Alert.1.0.TestEvent"},
+        full_action_type="#EventService.SubmitTestEvent",
+    )
+    assert result.data["executed"] is True
+
+    spans = span_exporter.get_finished_spans()
+    post = _client_span_attrs(spans, "POST")[0]
+    assert post["redfish.action.name"] == "SubmitTestEvent"
+    assert post["redfish.action.type"] == "#EventService.SubmitTestEvent"
+    assert post["redfish.action.target"] == (
+        "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent"
+    )
+    assert post["redfish.action.level"] == "reversible"
+
+
+def test_firmware_upload_post_emits_action_metadata(
+    span_exporter,
+    tmp_path,
+    monkeypatch,
+):
+    """Raw firmware upload POSTs are traced even though they bypass base_post."""
+    image = tmp_path / "fw.bin"
+    image.write_bytes(b"firmware")
+
+    class Response:
+        """Minimal response object returned by the monkeypatched upload call."""
+
+        status_code = 202
+        headers = {"Location": "/redfish/v1/TaskService/Tasks/JID_1"}
+
+    calls = []
+
+    def fake_post(url, **kwargs):
+        """Capture the upload call and return an accepted response."""
+        calls.append((url, kwargs))
+        return Response()
+
+    monkeypatch.setattr(
+        "redfish_ctl.firmware.cmd_firmware_update.requests.post",
+        fake_post,
+    )
+
+    cmd = FirmwareUpdate(
+        idrac_ip="mock-idrac",
+        idrac_username="root",
+        idrac_password="mock",
+    )
+    response = cmd._post_image_file(
+        "/redfish/v1/UpdateService/upload",
+        "HttpPushUri",
+        image,
+    )
+
+    assert response.status_code == 202
+    assert calls and calls[0][0] == "https://mock-idrac/redfish/v1/UpdateService/upload"
+    post = _client_span_attrs(span_exporter.get_finished_spans(), "POST")[0]
+    assert post["redfish.action.name"] == "FirmwareUpload"
+    assert post["redfish.action.type"] == "HttpPushUri"
+    assert post["redfish.action.target"] == "/redfish/v1/UpdateService/upload"
+    assert post["redfish.action.level"] == "destructive"
 
 
 def test_client_span_is_child_of_the_operation_span(span_exporter, redfish_mock):


### PR DESCRIPTION
## Summary

- Add client spans around Redfish POST, PATCH, and DELETE helpers, including async executor paths.
- Attach Redfish action metadata to POST spans created by the action primitive.
- Trace raw firmware push uploads and cover mutating spans with offline tests.

## Validation

- `make gb300-gate SLOT=17 REF=neroshige/mutating-spans`
  - `1305 passed, 62 skipped, 6 warnings`
  - Changed-file Ruff passed
  - Docstring gate passed