### PR TITLE
Source optional BMC credentials in the fleet container entrypoint

### DIFF
--- a/docker/gb300/entrypoint.sh
+++ b/docker/gb300/entrypoint.sh
@@ -34,6 +34,16 @@ if [ -f /secrets/splunk_token ]; then
     SPLUNK_ACCESS_TOKEN="$(tr -d '[:space:]' < /secrets/splunk_token)"
     export SPLUNK_ACCESS_TOKEN
 fi
+# BMC endpoint credentials (optional, operator-staged env file with
+# REDFISH_IP/REDFISH_USERNAME/REDFISH_PASSWORD): lets a container run the
+# read-only telemetry push gate without per-run credential plumbing. A
+# caller-provided REDFISH_IP wins — the file only fills an empty environment.
+if [ -f /secrets/bmc_env ] && [ -z "${REDFISH_IP:-}" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . /secrets/bmc_env
+    set +a
+fi
 if [ -f /secrets/splunk_realm ]; then
     _realm="$(tr -d '[:space:]' < /secrets/splunk_realm)"
     if [ -n "$_realm" ]; then


### PR DESCRIPTION
Adds the last optional secret to the container entrypoint pattern: `/secrets/bmc_env` (an env file with `REDFISH_IP`/`REDFISH_USERNAME`/`REDFISH_PASSWORD`, staged by the operator into the internal agent image like the git key, gh token, and Splunk credentials) is sourced with export only when the caller has not already provided `REDFISH_IP`, so per-run values always win. With it, the full telemetry hard gate — read-only exporter push plus the Splunk metric-visibility check — is runnable by any agent container with zero credential plumbing. Values are never echoed; the public base image is unaffected when the file is absent.