### PR TITLE
Split Splunk token scopes: ingest for pushes, API for the metric gate

### DIFF
--- a/docker/gb300/entrypoint.sh
+++ b/docker/gb300/entrypoint.sh
@@ -26,11 +26,20 @@ if [ -f /secrets/gh_token ]; then
     GH_TOKEN="$(tr -d '[:space:]' < /secrets/gh_token)"
     export GH_TOKEN
 fi
-# Observability ingest credentials (optional): the telemetry exporter reads
-# SPLUNK_ACCESS_TOKEN / SPLUNK_INGEST_URL, so a container can push and
-# live-verify metrics without any per-run token plumbing. An explicit
+# Observability credentials (optional). Splunk separates token scopes:
+# ingest tokens can write datapoints, API tokens can query them — so the
+# exporter's SPLUNK_ACCESS_TOKEN comes from splunk_ingest_token (falling
+# back to splunk_token for single-token orgs) while the metric gate's
+# SPLUNK_API_TOKEN always comes from splunk_token. An explicit
 # SPLUNK_INGEST_URL from the caller wins over the realm-derived default.
 if [ -f /secrets/splunk_token ]; then
+    SPLUNK_API_TOKEN="$(tr -d '[:space:]' < /secrets/splunk_token)"
+    export SPLUNK_API_TOKEN
+fi
+if [ -f /secrets/splunk_ingest_token ]; then
+    SPLUNK_ACCESS_TOKEN="$(tr -d '[:space:]' < /secrets/splunk_ingest_token)"
+    export SPLUNK_ACCESS_TOKEN
+elif [ -f /secrets/splunk_token ]; then
     SPLUNK_ACCESS_TOKEN="$(tr -d '[:space:]' < /secrets/splunk_token)"
     export SPLUNK_ACCESS_TOKEN
 fi

--- a/tests/test_splunk_metric_gate.py
+++ b/tests/test_splunk_metric_gate.py
@@ -21,6 +21,9 @@ def _env(monkeypatch, realm="us1", token="tok"):
         monkeypatch.setenv("SPLUNK_ACCESS_TOKEN", token)
     else:
         monkeypatch.delenv("SPLUNK_ACCESS_TOKEN", raising=False)
+    # Containers bake an API-scoped token too; tests control it explicitly so
+    # the config-error paths stay deterministic on the fleet.
+    monkeypatch.delenv("SPLUNK_API_TOKEN", raising=False)
 
 
 def test_gate_passes_when_all_metrics_fresh(monkeypatch, capsys):
@@ -119,6 +122,33 @@ def test_metrics_file_loading(tmp_path, monkeypatch, capsys):
     rc = gate.run_gate(["--metrics-file", str(spec)])
     assert rc == 0
     assert seen == ["hw.health", "hw.power"]
+
+
+def test_gate_prefers_api_token_for_queries(monkeypatch, capsys):
+    """With the default token env, SPLUNK_API_TOKEN wins over the ingest token.
+
+    Splunk separates token scopes; querying with an ingest-scoped token gets
+    401s, so the gate must pick the API token when both are present.
+    """
+    _env(monkeypatch)
+    monkeypatch.setenv("SPLUNK_API_TOKEN", "api-tok")
+    seen = {}
+
+    def record(realm, token, metric, timeout):
+        """Record the token used and return a fresh series.
+
+        :param realm: ignored.
+        :param token: captured for the assertion.
+        :param metric: ignored.
+        :param timeout: ignored.
+        :return: a fresh single-series result.
+        """
+        seen["token"] = token
+        return {"count": 1, "newest_ms": int(time.time() * 1000)}
+
+    monkeypatch.setattr(gate, "query_metric", record)
+    assert gate.run_gate(["hw.component.health"]) == 0
+    assert seen["token"] == "api-tok"
 
 
 def test_default_metric_set_includes_p0_signals(monkeypatch):

--- a/tools/splunk_metric_gate.py
+++ b/tools/splunk_metric_gate.py
@@ -137,7 +137,12 @@ def run_gate(argv: list[str] | None = None) -> int:
     """
     args = build_parser().parse_args(argv)
     realm = args.realm or os.environ.get("SPLUNK_O11Y_REALM", "")
+    # Query needs an API-scoped token; ingest-scoped tokens get 401s from
+    # the metrics API, so prefer SPLUNK_API_TOKEN when the caller kept the
+    # default env name and it is set.
     token = os.environ.get(args.token_env, "")
+    if not token or args.token_env == "SPLUNK_ACCESS_TOKEN":
+        token = os.environ.get("SPLUNK_API_TOKEN", "") or token
     if not realm:
         print("splunk-gate: realm is not set (--realm or SPLUNK_O11Y_REALM)", file=sys.stderr)
         return 2


### PR DESCRIPTION
The P1 live-gate run surfaced a scope mismatch: the staged token is API-scoped, so the ingest endpoint returns 401 (the exporter's large urllib POST sees it as a connection reset — confirmed by a minimal in-container probe: same token, API 200 vs ingest 401). The entrypoint now exports `SPLUNK_API_TOKEN` from the staged API token and takes `SPLUNK_ACCESS_TOKEN` from an ingest-scoped `splunk_ingest_token` secret when present, falling back to the single token for single-token orgs; the metric gate prefers the API token for queries when the caller keeps the default env. Regression test pins the preference, and the config-error tests now control both variables so they remain deterministic inside fleet containers that bake tokens. Fleet gate green.