### PR TITLE
Validate raw Redfish GET paths

### DIFF
--- a/redfish_ctl/cmd_get.py
+++ b/redfish_ctl/cmd_get.py
@@ -5,10 +5,43 @@
 """
 from abc import abstractmethod
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
 
+from .cmd_exceptions import InvalidArgument
 from .redfish_manager_base import RedfishManagerBase
 from .redfish_manager_shared import ApiRequestType, Singleton
 from .redfish_manager import CommandResult
+
+
+def _normalize_redfish_uri(uri: str) -> str:
+    """Validate and normalize a caller-provided Redfish resource URI.
+
+    :param uri: resource URI supplied to the ``get`` command.
+    :return: normalized path, with a query string preserved when present.
+    :raises InvalidArgument: when the value is not a local ``/redfish/v1`` path.
+    """
+    if not isinstance(uri, str) or not uri.strip():
+        raise InvalidArgument("get requires a /redfish/v1 resource URI")
+
+    raw_uri = uri.strip()
+    if "\\" in raw_uri:
+        raise InvalidArgument("get URI must use forward slashes")
+
+    parsed = urlsplit(raw_uri)
+    if parsed.scheme or parsed.netloc:
+        raise InvalidArgument("get accepts Redfish resource paths, not absolute URLs")
+    if parsed.fragment:
+        raise InvalidArgument("get URI must not include a fragment")
+
+    path = parsed.path
+    if path != "/redfish/v1" and not path.startswith("/redfish/v1/"):
+        raise InvalidArgument("get URI must start with /redfish/v1")
+
+    for segment in path.split("/"):
+        if segment in {".", ".."}:
+            raise InvalidArgument("get URI must not contain path traversal segments")
+
+    return urlunsplit(("", "", path, parsed.query, ""))
 
 
 class RawGet(
@@ -59,8 +92,9 @@ class RawGet(
         :param do_expanded: issue an expanded ($expand) Redfish query.
         :return: CommandResult with the fetched resource data.
         """
+        resource_uri = _normalize_redfish_uri(uri)
         return self.base_query(
-            uri,
+            resource_uri,
             filename=filename,
             do_async=do_async,
             do_expanded=do_expanded,

--- a/tests/test_query_idrac_dualmode.py
+++ b/tests/test_query_idrac_dualmode.py
@@ -3,6 +3,9 @@ import argparse
 import json
 from urllib.parse import unquote, urlsplit
 
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
 from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.redfish_main import create_cmd_tree
 from redfish_ctl.redfish_manager import CommandResult
@@ -61,6 +64,57 @@ def test_raw_get_returns_requested_resource(redfish_api):
     )
 
     _assert_system_resource(result)
+
+
+def test_raw_get_trims_requested_redfish_resource(redfish_api):
+    """raw_get trims whitespace before issuing a Redfish resource read."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.RawGet,
+        "raw_get",
+        uri=f"  {MANAGERS_RESOURCE}  ",
+    )
+
+    _assert_manager_collection(result)
+
+
+def test_raw_get_preserves_safe_query_string(redfish_mock, redfish_service):
+    """raw_get keeps an inline Redfish query string on the requested path."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.RawGet,
+        "raw_get",
+        uri=f"{MANAGERS_RESOURCE}?$top=1",
+    )
+
+    _assert_manager_collection(result)
+    request = redfish_service.last_request
+    assert request.method == "GET"
+    assert request.path.lower() == MANAGERS_RESOURCE.lower()
+
+    raw_query = request.query or urlsplit(request.url).query
+    assert unquote(raw_query) == "$top=1"
+
+
+@pytest.mark.parametrize(
+    ("uri", "message"),
+    [
+        ("", "requires a /redfish/v1 resource URI"),
+        ("https://example.invalid/redfish/v1/Managers", "not absolute URLs"),
+        ("//example.invalid/redfish/v1/Managers", "not absolute URLs"),
+        ("/redfish/v1/../Managers", "path traversal"),
+        ("/redfish/v1/Managers#top", "must not include a fragment"),
+        ("/api/v1/Managers", "must start with /redfish/v1"),
+        ("redfish/v1/Managers", "must start with /redfish/v1"),
+        (r"/redfish/v1\\Managers", "forward slashes"),
+    ],
+)
+def test_raw_get_rejects_non_resource_paths(redfish_api, uri, message):
+    """raw_get fails closed before querying non-resource paths."""
+    with pytest.raises(InvalidArgument, match=message):
+        redfish_api.sync_invoke(
+            ApiRequestType.RawGet,
+            "raw_get",
+            uri=uri,
+        )
 
 
 def test_query_idrac_returns_manager_collection(redfish_api):


### PR DESCRIPTION
Summary:
- restrict the generic get command to local /redfish/v1 resource paths
- reject absolute URLs, fragments, traversal segments, and non-Redfish paths before any request is sent
- keep whitespace trimming and safe query-string support covered by tests

Validation:
- git diff --check
- Not run: remote gate unavailable; the fleet health check reported every slot unreachable, and a direct representative node ping had 100% packet loss