### PR TITLE
Add controller OTLP tracing hooks

### DIFF
--- a/charts/redfish-controller/templates/deployment.yaml
+++ b/charts/redfish-controller/templates/deployment.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: REDFISH_CONTROLLER_POLL_INTERVAL
               value: {{ .Values.controller.pollInterval | quote }}
+            - name: REDFISH_CONTROLLER_OTLP_TRACES
+              value: {{ .Values.controller.otlpTraces | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/charts/redfish-controller/values.yaml
+++ b/charts/redfish-controller/values.yaml
@@ -5,6 +5,7 @@ image:
 
 controller:
   pollInterval: 30s
+  otlpTraces: false
   resources:
     requests:
       cpu: 25m

--- a/docker/Dockerfile.controller
+++ b/docker/Dockerfile.controller
@@ -28,7 +28,7 @@ COPY redfish_ctl ./redfish_ctl
 COPY k8s/controller ./k8s/controller
 
 RUN python -m pip install --upgrade pip \
-    && python -m pip install --no-cache-dir . "kopf>=1.37" "kubernetes>=29" \
+    && python -m pip install --no-cache-dir ".[otlp]" "kopf>=1.37" "kubernetes>=29" \
     && python -m pip check
 
 USER redfish

--- a/k8s/controller/deployment.yaml
+++ b/k8s/controller/deployment.yaml
@@ -45,6 +45,10 @@ spec:
             # (Helm renders the same var from .Values.controller.pollInterval.)
             - name: REDFISH_CONTROLLER_POLL_INTERVAL
               value: "30s"
+            # Opt-in controller reconcile spans. OTLP endpoint and protocol are
+            # supplied through the standard OTEL_EXPORTER_OTLP_* env vars.
+            - name: REDFISH_CONTROLLER_OTLP_TRACES
+              value: "false"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/k8s/controller/redfish_endpoint_controller.py
+++ b/k8s/controller/redfish_endpoint_controller.py
@@ -37,6 +37,7 @@ from redfish_ctl.redfish_exceptions import (
     RedfishUnauthorized,
 )
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.telemetry import tracing
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -256,6 +257,8 @@ def parse_interval_seconds(text: Any, default: float) -> float:
 #: retune the controller's base timer cadence. The old handler hard-coded
 #: ``interval=30`` and never read it, so this knob was wired but dead.
 POLL_INTERVAL_ENV = "REDFISH_CONTROLLER_POLL_INTERVAL"
+OTLP_TRACES_ENV = "REDFISH_CONTROLLER_OTLP_TRACES"
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
 def base_interval_seconds() -> float:
@@ -273,6 +276,77 @@ def base_interval_seconds() -> float:
         os.environ.get(POLL_INTERVAL_ENV),
         DEFAULT_POLL_INTERVAL_SECONDS,
     )
+
+
+def _controller_otlp_traces_enabled(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether controller OTLP tracing is enabled by env.
+
+    The ``REDFISH_CONTROLLER_OTLP_TRACES`` env var, rendered by the deployment
+    and Helm chart, enables the controller's OTLP span pipeline when set to a
+    true-like value.
+
+    :param environ: environment mapping to read; defaults to ``os.environ``.
+    :return: True when controller tracing should be set up.
+    """
+    values = os.environ if environ is None else environ
+    return str(values.get(OTLP_TRACES_ENV, "")).strip().lower() in _TRUE_ENV_VALUES
+
+
+def setup_controller_tracing(environ: Mapping[str, str] | None = None) -> None:
+    """Set up the controller OTLP span pipeline when enabled by env.
+
+    :param environ: environment mapping to read; defaults to ``os.environ``.
+    """
+    if _controller_otlp_traces_enabled(environ):
+        tracing.setup_otlp("redfish-controller")
+
+
+def _server_address(spec: Mapping[str, Any]) -> str:
+    """Return the BMC host value used on controller root spans.
+
+    :param spec: RedfishEndpoint spec.
+    :return: host from ``spec.address``, with URL schemes stripped when present.
+    """
+    raw_address = str(spec.get("address") or "").strip()
+    parsed = urlsplit(raw_address)
+    if parsed.scheme in {"http", "https"}:
+        return parsed.hostname or parsed.netloc or raw_address
+    return raw_address
+
+
+def _set_span_attribute(span: Any, key: str, value: Any) -> None:
+    """Set a span attribute when tracing is enabled and a value is present.
+
+    :param span: current span, or None when tracing is disabled.
+    :param key: span attribute key.
+    :param value: span attribute value.
+    """
+    if span is not None and value not in (None, ""):
+        span.set_attribute(key, value)
+
+
+def _set_controller_span_attributes(
+    span: Any,
+    spec: Mapping[str, Any],
+    *,
+    namespace: str | None,
+    name: str | None,
+    resource_kind: str,
+) -> None:
+    """Attach bounded Kubernetes/BMC identity to a controller root span.
+
+    :param span: current operation span, or None when tracing is disabled.
+    :param spec: resource spec containing the endpoint address.
+    :param namespace: Kubernetes namespace.
+    :param name: Kubernetes object name.
+    :param resource_kind: Kubernetes custom resource kind.
+    """
+    _set_span_attribute(span, "server.address", _server_address(spec))
+    _set_span_attribute(span, "k8s.namespace.name", namespace)
+    _set_span_attribute(span, "k8s.resource.name", name)
+    _set_span_attribute(span, "k8s.resource.kind", resource_kind)
 
 
 def _parse_rfc3339(text: Any) -> datetime | None:
@@ -689,40 +763,49 @@ def poll_redfish_endpoint(
         ``body`` when ``None``.
     :param force: when ``True``, poll immediately and bypass the cadence gate.
     """
-    current_status = status if status is not None else _mapping(body).get("status")
-    current_status = _mapping(current_status)
-    now = _utc_now()
-    if not force and not poll_due(spec, current_status, now):
-        return None
-
-    credentials = load_secret_credentials(namespace, spec.get("secretRef"))
-    base = base_interval_seconds()
-    try:
-        readings = poll_endpoint(
+    with tracing.operation_span("k8s.redfish_endpoint.reconcile") as span:
+        _set_controller_span_attributes(
+            span,
             spec,
-            credentials=credentials,
-            manager_factory=MANAGER_FACTORY,
-            polled_at=now,
+            namespace=namespace,
+            name=name,
+            resource_kind="RedfishEndpoint",
         )
-    except POLL_ERRORS as exc:
-        new_status = build_error_status(
-            current_status, exc, now=now, base_interval=base
-        )
-        if logger is not None:
-            logger.warning(
-                "RedfishEndpoint %s/%s poll failed (%s): %s",
-                namespace or "",
-                name or "",
-                new_status["consecutiveFailures"],
-                new_status["lastError"],
-            )
-    else:
-        new_status = build_success_status(readings, now=now)
-        if logger is not None:
-            logger.info("polled RedfishEndpoint %s/%s", namespace or "", name or "")
+        current_status = status if status is not None else _mapping(body).get("status")
+        current_status = _mapping(current_status)
+        now = _utc_now()
+        if not force and not poll_due(spec, current_status, now):
+            return None
 
-    if patch is not None:
-        patch.setdefault("status", {}).update(new_status)
+        credentials = load_secret_credentials(namespace, spec.get("secretRef"))
+        base = base_interval_seconds()
+        try:
+            readings = poll_endpoint(
+                spec,
+                credentials=credentials,
+                manager_factory=MANAGER_FACTORY,
+                polled_at=now,
+            )
+        except POLL_ERRORS as exc:
+            tracing.record_exception(span, exc)
+            new_status = build_error_status(
+                current_status, exc, now=now, base_interval=base
+            )
+            if logger is not None:
+                logger.warning(
+                    "RedfishEndpoint %s/%s poll failed (%s): %s",
+                    namespace or "",
+                    name or "",
+                    new_status["consecutiveFailures"],
+                    new_status["lastError"],
+                )
+        else:
+            new_status = build_success_status(readings, now=now)
+            if logger is not None:
+                logger.info("polled RedfishEndpoint %s/%s", namespace or "", name or "")
+
+        if patch is not None:
+            patch.setdefault("status", {}).update(new_status)
     return None
 
 
@@ -735,6 +818,7 @@ def poll_on_change(**kwargs: Any) -> None:  # pragma: no cover - runtime kopf wi
 
 
 if kopf is not None:  # pragma: no cover - decorator wiring is runtime-only.
+    setup_controller_tracing()
     # Lifecycle events poll now (force=True); the timer polls on the per-CR
     # cadence via poll_due. Distinct functions so kopf registers distinct
     # handler ids for the change causes vs the timer.

--- a/k8s/controller/redfish_node_profile_controller.py
+++ b/k8s/controller/redfish_node_profile_controller.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
 from datetime import datetime, timezone
 from typing import Any, Callable, Mapping, MutableMapping
 from urllib.parse import urlsplit
@@ -17,15 +18,89 @@ except ImportError:  # pragma: no cover - unit tests call the handler directly.
 
 from redfish_ctl.kube_client import get_core_v1_api
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.telemetry import tracing
 
 REDFISH_GROUP = "redfish.ctl.dev"
 REDFISH_VERSION = "v1alpha1"
 REDFISH_PLURAL = "redfishnodeprofiles"
 DEFAULT_PORT = 443
 DEFAULT_USERNAME = "root"
+OTLP_TRACES_ENV = "REDFISH_CONTROLLER_OTLP_TRACES"
+_TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
 
 ManagerFactory = Callable[..., Any]
 ReconcileFunc = Callable[..., Any]
+
+
+def _controller_otlp_traces_enabled(
+    environ: Mapping[str, str] | None = None,
+) -> bool:
+    """Return whether controller OTLP tracing is enabled by env.
+
+    The ``REDFISH_CONTROLLER_OTLP_TRACES`` env var, rendered by the deployment
+    and Helm chart, enables the controller's OTLP span pipeline when set to a
+    true-like value.
+
+    :param environ: environment mapping to read; defaults to ``os.environ``.
+    :return: True when controller tracing should be set up.
+    """
+    values = os.environ if environ is None else environ
+    return str(values.get(OTLP_TRACES_ENV, "")).strip().lower() in _TRUE_ENV_VALUES
+
+
+def setup_controller_tracing(environ: Mapping[str, str] | None = None) -> None:
+    """Set up the controller OTLP span pipeline when enabled by env.
+
+    :param environ: environment mapping to read; defaults to ``os.environ``.
+    """
+    if _controller_otlp_traces_enabled(environ):
+        tracing.setup_otlp("redfish-controller")
+
+
+def _server_address(endpoint: Mapping[str, Any]) -> str:
+    """Return the BMC host value used on controller root spans.
+
+    :param endpoint: RedfishNodeProfile ``spec.endpoint`` mapping.
+    :return: host from ``endpoint.address``, with URL schemes stripped when present.
+    """
+    raw_address = str(endpoint.get("address") or "").strip()
+    parsed = urlsplit(raw_address)
+    if parsed.scheme in {"http", "https"}:
+        return parsed.hostname or parsed.netloc or raw_address
+    return raw_address
+
+
+def _set_span_attribute(span: Any, key: str, value: Any) -> None:
+    """Set a span attribute when tracing is enabled and a value is present.
+
+    :param span: current span, or None when tracing is disabled.
+    :param key: span attribute key.
+    :param value: span attribute value.
+    """
+    if span is not None and value not in (None, ""):
+        span.set_attribute(key, value)
+
+
+def _set_controller_span_attributes(
+    span: Any,
+    endpoint: Mapping[str, Any],
+    *,
+    namespace: str | None,
+    name: str | None,
+    resource_kind: str,
+) -> None:
+    """Attach bounded Kubernetes/BMC identity to a controller root span.
+
+    :param span: current operation span, or None when tracing is disabled.
+    :param endpoint: endpoint mapping from the resource spec.
+    :param namespace: Kubernetes namespace.
+    :param name: Kubernetes object name.
+    :param resource_kind: Kubernetes custom resource kind.
+    """
+    _set_span_attribute(span, "server.address", _server_address(endpoint))
+    _set_span_attribute(span, "k8s.namespace.name", namespace)
+    _set_span_attribute(span, "k8s.resource.name", name)
+    _set_span_attribute(span, "k8s.resource.kind", resource_kind)
 
 
 def _utc_now() -> datetime:
@@ -507,22 +582,32 @@ def reconcile_redfish_node_profile(
     :param patch: kopf patch object the new ``.status`` is written into.
     """
     endpoint = _mapping(spec.get("endpoint"))
-    credentials = load_secret_credentials(namespace, endpoint.get("secretRef"))
-    try:
-        status = reconcile_profile(
-            spec,
-            credentials=credentials,
-            current_status=_mapping(_mapping(body).get("status")),
+    with tracing.operation_span("k8s.redfish_node_profile.reconcile") as span:
+        _set_controller_span_attributes(
+            span,
+            endpoint,
+            namespace=namespace,
+            name=name,
+            resource_kind="RedfishNodeProfile",
         )
-    except Exception as exc:
-        status = build_error_status(str(exc))
-    if patch is not None:
-        patch.setdefault("status", {}).update(status)
-    if logger is not None:
-        logger.info("reconciled RedfishNodeProfile %s/%s", namespace or "", name or "")
+        credentials = load_secret_credentials(namespace, endpoint.get("secretRef"))
+        try:
+            status = reconcile_profile(
+                spec,
+                credentials=credentials,
+                current_status=_mapping(_mapping(body).get("status")),
+            )
+        except Exception as exc:
+            tracing.record_exception(span, exc)
+            status = build_error_status(str(exc))
+        if patch is not None:
+            patch.setdefault("status", {}).update(status)
+        if logger is not None:
+            logger.info("reconciled RedfishNodeProfile %s/%s", namespace or "", name or "")
 
 
 if kopf is not None:  # pragma: no cover - decorator wiring is runtime-only.
+    setup_controller_tracing()
     reconcile_redfish_node_profile = kopf.on.create(
         REDFISH_GROUP,
         REDFISH_VERSION,

--- a/redfish_ctl/telemetry/tracing.py
+++ b/redfish_ctl/telemetry/tracing.py
@@ -26,6 +26,7 @@ from urllib.parse import urlsplit
 
 # Set by enable_tracing(); None means tracing is off and every helper no-ops.
 _TRACER: Any = None
+_OTLP_SETUP_SERVICE_NAME: str | None = None
 
 # The single downstream node name for every BMC. Setting peer.service (not just
 # server.address) is what makes an APM backend render one inferred "bmc" node
@@ -61,6 +62,9 @@ def setup_otlp(service_name: str = "redfish-ctl") -> None:
         service-map node name).
     :raises RuntimeError: when the OpenTelemetry SDK or an OTLP exporter is not installed.
     """
+    global _OTLP_SETUP_SERVICE_NAME
+    if _TRACER is not None and _OTLP_SETUP_SERVICE_NAME == service_name:
+        return
     try:
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
@@ -87,12 +91,14 @@ def setup_otlp(service_name: str = "redfish-ctl") -> None:
     provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
     provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     enable_tracing(provider.get_tracer("redfish_ctl"))
+    _OTLP_SETUP_SERVICE_NAME = service_name
 
 
 def disable_tracing() -> None:
     """Turn tracing off (used by tests to restore the default no-op state)."""
-    global _TRACER
+    global _TRACER, _OTLP_SETUP_SERVICE_NAME
     _TRACER = None
+    _OTLP_SETUP_SERVICE_NAME = None
 
 
 def is_enabled() -> bool:

--- a/specs/telemetry/gates.md
+++ b/specs/telemetry/gates.md
@@ -118,6 +118,22 @@ cross-node parentage         == 0
 unexpected orphan roots      == 0
 ```
 
+Kubernetes controllers:
+
+```
+k8s.redfish_endpoint.reconcile ROOT
+└── redfish.bmc.request CLIENT
+
+k8s.redfish_node_profile.reconcile ROOT
+├── dry-run plan operation
+└── approved apply operation
+```
+
+Controller root spans carry the bounded Kubernetes identity fields
+`k8s.namespace.name`, `k8s.resource.name`, and `k8s.resource.kind`, plus
+`server.address`. They do not record Secret data, request bodies, response
+bodies, raw URLs, or query strings.
+
 ## Lifecycle gate (G6 details)
 
 Required scenarios: successful command exit; command raising an exception;

--- a/specs/telemetry/span_contract.yaml
+++ b/specs/telemetry/span_contract.yaml
@@ -12,6 +12,17 @@ operation_span:
     - server.address
   forbidden: same as request_span
 
+controller_operation_span:
+  kind: INTERNAL
+  name: k8s.redfish_endpoint.reconcile or k8s.redfish_node_profile.reconcile
+  status: ERROR when the reconcile handler records a failure, else OK
+  required:
+    - server.address
+    - k8s.namespace.name
+    - k8s.resource.name
+    - k8s.resource.kind
+  forbidden: same as request_span
+
 request_span:
   kind: CLIENT
   required:

--- a/tests/test_helm_chart.py
+++ b/tests/test_helm_chart.py
@@ -61,6 +61,7 @@ def test_chart_metadata_and_default_values_are_pinned() -> None:
     assert values["mockBmc"]["image"]["repository"] == "spyroot/redfish-ctl-mock-bmc"
     assert values["mockBmc"]["enabled"] is False
     assert values["controller"]["pollInterval"] == "30s"
+    assert values["controller"]["otlpTraces"] is False
     assert values["rbac"]["create"] is True
     assert values["serviceAccount"]["create"] is True
 
@@ -107,6 +108,16 @@ def test_default_template_renders_controller_rbac_and_no_mock_bmc() -> None:
         "--standalone",
         "/app/k8s/controller/redfish_endpoint_controller.py",
         "/app/k8s/controller/redfish_node_profile_controller.py",
+    ]
+    assert container["env"] == [
+        {
+            "name": "REDFISH_CONTROLLER_POLL_INTERVAL",
+            "value": "30s",
+        },
+        {
+            "name": "REDFISH_CONTROLLER_OTLP_TRACES",
+            "value": "false",
+        },
     ]
     assert deployment["spec"]["template"]["spec"]["serviceAccountName"] == "redfish-controller"
     assert deployment["spec"]["template"]["spec"]["securityContext"]["runAsNonRoot"] is True

--- a/tests/test_k8s_controller.py
+++ b/tests/test_k8s_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 import json
 import threading
@@ -45,6 +46,22 @@ def _load_controller_module():
 def _fixture_for_path(path: str) -> Path | None:
     name = "_" + path.strip("/").replace("/", "_") + ".json"
     return GB300_INDEX.get(name.lower())
+
+
+class FakeSpan:
+    """Small span double that records attributes set by controller handlers."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def set_attribute(self, key: str, value: object) -> None:
+        """Record a span attribute assignment.
+
+        :param key: span attribute key.
+        :param value: span attribute value.
+        """
+        self.attributes[key] = value
 
 
 def test_crd_schema_pins_read_only_endpoint_spec_and_status_shape() -> None:
@@ -273,6 +290,65 @@ def test_kopf_handler_patches_status_only(monkeypatch) -> None:
             {},
         )
     ]
+
+
+def test_controller_tracing_setup_is_env_gated(monkeypatch) -> None:
+    """Controller OTLP setup runs only when the deployment env flag is true."""
+    module = _load_controller_module()
+    calls: list[str] = []
+    monkeypatch.setattr(
+        module.tracing,
+        "setup_otlp",
+        lambda service_name: calls.append(service_name),
+    )
+
+    module.setup_controller_tracing({})
+    module.setup_controller_tracing({module.OTLP_TRACES_ENV: "yes"})
+
+    assert calls == ["redfish-controller"]
+
+
+def test_kopf_handler_wraps_poll_in_controller_span(monkeypatch) -> None:
+    """Each endpoint reconcile gets a bounded root span with BMC identity."""
+    module = _load_controller_module()
+    spans: list[FakeSpan] = []
+
+    @contextlib.contextmanager
+    def fake_operation_span(name: str):
+        span = FakeSpan(name)
+        spans.append(span)
+        yield span
+
+    def fake_poll_endpoint(spec, credentials=None, manager_factory=None, polled_at=None):
+        return {
+            "powerState": "On",
+            "health": "OK",
+            "temperature": {"count": 1, "maxCelsius": 24.4},
+            "lastPolled": "2026-07-10T14:50:00Z",
+        }
+
+    monkeypatch.setattr(module.tracing, "operation_span", fake_operation_span)
+    monkeypatch.setattr(module, "poll_endpoint", fake_poll_endpoint)
+
+    patch: dict = {}
+    module.poll_redfish_endpoint(
+        spec={"address": "https://mock-bmc:8443"},
+        body={},
+        namespace="default",
+        name="node-a",
+        logger=None,
+        patch=patch,
+        force=True,
+    )
+
+    assert len(spans) == 1
+    assert spans[0].name == "k8s.redfish_endpoint.reconcile"
+    assert spans[0].attributes == {
+        "server.address": "mock-bmc",
+        "k8s.namespace.name": "default",
+        "k8s.resource.name": "node-a",
+        "k8s.resource.kind": "RedfishEndpoint",
+    }
 
 
 def test_sensor_health_falls_back_when_system_health_absent() -> None:

--- a/tests/test_k8s_node_profile_controller.py
+++ b/tests/test_k8s_node_profile_controller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import importlib.util
 from datetime import datetime, timezone
 from pathlib import Path
@@ -53,6 +54,22 @@ def _load_controller_module():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     return module
+
+
+class FakeSpan:
+    """Small span double that records attributes set by controller handlers."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.attributes: dict[str, object] = {}
+
+    def set_attribute(self, key: str, value: object) -> None:
+        """Record a span attribute assignment.
+
+        :param key: span attribute key.
+        :param value: span attribute value.
+        """
+        self.attributes[key] = value
 
 
 def test_crd_schema_pins_profile_spec_and_status_shape() -> None:
@@ -168,6 +185,72 @@ def test_reconcile_profile_requires_approval_before_confirming() -> None:
     ]
     assert status["dryRun"] is True
     assert {item["type"]: item["status"] for item in status["conditions"]}["Approved"] == "False"
+
+
+def test_controller_tracing_setup_is_env_gated(monkeypatch) -> None:
+    """Controller OTLP setup runs only when the deployment env flag is true."""
+    module = _load_controller_module()
+    calls: list[str] = []
+    monkeypatch.setattr(
+        module.tracing,
+        "setup_otlp",
+        lambda service_name: calls.append(service_name),
+    )
+
+    module.setup_controller_tracing({})
+    module.setup_controller_tracing({module.OTLP_TRACES_ENV: "true"})
+
+    assert calls == ["redfish-controller"]
+
+
+def test_kopf_handler_wraps_node_profile_reconcile_in_controller_span(
+    monkeypatch,
+) -> None:
+    """Each node-profile reconcile gets a root span with BMC identity."""
+    module = _load_controller_module()
+    spans: list[FakeSpan] = []
+
+    @contextlib.contextmanager
+    def fake_operation_span(name: str):
+        span = FakeSpan(name)
+        spans.append(span)
+        yield span
+
+    monkeypatch.setattr(module.tracing, "operation_span", fake_operation_span)
+    monkeypatch.setattr(module, "load_secret_credentials", lambda namespace, secret_ref: {})
+    monkeypatch.setattr(
+        module,
+        "reconcile_profile",
+        lambda *args, **kwargs: {
+            "dryRun": True,
+            "drift": False,
+            "plannedSteps": [],
+            "appliedChanges": [],
+        },
+    )
+
+    patch: dict = {}
+    module.reconcile_redfish_node_profile(
+        spec={
+            "endpoint": {"address": "https://mock-bmc:8443"},
+            "desiredState": {"biosProfile": "balanced"},
+        },
+        body={},
+        namespace="default",
+        name="profile-a",
+        logger=None,
+        patch=patch,
+    )
+
+    assert patch["status"]["dryRun"] is True
+    assert len(spans) == 1
+    assert spans[0].name == "k8s.redfish_node_profile.reconcile"
+    assert spans[0].attributes == {
+        "server.address": "mock-bmc",
+        "k8s.namespace.name": "default",
+        "k8s.resource.name": "profile-a",
+        "k8s.resource.kind": "RedfishNodeProfile",
+    }
 
 
 def test_reconcile_profile_confirms_only_for_matching_plan_hash() -> None:

--- a/tests/test_k8s_sandbox_harness.py
+++ b/tests/test_k8s_sandbox_harness.py
@@ -154,6 +154,16 @@ def test_controller_deployment_is_read_only_and_uses_local_image() -> None:
         "/app/k8s/controller/redfish_endpoint_controller.py",
         "/app/k8s/controller/redfish_node_profile_controller.py",
     ]
+    assert container["env"] == [
+        {
+            "name": "REDFISH_CONTROLLER_POLL_INTERVAL",
+            "value": "30s",
+        },
+        {
+            "name": "REDFISH_CONTROLLER_OTLP_TRACES",
+            "value": "false",
+        },
+    ]
 
     cluster_role = next(doc for doc in docs if doc["kind"] == "ClusterRole")
     cluster_verbs = set().union(
@@ -194,6 +204,7 @@ def test_controller_image_runs_kopf_without_credentials() -> None:
 
     assert "FROM python:3.12-slim" in dockerfile
     assert "redfish_ctl" in dockerfile
+    assert '".[otlp]"' in dockerfile
     assert "kopf" in dockerfile
     assert "kubernetes" in dockerfile
     assert "USER redfish" in dockerfile

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -278,3 +278,13 @@ def test_helpers_are_noop_without_a_tracer():
     tracing.record_response(None, 500)
     tracing.record_exception(None, RuntimeError("x"))
     tracing.record_result(None, CommandResult(None, None, None, "err"))
+
+
+def test_setup_otlp_is_idempotent_when_already_configured(monkeypatch):
+    """A second controller module import must not rebuild the OTLP pipeline."""
+    tracing.enable_tracing(object())
+    monkeypatch.setattr(tracing, "_OTLP_SETUP_SERVICE_NAME", "redfish-controller")
+    try:
+        tracing.setup_otlp("redfish-controller")
+    finally:
+        tracing.disable_tracing()


### PR DESCRIPTION
## Summary
- install the OTLP extra in the controller image and add a default-off tracing flag to the sandbox and Helm deployments
- initialize controller tracing when the flag is enabled and wrap both controller reconcile handlers in root spans with bounded Kubernetes and BMC identity
- document the controller span shape in the telemetry contract and add offline contract coverage

## Validation
- git diff --check