### PR TITLE
Add TelemetryService metric report clear command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -197,6 +197,7 @@ Safety labels:
 | `task-get` | Read one Redfish Task. | Read |
 | `task-watch` | Watch task progress. | Read |
 | `tasks` | Read the task collection. | Read |
+| `telemetry-clear-reports` | Clear generated TelemetryService MetricReports; dry-run by default and `--confirm` posts. | Guarded |
 | `telemetry-triggers` | Read TelemetryService triggers and thresholds. | Read |
 | `thermal` | Read Chassis `ThermalSubsystem` links, ThermalMetrics temperature readings, and fan collection counts from `redfish_ctl/thermal/cmd_thermal.py`. | Read |
 | `update_service` | Read UpdateService inventory links, push URIs, and advertised actions. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -96,6 +96,7 @@ from .metrics.cmd_memory_metrics import *
 from .metrics.cmd_gpu_metrics import *
 from .telemetry.cmd_metric_reports import *
 from .telemetry.cmd_metric_definitions import *
+from .telemetry.cmd_telemetry_clear_reports import *
 from .telemetry.cmd_exporter import *
 from .component_integrity.cmd_component_integrity import *
 from .component_integrity.cmd_spdm_measurements import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -75,6 +75,7 @@ ACTION_POLICY = {
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
+    "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -100,6 +100,7 @@ class ApiRequestType(Enum):
     GpuMetrics = auto()
     MetricReports = auto()
     MetricReportDefinitions = auto()
+    TelemetryClearReports = auto()
     ComponentIntegrity = auto()
     SpdmMeasurements = auto()
     NetworkAdapters = auto()

--- a/redfish_ctl/telemetry/cmd_telemetry_clear_reports.py
+++ b/redfish_ctl/telemetry/cmd_telemetry_clear_reports.py
@@ -1,0 +1,88 @@
+"""Clear generated Redfish TelemetryService MetricReports.
+
+    redfish_ctl telemetry-clear-reports
+    redfish_ctl telemetry-clear-reports --confirm
+
+The command resolves ``#TelemetryService.ClearMetricReports`` from the
+TelemetryService resource and previews by default. Clearing generated reports
+removes BMC telemetry samples, so the action only POSTs when ``--confirm`` is
+supplied.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_CLEAR_METRIC_REPORTS_ACTION = "#TelemetryService.ClearMetricReports"
+
+
+class TelemetryClearReports(RedfishManagerBase,
+                            scm_type=ApiRequestType.TelemetryClearReports,
+                            name="telemetry-clear-reports",
+                            metaclass=Singleton):
+    """Clear generated TelemetryService MetricReports."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the telemetry-clear-reports command."""
+        super(TelemetryClearReports, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``telemetry-clear-reports`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the ClearMetricReports POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "telemetry-clear-reports",
+            "command clear generated TelemetryService MetricReports",
+        )
+
+    def execute(self,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or run TelemetryService.ClearMetricReports.
+
+        :param confirm: authorize the ClearMetricReports POST to actually fire.
+        :param dry_run: resolve the target and show it without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query/POST on the async path.
+        :return: CommandResult with the resolved action target, preview, or POST result.
+        """
+        return self.invoke_action(
+            f"{RedfishApi.Version}/TelemetryService",
+            "ClearMetricReports",
+            payload={},
+            full_action_type=_CLEAR_METRIC_REPORTS_ACTION,
+            do_async=do_async,
+            expected_status=204,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -31,6 +31,7 @@ def test_policy_classifies_known_and_unknown():
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
+    assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE

--- a/tests/test_telemetry_clear_reports_dualmode.py
+++ b/tests/test_telemetry_clear_reports_dualmode.py
@@ -1,0 +1,88 @@
+"""Dual-mode-style coverage for TelemetryService.ClearMetricReports."""
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+_TELEMETRY_SERVICE = "/redfish/v1/TelemetryService"
+_CLEAR_TARGET = (
+    "/redfish/v1/TelemetryService/Actions/TelemetryService.ClearMetricReports"
+)
+
+
+def _post_requests(service):
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _seed_clear_metric_reports(service):
+    body = dict(service._state(_TELEMETRY_SERVICE))
+    body["Actions"] = {
+        "#TelemetryService.ClearMetricReports": {
+            "target": _CLEAR_TARGET,
+        },
+    }
+    service._overlay[_TELEMETRY_SERVICE] = body
+    service._overlay[_TELEMETRY_SERVICE.lower()] = body
+
+
+def test_telemetry_clear_reports_dry_run_blocks_post(redfish_mock_factory):
+    """The clear action previews by default and does not POST."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_clear_metric_reports(service)
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryClearReports,
+        "telemetry-clear-reports",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#TelemetryService.ClearMetricReports",
+        "target": _CLEAR_TARGET,
+        "payload": {},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(service) == []
+
+
+def test_telemetry_clear_reports_confirm_posts_to_discovered_target(redfish_mock_factory):
+    """With --confirm the command POSTs to the target from the Actions block."""
+    manager, service = redfish_mock_factory("supermicro")
+    _seed_clear_metric_reports(service)
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryClearReports,
+        "telemetry-clear-reports",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert len(posts) == 1
+    assert posts[0].path == _CLEAR_TARGET.lower()
+    assert posts[0].json() == {}
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#TelemetryService.ClearMetricReports"
+    assert result.data["target"] == _CLEAR_TARGET
+    assert result.data["level"] == "destructive"
+
+
+def test_telemetry_clear_reports_missing_action_reports_available(redfish_mock_factory):
+    """A BMC without ClearMetricReports returns a structured missing-action error."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryClearReports,
+        "telemetry-clear-reports",
+        confirm=True,
+    )
+
+    assert result.error == (
+        "action '#TelemetryService.ClearMetricReports' not found on "
+        "/redfish/v1/TelemetryService"
+    )
+    assert result.data["action"] == "#TelemetryService.ClearMetricReports"
+    assert result.data["available"] == []
+    assert _post_requests(service) == []


### PR DESCRIPTION
## Summary
- add a guarded telemetry-clear-reports command for TelemetryService.ClearMetricReports
- classify the action as destructive so it previews by default and only POSTs with --confirm
- add offline coverage for dry-run, confirmed POST, missing action behavior, and the command table row

## Validation
- git diff --check
- GitHub CI: Python 3.10, 3.11, 3.12, 3.13, and 3.14 passed
- Not run: remote fleet gate failed before tests because SSH was unreachable; local test suite not run per project policy