### PR TITLE
Add TelemetryService definition reset command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -200,6 +200,7 @@ Safety labels:
 | `task-watch` | Watch task progress. | Read |
 | `tasks` | Read the task collection. | Read |
 | `telemetry-clear-reports` | Clear generated TelemetryService MetricReports; dry-run by default and `--confirm` posts. | Guarded |
+| `telemetry-reset-definitions` | Reset TelemetryService MetricReportDefinitions to service defaults; dry-run by default and `--confirm` posts. | Guarded |
 | `telemetry-triggers` | Read TelemetryService triggers and thresholds. | Read |
 | `thermal` | Read Chassis `ThermalSubsystem` links, ThermalMetrics temperature readings, and fan collection counts from `redfish_ctl/thermal/cmd_thermal.py`. | Read |
 | `update-start` | Start updates staged for `UpdateService.StartUpdate`, the action advertised by UpdateService; previews unless `--confirm` is given. | Guarded |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -98,6 +98,7 @@ from .metrics.cmd_gpu_metrics import *
 from .telemetry.cmd_metric_reports import *
 from .telemetry.cmd_metric_definitions import *
 from .telemetry.cmd_telemetry_clear_reports import *
+from .telemetry.cmd_telemetry_reset_definitions import *
 from .telemetry.cmd_exporter import *
 from .component_integrity.cmd_component_integrity import *
 from .component_integrity.cmd_spdm_measurements import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -76,6 +76,7 @@ ACTION_POLICY = {
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
+    "#TelemetryService.ResetMetricReportDefinitionsToDefaults": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -103,6 +103,7 @@ class ApiRequestType(Enum):
     MetricReports = auto()
     MetricReportDefinitions = auto()
     TelemetryClearReports = auto()
+    TelemetryResetMetricDefinitions = auto()
     ComponentIntegrity = auto()
     SpdmMeasurements = auto()
     NetworkAdapters = auto()

--- a/redfish_ctl/telemetry/cmd_telemetry_reset_definitions.py
+++ b/redfish_ctl/telemetry/cmd_telemetry_reset_definitions.py
@@ -1,0 +1,117 @@
+"""Reset Redfish TelemetryService metric report definitions to defaults.
+
+    redfish_ctl telemetry-reset-definitions
+    redfish_ctl telemetry-reset-definitions --confirm
+    redfish_ctl telemetry-reset-definitions --dry_run
+
+The command resolves the service root's ``TelemetryService`` link and invokes
+the service resource's ``#TelemetryService.ResetMetricReportDefinitionsToDefaults``
+action. Resetting definitions rewrites telemetry configuration, so the shared
+action guard treats it as destructive and previews by default unless
+``--confirm`` is present.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_RESET_DEFINITIONS_ACTION = "#TelemetryService.ResetMetricReportDefinitionsToDefaults"
+
+
+class TelemetryResetMetricDefinitions(
+        RedfishManagerBase,
+        scm_type=ApiRequestType.TelemetryResetMetricDefinitions,
+        name="telemetry-reset-definitions",
+        metaclass=Singleton):
+    """Reset TelemetryService metric report definitions to vendor defaults."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the telemetry-reset-definitions command."""
+        super(TelemetryResetMetricDefinitions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``telemetry-reset-definitions`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the reset POST; without it the command only previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "telemetry-reset-definitions",
+            "command reset TelemetryService metric report definitions to defaults",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: parsed Redfish resource that may hold the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: linked Redfish URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _telemetry_service_uri(self, do_async):
+        """Resolve the TelemetryService URI from the service root.
+
+        :param do_async: issue the service-root query over the async path.
+        :return: the linked TelemetryService URI, or the standard fallback URI.
+        """
+        try:
+            root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
+        except Exception:
+            root = {}
+        return self._link(root, "TelemetryService") or f"{RedfishApi.Version}/TelemetryService"
+
+    def execute(self,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Resolve and invoke the metric-report-definition reset action.
+
+        :param confirm: authorize the destructive reset POST to run.
+        :param dry_run: force a dry-run preview even when ``confirm`` is true.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with a dry-run preview, POST result, or a
+            missing-action error from the TelemetryService resource.
+        """
+        return self.invoke_action(
+            self._telemetry_service_uri(bool(do_async)),
+            "ResetMetricReportDefinitionsToDefaults",
+            payload={},
+            full_action_type=_RESET_DEFINITIONS_ACTION,
+            do_async=do_async,
+            expected_status=204,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -32,6 +32,10 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
+    assert (
+        classify("#TelemetryService.ResetMetricReportDefinitionsToDefaults")
+        is Destructiveness.DESTRUCTIVE
+    )
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE

--- a/tests/test_telemetry_reset_definitions_dualmode.py
+++ b/tests/test_telemetry_reset_definitions_dualmode.py
@@ -1,0 +1,135 @@
+"""Dual-mode-style coverage for resetting TelemetryService report definitions."""
+
+import json
+
+import pytest
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+TELEMETRY_SERVICE = "/redfish/v1/TelemetryService"
+RESET_ACTION = "#TelemetryService.ResetMetricReportDefinitionsToDefaults"
+RESET_TARGET = (
+    "/redfish/v1/TelemetryService/Actions/"
+    "TelemetryService.ResetMetricReportDefinitionsToDefaults"
+)
+
+
+@pytest.fixture
+def telemetry_reset_manager(redfish_mock_factory):
+    """Serve Supermicro fixtures with the reset action added to TelemetryService."""
+    manager, service = redfish_mock_factory("supermicro")
+    service_body = service._state(TELEMETRY_SERVICE)
+    service_with_action = {
+        **service_body,
+        "Actions": {
+            RESET_ACTION: {
+                "target": RESET_TARGET,
+            },
+        },
+    }
+    service._overlay[TELEMETRY_SERVICE] = service_with_action
+    service._overlay[TELEMETRY_SERVICE.lower()] = service_with_action
+    return manager, service
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_telemetry_reset_definitions_without_confirm_is_preview_only(
+        telemetry_reset_manager):
+    """The reset action resolves but does not POST without --confirm."""
+    manager, service = telemetry_reset_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryResetMetricDefinitions,
+        "telemetry-reset-definitions",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == RESET_ACTION
+    assert result.data["target"] == RESET_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(service) == []
+
+
+def test_telemetry_reset_definitions_confirm_posts_empty_payload(
+        telemetry_reset_manager):
+    """--confirm POSTs the reset action to the discovered target."""
+    manager, service = telemetry_reset_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryResetMetricDefinitions,
+        "telemetry-reset-definitions",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == RESET_ACTION
+    assert result.data["target"] == RESET_TARGET
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == RESET_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_telemetry_reset_definitions_confirm_dry_run_still_does_not_post(
+        telemetry_reset_manager):
+    """--dry_run remains a no-POST preview even when --confirm is present."""
+    manager, service = telemetry_reset_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryResetMetricDefinitions,
+        "telemetry-reset-definitions",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == RESET_TARGET
+    assert _post_requests(service) == []
+
+
+def test_telemetry_reset_definitions_missing_action_reports_error(
+        redfish_mock_factory):
+    """A TelemetryService without the reset action errors without POSTing."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryResetMetricDefinitions,
+        "telemetry-reset-definitions",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#TelemetryService.ResetMetricReportDefinitionsToDefaults' "
+        "not found on /redfish/v1/TelemetryService"
+    )
+    assert result.data["action"] == RESET_ACTION
+    assert RESET_ACTION not in result.data["available"]
+    assert _post_requests(service) == []
+
+
+def test_telemetry_reset_definitions_result_is_json_serializable(
+        telemetry_reset_manager):
+    """The preview payload can be rendered through the normal JSON output path."""
+    manager, _service = telemetry_reset_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.TelemetryResetMetricDefinitions,
+        "telemetry-reset-definitions",
+        dry_run=True,
+    )
+
+    json.dumps(result.data, sort_keys=True)


### PR DESCRIPTION
## Summary
- add `telemetry-reset-definitions` for `#TelemetryService.ResetMetricReportDefinitionsToDefaults`
- guard the reset through the shared action policy so it previews by default and only posts with `--confirm`
- add fixture-backed coverage for preview, confirm, dry-run override, missing-action handling, and the command reference row

## Validation
- `git diff --check`
- GitHub CI passed for Python 3.10, 3.11, 3.12, 3.13, and 3.14
- Remote fleet gate could not run because the configured fleet was unreachable after refreshing support files; no local pytest or Ruff was run.
