### PR TITLE
Add HPE manager OEM action command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,6 +132,7 @@ Safety labels:
 | `get` | Read an arbitrary Redfish resource URI. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
+| `hpe-manager-actions` | List or run selected HPE iLO manager OEM actions such as cloud-connect retry/enable/disable and clear hot keys or REST API state; dry-run by default and `--confirm` posts. | Guarded |
 | `hpe-test-actions` | List or send HPE iLO directory, SNMP, mail, and syslog test actions; dry-run by default and `--confirm` posts. | Guarded |
 | `identify-led` | Read or set a chassis/system identify LED; requires `--confirm` to write. | Guarded |
 | `insert_vm` | Insert virtual media from a URI. | Write |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,7 +132,7 @@ Safety labels:
 | `get` | Read an arbitrary Redfish resource URI. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
-| `hpe-manager-actions` | List or run selected HPE iLO manager OEM actions such as cloud-connect retry/enable/disable and clear hot keys or REST API state; dry-run by default and `--confirm` posts. | Guarded |
+| `hpe-manager-actions` | List or run selected HPE iLO manager OEM actions such as cloud-connect retry/enable/disable and clear hot keys or REST API state; cloud-connect actions may contact HPE cloud services, and `clear-rest-api-state` can require an iLO reset to complete; dry-run by default and `--confirm` posts. | Guarded |
 | `hpe-test-actions` | List or send HPE iLO directory, SNMP, mail, and syslog test actions; dry-run by default and `--confirm` posts. | Guarded |
 | `identify-led` | Read or set a chassis/system identify LED; requires `--confirm` to write. | Guarded |
 | `insert_vm` | Insert virtual media from a URI. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -122,6 +122,7 @@ from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
+from .oem.cmd_hpe_manager_actions import *
 from .oem.cmd_nvidia_debug_token import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -36,8 +36,8 @@ class Destructiveness(Enum):
 
 
 # Keyed by the full Redfish action type "#Type.Action" (as discover_redfish_actions
-# reports it in RedfishAction.full_redfish_name). Covers the 25 action types the
-# GB300 NVL exposes plus a couple of standard siblings.
+# reports it in RedfishAction.full_redfish_name). Covers the corpus-backed
+# standard, NVIDIA, Dell, and HPE action types this package exposes.
 ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
@@ -85,12 +85,16 @@ ACTION_POLICY = {
     "#HpeiLO.DisableCloudConnect": Destructiveness.DESTRUCTIVE,
     "#HpeiLO.EnableCloudConnect": Destructiveness.DESTRUCTIVE,
     "#HpeiLO.RetryCloudConnect": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.ClearNVRAM": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.DisableiLOFunctionality": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.RequestFirmwareAndOsRecovery": Destructiveness.DESTRUCTIVE,
     "#UpdateService.SimpleUpdate": Destructiveness.DESTRUCTIVE,
     "#UpdateService.StartUpdate": Destructiveness.DESTRUCTIVE,
 
     # irreversible: data loss or one-way security change — needs the extra token
     "#Drive.SecureErase": Destructiveness.IRREVERSIBLE,
     "#Manager.ResetToDefaults": Destructiveness.IRREVERSIBLE,
+    "#HpeiLO.ResetToFactoryDefaults": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.RevokeKeys": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.UpdateMinimumSecurityVersion": Destructiveness.IRREVERSIBLE,
 }

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -80,6 +80,11 @@ ACTION_POLICY = {
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.ClearHotKeys": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.ClearRestApiState": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.DisableCloudConnect": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.EnableCloudConnect": Destructiveness.DESTRUCTIVE,
+    "#HpeiLO.RetryCloudConnect": Destructiveness.DESTRUCTIVE,
     "#UpdateService.SimpleUpdate": Destructiveness.DESTRUCTIVE,
     "#UpdateService.StartUpdate": Destructiveness.DESTRUCTIVE,
 

--- a/redfish_ctl/oem/cmd_hpe_manager_actions.py
+++ b/redfish_ctl/oem/cmd_hpe_manager_actions.py
@@ -1,0 +1,239 @@
+"""Preview or run selected HPE iLO manager OEM Redfish actions.
+
+    redfish_ctl hpe-manager-actions
+    redfish_ctl hpe-manager-actions --action retry-cloud-connect
+    redfish_ctl hpe-manager-actions --action clear-rest-api-state --confirm
+
+The command discovers supported HPE OEM actions from each Manager resource's
+``Oem.Hpe.Actions`` block. Factory reset, manager reset, NVRAM clear, firmware
+recovery, and iLO disable actions are deliberately not exposed by this command.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+
+@dataclass(frozen=True)
+class _HpeManagerActionSpec:
+    """Static selector metadata for one supported HPE Manager OEM action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_ACTION_SPECS = {
+    "clear-hotkeys": _HpeManagerActionSpec(
+        selector="clear-hotkeys",
+        full_type="#HpeiLO.ClearHotKeys",
+        action_name="ClearHotKeys",
+        description="clear configured Integrated Remote Console hot keys",
+    ),
+    "clear-rest-api-state": _HpeManagerActionSpec(
+        selector="clear-rest-api-state",
+        full_type="#HpeiLO.ClearRestApiState",
+        action_name="ClearRestApiState",
+        description="clear iLO REST API state data",
+    ),
+    "disable-cloud-connect": _HpeManagerActionSpec(
+        selector="disable-cloud-connect",
+        full_type="#HpeiLO.DisableCloudConnect",
+        action_name="DisableCloudConnect",
+        description="disable HPE cloud-connect integration",
+    ),
+    "enable-cloud-connect": _HpeManagerActionSpec(
+        selector="enable-cloud-connect",
+        full_type="#HpeiLO.EnableCloudConnect",
+        action_name="EnableCloudConnect",
+        description="enable HPE cloud-connect integration",
+    ),
+    "retry-cloud-connect": _HpeManagerActionSpec(
+        selector="retry-cloud-connect",
+        full_type="#HpeiLO.RetryCloudConnect",
+        action_name="RetryCloudConnect",
+        description="retry HPE cloud-connect registration",
+    ),
+}
+
+
+class HpeManagerActions(RedfishManagerBase,
+                        scm_type=ApiRequestType.HpeManagerActions,
+                        name="hpe-manager-actions",
+                        metaclass=Singleton):
+    """Discover and invoke selected HPE iLO Manager OEM actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the hpe-manager-actions command."""
+        super(HpeManagerActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``hpe-manager-actions`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="HPE Manager OEM action to preview or run; omit to list targets",
+        )
+        cmd_parser.add_argument(
+            "--manager-uri",
+            dest="manager_uri",
+            default=None,
+            help="specific Manager resource URI when more than one target advertises the action",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="run the selected manager action instead of dry-running it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return cmd_parser, "hpe-manager-actions", "command run HPE iLO manager OEM actions"
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _manager_uris(self):
+        """Return discovered Manager resource URIs.
+
+        :return: list of Manager resource URIs.
+        """
+        uris = self.discover_manager_ids() or []
+        return [uri for uri in uris if isinstance(uri, str) and uri]
+
+    def _target_for(self, manager_uri, spec, do_async):
+        """Return the advertised target URI for an HPE Manager OEM action.
+
+        :param manager_uri: candidate Manager resource URI.
+        :param spec: HPE manager-action selector metadata.
+        :param do_async: run the manager query asynchronously when True.
+        :return: action target URI, or None when absent.
+        """
+        manager = self._get(manager_uri, do_async)
+        targets = self._flatten_action_targets(manager)
+        return targets.get(spec.full_type)
+
+    def _discover_rows(self, do_async):
+        """Discover supported HPE Manager OEM action rows.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of available manager-action rows.
+        """
+        rows = []
+        for manager_uri in self._manager_uris():
+            for spec in _ACTION_SPECS.values():
+                target = self._target_for(manager_uri, spec, do_async)
+                if target:
+                    rows.append({
+                        "Action": spec.selector,
+                        "FullType": spec.full_type,
+                        "Resource": manager_uri,
+                        "Target": target,
+                        "Description": spec.description,
+                    })
+        return rows
+
+    @staticmethod
+    def _matches(rows, action, manager_uri):
+        """Filter discovered rows by action selector and optional manager URI.
+
+        :param rows: discovered HPE manager-action rows.
+        :param action: selected action name.
+        :param manager_uri: optional Manager URI selector.
+        :return: matching rows.
+        """
+        matches = [row for row in rows if row["Action"] == action]
+        if manager_uri:
+            normalized = manager_uri.rstrip("/")
+            matches = [
+                row for row in matches
+                if row["Resource"].rstrip("/") == normalized
+            ]
+        return matches
+
+    def execute(self,
+                action: Optional[str] = None,
+                manager_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or run selected HPE iLO Manager OEM actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param manager_uri: optional Manager URI to disambiguate multiple targets.
+        :param confirm: run the selected action when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if action is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = self._matches(rows, action, manager_uri)
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"HPE manager action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                "multiple HPE manager-action targets found; pass --manager-uri",
+            )
+
+        row = matches[0]
+        spec = _ACTION_SPECS[action]
+        result = self.invoke_action(
+            row["Resource"],
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        if not confirm and isinstance(result.data, dict):
+            result.data["requires_confirm"] = True
+            result.data["blocked"] = "HPE manager action requires --confirm"
+        return result

--- a/redfish_ctl/oem/cmd_hpe_manager_actions.py
+++ b/redfish_ctl/oem/cmd_hpe_manager_actions.py
@@ -7,6 +7,8 @@
 The command discovers supported HPE OEM actions from each Manager resource's
 ``Oem.Hpe.Actions`` block. Factory reset, manager reset, NVRAM clear, firmware
 recovery, and iLO disable actions are deliberately not exposed by this command.
+``clear-rest-api-state`` can require an iLO reset to complete; the command
+reports that consequence in previews and listings.
 
 Author Mus spyroot@gmail.com
 """
@@ -27,6 +29,7 @@ class _HpeManagerActionSpec:
     full_type: str
     action_name: str
     description: str
+    note: Optional[str] = None
 
 
 _ACTION_SPECS = {
@@ -41,6 +44,7 @@ _ACTION_SPECS = {
         full_type="#HpeiLO.ClearRestApiState",
         action_name="ClearRestApiState",
         description="clear iLO REST API state data",
+        note="HPE reports this action can require an iLO reset to complete",
     ),
     "disable-cloud-connect": _HpeManagerActionSpec(
         selector="disable-cloud-connect",
@@ -53,12 +57,14 @@ _ACTION_SPECS = {
         full_type="#HpeiLO.EnableCloudConnect",
         action_name="EnableCloudConnect",
         description="enable HPE cloud-connect integration",
+        note="may contact HPE cloud services from the BMC",
     ),
     "retry-cloud-connect": _HpeManagerActionSpec(
         selector="retry-cloud-connect",
         full_type="#HpeiLO.RetryCloudConnect",
         action_name="RetryCloudConnect",
         description="retry HPE cloud-connect registration",
+        note="may contact HPE cloud services from the BMC",
     ),
 }
 
@@ -130,36 +136,30 @@ class HpeManagerActions(RedfishManagerBase,
         uris = self.discover_manager_ids() or []
         return [uri for uri in uris if isinstance(uri, str) and uri]
 
-    def _target_for(self, manager_uri, spec, do_async):
-        """Return the advertised target URI for an HPE Manager OEM action.
-
-        :param manager_uri: candidate Manager resource URI.
-        :param spec: HPE manager-action selector metadata.
-        :param do_async: run the manager query asynchronously when True.
-        :return: action target URI, or None when absent.
-        """
-        manager = self._get(manager_uri, do_async)
-        targets = self._flatten_action_targets(manager)
-        return targets.get(spec.full_type)
-
-    def _discover_rows(self, do_async):
+    def _discover_rows(self, do_async, manager_uri=None):
         """Discover supported HPE Manager OEM action rows.
 
         :param do_async: run underlying queries asynchronously when True.
+        :param manager_uri: optional exact Manager URI to inspect.
         :return: list of available manager-action rows.
         """
         rows = []
-        for manager_uri in self._manager_uris():
+        manager_uris = [manager_uri.rstrip("/")] if manager_uri else self._manager_uris()
+        for manager_uri in manager_uris:
+            targets = self._flatten_action_targets(self._get(manager_uri, do_async))
             for spec in _ACTION_SPECS.values():
-                target = self._target_for(manager_uri, spec, do_async)
+                target = targets.get(spec.full_type)
                 if target:
-                    rows.append({
+                    row = {
                         "Action": spec.selector,
                         "FullType": spec.full_type,
                         "Resource": manager_uri,
                         "Target": target,
                         "Description": spec.description,
-                    })
+                    }
+                    if spec.note:
+                        row["Note"] = spec.note
+                    rows.append(row)
         return rows
 
     @staticmethod
@@ -202,7 +202,7 @@ class HpeManagerActions(RedfishManagerBase,
         :param do_async: issue the underlying queries/POST on the async path when True.
         :return: CommandResult with a listing, preview, execution result, or error.
         """
-        rows = self._discover_rows(bool(do_async))
+        rows = self._discover_rows(bool(do_async), manager_uri)
         if action is None:
             return CommandResult(rows, None, None, None)
 
@@ -233,7 +233,9 @@ class HpeManagerActions(RedfishManagerBase,
             dry_run=bool(dry_run) or not bool(confirm),
             confirm=bool(confirm),
         )
-        if not confirm and isinstance(result.data, dict):
+        if result.error is None and not confirm and isinstance(result.data, dict):
             result.data["requires_confirm"] = True
             result.data["blocked"] = "HPE manager action requires --confirm"
+        if result.error is None and spec.note and isinstance(result.data, dict):
+            result.data["note"] = spec.note
         return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -112,6 +112,7 @@ class ApiRequestType(Enum):
     ActionList = auto()
     EventSubmitTest = auto()
     HpeTestActions = auto()
+    HpeManagerActions = auto()
     NvidiaDebugToken = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -35,9 +35,13 @@ def test_policy_classifies_known_and_unknown():
         "#HpeiLO.DisableCloudConnect",
         "#HpeiLO.EnableCloudConnect",
         "#HpeiLO.RetryCloudConnect",
+        "#HpeiLO.ClearNVRAM",
+        "#HpeiLO.DisableiLOFunctionality",
+        "#HpeiLO.RequestFirmwareAndOsRecovery",
     )
     for action in hpe_manager_actions:
         assert classify(action) is Destructiveness.DESTRUCTIVE
+    assert classify("#HpeiLO.ResetToFactoryDefaults") is Destructiveness.IRREVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -29,6 +29,15 @@ def test_policy_classifies_known_and_unknown():
     )
     for action in hpe_reversible_actions:
         assert classify(action) is Destructiveness.REVERSIBLE
+    hpe_manager_actions = (
+        "#HpeiLO.ClearHotKeys",
+        "#HpeiLO.ClearRestApiState",
+        "#HpeiLO.DisableCloudConnect",
+        "#HpeiLO.EnableCloudConnect",
+        "#HpeiLO.RetryCloudConnect",
+    )
+    for action in hpe_manager_actions:
+        assert classify(action) is Destructiveness.DESTRUCTIVE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE

--- a/tests/test_hpe_manager_actions_dualmode.py
+++ b/tests/test_hpe_manager_actions_dualmode.py
@@ -93,7 +93,9 @@ def test_hpe_manager_actions_manager_uri_short_circuits_discovery(
         "enable-cloud-connect",
         "retry-cloud-connect",
     }
-    assert [request.path for request in _get_requests(service)] == [_MANAGER_URI]
+    assert [request.path.lower() for request in _get_requests(service)] == [
+        _MANAGER_URI.lower()
+    ]
     assert projected_walltime(service, "india-vpn-to-us") <= 0.31
     assert _post_requests(service) == []
 

--- a/tests/test_hpe_manager_actions_dualmode.py
+++ b/tests/test_hpe_manager_actions_dualmode.py
@@ -1,0 +1,130 @@
+"""Dual-mode tests for selected HPE iLO Manager OEM actions."""
+from redfish_ctl.oem.cmd_hpe_manager_actions import HpeManagerActions
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+_MANAGER_URI = "/redfish/v1/Managers/1"
+_REST_API_TARGET = (
+    "/redfish/v1/Managers/1/Actions/Oem/Hpe/"
+    "HpeiLO.ClearRestApiState"
+)
+_RETRY_TARGET = (
+    "/redfish/v1/Managers/1/Actions/Oem/Hpe/"
+    "HpeiLO.RetryCloudConnect"
+)
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_hpe_manager_actions_list_targets_without_post(redfish_mock_factory):
+    """Listing discovers only the supported HPE Manager OEM action subset."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeManagerActions,
+        "hpe-manager-actions",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    actions = {row["Action"]: row for row in result.data}
+    assert set(actions) == {
+        "clear-hotkeys",
+        "clear-rest-api-state",
+        "disable-cloud-connect",
+        "enable-cloud-connect",
+        "retry-cloud-connect",
+    }
+    assert actions["clear-rest-api-state"]["Resource"] == _MANAGER_URI
+    assert actions["clear-rest-api-state"]["Target"] == _REST_API_TARGET
+    assert actions["retry-cloud-connect"]["Target"] == _RETRY_TARGET
+    assert "reset-to-factory-defaults" not in actions
+    assert "clear-nvram" not in actions
+    assert "disable-ilo-functionality" not in actions
+    assert "request-firmware-recovery" not in actions
+    assert _post_requests(service) == []
+
+
+def test_hpe_manager_action_dry_runs_by_default(redfish_mock_factory):
+    """A selected HPE Manager action resolves the target but does not POST."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeManagerActions,
+        "hpe-manager-actions",
+        action="clear-rest-api-state",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["requires_confirm"] is True
+    assert result.data["blocked"] == "HPE manager action requires --confirm"
+    assert result.data["level"] == "destructive"
+    assert result.data["payload"] == {}
+    assert result.data["target"] == _REST_API_TARGET
+    assert _post_requests(service) == []
+
+
+def test_hpe_manager_action_confirm_posts_selected_target(redfish_mock_factory):
+    """--confirm posts exactly one selected HPE Manager OEM action."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeManagerActions,
+        "hpe-manager-actions",
+        action="retry-cloud-connect",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == _RETRY_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_hpe_manager_action_missing_target_reports_without_post(
+    redfish_mock_factory,
+):
+    """A non-HPE fixture reports an error and never POSTs."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeManagerActions,
+        "hpe-manager-actions",
+        action="enable-cloud-connect",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "HPE manager action not found: enable-cloud-connect"
+    assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_hpe_manager_actions_exposes_cli_entrypoint():
+    """The hpe-manager-actions command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.HpeManagerActions]["hpe-manager-actions"] is (
+        HpeManagerActions
+    )
+
+    cmd_parser, cmd_name, cmd_help = HpeManagerActions.register_subcommand(
+        HpeManagerActions
+    )
+
+    assert "--action" in cmd_parser.format_help()
+    assert cmd_name == "hpe-manager-actions"
+    assert "HPE" in cmd_help

--- a/tests/test_hpe_manager_actions_dualmode.py
+++ b/tests/test_hpe_manager_actions_dualmode.py
@@ -3,6 +3,7 @@ from redfish_ctl.oem.cmd_hpe_manager_actions import HpeManagerActions
 from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
+from test_roundtrip_budget import projected_walltime
 
 _MANAGER_URI = "/redfish/v1/Managers/1"
 _REST_API_TARGET = (
@@ -22,6 +23,20 @@ def _post_requests(service):
     :return: recorded POST requests.
     """
     return [request for request in service.requests if request.method == "POST"]
+
+
+def _get_requests(service, path=None):
+    """Return GET requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :param path: optional Redfish path to match.
+    :return: recorded GET requests.
+    """
+    return [
+        request for request in service.requests
+        if request.method == "GET"
+        and (path is None or request.path.rstrip("/").lower() == path.lower())
+    ]
 
 
 def test_hpe_manager_actions_list_targets_without_post(redfish_mock_factory):
@@ -45,11 +60,41 @@ def test_hpe_manager_actions_list_targets_without_post(redfish_mock_factory):
     }
     assert actions["clear-rest-api-state"]["Resource"] == _MANAGER_URI
     assert actions["clear-rest-api-state"]["Target"] == _REST_API_TARGET
+    assert "iLO reset" in actions["clear-rest-api-state"]["Note"]
     assert actions["retry-cloud-connect"]["Target"] == _RETRY_TARGET
+    assert "cloud services" in actions["enable-cloud-connect"]["Note"]
+    assert "cloud services" in actions["retry-cloud-connect"]["Note"]
+    assert len(_get_requests(service, _MANAGER_URI)) == 1
     assert "reset-to-factory-defaults" not in actions
     assert "clear-nvram" not in actions
     assert "disable-ilo-functionality" not in actions
     assert "request-firmware-recovery" not in actions
+    assert _post_requests(service) == []
+
+
+def test_hpe_manager_actions_manager_uri_short_circuits_discovery(
+    redfish_mock_factory,
+):
+    """An exact Manager URI reads that manager directly instead of fan-out."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeManagerActions,
+        "hpe-manager-actions",
+        manager_uri=_MANAGER_URI,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert {row["Action"] for row in result.data} == {
+        "clear-hotkeys",
+        "clear-rest-api-state",
+        "disable-cloud-connect",
+        "enable-cloud-connect",
+        "retry-cloud-connect",
+    }
+    assert [request.path for request in _get_requests(service)] == [_MANAGER_URI]
+    assert projected_walltime(service, "india-vpn-to-us") <= 0.31
     assert _post_requests(service) == []
 
 
@@ -71,6 +116,23 @@ def test_hpe_manager_action_dry_runs_by_default(redfish_mock_factory):
     assert result.data["level"] == "destructive"
     assert result.data["payload"] == {}
     assert result.data["target"] == _REST_API_TARGET
+    assert "iLO reset" in result.data["note"]
+    assert _post_requests(service) == []
+
+
+def test_hpe_manager_cloud_actions_report_egress_note(redfish_mock_factory):
+    """Cloud-connect previews carry the BMC egress consequence."""
+    manager, service = redfish_mock_factory("hpe")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeManagerActions,
+        "hpe-manager-actions",
+        action="enable-cloud-connect",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert "cloud services" in result.data["note"]
     assert _post_requests(service) == []
 
 
@@ -111,6 +173,29 @@ def test_hpe_manager_action_missing_target_reports_without_post(
     assert isinstance(result, CommandResult)
     assert result.error == "HPE manager action not found: enable-cloud-connect"
     assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_hpe_manager_action_not_found_keeps_error_without_confirm_label(
+    redfish_mock_factory,
+):
+    """Missing advertised actions are not mislabeled as requiring confirm."""
+    manager, service = redfish_mock_factory("hpe")
+    manager_body = service._state(_MANAGER_URI.lower())
+    manager_body["Oem"]["Hpe"]["Actions"].pop("#HpeiLO.ClearRestApiState")
+    service._overlay[_MANAGER_URI] = manager_body
+    service._overlay[_MANAGER_URI.lower()] = manager_body
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeManagerActions,
+        "hpe-manager-actions",
+        action="clear-rest-api-state",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "HPE manager action not found: clear-rest-api-state"
+    assert result.data["available"]
+    assert "blocked" not in result.data
     assert _post_requests(service) == []
 
 


### PR DESCRIPTION
## Summary

- Add `hpe-manager-actions` to discover selected HPE iLO Manager OEM actions from each Manager resource.
- Support guarded previews and confirmed POSTs for clearing hot keys, clearing REST API state, and cloud-connect enable/disable/retry.
- Keep reset, factory reset, NVRAM clear, firmware recovery, and iLO disable actions out of the command surface.
- Add conservative action-policy entries, command registration, command docs, and HPE fixture-backed coverage.

## Validation

- `git diff --cached --check`
- Not run locally: the project gate runs on the configured remote Linux test fleet, which was unreachable from this checkout.
