### PR TITLE
Add guarded UpdateService StartUpdate command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -199,6 +199,7 @@ Safety labels:
 | `tasks` | Read the task collection. | Read |
 | `telemetry-triggers` | Read TelemetryService triggers and thresholds. | Read |
 | `thermal` | Read Chassis `ThermalSubsystem` links, ThermalMetrics temperature readings, and fan collection counts from `redfish_ctl/thermal/cmd_thermal.py`. | Read |
+| `update-start` | Start updates staged for `UpdateService.StartUpdate`, the action advertised by UpdateService; previews unless `--confirm` is given. | Guarded |
 | `update_service` | Read UpdateService inventory links, push URIs, and advertised actions. | Read |
 | `vm-mount` | Mount/unmount an ISO via Supermicro OEM virtual media (CfgCD). | Write |
 | `volume-check-consistency` | Start a Redfish Volume.CheckConsistency action; previews unless `--confirm` is given. | Guarded |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -49,6 +49,7 @@ from .jobs.cmd_job_apply import *
 from .firmware.cmd_firmware import *
 from .firmware.cmd_firmware_inv import *
 from .firmware.cmd_update_service import *
+from .firmware.cmd_update_start import *
 
 from .pci.cmd_pci import *
 

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -80,6 +80,7 @@ ACTION_POLICY = {
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,
     "#UpdateService.SimpleUpdate": Destructiveness.DESTRUCTIVE,
+    "#UpdateService.StartUpdate": Destructiveness.DESTRUCTIVE,
 
     # irreversible: data loss or one-way security change — needs the extra token
     "#Drive.SecureErase": Destructiveness.IRREVERSIBLE,

--- a/redfish_ctl/firmware/cmd_update_start.py
+++ b/redfish_ctl/firmware/cmd_update_start.py
@@ -1,0 +1,117 @@
+"""Start a scheduled Redfish UpdateService update batch.
+
+    redfish_ctl update-start
+    redfish_ctl update-start --dry_run
+    redfish_ctl update-start --confirm
+
+``#UpdateService.StartUpdate`` applies software images that were staged with
+``OperationApplyTime=OnStartUpdateRequest``. Starting an update can flash
+firmware or software, so this command is guarded: it resolves the advertised
+action target and previews by default, and it only POSTs with ``--confirm``.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_START_UPDATE_ACTION = "#UpdateService.StartUpdate"
+
+
+class UpdateStart(RedfishManagerBase,
+                  scm_type=ApiRequestType.UpdateStart,
+                  name="update-start",
+                  metaclass=Singleton):
+    """Start UpdateService updates staged for OnStartUpdateRequest."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the update-start command."""
+        super(UpdateStart, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``update-start`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the UpdateService.StartUpdate POST; without it the "
+                 "command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "update-start",
+            "command start staged Redfish UpdateService updates",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _update_service_uri(self, do_async):
+        """Resolve the UpdateService URI from the service root.
+
+        :param do_async: issue the service-root query over the async Redfish path.
+        :return: the UpdateService URI, or the standard fallback URI.
+        """
+        try:
+            root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
+        except Exception:
+            root = {}
+        return self._link(root, "UpdateService") or REDFISH_API.UpdateServiceQuery
+
+    def execute(self,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Resolve and optionally invoke ``#UpdateService.StartUpdate``.
+
+        :param confirm: authorize the StartUpdate POST to actually fire.
+        :param dry_run: resolve the target and show it without POSTing;
+            overrides ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a dry-run preview, execution result, or
+            missing-action error.
+        """
+        return self.invoke_action(
+            self._update_service_uri(do_async),
+            "StartUpdate",
+            payload={},
+            full_action_type=_START_UPDATE_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -58,6 +58,7 @@ class ApiRequestType(Enum):
     FirmwareQuery = auto()
     FirmwareInventoryQuery = auto()
     UpdateServiceQuery = auto()
+    UpdateStart = auto()
     PciDeviceQuery = auto()
     SystemQuery = auto()
     VirtualDiskQuery = auto()

--- a/tests/test_update_start_dualmode.py
+++ b/tests/test_update_start_dualmode.py
@@ -1,0 +1,136 @@
+"""Dual-mode-style tests for the guarded update-start command."""
+
+from redfish_ctl.firmware.cmd_update_start import UpdateStart
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult
+
+UPDATE_SERVICE_PATH = "/redfish/v1/UpdateService"
+START_UPDATE_TARGET = (
+    "/redfish/v1/UpdateService/Actions/UpdateService.StartUpdate"
+)
+
+
+def _start_update_service():
+    """Return an UpdateService body exposing StartUpdate."""
+    return {
+        "@odata.id": UPDATE_SERVICE_PATH,
+        "@odata.type": "#UpdateService.v1_14_0.UpdateService",
+        "Id": "UpdateService",
+        "Name": "Update Service",
+        "Actions": {
+            "#UpdateService.StartUpdate": {
+                "target": START_UPDATE_TARGET,
+            }
+        },
+    }
+
+
+def _set_update_service(redfish_service, body):
+    """Overlay UpdateService under both path casings used by requests-mock."""
+    redfish_service._overlay[UPDATE_SERVICE_PATH] = body
+    redfish_service._overlay[UPDATE_SERVICE_PATH.lower()] = body
+
+
+def _post_requests(redfish_service):
+    """Return POST requests recorded by the offline mock service."""
+    return [
+        request
+        for request in redfish_service.requests
+        if request.method == "POST"
+    ]
+
+
+def test_update_start_defaults_to_dry_run(redfish_mock, redfish_service):
+    """update-start previews StartUpdate by default without POSTing."""
+    _set_update_service(redfish_service, _start_update_service())
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.UpdateStart,
+        "update-start",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#UpdateService.StartUpdate"
+    assert result.data["target"] == START_UPDATE_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(redfish_service) == []
+
+
+def test_update_start_confirm_posts_empty_payload(redfish_mock, redfish_service):
+    """update-start --confirm POSTs one StartUpdate request."""
+    _set_update_service(redfish_service, _start_update_service())
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.UpdateStart,
+        "update-start",
+        confirm=True,
+    )
+
+    posts = [
+        request
+        for request in _post_requests(redfish_service)
+        if request.path.lower() == START_UPDATE_TARGET.lower()
+    ]
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#UpdateService.StartUpdate"
+    assert result.data["target"] == START_UPDATE_TARGET
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].json() == {}
+
+
+def test_update_start_dry_run_overrides_confirm(redfish_mock, redfish_service):
+    """update-start --dry_run remains a preview even with --confirm."""
+    _set_update_service(redfish_service, _start_update_service())
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.UpdateStart,
+        "update-start",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert _post_requests(redfish_service) == []
+
+
+def test_update_start_reports_missing_action(redfish_api, redfish_service):
+    """An UpdateService without StartUpdate returns an actionable error."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.UpdateStart,
+        "update-start",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["action"] == "#UpdateService.StartUpdate"
+    assert "#UpdateService.SimpleUpdate" in result.data["available"]
+    assert result.error == (
+        "action '#UpdateService.StartUpdate' not found on "
+        "/redfish/v1/UpdateService"
+    )
+    assert _post_requests(redfish_service) == []
+
+
+def test_update_start_is_registered():
+    """The update-start command is wired into the command registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.UpdateStart]["update-start"] is UpdateStart
+
+    cmd_parser, cmd_name, cmd_help = UpdateStart.register_subcommand(UpdateStart)
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "update-start"
+    assert "StartUpdate" in cmd_help or "staged" in cmd_help
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text


### PR DESCRIPTION
Summary:
- Add an update-start command for UpdateService.StartUpdate, discovered from the UpdateService Actions block.
- Keep the action guarded by default: preview unless --confirm is supplied, with --dry_run as an override.
- Register the command, classify the action as destructive, document it, and cover preview/confirm/missing-action behavior in offline mock tests.

Verification:
- git diff --check
- GitHub CI test matrix passed: Python 3.10, 3.11, 3.12, 3.13, and 3.14.
- Remote fleet gate was unavailable from this environment, so that gate was not run.