### PR TITLE
Add guarded SecureBoot reset keys command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -179,6 +179,7 @@ Safety labels:
 | `raid` | Read RAID service data. | Read |
 | `reboot` | Reset the host ComputerSystem; `--dry_run` previews, but the command writes by default. | Write |
 | `secure-boot` | Read SecureBoot state and key databases. | Read |
+| `secure-boot-reset-keys` | Reset SecureBoot keys through `SecureBoot.ResetKeys` or `SecureBootDatabase.ResetKeys`; lists discovered targets when no reset type is supplied and requires `--confirm` to write. | Guarded |
 | `sensors` | Read Chassis Sensor collections across vendors (auto `$expand`, per-sensor fallback). | Read |
 | `serial-console` | Report host serial redirection + BMC SOL; `--enable --confirm` sets both. | Guarded |
 | `service-api-rs-status` | Read remote service API status. | Read |

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -78,6 +78,7 @@ ACTION_POLICY = {
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
+    "#SecureBoot.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,
     "#UpdateService.SimpleUpdate": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -123,6 +123,7 @@ class ApiRequestType(Enum):
     LicenseInstall = auto()
     EthernetInterfaces = auto()
     SecureBoot = auto()
+    SecureBootResetKeys = auto()
     CertificatesQuery = auto()
     CertificateGenerateCSR = auto()
     FirmwareUpdate = auto()

--- a/redfish_ctl/security/cmd_secure_boot.py
+++ b/redfish_ctl/security/cmd_secure_boot.py
@@ -1,6 +1,9 @@
 """Read Redfish SecureBoot state + key databases (PK/KEK/db/dbx).
 
     redfish_ctl secure-boot
+    redfish_ctl secure-boot-reset-keys
+    redfish_ctl secure-boot-reset-keys --reset-type ResetAllKeysToDefault
+    redfish_ctl secure-boot-reset-keys --database PK --reset-type DeleteAllKeys --confirm
 
 For every ComputerSystem, reads ``Systems/{id}/SecureBoot`` (enable / mode /
 current-boot) and walks its ``SecureBootDatabases`` collection, returning one row
@@ -15,9 +18,13 @@ Author Mus spyroot@gmail.com
 from abc import abstractmethod
 from typing import Optional
 
+from ..cmd_exceptions import InvalidArgument
 from ..redfish_manager_base import RedfishManagerBase
 from ..redfish_manager_shared import ApiRequestType, Singleton
 from ..redfish_manager import CommandResult
+
+_SECURE_BOOT_RESET_ACTION = "#SecureBoot.ResetKeys"
+_SECURE_BOOT_DATABASE_RESET_ACTION = "#SecureBootDatabase.ResetKeys"
 
 
 class SecureBoot(RedfishManagerBase,
@@ -134,3 +141,306 @@ class SecureBoot(RedfishManagerBase,
                     "Certificates": self._cert_count(db, do_async),
                 })
         return CommandResult(rows, None, None, None)
+
+
+class SecureBootResetKeys(RedfishManagerBase,
+                          scm_type=ApiRequestType.SecureBootResetKeys,
+                          name="secure-boot-reset-keys",
+                          metaclass=Singleton):
+    """Preview or run guarded SecureBoot ResetKeys actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the secure-boot-reset-keys command."""
+        super(SecureBootResetKeys, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``secure-boot-reset-keys`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--system",
+            dest="system",
+            default=None,
+            help="ComputerSystem id or URI; omit when only one target matches",
+        )
+        cmd_parser.add_argument(
+            "--database",
+            dest="database",
+            default=None,
+            help="SecureBootDatabase id or URI; omit to target SecureBoot",
+        )
+        cmd_parser.add_argument(
+            "--reset-type",
+            dest="reset_type",
+            default=None,
+            help="ResetKeysType value advertised by the selected target",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="POST the reset action; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="force a preview even when --confirm is present",
+        )
+        return (
+            cmd_parser,
+            "secure-boot-reset-keys",
+            "command reset SecureBoot keys through guarded Redfish actions",
+        )
+
+    def _get(self, uri, do_async):
+        """GET a Redfish object body or fail with a clear CLI error.
+
+        :param uri: Redfish URI to fetch.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body.
+        :raises InvalidArgument: when the resource cannot be read or is not an object.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            raise InvalidArgument(f"failed to read {uri}: {exc}") from exc
+        if not isinstance(data, dict):
+            raise InvalidArgument(f"unexpected response from {uri}: expected object")
+        return data
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish ``@odata.id`` link value.
+
+        :param data: object that may contain a Redfish link.
+        :param key: link property name.
+        :return: linked URI or None.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _members(data):
+        """Return collection member URIs from a Redfish collection body.
+
+        :param data: Redfish collection body.
+        :return: list of member ``@odata.id`` strings.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict) and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _action_metadata(data, action_name):
+        """Return an action target and ResetKeysType allowlist.
+
+        :param data: Redfish resource body with an ``Actions`` block.
+        :param action_name: full Redfish action name to inspect.
+        :return: tuple of ``(target, reset_types)``.
+        """
+        actions = data.get("Actions") if isinstance(data, dict) else None
+        action = actions.get(action_name) if isinstance(actions, dict) else None
+        if not isinstance(action, dict):
+            return None, []
+        target = action.get("target")
+        values = action.get("ResetKeysType@Redfish.AllowableValues") or []
+        if not isinstance(values, list):
+            values = []
+        return target, [value for value in values if isinstance(value, str)]
+
+    def _database_rows(self, system_uri, secure_boot, do_async):
+        """Discover SecureBootDatabase reset targets below one SecureBoot resource.
+
+        :param system_uri: parent ComputerSystem URI.
+        :param secure_boot: SecureBoot resource body.
+        :param do_async: issue the queries on the async path when True.
+        :return: list of database reset target rows.
+        """
+        dbs_uri = self._link(secure_boot, "SecureBootDatabases")
+        if not dbs_uri:
+            return []
+        rows = []
+        for db_uri in self._members(self._get(dbs_uri, do_async)):
+            try:
+                db = self._get(db_uri, do_async)
+            except InvalidArgument:
+                continue
+            target, reset_types = self._action_metadata(
+                db,
+                _SECURE_BOOT_DATABASE_RESET_ACTION,
+            )
+            if not target:
+                continue
+            rows.append({
+                "System": system_uri.rsplit("/", 1)[-1],
+                "SystemUri": system_uri,
+                "Scope": "database",
+                "Database": db.get("Id") or db_uri.rsplit("/", 1)[-1],
+                "DatabaseId": db.get("DatabaseId"),
+                "Resource": db_uri,
+                "Action": _SECURE_BOOT_DATABASE_RESET_ACTION,
+                "Target": target,
+                "ResetKeysType": reset_types,
+            })
+        return rows
+
+    def _discover_rows(self, do_async):
+        """Discover SecureBoot and SecureBootDatabase reset targets.
+
+        :param do_async: issue discovery reads on the async path when True.
+        :return: list of discovered reset target rows.
+        """
+        rows = []
+        try:
+            system_uris = self.discover_computer_system_ids() or []
+        except Exception:
+            system_uris = []
+        for system_uri in system_uris:
+            secure_boot_uri = f"{system_uri}/SecureBoot"
+            secure_boot = self._get(secure_boot_uri, do_async)
+            target, reset_types = self._action_metadata(
+                secure_boot,
+                _SECURE_BOOT_RESET_ACTION,
+            )
+            if target:
+                rows.append({
+                    "System": system_uri.rsplit("/", 1)[-1],
+                    "SystemUri": system_uri,
+                    "Scope": "secure-boot",
+                    "Database": None,
+                    "DatabaseId": None,
+                    "Resource": secure_boot_uri,
+                    "Action": _SECURE_BOOT_RESET_ACTION,
+                    "Target": target,
+                    "ResetKeysType": reset_types,
+                })
+            rows.extend(self._database_rows(system_uri, secure_boot, do_async))
+        return rows
+
+    @staticmethod
+    def _match_system(row, system):
+        """Return whether a discovered row matches a system selector.
+
+        :param row: discovered reset target row.
+        :param system: optional system id or URI.
+        :return: True when the row matches.
+        """
+        if system is None:
+            return True
+        wanted = system.rstrip("/")
+        return wanted in {
+            row["System"],
+            row["SystemUri"].rstrip("/"),
+            row["Resource"].rsplit("/SecureBoot", 1)[0].rstrip("/"),
+        }
+
+    @staticmethod
+    def _match_database(row, database):
+        """Return whether a discovered row matches a database selector.
+
+        :param row: discovered reset target row.
+        :param database: optional database id or URI.
+        :return: True when the row matches.
+        """
+        if database is None:
+            return row["Scope"] == "secure-boot"
+        wanted = database.rstrip("/")
+        return row["Scope"] == "database" and wanted in {
+            str(row["Database"]),
+            str(row["DatabaseId"]),
+            row["Resource"].rstrip("/"),
+        }
+
+    def _select_row(self, rows, system, database):
+        """Resolve CLI selectors to one reset target row.
+
+        :param rows: discovered reset target rows.
+        :param system: optional system selector.
+        :param database: optional database selector.
+        :return: selected reset target row.
+        :raises InvalidArgument: when no target or multiple targets match.
+        """
+        matches = [
+            row for row in rows
+            if self._match_system(row, system) and self._match_database(row, database)
+        ]
+        if not matches:
+            raise InvalidArgument(
+                "no SecureBoot reset target matched the supplied selectors"
+            )
+        if len(matches) > 1:
+            raise InvalidArgument(
+                "multiple SecureBoot reset targets matched; pass --system"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _payload(row, reset_type):
+        """Build and validate a ResetKeys payload.
+
+        :param row: selected reset target row.
+        :param reset_type: requested ResetKeysType value.
+        :return: payload for the Redfish action.
+        :raises InvalidArgument: when reset_type is absent or not advertised.
+        """
+        value = (reset_type or "").strip()
+        if not value:
+            raise InvalidArgument("reset type is required to run a reset action")
+        allowed = row.get("ResetKeysType") or []
+        if allowed and value not in allowed:
+            raise InvalidArgument(
+                f"invalid ResetKeysType {value}; allowed: {', '.join(allowed)}"
+            )
+        return {"ResetKeysType": value}
+
+    def execute(self,
+                system: Optional[str] = None,
+                database: Optional[str] = None,
+                reset_type: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke guarded SecureBoot ResetKeys actions.
+
+        :param system: optional ComputerSystem id or URI selector.
+        :param database: optional SecureBootDatabase id or URI selector.
+        :param reset_type: ResetKeysType value to send.
+        :param confirm: authorize the destructive POST when True.
+        :param dry_run: force a preview even when confirm is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue Redfish reads and POST on the async path.
+        :return: CommandResult with discovered targets, dry-run, POST result, or error.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if reset_type is None:
+            return CommandResult(rows, None, None, None)
+
+        row = self._select_row(rows, system, database)
+        return self.invoke_action(
+            row["Resource"],
+            "ResetKeys",
+            payload=self._payload(row, reset_type),
+            full_action_type=row["Action"],
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -32,6 +32,8 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
+    assert classify("#SecureBoot.ResetKeys") is Destructiveness.DESTRUCTIVE
+    assert classify("#SecureBootDatabase.ResetKeys") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE

--- a/tests/test_secure_boot_dualmode.py
+++ b/tests/test_secure_boot_dualmode.py
@@ -1,8 +1,28 @@
 """Dual-mode test for the read-only secure-boot command."""
 import json
 
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.security.cmd_secure_boot import SecureBootResetKeys
+
+_SYSTEM_ID = "437XR1138R2"
+_SECURE_BOOT_URI = f"/redfish/v1/Systems/{_SYSTEM_ID}/SecureBoot"
+_SECURE_BOOT_RESET_TARGET = f"{_SECURE_BOOT_URI}/Actions/SecureBoot.ResetKeys"
+_PK_URI = f"{_SECURE_BOOT_URI}/SecureBootDatabases/PK"
+_PK_RESET_TARGET = f"{_PK_URI}/Actions/SecureBootDatabase.ResetKeys"
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
 
 
 def test_secure_boot_returns_fixture_database_rows_without_mutation(
@@ -39,3 +59,113 @@ def test_secure_boot_returns_fixture_database_rows_without_mutation(
         request.method not in {"POST", "PATCH", "DELETE"}
         for request in redfish_service.requests
     )
+
+
+def test_secure_boot_reset_keys_lists_generic_targets_without_post(
+    redfish_mock_factory,
+):
+    """secure-boot-reset-keys lists system and database reset actions only."""
+    redfish_api, redfish_service = redfish_mock_factory("generic")
+
+    result = redfish_api.sync_invoke(
+        ApiRequestType.SecureBootResetKeys,
+        "secure-boot-reset-keys",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert _post_requests(redfish_service) == []
+    targets = {row["Target"]: row for row in result.data}
+    assert _SECURE_BOOT_RESET_TARGET in targets
+    assert _PK_RESET_TARGET in targets
+    assert targets[_SECURE_BOOT_RESET_TARGET]["ResetKeysType"] == [
+        "ResetAllKeysToDefault",
+        "DeleteAllKeys",
+        "DeletePK",
+    ]
+    assert targets[_PK_RESET_TARGET]["Database"] == "PK"
+
+
+def test_secure_boot_reset_keys_dry_runs_system_reset_without_post(
+    redfish_mock_factory,
+):
+    """secure-boot-reset-keys previews SecureBoot.ResetKeys by default."""
+    redfish_api, redfish_service = redfish_mock_factory("generic")
+
+    result = redfish_api.sync_invoke(
+        ApiRequestType.SecureBootResetKeys,
+        "secure-boot-reset-keys",
+        reset_type="ResetAllKeysToDefault",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#SecureBoot.ResetKeys",
+        "target": _SECURE_BOOT_RESET_TARGET,
+        "payload": {"ResetKeysType": "ResetAllKeysToDefault"},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(redfish_service) == []
+
+
+def test_secure_boot_reset_keys_confirm_posts_database_reset(
+    redfish_mock_factory,
+):
+    """--confirm posts SecureBootDatabase.ResetKeys to the selected database."""
+    redfish_api, redfish_service = redfish_mock_factory("generic")
+
+    result = redfish_api.sync_invoke(
+        ApiRequestType.SecureBootResetKeys,
+        "secure-boot-reset-keys",
+        database="PK",
+        reset_type="DeleteAllKeys",
+        confirm=True,
+    )
+
+    posts = _post_requests(redfish_service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#SecureBootDatabase.ResetKeys"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == _PK_RESET_TARGET.lower()
+    assert posts[0].json() == {"ResetKeysType": "DeleteAllKeys"}
+
+
+def test_secure_boot_reset_keys_rejects_unadvertised_reset_type_without_post(
+    redfish_mock_factory,
+):
+    """ResetKeysType must be one of the values advertised by the target."""
+    redfish_api, redfish_service = redfish_mock_factory("generic")
+
+    with pytest.raises(InvalidArgument, match="ResetKeysType"):
+        redfish_api.sync_invoke(
+            ApiRequestType.SecureBootResetKeys,
+            "secure-boot-reset-keys",
+            database="PK",
+            reset_type="DeletePK",
+            confirm=True,
+        )
+
+    assert _post_requests(redfish_service) == []
+
+
+def test_secure_boot_reset_keys_exposes_cli_entrypoint():
+    """The guarded reset command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.SecureBootResetKeys][
+        "secure-boot-reset-keys"
+    ] is SecureBootResetKeys
+
+    cmd_parser, cmd_name, cmd_help = SecureBootResetKeys.register_subcommand(
+        SecureBootResetKeys
+    )
+
+    help_text = cmd_parser.format_help()
+    assert "--reset-type" in help_text
+    assert "--confirm" in help_text
+    assert cmd_name == "secure-boot-reset-keys"
+    assert "SecureBoot" in cmd_help


### PR DESCRIPTION
## Summary
- add a guarded secure-boot-reset-keys command for SecureBoot.ResetKeys and SecureBootDatabase.ResetKeys
- discover reset targets from SecureBoot resources and validate advertised ResetKeysType values
- add fixture-backed coverage for listing, dry-run, confirmed database reset, invalid reset type, and registry wiring

## Validation
- git diff --check
- GitHub CI pending