### PR TITLE
Add guarded HPE chassis MCTP action

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,6 +132,7 @@ Safety labels:
 | `get` | Read an arbitrary Redfish resource URI. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
+| `hpe-chassis-actions` | List or disable HPE server-side MCTP; dry-run by default and `--confirm` posts. | Guarded |
 | `hpe-test-actions` | List or send HPE iLO directory, SNMP, mail, and syslog test actions; dry-run by default and `--confirm` posts. | Guarded |
 | `identify-led` | Read or set a chassis/system identify LED; requires `--confirm` to write. | Guarded |
 | `insert_vm` | Insert virtual media from a URI. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_hpe_chassis_actions import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,7 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#HpeServerChassis.DisableMCTPOnServer": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for
@@ -86,6 +87,7 @@ ACTION_POLICY = {
     # irreversible: data loss or one-way security change — needs the extra token
     "#Drive.SecureErase": Destructiveness.IRREVERSIBLE,
     "#Manager.ResetToDefaults": Destructiveness.IRREVERSIBLE,
+    "#HpeServerChassis.FactoryResetMCTP": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.RevokeKeys": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.UpdateMinimumSecurityVersion": Destructiveness.IRREVERSIBLE,
 }

--- a/redfish_ctl/oem/cmd_hpe_chassis_actions.py
+++ b/redfish_ctl/oem/cmd_hpe_chassis_actions.py
@@ -1,0 +1,242 @@
+"""Preview or run guarded HPE iLO chassis OEM actions.
+
+    redfish_ctl hpe-chassis-actions
+    redfish_ctl hpe-chassis-actions --action disable-mctp
+    redfish_ctl hpe-chassis-actions --action disable-mctp --confirm
+
+The command discovers supported HPE chassis OEM action targets from the live
+Redfish tree and dry-runs by default. It deliberately exposes only
+``HpeServerChassis.DisableMCTPOnServer``; adjacent factory-reset actions are not
+selectable from this command.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+
+@dataclass(frozen=True)
+class _HpeChassisActionSpec:
+    """Static selector metadata for one HPE chassis action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_ACTION_SPECS = {
+    "disable-mctp": _HpeChassisActionSpec(
+        selector="disable-mctp",
+        full_type="#HpeServerChassis.DisableMCTPOnServer",
+        action_name="DisableMCTPOnServer",
+        description="disable server-side MCTP on an HPE chassis",
+    ),
+}
+
+
+class HpeChassisActions(RedfishManagerBase,
+                        scm_type=ApiRequestType.HpeChassisActions,
+                        name="hpe-chassis-actions",
+                        metaclass=Singleton):
+    """Discover and invoke guarded HPE iLO chassis OEM actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the hpe-chassis-actions command."""
+        super(HpeChassisActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``hpe-chassis-actions`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="HPE chassis action to preview or send; omit to list targets",
+        )
+        cmd_parser.add_argument(
+            "--chassis-uri",
+            dest="chassis_uri",
+            default=None,
+            help="specific Chassis resource URI when more than one target advertises the action",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="send the selected chassis action instead of dry-running it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return cmd_parser, "hpe-chassis-actions", "command run guarded HPE chassis actions"
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _members(data):
+        """Return collection member ``@odata.id`` values.
+
+        :param data: Redfish collection body.
+        :return: list of member URIs.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [
+            item["@odata.id"]
+            for item in data.get("Members", [])
+            if isinstance(item, dict) and isinstance(item.get("@odata.id"), str)
+        ]
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _chassis_collection_uri(self, do_async):
+        """Resolve the Chassis collection URI from ServiceRoot.
+
+        :param do_async: run the ServiceRoot query asynchronously when True.
+        :return: linked Chassis collection URI, or the standard fallback.
+        """
+        root = self._get(RedfishApi.Version, do_async)
+        return self._link(root, "Chassis") or f"{RedfishApi.Version}/Chassis"
+
+    def _chassis_uris(self, do_async):
+        """Return Chassis member URIs from the Redfish Chassis collection.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of Chassis resource URIs.
+        """
+        return self._members(self._get(self._chassis_collection_uri(do_async), do_async))
+
+    def _discover_rows(self, do_async):
+        """Discover available supported HPE chassis actions.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of available HPE chassis action rows.
+        """
+        rows = []
+        for chassis_uri in self._chassis_uris(do_async):
+            chassis = self._get(chassis_uri, do_async)
+            targets = self._flatten_action_targets(chassis)
+            for spec in _ACTION_SPECS.values():
+                target = targets.get(spec.full_type)
+                if target:
+                    rows.append({
+                        "Action": spec.selector,
+                        "FullType": spec.full_type,
+                        "Chassis": chassis_uri,
+                        "Target": target,
+                        "Description": spec.description,
+                    })
+        return rows
+
+    @staticmethod
+    def _matches(rows, action, chassis_uri):
+        """Filter discovered rows by action selector and optional Chassis URI.
+
+        :param rows: discovered HPE chassis action rows.
+        :param action: selected action name.
+        :param chassis_uri: optional Chassis resource URI selector.
+        :return: matching rows.
+        """
+        matches = [row for row in rows if row["Action"] == action]
+        if chassis_uri:
+            normalized = chassis_uri.rstrip("/")
+            matches = [
+                row for row in matches
+                if row["Chassis"].rstrip("/") == normalized
+            ]
+        return matches
+
+    def execute(self,
+                action: Optional[str] = None,
+                chassis_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or send guarded HPE chassis OEM actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param chassis_uri: optional Chassis URI to disambiguate multiple targets.
+        :param confirm: send the selected chassis action when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if action is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = self._matches(rows, action, chassis_uri)
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"HPE chassis action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                "multiple HPE chassis-action targets found; pass --chassis-uri",
+            )
+
+        row = matches[0]
+        spec = _ACTION_SPECS[action]
+        result = self.invoke_action(
+            row["Chassis"],
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        if not confirm and isinstance(result.data, dict):
+            result.data["requires_confirm"] = True
+            result.data["blocked"] = "HPE chassis action requires --confirm"
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -113,6 +113,7 @@ class ApiRequestType(Enum):
     EventSubmitTest = auto()
     HpeTestActions = auto()
     NvidiaDebugToken = auto()
+    HpeChassisActions = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()
     SubscriptionDelete = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -20,6 +20,8 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComputerSystem.Reset") is Destructiveness.DESTRUCTIVE
     assert classify("#Drive.SecureErase") is Destructiveness.IRREVERSIBLE
     assert classify("#EventService.SubmitTestEvent") is Destructiveness.REVERSIBLE
+    assert classify("#HpeServerChassis.DisableMCTPOnServer") is Destructiveness.DESTRUCTIVE
+    assert classify("#HpeServerChassis.FactoryResetMCTP") is Destructiveness.IRREVERSIBLE
     hpe_reversible_actions = (
         "#HpeDirectoryTest.StartTest",
         "#HpeDirectoryTest.StopTest",

--- a/tests/test_hpe_chassis_actions_dualmode.py
+++ b/tests/test_hpe_chassis_actions_dualmode.py
@@ -1,0 +1,151 @@
+"""Dual-mode tests for guarded HPE iLO chassis OEM actions."""
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.oem.cmd_hpe_chassis_actions import HpeChassisActions
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HPE_CORPUS = corpus_dir(REPO_ROOT / "tests" / "hpe_dl360_corpus.tar.gz", "10.43.3.209")
+
+
+@pytest.fixture
+def hpe_corpus_mock():
+    """Return a manager and mock service backed by the full HPE DL360 corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-hpe-dl360",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_hpe_chassis_actions_list_disable_mctp_without_post(hpe_corpus_mock):
+    """Listing discovers DisableMCTPOnServer and omits FactoryResetMCTP."""
+    manager, service = hpe_corpus_mock
+
+    result = manager.sync_invoke(ApiRequestType.HpeChassisActions, "hpe-chassis-actions")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    actions = {row["Action"]: row for row in result.data}
+    assert set(actions) == {"disable-mctp"}
+    assert actions["disable-mctp"]["Chassis"] == "/redfish/v1/Chassis/1"
+    assert actions["disable-mctp"]["Target"] == (
+        "/redfish/v1/Chassis/1/Actions/Oem/Hpe/"
+        "HpeServerChassis.DisableMCTPOnServer"
+    )
+    assert "FactoryResetMCTP" not in {
+        row["FullType"].rsplit(".", 1)[-1] for row in result.data
+    }
+    assert _post_requests(service) == []
+
+
+def test_hpe_chassis_action_dry_runs_by_default(hpe_corpus_mock):
+    """A selected HPE chassis action resolves the target but does not POST by default."""
+    manager, service = hpe_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeChassisActions,
+        "hpe-chassis-actions",
+        action="disable-mctp",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["requires_confirm"] is True
+    assert result.data["blocked"] == "HPE chassis action requires --confirm"
+    assert result.data["level"] == "destructive"
+    assert result.data["payload"] == {}
+    assert result.data["target"] == (
+        "/redfish/v1/Chassis/1/Actions/Oem/Hpe/"
+        "HpeServerChassis.DisableMCTPOnServer"
+    )
+    assert _post_requests(service) == []
+
+
+def test_hpe_chassis_action_confirm_posts_selected_target(hpe_corpus_mock):
+    """--confirm posts exactly one selected HPE chassis action."""
+    manager, service = hpe_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeChassisActions,
+        "hpe-chassis-actions",
+        action="disable-mctp",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/chassis/1/actions/oem/hpe/"
+        "hpeserverchassis.disablemctponserver"
+    )
+    assert posts[0].json() == {}
+
+
+def test_hpe_chassis_action_missing_target_reports_without_post(redfish_mock_factory):
+    """A fixture without HPE chassis OEM actions reports an error and no POST."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeChassisActions,
+        "hpe-chassis-actions",
+        action="disable-mctp",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "HPE chassis action not found: disable-mctp"
+    assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_hpe_chassis_actions_exposes_cli_entrypoint():
+    """The hpe-chassis-actions command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.HpeChassisActions]["hpe-chassis-actions"] is (
+        HpeChassisActions
+    )
+
+    cmd_parser, cmd_name, cmd_help = HpeChassisActions.register_subcommand(
+        HpeChassisActions
+    )
+
+    assert "--action" in cmd_parser.format_help()
+    assert cmd_name == "hpe-chassis-actions"
+    assert "HPE" in cmd_help


### PR DESCRIPTION
Summary:
- Add hpe-chassis-actions to discover HPE chassis DisableMCTPOnServer targets and list them by default.
- Keep the action dry-run by default, requiring --confirm before POST.
- Exclude the adjacent factory-reset action and classify it as irreversible for fail-safe handling.
- Add HPE corpus-backed coverage and the command reference row.

Tests:
- git diff --check
- Remote fleet gate unavailable: SSH to the test fleet timed out before pytest/Ruff/docstring gate started.