### PR TITLE
Add guarded NetworkAdapter reset command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -156,6 +156,7 @@ Safety labels:
 | `metric-definitions` | Read TelemetryService metric definitions. | Read |
 | `metric-reports` | Read TelemetryService metric reports; `--report` filters by id substring. | Read |
 | `network-adapters` | Read chassis NetworkAdapters such as NICs and DPUs. | Read |
+| `network-adapter-reset` | Reset a discovered NetworkAdapter through `NetworkAdapter.Reset`; lists reset-capable adapters when no target is given, requires `--confirm` to write. | Guarded |
 | `network-ports` | Read NetworkAdapter port link state and speed. | Read |
 | `ntp-set` | Set or clear Manager NTP servers through standard ManagerNetworkProtocol or legacy Manager NTP resources; dry-run by default and `--confirm` applies an NTP-only PATCH. | Guarded |
 | `nvlink-ports` | Read GPU NVLink port resources where the BMC exposes them. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -100,6 +100,7 @@ from .telemetry.cmd_exporter import *
 from .component_integrity.cmd_component_integrity import *
 from .component_integrity.cmd_spdm_measurements import *
 from .network.cmd_network_adapters import *
+from .network.cmd_network_adapter_reset import *
 from .network.cmd_nic_firmware import *
 from .ports.cmd_nvlink_ports import *
 from .actions.cmd_action_list import *

--- a/redfish_ctl/network/cmd_network_adapter_reset.py
+++ b/redfish_ctl/network/cmd_network_adapter_reset.py
@@ -16,9 +16,14 @@ from typing import Optional
 from ..cmd_exceptions import InvalidArgument
 from ..redfish_manager import CommandResult
 from ..redfish_manager_base import RedfishManagerBase
-from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
+from ..redfish_manager_shared import REDFISH_API, ApiRequestType, ResetType, Singleton
 
 _NETWORK_ADAPTER_RESET_ACTION = "#NetworkAdapter.Reset"
+_RESET_TYPE_VALUES = frozenset(item.value for item in ResetType)
+
+
+class _DiscoveryError(RuntimeError):
+    """Raised when required reset discovery reads fail."""
 
 
 class NetworkAdapterReset(RedfishManagerBase,
@@ -128,18 +133,55 @@ class NetworkAdapterReset(RedfishManagerBase,
         )
         return [value for value in values or [] if isinstance(value, str)]
 
-    def _get(self, uri, do_async):
-        """GET a Redfish resource body, returning an empty dict on failure.
+    def _get(self, uri, do_async, required=False):
+        """GET a Redfish resource body.
 
         :param uri: Redfish resource URI.
         :param do_async: run the query through the async path when True.
-        :return: parsed resource body dict, or ``{}``.
+        :param required: raise when the read fails instead of returning ``{}``.
+        :return: parsed resource body dict, or ``{}`` for optional failures.
+        :raises _DiscoveryError: when a required resource cannot be read.
         """
         try:
-            data = self.base_query(uri, do_async=do_async).data or {}
-        except Exception:
+            result = self.base_query(uri, do_async=do_async)
+        except Exception as exc:
+            if required:
+                raise _DiscoveryError(f"failed to read {uri}: {exc}") from exc
             return {}
+        if result.error:
+            if required:
+                raise _DiscoveryError(f"failed to read {uri}: {result.error}")
+            return {}
+        data = result.data or {}
+        if required and not isinstance(data, dict):
+            raise _DiscoveryError(f"failed to read {uri}: expected a Redfish object")
         return data if isinstance(data, dict) else {}
+
+    def _row_from_adapter(self, adapter_uri, adapter):
+        """Build a resettable-adapter row from one adapter resource.
+
+        :param adapter_uri: Redfish NetworkAdapter URI.
+        :param adapter: parsed NetworkAdapter resource body.
+        :return: reset-capable adapter row, or None when no Reset action exists.
+        """
+        target = self._flatten_action_targets(adapter).get(
+            _NETWORK_ADAPTER_RESET_ACTION
+        )
+        if not target:
+            return None
+        status = adapter.get("Status") if isinstance(adapter, dict) else {}
+        return {
+            "Adapter": (
+                adapter.get("Id") or adapter_uri.rstrip("/").rsplit("/", 1)[-1]
+            ),
+            "Chassis": self._chassis_id(adapter_uri),
+            "Model": adapter.get("Model"),
+            "Manufacturer": adapter.get("Manufacturer"),
+            "Health": status.get("Health") if isinstance(status, dict) else None,
+            "Resource": adapter_uri,
+            "Target": target,
+            "ResetTypes": self._allowed_reset_types(adapter),
+        }
 
     def _resettable_adapters(self, do_async):
         """Discover adapters that advertise ``#NetworkAdapter.Reset``.
@@ -148,7 +190,7 @@ class NetworkAdapterReset(RedfishManagerBase,
         :return: list of reset-capable adapter rows.
         """
         rows = []
-        chassis = self._get(REDFISH_API.Chassis, do_async)
+        chassis = self._get(REDFISH_API.Chassis, do_async, required=True)
         for chassis_uri in self._members(chassis):
             adapters_uri = self._link(
                 self._get(chassis_uri, do_async),
@@ -158,22 +200,9 @@ class NetworkAdapterReset(RedfishManagerBase,
                 continue
             for adapter_uri in self._members(self._get(adapters_uri, do_async)):
                 adapter = self._get(adapter_uri, do_async)
-                target = self._flatten_action_targets(adapter).get(
-                    _NETWORK_ADAPTER_RESET_ACTION
-                )
-                if not target:
-                    continue
-                status = adapter.get("Status") if isinstance(adapter, dict) else {}
-                rows.append({
-                    "Adapter": adapter.get("Id") or adapter_uri.rsplit("/", 1)[-1],
-                    "Chassis": self._chassis_id(adapter_uri),
-                    "Model": adapter.get("Model"),
-                    "Manufacturer": adapter.get("Manufacturer"),
-                    "Health": status.get("Health") if isinstance(status, dict) else None,
-                    "Resource": adapter_uri,
-                    "Target": target,
-                    "ResetTypes": self._allowed_reset_types(adapter),
-                })
+                row = self._row_from_adapter(adapter_uri, adapter)
+                if row:
+                    rows.append(row)
         return rows
 
     @staticmethod
@@ -201,6 +230,17 @@ class NetworkAdapterReset(RedfishManagerBase,
         """
         if not (adapter or "").strip():
             raise InvalidArgument("network-adapter-reset requires --adapter")
+        selector = adapter.strip()
+        if selector.startswith("/redfish/"):
+            row = self._row_from_adapter(
+                selector.rstrip("/"),
+                self._get(selector.rstrip("/"), do_async, required=True),
+            )
+            if not row:
+                raise InvalidArgument(
+                    f"network adapter reset action not found on: {adapter}"
+                )
+            return row
         matches = [
             row for row in self._resettable_adapters(do_async)
             if self._matches(row, adapter)
@@ -227,11 +267,24 @@ class NetworkAdapterReset(RedfishManagerBase,
         :raises InvalidArgument: when the selected ResetType is not advertised.
         """
         allowed = row.get("ResetTypes") or []
-        selected = reset_type or (allowed[0] if len(allowed) == 1 else None)
-        if selected and allowed and selected not in allowed:
+        if reset_type and allowed and reset_type not in allowed:
             raise InvalidArgument(
-                f"invalid ResetType for {row['Adapter']}: {selected}; "
+                f"invalid ResetType for {row['Adapter']}: {reset_type}; "
                 f"allowed: {', '.join(allowed)}"
+            )
+        if reset_type and not allowed and reset_type not in _RESET_TYPE_VALUES:
+            raise InvalidArgument(
+                f"invalid ResetType for {row['Adapter']}: {reset_type}; "
+                f"allowed: {', '.join(sorted(_RESET_TYPE_VALUES))}"
+            )
+        if reset_type:
+            selected = reset_type
+        elif len(allowed) == 1:
+            selected = allowed[0]
+        else:
+            raise InvalidArgument(
+                f"network adapter {row['Adapter']} advertises "
+                f"{len(allowed)} ResetType values; pass --reset-type explicitly"
             )
         return {"ResetType": selected} if selected else {}
 
@@ -254,14 +307,16 @@ class NetworkAdapterReset(RedfishManagerBase,
             preview/result metadata.
         """
         if not adapter:
-            return CommandResult(
-                {"resettable_adapters": self._resettable_adapters(bool(do_async))},
-                None,
-                None,
-                None,
-            )
+            try:
+                rows = self._resettable_adapters(bool(do_async))
+            except _DiscoveryError as exc:
+                return CommandResult(None, None, None, str(exc))
+            return CommandResult({"resettable_adapters": rows}, None, None, None)
 
-        row = self._resolve_adapter(adapter, bool(do_async))
+        try:
+            row = self._resolve_adapter(adapter, bool(do_async))
+        except _DiscoveryError as exc:
+            return CommandResult(None, None, None, str(exc))
         result = self.invoke_action(
             row["Resource"],
             "Reset",

--- a/redfish_ctl/network/cmd_network_adapter_reset.py
+++ b/redfish_ctl/network/cmd_network_adapter_reset.py
@@ -1,0 +1,281 @@
+"""Preview or run Redfish NetworkAdapter.Reset on a discovered adapter.
+
+    redfish_ctl network-adapter-reset
+    redfish_ctl network-adapter-reset --adapter IO_Board_0_CX8_0 --dry_run
+    redfish_ctl network-adapter-reset --adapter IO_Board_0_CX8_0 --confirm
+
+The command discovers ``#NetworkAdapter.Reset`` from each NetworkAdapter resource
+and previews by default. Use ``--confirm`` only after reviewing the target and
+payload, because a network-adapter reset can disrupt host or fabric traffic.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
+
+_NETWORK_ADAPTER_RESET_ACTION = "#NetworkAdapter.Reset"
+
+
+class NetworkAdapterReset(RedfishManagerBase,
+                          scm_type=ApiRequestType.NetworkAdapterReset,
+                          name="network-adapter-reset",
+                          metaclass=Singleton):
+    """Resolve and invoke NetworkAdapter.Reset through the action guard."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the network-adapter-reset command."""
+        super(NetworkAdapterReset, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``network-adapter-reset`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--adapter",
+            default=None,
+            help="NetworkAdapter Id or Redfish URI; omit to list reset-capable adapters",
+        )
+        cmd_parser.add_argument(
+            "--reset-type",
+            dest="reset_type",
+            default=None,
+            help="ResetType payload value; defaults to the only advertised value when unambiguous",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the adapter reset action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "network-adapter-reset",
+            "run NetworkAdapter.Reset on a discovered adapter (guarded)",
+        )
+
+    @staticmethod
+    def _members(data):
+        """Return member ``@odata.id`` values from a Redfish collection.
+
+        :param data: Redfish collection body.
+        :return: list of member URI strings.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict) and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        """Return a linked resource URI from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked ``@odata.id`` string, or None.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _chassis_id(adapter_uri):
+        """Return the chassis id embedded in a NetworkAdapter URI.
+
+        :param adapter_uri: Redfish NetworkAdapter URI.
+        :return: chassis id string, or None when the URI is not chassis-scoped.
+        """
+        parts = adapter_uri.strip("/").split("/")
+        if len(parts) >= 6 and parts[0:3] == ["redfish", "v1", "Chassis"]:
+            return parts[3]
+        return None
+
+    @staticmethod
+    def _allowed_reset_types(adapter):
+        """Return advertised ResetType values for ``#NetworkAdapter.Reset``.
+
+        :param adapter: Redfish NetworkAdapter resource body.
+        :return: list of ResetType strings.
+        """
+        actions = adapter.get("Actions") if isinstance(adapter, dict) else None
+        action = (
+            actions.get(_NETWORK_ADAPTER_RESET_ACTION)
+            if isinstance(actions, dict)
+            else None
+        )
+        values = (
+            action.get("ResetType@Redfish.AllowableValues")
+            if isinstance(action, dict)
+            else None
+        )
+        return [value for value in values or [] if isinstance(value, str)]
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, returning an empty dict on failure.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query through the async path when True.
+        :return: parsed resource body dict, or ``{}``.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _resettable_adapters(self, do_async):
+        """Discover adapters that advertise ``#NetworkAdapter.Reset``.
+
+        :param do_async: run the underlying reads through the async path when True.
+        :return: list of reset-capable adapter rows.
+        """
+        rows = []
+        chassis = self._get(REDFISH_API.Chassis, do_async)
+        for chassis_uri in self._members(chassis):
+            adapters_uri = self._link(
+                self._get(chassis_uri, do_async),
+                "NetworkAdapters",
+            )
+            if not adapters_uri:
+                continue
+            for adapter_uri in self._members(self._get(adapters_uri, do_async)):
+                adapter = self._get(adapter_uri, do_async)
+                target = self._flatten_action_targets(adapter).get(
+                    _NETWORK_ADAPTER_RESET_ACTION
+                )
+                if not target:
+                    continue
+                status = adapter.get("Status") if isinstance(adapter, dict) else {}
+                rows.append({
+                    "Adapter": adapter.get("Id") or adapter_uri.rsplit("/", 1)[-1],
+                    "Chassis": self._chassis_id(adapter_uri),
+                    "Model": adapter.get("Model"),
+                    "Manufacturer": adapter.get("Manufacturer"),
+                    "Health": status.get("Health") if isinstance(status, dict) else None,
+                    "Resource": adapter_uri,
+                    "Target": target,
+                    "ResetTypes": self._allowed_reset_types(adapter),
+                })
+        return rows
+
+    @staticmethod
+    def _matches(row, adapter):
+        """Return whether a resettable row matches an adapter selector.
+
+        :param row: resettable adapter row.
+        :param adapter: adapter id or resource URI supplied by the caller.
+        :return: True when the row matches.
+        """
+        selector = (adapter or "").strip()
+        return selector in {
+            row.get("Adapter"),
+            row.get("Resource"),
+            row.get("Resource", "").rstrip("/").rsplit("/", 1)[-1],
+        }
+
+    def _resolve_adapter(self, adapter, do_async):
+        """Resolve one adapter selector to a resettable adapter row.
+
+        :param adapter: adapter id or Redfish URI.
+        :param do_async: run the underlying reads through the async path when True.
+        :return: matching resettable adapter row.
+        :raises InvalidArgument: when the selector is empty, unknown, or ambiguous.
+        """
+        if not (adapter or "").strip():
+            raise InvalidArgument("network-adapter-reset requires --adapter")
+        matches = [
+            row for row in self._resettable_adapters(do_async)
+            if self._matches(row, adapter)
+        ]
+        if not matches:
+            raise InvalidArgument(
+                f"network adapter reset target not found: {adapter}"
+            )
+        if len(matches) > 1:
+            resources = ", ".join(row["Resource"] for row in matches)
+            raise InvalidArgument(
+                f"ambiguous network adapter '{adapter}'; use one URI: {resources}"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _payload_for(row, reset_type):
+        """Build the NetworkAdapter.Reset payload.
+
+        :param row: resettable adapter row with advertised ResetTypes.
+        :param reset_type: caller-selected ResetType, or None to use the sole
+            advertised value.
+        :return: Redfish action payload.
+        :raises InvalidArgument: when the selected ResetType is not advertised.
+        """
+        allowed = row.get("ResetTypes") or []
+        selected = reset_type or (allowed[0] if len(allowed) == 1 else None)
+        if selected and allowed and selected not in allowed:
+            raise InvalidArgument(
+                f"invalid ResetType for {row['Adapter']}: {selected}; "
+                f"allowed: {', '.join(allowed)}"
+            )
+        return {"ResetType": selected} if selected else {}
+
+    def execute(self,
+                adapter: Optional[str] = None,
+                reset_type: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or run NetworkAdapter.Reset for one discovered adapter.
+
+        :param adapter: NetworkAdapter id or Redfish URI; when omitted, list
+            reset-capable adapters.
+        :param reset_type: optional ResetType payload value.
+        :param confirm: actually POST the destructive reset action.
+        :param dry_run: force a no-POST preview even when confirm is set.
+        :param do_async: run reads and POST through the async path when True.
+        :return: CommandResult with either the resettable-adapter list or action
+            preview/result metadata.
+        """
+        if not adapter:
+            return CommandResult(
+                {"resettable_adapters": self._resettable_adapters(bool(do_async))},
+                None,
+                None,
+                None,
+            )
+
+        row = self._resolve_adapter(adapter, bool(do_async))
+        result = self.invoke_action(
+            row["Resource"],
+            "Reset",
+            payload=self._payload_for(row, reset_type),
+            full_action_type=_NETWORK_ADAPTER_RESET_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        if isinstance(result.data, dict):
+            data = dict(result.data)
+            data.setdefault("adapter", row["Adapter"])
+            data.setdefault("resource", row["Resource"])
+            data.setdefault("reset_types", row["ResetTypes"])
+            return CommandResult(data, result.discovered, result.extra, result.error)
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -103,6 +103,7 @@ class ApiRequestType(Enum):
     ComponentIntegrity = auto()
     SpdmMeasurements = auto()
     NetworkAdapters = auto()
+    NetworkAdapterReset = auto()
     NicFirmware = auto()
     NvLinkPorts = auto()
     Exporter = auto()

--- a/tests/test_network_adapter_reset_dualmode.py
+++ b/tests/test_network_adapter_reset_dualmode.py
@@ -1,0 +1,160 @@
+"""Dual-mode-style tests for guarded NetworkAdapter.Reset actions."""
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.network.cmd_network_adapter_reset import NetworkAdapterReset
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GB300_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz",
+    "172.25.230.37",
+)
+ADAPTER = "IO_Board_0_CX8_0"
+ADAPTER_URI = f"/redfish/v1/Chassis/IO_Board_0/NetworkAdapters/{ADAPTER}"
+RESET_TARGET = f"{ADAPTER_URI}/Actions/NetworkAdapter.Reset"
+
+
+@pytest.fixture
+def gb300_corpus_mock():
+    """Return a manager and mock service backed by the GB300 corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        GB300_CORPUS,
+        index=_build_fixture_index(GB300_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-gb300",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_network_adapter_reset_lists_gb300_targets_without_post(gb300_corpus_mock):
+    """Listing reports the GB300 reset-capable adapters without mutating."""
+    manager, service = gb300_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.NetworkAdapterReset,
+        "network-adapter-reset",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    rows = result.data["resettable_adapters"]
+    assert len(rows) == 5
+    row = next(item for item in rows if item["Adapter"] == ADAPTER)
+    assert row["Resource"] == ADAPTER_URI
+    assert row["Target"] == RESET_TARGET
+    assert row["ResetTypes"] == ["ForceRestart"]
+    assert _post_requests(service) == []
+
+
+def test_network_adapter_reset_defaults_to_dry_run(gb300_corpus_mock):
+    """A selected NetworkAdapter.Reset previews by default and sends no POST."""
+    manager, service = gb300_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.NetworkAdapterReset,
+        "network-adapter-reset",
+        adapter=ADAPTER,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#NetworkAdapter.Reset"
+    assert result.data["adapter"] == ADAPTER
+    assert result.data["resource"] == ADAPTER_URI
+    assert result.data["target"] == RESET_TARGET
+    assert result.data["payload"] == {"ResetType": "ForceRestart"}
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(service) == []
+
+
+def test_network_adapter_reset_confirm_posts_discovered_action(gb300_corpus_mock):
+    """--confirm POSTs NetworkAdapter.Reset to exactly one discovered target."""
+    manager, service = gb300_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.NetworkAdapterReset,
+        "network-adapter-reset",
+        adapter=ADAPTER_URI,
+        reset_type="ForceRestart",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#NetworkAdapter.Reset"
+    assert result.data["adapter"] == ADAPTER
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == RESET_TARGET.lower()
+    assert posts[0].json() == {"ResetType": "ForceRestart"}
+
+
+def test_network_adapter_reset_rejects_invalid_reset_type(gb300_corpus_mock):
+    """Invalid ResetType values are rejected before any POST."""
+    manager, service = gb300_corpus_mock
+
+    with pytest.raises(InvalidArgument, match="invalid ResetType"):
+        manager.sync_invoke(
+            ApiRequestType.NetworkAdapterReset,
+            "network-adapter-reset",
+            adapter=ADAPTER,
+            reset_type="GracefulRestart",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_network_adapter_reset_exposes_cli_entrypoint():
+    """The network-adapter-reset command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.NetworkAdapterReset]["network-adapter-reset"] is (
+        NetworkAdapterReset
+    )
+
+    cmd_parser, cmd_name, cmd_help = NetworkAdapterReset.register_subcommand(
+        NetworkAdapterReset
+    )
+
+    help_text = cmd_parser.format_help()
+    assert "--adapter" in help_text
+    assert "--reset-type" in help_text
+    assert cmd_name == "network-adapter-reset"
+    assert "NetworkAdapter.Reset" in cmd_help

--- a/tests/test_network_adapter_reset_dualmode.py
+++ b/tests/test_network_adapter_reset_dualmode.py
@@ -1,53 +1,27 @@
 """Dual-mode-style tests for guarded NetworkAdapter.Reset actions."""
-from pathlib import Path
+import copy
 
 import pytest
-from conftest import MockRedfishService, _build_fixture_index
-from vendor_corpus import corpus_dir
 
 from redfish_ctl.cmd_exceptions import InvalidArgument
 from redfish_ctl.network.cmd_network_adapter_reset import NetworkAdapterReset
 from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
+from test_roundtrip_budget import projected_walltime
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-GB300_CORPUS = corpus_dir(
-    REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz",
-    "172.25.230.37",
-)
 ADAPTER = "IO_Board_0_CX8_0"
 ADAPTER_URI = f"/redfish/v1/Chassis/IO_Board_0/NetworkAdapters/{ADAPTER}"
 RESET_TARGET = f"{ADAPTER_URI}/Actions/NetworkAdapter.Reset"
 
 
 @pytest.fixture
-def gb300_corpus_mock():
+def gb300_corpus_mock(redfish_mock_factory):
     """Return a manager and mock service backed by the GB300 corpus.
 
     :return: tuple of Redfish manager and mock service.
     """
-    requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(
-        GB300_CORPUS,
-        index=_build_fixture_index(GB300_CORPUS),
-    )
-    with requests_mock.Mocker() as mocker:
-        mocker.get(requests_mock.ANY, text=service.get_cb)
-        mocker.patch(requests_mock.ANY, text=service.patch_cb)
-        mocker.post(requests_mock.ANY, text=service.post_cb)
-        mocker.delete(requests_mock.ANY, text=service.delete_cb)
-        service.mocker = mocker
-        yield (
-            RedfishManagerBase(
-                idrac_ip="mock-gb300",
-                idrac_username="root",
-                idrac_password="mock",
-                insecure=True,
-                is_debug=False,
-            ),
-            service,
-        )
+    yield redfish_mock_factory("supermicro")
 
 
 def _post_requests(service):
@@ -57,6 +31,25 @@ def _post_requests(service):
     :return: recorded POST requests.
     """
     return [request for request in service.requests if request.method == "POST"]
+
+
+def _get_requests(service):
+    """Return GET requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded GET requests.
+    """
+    return [request for request in service.requests if request.method == "GET"]
+
+
+def _replace_adapter(service, adapter):
+    """Replace the GB300 adapter fixture body in the mock overlay.
+
+    :param service: mock Redfish service.
+    :param adapter: replacement adapter body.
+    """
+    service._overlay[ADAPTER_URI] = adapter
+    service._overlay[ADAPTER_URI.lower()] = adapter
 
 
 def test_network_adapter_reset_lists_gb300_targets_without_post(gb300_corpus_mock):
@@ -71,11 +64,36 @@ def test_network_adapter_reset_lists_gb300_targets_without_post(gb300_corpus_moc
     assert isinstance(result, CommandResult)
     assert result.error is None
     rows = result.data["resettable_adapters"]
-    assert len(rows) == 5
     row = next(item for item in rows if item["Adapter"] == ADAPTER)
     assert row["Resource"] == ADAPTER_URI
     assert row["Target"] == RESET_TARGET
     assert row["ResetTypes"] == ["ForceRestart"]
+    assert _post_requests(service) == []
+
+
+def test_network_adapter_reset_reports_root_read_failures(gb300_corpus_mock):
+    """A failed top-level Chassis read is reported instead of an empty list."""
+    requests_mock = pytest.importorskip("requests_mock")
+    manager, service = gb300_corpus_mock
+
+    def get_cb(request, context):
+        if request.path.rstrip("/").lower() == "/redfish/v1/chassis":
+            service.requests.append(request)
+            context.status_code = 401
+            return '{"error": "denied"}'
+        return service.get_cb(request, context)
+
+    service.mocker.get(requests_mock.ANY, text=get_cb)
+
+    result = manager.sync_invoke(
+        ApiRequestType.NetworkAdapterReset,
+        "network-adapter-reset",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data is None
+    assert "failed to read /redfish/v1/Chassis" in result.error
+    assert "Authentication failed" in result.error
     assert _post_requests(service) == []
 
 
@@ -99,6 +117,25 @@ def test_network_adapter_reset_defaults_to_dry_run(gb300_corpus_mock):
     assert result.data["payload"] == {"ResetType": "ForceRestart"}
     assert result.data["level"] == "destructive"
     assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(service) == []
+
+
+def test_network_adapter_reset_exact_uri_skips_full_chassis_crawl(gb300_corpus_mock):
+    """A full Redfish URI selector fetches only the named adapter before preview."""
+    manager, service = gb300_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.NetworkAdapterReset,
+        "network-adapter-reset",
+        adapter=ADAPTER_URI,
+    )
+
+    get_paths = [request.path.lower() for request in _get_requests(service)]
+    assert result.error is None
+    assert result.data["payload"] == {"ResetType": "ForceRestart"}
+    assert get_paths.count(ADAPTER_URI.lower()) == 2
+    assert "/redfish/v1/chassis" not in get_paths
+    assert projected_walltime(service, "india-vpn-to-us") <= 0.61
     assert _post_requests(service) == []
 
 
@@ -126,6 +163,26 @@ def test_network_adapter_reset_confirm_posts_discovered_action(gb300_corpus_mock
     assert posts[0].json() == {"ResetType": "ForceRestart"}
 
 
+def test_network_adapter_reset_requires_type_when_multiple_values(gb300_corpus_mock):
+    """Ambiguous advertised ResetType choices require an explicit selector."""
+    manager, service = gb300_corpus_mock
+    adapter = copy.deepcopy(service._state(ADAPTER_URI.lower()))
+    adapter["Actions"]["#NetworkAdapter.Reset"][
+        "ResetType@Redfish.AllowableValues"
+    ] = ["ForceRestart", "GracefulRestart"]
+    _replace_adapter(service, adapter)
+
+    with pytest.raises(InvalidArgument, match="pass --reset-type explicitly"):
+        manager.sync_invoke(
+            ApiRequestType.NetworkAdapterReset,
+            "network-adapter-reset",
+            adapter=ADAPTER_URI,
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
 def test_network_adapter_reset_rejects_invalid_reset_type(gb300_corpus_mock):
     """Invalid ResetType values are rejected before any POST."""
     manager, service = gb300_corpus_mock
@@ -136,6 +193,27 @@ def test_network_adapter_reset_rejects_invalid_reset_type(gb300_corpus_mock):
             "network-adapter-reset",
             adapter=ADAPTER,
             reset_type="GracefulRestart",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_network_adapter_reset_validates_type_without_allowables(gb300_corpus_mock):
+    """A missing AllowableValues list still rejects unknown ResetType strings."""
+    manager, service = gb300_corpus_mock
+    adapter = copy.deepcopy(service._state(ADAPTER_URI.lower()))
+    adapter["Actions"]["#NetworkAdapter.Reset"].pop(
+        "ResetType@Redfish.AllowableValues"
+    )
+    _replace_adapter(service, adapter)
+
+    with pytest.raises(InvalidArgument, match="invalid ResetType"):
+        manager.sync_invoke(
+            ApiRequestType.NetworkAdapterReset,
+            "network-adapter-reset",
+            adapter=ADAPTER_URI,
+            reset_type="VendorMagic",
             confirm=True,
         )
 


### PR DESCRIPTION
## Summary
- add a guarded `network-adapter-reset` command for Redfish `NetworkAdapter.Reset`
- discover reset-capable adapters from Redfish NetworkAdapter Actions and preview by default
- add Supermicro corpus coverage and command documentation

## Validation
- `git diff --check github/main...HEAD`
- GitHub CI will run on the pull request