### PR TITLE
Add guarded Control reset command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -114,6 +114,7 @@ Safety labels:
 | `chassis-reset` | Change chassis power state. | Write |
 | `component-integrity` | Read ComponentIntegrity/SPDM attestation resources. | Read |
 | `controls` | Read Chassis Controls collections, setpoints, ranges, and current readings from `redfish_ctl/controls/cmd_controls.py`. | Read |
+| `control-reset-defaults` | Reset a Redfish Control resource through discovered `#Control.ResetToDefaults`; lists reset-capable controls by default, requires `--confirm` to write. | Guarded |
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -85,6 +85,7 @@ from .chassis.cmd_asset_tag_set import *
 from .chassis.cmd_identify_led import *
 from .sensors.cmd_sensors import *
 from .controls.cmd_controls import *
+from .controls.cmd_control_reset_defaults import *
 from .thermal.cmd_thermal import *
 from .power.cmd_power import *
 from .power.cmd_power_smoothing import *

--- a/redfish_ctl/controls/cmd_control_reset_defaults.py
+++ b/redfish_ctl/controls/cmd_control_reset_defaults.py
@@ -116,6 +116,18 @@ class ControlResetDefaults(RedfishManagerBase,
         return chassis_uri.rstrip("/").rsplit("/", 1)[-1]
 
     @staticmethod
+    def _chassis_id_from_control(control_uri):
+        """Derive the owning chassis identifier from a Control URI.
+
+        :param control_uri: Redfish Control resource URI.
+        :return: chassis id string, or None when the URI is not chassis-scoped.
+        """
+        parts = control_uri.strip("/").split("/")
+        if len(parts) >= 6 and parts[0:3] == ["redfish", "v1", "Chassis"]:
+            return parts[3]
+        return None
+
+    @staticmethod
     def _action_target(control):
         """Return the Control.ResetToDefaults target from a Control body.
 
@@ -144,6 +156,31 @@ class ControlResetDefaults(RedfishManagerBase,
         except Exception:
             return {}
         return data if isinstance(data, dict) else {}
+
+    def _query_required(self, uri, do_async=False):
+        """Query a required URI.
+
+        :param uri: Redfish resource URI to query.
+        :param do_async: when True, issue the query asynchronously.
+        :return: response data dict.
+        :raises InvalidArgument: when the resource cannot be read as an object.
+        """
+        try:
+            result = self.base_query(uri, do_async=do_async)
+        except Exception as exc:
+            raise InvalidArgument(
+                f"failed to read Control resource {uri}: {exc}"
+            ) from exc
+        data = result.data or {}
+        if result.error:
+            raise InvalidArgument(
+                f"failed to read Control resource {uri}: {result.error}"
+            )
+        if not isinstance(data, dict):
+            raise InvalidArgument(
+                f"failed to read Control resource {uri}: expected object"
+            )
+        return data
 
     @staticmethod
     def _target_row(chassis_id, member_uri, control):
@@ -190,6 +227,43 @@ class ControlResetDefaults(RedfishManagerBase,
                 rows.append(self._target_row(chassis_id, member_uri, control))
         return rows
 
+    def _row_from_exact_selector(self, control, do_async=False):
+        """Resolve an exact Control resource or action URI without a full crawl.
+
+        :param control: exact Redfish Control resource URI or Control action URI.
+        :param do_async: when True, issue Redfish queries asynchronously.
+        :return: reset-capable Control row, or None when the Control has no action.
+        :raises InvalidArgument: when the URI is not a Control reset selector.
+        """
+        selector = control.rstrip("/")
+        action_suffix = "/Actions/Control.ResetToDefaults"
+        if "/Actions/" in selector:
+            if not selector.endswith(action_suffix):
+                raise InvalidArgument(
+                    "control-reset-defaults only accepts a Control resource URI "
+                    "or Control.ResetToDefaults action URI"
+                )
+            control_uri = selector[: -len(action_suffix)]
+        else:
+            control_uri = selector
+        if "/Controls/" not in control_uri:
+            raise InvalidArgument(
+                "control-reset-defaults requires a Redfish Control resource URI"
+            )
+        control_data = self._query_required(control_uri, do_async=do_async)
+        target = self._action_target(control_data)
+        if not target:
+            return None
+        if "/Actions/" in selector and selector != target.rstrip("/"):
+            raise InvalidArgument(
+                f"Control.ResetToDefaults action URI mismatch for {control_uri}"
+            )
+        return self._target_row(
+            self._chassis_id_from_control(control_uri),
+            control_uri,
+            control_data,
+        )
+
     @staticmethod
     def _matches(rows, control, chassis=None):
         """Filter reset-capable rows by selector and optional chassis.
@@ -229,6 +303,21 @@ class ControlResetDefaults(RedfishManagerBase,
             ]
         return matches
 
+    @staticmethod
+    def _with_selected_row(result, row):
+        """Return an action result annotated with the selected Control row.
+
+        :param result: invoke_action result.
+        :param row: selected Control row with rollback context.
+        :return: CommandResult with row metadata merged into ``data`` when possible.
+        """
+        if not isinstance(result.data, dict):
+            return result
+        data = dict(result.data)
+        for key, value in row.items():
+            data.setdefault(key, value)
+        return CommandResult(data, result.discovered, result.extra, result.error)
+
     def execute(self,
                 control: Optional[str] = None,
                 chassis: Optional[str] = None,
@@ -257,18 +346,35 @@ class ControlResetDefaults(RedfishManagerBase,
         :param do_async: issue the underlying query and POST on the async path.
         :return: CommandResult with targets, preview, execution result, or error.
         """
-        rows = self._discover_targets(do_async=bool(do_async))
         if control is None:
+            if chassis:
+                raise InvalidArgument("--chassis requires --control")
+            rows = self._discover_targets(do_async=bool(do_async))
             return CommandResult({"control_reset_targets": rows}, None, None, None)
 
-        matches = self._matches(rows, control, chassis=chassis)
-        if not matches:
-            return CommandResult(
-                {"available": rows},
-                None,
-                None,
-                f"Control.ResetToDefaults target not found: {control}",
+        if control.strip().startswith("/redfish/"):
+            row = self._row_from_exact_selector(
+                control.strip(),
+                do_async=bool(do_async),
             )
+            if not row:
+                return CommandResult(
+                    {"available": []},
+                    None,
+                    None,
+                    f"Control.ResetToDefaults target not found: {control}",
+                )
+            matches = [row]
+        else:
+            rows = self._discover_targets(do_async=bool(do_async))
+            matches = self._matches(rows, control, chassis=chassis)
+            if not matches:
+                return CommandResult(
+                    {"available": rows},
+                    None,
+                    None,
+                    f"Control.ResetToDefaults target not found: {control}",
+                )
         if len(matches) > 1:
             return CommandResult(
                 {"matches": matches},
@@ -279,7 +385,7 @@ class ControlResetDefaults(RedfishManagerBase,
             )
 
         row = matches[0]
-        return self.invoke_action(
+        result = self.invoke_action(
             row["Uri"],
             "ResetToDefaults",
             payload={},
@@ -288,3 +394,4 @@ class ControlResetDefaults(RedfishManagerBase,
             dry_run=bool(dry_run),
             confirm=bool(confirm),
         )
+        return self._with_selected_row(result, row)

--- a/redfish_ctl/controls/cmd_control_reset_defaults.py
+++ b/redfish_ctl/controls/cmd_control_reset_defaults.py
@@ -1,0 +1,290 @@
+"""Reset Redfish Control resources to their default setpoints.
+
+    redfish_ctl control-reset-defaults
+    redfish_ctl control-reset-defaults --control HGX_GPU_0/ClockLimit_0
+    redfish_ctl control-reset-defaults --control HGX_GPU_0/ClockLimit_0 --confirm
+
+The command discovers ``#Control.ResetToDefaults`` from each Control resource's
+own ``Actions`` block. Resetting a Control rewrites a BMC-managed control value,
+so the action is DESTRUCTIVE: without ``--confirm`` the command only previews
+the POST.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
+
+_CONTROL_RESET_ACTION = "#Control.ResetToDefaults"
+
+
+class ControlResetDefaults(RedfishManagerBase,
+                           scm_type=ApiRequestType.ControlResetDefaults,
+                           name="control-reset-defaults",
+                           metaclass=Singleton):
+    """Discover and reset Redfish Control resources to default values."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the control-reset-defaults command."""
+        super(ControlResetDefaults, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``control-reset-defaults`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--control",
+            required=False,
+            dest="control",
+            default=None,
+            help="Control Id, Chassis/Id selector, Control URI, or action URI; "
+                 "omit to list reset-capable controls",
+        )
+        cmd_parser.add_argument(
+            "--chassis",
+            required=False,
+            dest="chassis",
+            default=None,
+            help="chassis Id used to disambiguate duplicate Control ids",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the Control.ResetToDefaults POST; without it the "
+                 "command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "control-reset-defaults",
+            "command reset a Redfish Control resource to defaults",
+        )
+
+    @staticmethod
+    def _members(data):
+        """Extract member ``@odata.id`` links from a Redfish collection.
+
+        :param data: collection payload expected to hold a ``Members`` array.
+        :return: list of member ``@odata.id`` strings; empty when malformed.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        """Return the ``@odata.id`` of a linked resource under ``key``.
+
+        :param data: resource payload to read the link from.
+        :param key: name of the property holding the linked resource object.
+        :return: linked ``@odata.id`` string, or None when absent.
+        """
+        value = data.get(key) if isinstance(data, dict) else None
+        if isinstance(value, dict) and isinstance(value.get("@odata.id"), str):
+            return value["@odata.id"]
+        return None
+
+    @staticmethod
+    def _chassis_id(chassis_uri):
+        """Derive a chassis identifier from a chassis URI.
+
+        :param chassis_uri: chassis ``@odata.id`` path.
+        :return: the last path segment of the URI.
+        """
+        return chassis_uri.rstrip("/").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _action_target(control):
+        """Return the Control.ResetToDefaults target from a Control body.
+
+        :param control: decoded Control resource body.
+        :return: action target URI, or None when the action is absent.
+        """
+        actions = control.get("Actions") if isinstance(control, dict) else None
+        action = (
+            actions.get(_CONTROL_RESET_ACTION)
+            if isinstance(actions, dict) else None
+        )
+        if not isinstance(action, dict):
+            return None
+        target = action.get("target")
+        return target if isinstance(target, str) and target else None
+
+    def _query_optional(self, uri, do_async=False):
+        """Query a URI, returning an empty dict instead of raising.
+
+        :param uri: Redfish resource URI to query.
+        :param do_async: when True, issue the query asynchronously.
+        :return: response data dict, or an empty dict on any read error.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _target_row(chassis_id, member_uri, control):
+        """Build one reset-capable Control target row.
+
+        :param chassis_id: chassis identifier that owns the Control collection.
+        :param member_uri: Control resource URI read from the collection.
+        :param control: decoded Control resource body.
+        :return: public row describing the reset-capable Control.
+        """
+        uri = control.get("@odata.id", member_uri)
+        return {
+            "Chassis": chassis_id,
+            "Id": control.get("Id") or uri.rstrip("/").rsplit("/", 1)[-1],
+            "Name": control.get("Name"),
+            "ControlType": control.get("ControlType"),
+            "ControlMode": control.get("ControlMode"),
+            "SetPoint": control.get("SetPoint"),
+            "SetPointUnits": control.get("SetPointUnits"),
+            "DefaultSetPoint": control.get("DefaultSetPoint"),
+            "Uri": uri,
+            "Target": ControlResetDefaults._action_target(control),
+        }
+
+    def _discover_targets(self, do_async=False):
+        """Discover Controls that advertise Control.ResetToDefaults.
+
+        :param do_async: when True, issue Redfish queries asynchronously.
+        :return: list of reset-capable Control target rows.
+        """
+        chassis = self.base_query(REDFISH_API.Chassis, do_async=do_async)
+        rows = []
+        for chassis_uri in self._members(chassis.data):
+            chassis_id = self._chassis_id(chassis_uri)
+            chassis_data = self._query_optional(chassis_uri, do_async=do_async)
+            controls_uri = self._link(chassis_data, "Controls")
+            if not controls_uri:
+                continue
+            collection = self._query_optional(controls_uri, do_async=do_async)
+            for member_uri in self._members(collection):
+                control = self._query_optional(member_uri, do_async=do_async)
+                if not self._action_target(control):
+                    continue
+                rows.append(self._target_row(chassis_id, member_uri, control))
+        return rows
+
+    @staticmethod
+    def _matches(rows, control, chassis=None):
+        """Filter reset-capable rows by selector and optional chassis.
+
+        :param rows: discovered reset-capable target rows.
+        :param control: Control Id, ``Chassis/Id``, resource URI, or action URI.
+        :param chassis: optional chassis Id to disambiguate duplicate Ids.
+        :return: list of matching rows.
+        """
+        wanted = (control or "").strip()
+        if not wanted:
+            raise InvalidArgument("control selector cannot be empty")
+
+        if wanted.startswith("/redfish/"):
+            matches = [
+                row for row in rows
+                if wanted in {row["Uri"], row["Target"]}
+            ]
+        elif "/" in wanted:
+            chassis_id, control_id = wanted.split("/", 1)
+            matches = [
+                row for row in rows
+                if row["Chassis"].lower() == chassis_id.lower()
+                and str(row["Id"]).lower() == control_id.lower()
+            ]
+        else:
+            matches = [
+                row for row in rows
+                if str(row["Id"]).lower() == wanted.lower()
+            ]
+
+        if chassis:
+            folded_chassis = chassis.strip().lower()
+            matches = [
+                row for row in matches
+                if row["Chassis"].lower() == folded_chassis
+            ]
+        return matches
+
+    def execute(self,
+                control: Optional[str] = None,
+                chassis: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or reset Redfish Control resources to default values.
+
+        With no ``--control`` selector the command lists every Control resource
+        that advertises ``#Control.ResetToDefaults`` and does not POST. With a
+        selector it invokes the discovered action; because the action is
+        DESTRUCTIVE, the POST only fires with ``--confirm``. ``--dry_run`` remains
+        a no-POST override even when ``--confirm`` is also set.
+
+        :param control: Control Id, ``Chassis/Id``, resource URI, or action URI.
+        :param chassis: optional chassis Id to disambiguate duplicate controls.
+        :param confirm: authorize the Control.ResetToDefaults POST to fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: CommandResult with targets, preview, execution result, or error.
+        """
+        rows = self._discover_targets(do_async=bool(do_async))
+        if control is None:
+            return CommandResult({"control_reset_targets": rows}, None, None, None)
+
+        matches = self._matches(rows, control, chassis=chassis)
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"Control.ResetToDefaults target not found: {control}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                "multiple Control.ResetToDefaults targets found; "
+                "pass --chassis or a full --control URI",
+            )
+
+        row = matches[0]
+        return self.invoke_action(
+            row["Uri"],
+            "ResetToDefaults",
+            payload={},
+            full_action_type=_CONTROL_RESET_ACTION,
+            do_async=do_async,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -89,6 +89,7 @@ class ApiRequestType(Enum):
     EnableBootOptions = auto()
     Sensors = auto()
     ControlsQuery = auto()
+    ControlResetDefaults = auto()
     Thermal = auto()
     Power = auto()
     PowerSmoothing = auto()

--- a/tests/test_control_reset_defaults_dualmode.py
+++ b/tests/test_control_reset_defaults_dualmode.py
@@ -1,0 +1,164 @@
+"""Dual-mode-style coverage for Control.ResetToDefaults."""
+
+import json
+
+from redfish_ctl.controls.cmd_control_reset_defaults import ControlResetDefaults
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_control_reset_defaults_lists_supermicro_targets_without_post(
+        redfish_mock_factory):
+    """Listing discovers reset-capable Controls and never POSTs."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ControlResetDefaults,
+        "control-reset-defaults",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    json.dumps(result.data, sort_keys=True)
+
+    targets = result.data["control_reset_targets"]
+    assert len(targets) == 4
+    target_map = {(row["Chassis"], row["Id"]): row for row in targets}
+    assert target_map[("HGX_GPU_0", "ClockLimit_0")] == {
+        "Chassis": "HGX_GPU_0",
+        "Id": "ClockLimit_0",
+        "Name": "Control for GPU_0 ClockLimit_0",
+        "ControlType": "FrequencyMHz",
+        "ControlMode": "Automatic",
+        "SetPoint": None,
+        "SetPointUnits": "MHz",
+        "DefaultSetPoint": None,
+        "Uri": "/redfish/v1/Chassis/HGX_GPU_0/Controls/ClockLimit_0",
+        "Target": (
+            "/redfish/v1/Chassis/HGX_GPU_0/Controls/ClockLimit_0/"
+            "Actions/Control.ResetToDefaults"
+        ),
+    }
+    assert set(target_map) == {
+        ("HGX_GPU_0", "ClockLimit_0"),
+        ("HGX_GPU_1", "ClockLimit_0"),
+        ("HGX_GPU_2", "ClockLimit_0"),
+        ("HGX_GPU_3", "ClockLimit_0"),
+    }
+    assert _post_requests(service) == []
+
+
+def test_control_reset_defaults_dry_runs_by_default(redfish_mock_factory):
+    """A selected Control reset resolves the target but does not POST by default."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ControlResetDefaults,
+        "control-reset-defaults",
+        control="HGX_GPU_0/ClockLimit_0",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["level"] == "destructive"
+    assert result.data["payload"] == {}
+    assert result.data["target"] == (
+        "/redfish/v1/Chassis/HGX_GPU_0/Controls/ClockLimit_0/"
+        "Actions/Control.ResetToDefaults"
+    )
+    assert _post_requests(service) == []
+
+
+def test_control_reset_defaults_confirm_posts_selected_target(
+        redfish_mock_factory):
+    """--confirm POSTs exactly one selected Control reset action."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ControlResetDefaults,
+        "control-reset-defaults",
+        control="ClockLimit_0",
+        chassis="HGX_GPU_2",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#Control.ResetToDefaults"
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/chassis/hgx_gpu_2/controls/clocklimit_0/"
+        "actions/control.resettodefaults"
+    )
+    assert posts[0].json() == {}
+
+
+def test_control_reset_defaults_ambiguous_selector_reports_without_post(
+        redfish_mock_factory):
+    """Duplicate Control ids require a chassis or URI selector."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ControlResetDefaults,
+        "control-reset-defaults",
+        control="ClockLimit_0",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "multiple Control.ResetToDefaults targets found; "
+        "pass --chassis or a full --control URI"
+    )
+    assert len(result.data["matches"]) == 4
+    assert _post_requests(service) == []
+
+
+def test_control_reset_defaults_missing_target_reports_without_post(
+        redfish_mock_factory):
+    """A fixture with no reset-capable Controls returns a structured error."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ControlResetDefaults,
+        "control-reset-defaults",
+        control="ClockLimit_0",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Control.ResetToDefaults target not found: ClockLimit_0"
+    assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_control_reset_defaults_exposes_cli_entrypoint():
+    """The control-reset-defaults command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.ControlResetDefaults][
+        "control-reset-defaults"
+    ] is ControlResetDefaults
+
+    cmd_parser, cmd_name, cmd_help = ControlResetDefaults.register_subcommand(
+        ControlResetDefaults
+    )
+
+    assert "--control" in cmd_parser.format_help()
+    assert "--confirm" in cmd_parser.format_help()
+    assert cmd_name == "control-reset-defaults"
+    assert "Control" in cmd_help

--- a/tests/test_control_reset_defaults_dualmode.py
+++ b/tests/test_control_reset_defaults_dualmode.py
@@ -2,10 +2,17 @@
 
 import json
 
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
 from redfish_ctl.controls.cmd_control_reset_defaults import ControlResetDefaults
 from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
+from test_roundtrip_budget import projected_walltime
+
+_CONTROL_URI = "/redfish/v1/Chassis/HGX_GPU_0/Controls/ClockLimit_0"
+_CONTROL_TARGET = f"{_CONTROL_URI}/Actions/Control.ResetToDefaults"
 
 
 def _post_requests(service):
@@ -15,6 +22,15 @@ def _post_requests(service):
     :return: recorded POST requests.
     """
     return [request for request in service.requests if request.method == "POST"]
+
+
+def _get_requests(service):
+    """Return GET requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded GET requests.
+    """
+    return [request for request in service.requests if request.method == "GET"]
 
 
 def test_control_reset_defaults_lists_supermicro_targets_without_post(
@@ -43,11 +59,8 @@ def test_control_reset_defaults_lists_supermicro_targets_without_post(
         "SetPoint": None,
         "SetPointUnits": "MHz",
         "DefaultSetPoint": None,
-        "Uri": "/redfish/v1/Chassis/HGX_GPU_0/Controls/ClockLimit_0",
-        "Target": (
-            "/redfish/v1/Chassis/HGX_GPU_0/Controls/ClockLimit_0/"
-            "Actions/Control.ResetToDefaults"
-        ),
+        "Uri": _CONTROL_URI,
+        "Target": _CONTROL_TARGET,
     }
     assert set(target_map) == {
         ("HGX_GPU_0", "ClockLimit_0"),
@@ -74,10 +87,32 @@ def test_control_reset_defaults_dry_runs_by_default(redfish_mock_factory):
     assert result.data["blocked"] == "destructive action requires --confirm"
     assert result.data["level"] == "destructive"
     assert result.data["payload"] == {}
-    assert result.data["target"] == (
-        "/redfish/v1/Chassis/HGX_GPU_0/Controls/ClockLimit_0/"
-        "Actions/Control.ResetToDefaults"
+    assert result.data["target"] == _CONTROL_TARGET
+    assert result.data["Uri"] == _CONTROL_URI
+    assert result.data["Target"] == _CONTROL_TARGET
+    assert result.data["SetPoint"] is None
+    assert result.data["DefaultSetPoint"] is None
+    assert _post_requests(service) == []
+
+
+def test_control_reset_defaults_exact_uri_skips_full_chassis_crawl(
+        redfish_mock_factory):
+    """An exact Control URI fetches only the selected Control before preview."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ControlResetDefaults,
+        "control-reset-defaults",
+        control=_CONTROL_URI,
     )
+
+    get_paths = [request.path.lower() for request in _get_requests(service)]
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["target"] == _CONTROL_TARGET
+    assert get_paths.count(_CONTROL_URI.lower()) == 2
+    assert "/redfish/v1/chassis" not in get_paths
+    assert projected_walltime(service, "india-vpn-to-us") <= 0.61
     assert _post_requests(service) == []
 
 
@@ -100,12 +135,44 @@ def test_control_reset_defaults_confirm_posts_selected_target(
     assert result.data["executed"] is True
     assert result.data["action"] == "#Control.ResetToDefaults"
     assert result.data["level"] == "destructive"
+    assert result.data["Chassis"] == "HGX_GPU_2"
+    assert result.data["Id"] == "ClockLimit_0"
+    assert result.data["ControlMode"] == "Automatic"
+    assert result.data["SetPoint"] is None
+    assert result.data["SetPointUnits"] == "MHz"
+    assert result.data["DefaultSetPoint"] is None
+    assert result.data["Uri"] == "/redfish/v1/Chassis/HGX_GPU_2/Controls/ClockLimit_0"
+    assert result.data["Target"] == (
+        "/redfish/v1/Chassis/HGX_GPU_2/Controls/ClockLimit_0/"
+        "Actions/Control.ResetToDefaults"
+    )
     assert len(posts) == 1
     assert posts[0].path.lower() == (
         "/redfish/v1/chassis/hgx_gpu_2/controls/clocklimit_0/"
         "actions/control.resettodefaults"
     )
     assert posts[0].json() == {}
+
+
+def test_control_reset_defaults_confirm_dry_run_still_does_not_post(
+        redfish_mock_factory):
+    """--dry_run wins over --confirm and leaves the BMC untouched."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.ControlResetDefaults,
+        "control-reset-defaults",
+        control=_CONTROL_URI,
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["Uri"] == _CONTROL_URI
+    assert _post_requests(service) == []
 
 
 def test_control_reset_defaults_ambiguous_selector_reports_without_post(
@@ -126,6 +193,42 @@ def test_control_reset_defaults_ambiguous_selector_reports_without_post(
         "pass --chassis or a full --control URI"
     )
     assert len(result.data["matches"]) == 4
+    assert _post_requests(service) == []
+
+
+@pytest.mark.parametrize("unsafe_uri", [
+    "/redfish/v1/Managers/BMC_0/Actions/Manager.Reset",
+    "/redfish/v1/Managers/BMC_0/Actions/Manager.ResetToDefaults",
+    "/redfish/v1/Systems/System_0/Actions/ComputerSystem.Reset",
+    "/redfish/v1/Chassis/HGX_GPU_0/Actions/Chassis.Reset",
+])
+def test_control_reset_defaults_rejects_non_control_reset_uris_without_post(
+        redfish_mock_factory, unsafe_uri):
+    """Only Control.ResetToDefaults action URIs are accepted."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument, match="Control"):
+        manager.sync_invoke(
+            ApiRequestType.ControlResetDefaults,
+            "control-reset-defaults",
+            control=unsafe_uri,
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_control_reset_defaults_chassis_requires_control(redfish_mock_factory):
+    """--chassis without --control is rejected instead of silently listing."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument, match="--chassis requires --control"):
+        manager.sync_invoke(
+            ApiRequestType.ControlResetDefaults,
+            "control-reset-defaults",
+            chassis="HGX_GPU_0",
+        )
+
     assert _post_requests(service) == []
 
 


### PR DESCRIPTION
## Summary
- add a guarded control-reset-defaults command for discovered #Control.ResetToDefaults targets
- list reset-capable Controls by default and require --confirm before POSTing
- add Supermicro fixture-backed coverage and the command reference row

## Validation
- git diff --cached --check
- GitHub CI pending