### PR TITLE
Add Dell LC network share test command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-network-share-test` | Test Dell Lifecycle Controller network-share reachability; previews unless `--confirm` is given. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_network_share_test import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -50,6 +50,7 @@ ACTION_POLICY = {
     "#HpeiLOSnmpService.SendSNMPTestAlert": Destructiveness.REVERSIBLE,
     "#HpeiLOManagerNetworkService.SendTestAlertMail": Destructiveness.REVERSIBLE,
     "#HpeiLOManagerNetworkService.SendTestSyslog": Destructiveness.REVERSIBLE,
+    "#DellLCService.TestNetworkShare": Destructiveness.REVERSIBLE,
     "#VirtualMedia.InsertMedia": Destructiveness.REVERSIBLE,
     "#VirtualMedia.EjectMedia": Destructiveness.REVERSIBLE,
     "#CertificateService.GenerateCSR": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/dell_lc/cmd_dell_lc_network_share_test.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_network_share_test.py
@@ -1,0 +1,261 @@
+"""Test Dell Lifecycle Controller network-share reachability.
+
+    redfish_ctl dell-lc-network-share-test
+    redfish_ctl dell-lc-network-share-test --host repo.example.test --dry_run
+    redfish_ctl dell-lc-network-share-test --host repo.example.test --confirm
+
+The command resolves ``#DellLCService.TestNetworkShare`` from the Dell
+Lifecycle Controller service. The action can send test traffic from the BMC, so
+it previews by default and only POSTs when ``--confirm`` is provided.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton, TestNetworkShareReq
+
+_TEST_NETWORK_SHARE_ACTION = "#DellLCService.TestNetworkShare"
+
+
+def _link(data, key):
+    """Return an ``@odata.id`` link from a Redfish object.
+
+    :param data: Redfish resource body.
+    :param key: property name to inspect.
+    :return: linked URI, or None when absent.
+    """
+    link = data.get(key) if isinstance(data, dict) else None
+    return link.get("@odata.id") if isinstance(link, dict) else None
+
+
+class DellLcNetworkShareTest(RedfishManagerBase,
+                             scm_type=ApiRequestType.DellLcNetworkShareTest,
+                             name="dell-lc-network-share-test",
+                             metaclass=Singleton):
+    """Preview or invoke DellLCService.TestNetworkShare."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-network-share-test command."""
+        super(DellLcNetworkShareTest, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-network-share-test`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--host",
+            required=False,
+            type=str,
+            default=None,
+            help="network share host/IP to test; omit to list the action target",
+        )
+        cmd_parser.add_argument(
+            "--share-type",
+            required=False,
+            dest="share_type",
+            type=str,
+            default="HTTPS",
+            help="DellLCService.TestNetworkShare ShareType value",
+        )
+        cmd_parser.add_argument(
+            "--proxy-support",
+            required=False,
+            dest="proxy_support",
+            type=str,
+            default="Off",
+            help="ProxySupport value, such as Off or ParametersProxy",
+        )
+        cmd_parser.add_argument(
+            "--ignore-cert-warning",
+            required=False,
+            dest="ignore_cert_warning",
+            type=str,
+            default="On",
+            help="IgnoreCertWarning value, usually On or Off",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the TestNetworkShare action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-network-share-test",
+            "command test Dell Lifecycle Controller network-share reachability",
+        )
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource, returning an empty dict on optional misses.
+
+        :param uri: Redfish URI to read.
+        :param do_async: issue the read on the async path when True.
+        :return: resource body, or an empty dict when missing/unreadable.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the ``Links.Oem.Dell`` block from a Manager resource.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM link block, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _candidate_service_uris(self, do_async):
+        """Return DellLCService URI candidates in discovery-first order.
+
+        :param do_async: issue supporting reads on the async path when True.
+        :return: de-duplicated candidate DellLCService URIs.
+        """
+        candidates = []
+        for manager_uri in self.discover_manager_ids() or []:
+            manager = self._get(manager_uri, do_async)
+            service_uri = _link(self._dell_oem_links(manager), "DellLCService")
+            if service_uri:
+                candidates.append(service_uri)
+            candidates.append(f"{manager_uri.rstrip('/')}/Oem/Dell/DellLCService")
+            candidates.append(f"{manager_uri.rstrip('/')}/DellLCService")
+        candidates.append("/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService")
+
+        seen = set()
+        ordered = []
+        for uri in candidates:
+            if uri and uri not in seen:
+                seen.add(uri)
+                ordered.append(uri)
+        return ordered
+
+    def _service_metadata(self, do_async):
+        """Return metadata for the first service advertising TestNetworkShare.
+
+        :param do_async: issue reads on the async path when True.
+        :return: CommandResult with discovered metadata, or a not-found error.
+        """
+        checked = []
+        for service_uri in self._candidate_service_uris(do_async):
+            service = self._get(service_uri, do_async)
+            if not service:
+                checked.append(service_uri)
+                continue
+            actions = self.discover_redfish_actions(self, service)
+            target = self._flatten_action_targets(service).get(
+                _TEST_NETWORK_SHARE_ACTION
+            )
+            action = actions.get("TestNetworkShare")
+            if target:
+                return CommandResult(
+                    {
+                        "service": service_uri,
+                        "action": _TEST_NETWORK_SHARE_ACTION,
+                        "target": target,
+                        "allowable_values": getattr(action, "args", {}) or {},
+                    },
+                    actions,
+                    None,
+                    None,
+                )
+            checked.append(service_uri)
+
+        return CommandResult(
+            {
+                "action": _TEST_NETWORK_SHARE_ACTION,
+                "checked": checked,
+            },
+            None,
+            None,
+            f"action '{_TEST_NETWORK_SHARE_ACTION}' not found",
+        )
+
+    @staticmethod
+    def _payload(host, share_type, proxy_support, ignore_cert_warning):
+        """Build a DellLCService.TestNetworkShare payload.
+
+        :param host: share host/IP address to test.
+        :param share_type: Dell ShareType value.
+        :param proxy_support: Dell ProxySupport value.
+        :param ignore_cert_warning: Dell IgnoreCertWarning value.
+        :return: JSON payload for the action.
+        :raises InvalidArgument: when host is empty.
+        """
+        clean_host = (host or "").strip()
+        if not clean_host:
+            raise InvalidArgument("network share host cannot be empty")
+        return TestNetworkShareReq(
+            host=clean_host,
+            share_type=(share_type or "").strip() or "HTTPS",
+            proxy_support=(proxy_support or "").strip() or "Off",
+            ignore_cert_warning=(ignore_cert_warning or "").strip() or "On",
+        ).network_share_req
+
+    def execute(self,
+                host: Optional[str] = None,
+                share_type: Optional[str] = "HTTPS",
+                proxy_support: Optional[str] = "Off",
+                ignore_cert_warning: Optional[str] = "On",
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke DellLCService.TestNetworkShare.
+
+        :param host: share host/IP address to test; omitted means list metadata.
+        :param share_type: Dell ShareType payload value.
+        :param proxy_support: Dell ProxySupport payload value.
+        :param ignore_cert_warning: Dell IgnoreCertWarning payload value.
+        :param confirm: authorize the TestNetworkShare POST.
+        :param dry_run: force preview mode even when ``confirm`` is true.
+        :param filename: accepted for CLI compatibility; not used.
+        :param data_type: accepted for CLI compatibility; not used.
+        :param verbose: accepted for CLI compatibility; not used.
+        :param do_async: issue underlying reads/POST on the async path.
+        :return: CommandResult with metadata, dry-run preview, or POST result.
+        """
+        metadata = self._service_metadata(bool(do_async))
+        if metadata.error:
+            return metadata
+        if host is None:
+            return metadata
+
+        return self.invoke_action(
+            metadata.data["service"],
+            "TestNetworkShare",
+            payload=self._payload(
+                host,
+                share_type=share_type,
+                proxy_support=proxy_support,
+                ignore_cert_warning=ignore_cert_warning,
+            ),
+            full_action_type=_TEST_NETWORK_SHARE_ACTION,
+            do_async=do_async,
+            expected_status=200,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -41,6 +41,7 @@ class ApiRequestType(Enum):
 
     RemoteServicesRssAPIStatus = auto()
     RemoteServicesAPIStatus = auto()
+    DellLcNetworkShareTest = auto()
     TasksList = auto()
 
     ChangeBootOrder = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -20,14 +20,15 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComputerSystem.Reset") is Destructiveness.DESTRUCTIVE
     assert classify("#Drive.SecureErase") is Destructiveness.IRREVERSIBLE
     assert classify("#EventService.SubmitTestEvent") is Destructiveness.REVERSIBLE
-    hpe_reversible_actions = (
+    reversible_actions = (
+        "#DellLCService.TestNetworkShare",
         "#HpeDirectoryTest.StartTest",
         "#HpeDirectoryTest.StopTest",
         "#HpeiLOSnmpService.SendSNMPTestAlert",
         "#HpeiLOManagerNetworkService.SendTestAlertMail",
         "#HpeiLOManagerNetworkService.SendTestSyslog",
     )
-    for action in hpe_reversible_actions:
+    for action in reversible_actions:
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE

--- a/tests/test_dell_lc_network_share_test_dualmode.py
+++ b/tests/test_dell_lc_network_share_test_dualmode.py
@@ -1,0 +1,232 @@
+"""Dual-mode-style coverage for DellLCService.TestNetworkShare."""
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.dell_lc.cmd_dell_lc_network_share_test import (
+    DellLcNetworkShareTest,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+SERVICE_URI = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+TARGET_URI = f"{SERVICE_URI}/Actions/DellLCService.TestNetworkShare"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: requests-mock request path.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_lc_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase and recorded requests.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 200
+        return json.dumps({
+            "@Message.ExtendedInfo": [{
+                "MessageId": "Base.1.12.Success",
+                "Message": "Successfully Completed Request",
+                "Severity": "OK",
+            }]
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-lc",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_lc_network_share_test_lists_target_without_mutating(
+    dell_lc_manager,
+):
+    """Without --host, the command lists the discovered action target only."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcNetworkShareTest,
+        "dell-lc-network-share-test",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["service"] == SERVICE_URI
+    assert result.data["action"] == "#DellLCService.TestNetworkShare"
+    assert result.data["target"] == TARGET_URI
+    assert result.data["allowable_values"]["ShareType"] == [
+        "CIFS",
+        "FTP",
+        "HTTP",
+        "HTTPS",
+        "NFS",
+        "TFTP",
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_network_share_test_without_confirm_is_preview_only(
+    dell_lc_manager,
+):
+    """A host payload is resolved but not POSTed unless --confirm is present."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcNetworkShareTest,
+        "dell-lc-network-share-test",
+        host="repo.example.test",
+        share_type="HTTPS",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.TestNetworkShare"
+    assert result.data["target"] == TARGET_URI
+    assert result.data["level"] == "reversible"
+    assert result.data["payload"] == {
+        "IPAddress": "repo.example.test",
+        "ShareType": "HTTPS",
+        "ProxySupport": "Off",
+        "IgnoreCertWarning": "On",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_network_share_test_confirm_posts_payload(dell_lc_manager):
+    """--confirm POSTs TestNetworkShare to the discovered action target."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcNetworkShareTest,
+        "dell-lc-network-share-test",
+        host="repo.example.test",
+        share_type="HTTPS",
+        proxy_support="ParametersProxy",
+        ignore_cert_warning="Off",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellLCService.TestNetworkShare"
+    assert result.data["target"] == TARGET_URI
+    assert result.data["level"] == "reversible"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == TARGET_URI.lower()
+    assert posts[0].json() == {
+        "IPAddress": "repo.example.test",
+        "ShareType": "HTTPS",
+        "ProxySupport": "ParametersProxy",
+        "IgnoreCertWarning": "Off",
+    }
+
+
+def test_dell_lc_network_share_test_rejects_invalid_share_type(
+    dell_lc_manager,
+):
+    """Inline allowable values reject an unsupported ShareType before POST."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcNetworkShareTest,
+        "dell-lc-network-share-test",
+        host="repo.example.test",
+        share_type="Local",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.TestNetworkShare ShareType: "
+        "Local; allowed: CIFS, FTP, HTTP, HTTPS, NFS, TFTP"
+    )
+    assert result.data["validation_errors"] == [{
+        "parameter": "ShareType",
+        "value": "Local",
+        "allowed": ["CIFS", "FTP", "HTTP", "HTTPS", "NFS", "TFTP"],
+    }]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_network_share_test_requires_nonempty_host():
+    """Payload construction rejects an empty network share host."""
+    with pytest.raises(InvalidArgument, match="network share host cannot be empty"):
+        DellLcNetworkShareTest._payload("  ", "HTTPS", "Off", "On")
+
+
+def test_dell_lc_network_share_test_missing_action_does_not_post(redfish_mock):
+    """A Dell LC fixture without TestNetworkShare returns an error and no POST."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcNetworkShareTest,
+        "dell-lc-network-share-test",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "action '#DellLCService.TestNetworkShare' not found"
+    assert "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService" in (
+        result.data["checked"]
+    )
+
+
+def test_dell_lc_network_share_test_registry_wiring():
+    """The dell-lc-network-share-test command is wired into the registry."""
+    registry = RedfishManagerBase.get_registry()
+
+    assert registry[ApiRequestType.DellLcNetworkShareTest][
+        "dell-lc-network-share-test"
+    ] is DellLcNetworkShareTest
+    cmd_parser, cmd_name, cmd_help = DellLcNetworkShareTest.register_subcommand(
+        DellLcNetworkShareTest
+    )
+    args = {action.dest for action in cmd_parser._actions}
+    assert cmd_name == "dell-lc-network-share-test"
+    assert "network-share" in cmd_help
+    assert {"host", "share_type", "proxy_support", "confirm", "dry_run"} <= args


### PR DESCRIPTION
## Summary
- add guarded dell-lc-network-share-test for DellLCService.TestNetworkShare
- discover DellLCService from Manager OEM links with legacy fallbacks
- validate advertised allowable values and cover list, preview, confirm, error, and registry paths

## Validation
- git diff --cached --check