### PR TITLE
Add guarded BIOS password command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -87,6 +87,7 @@ Safety labels:
 | `attr-update` | Stage manager attribute changes. | Write |
 | `bios` | Read BIOS attributes. | Read |
 | `bios-change` | Stage BIOS attributes from a spec or attribute pair. | Write |
+| `bios-change-password` | Change a BIOS password through `Bios.ChangePassword`; lists the discovered target when no password sources are given, requires `--confirm` to write. | Guarded |
 | `bios-clear-pending` | Clear pending BIOS values. | Write |
 | `bios-pending` | Read pending BIOS values. | Read |
 | `bios-profile` | List/show committed BIOS tuning profiles, diff against current BIOS attributes, or preview/apply a profile with `--confirm`. | Guarded |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -29,6 +29,7 @@ from .bios.cmd_bios_profile import *
 from .bios.cmd_change_bios import *
 from .bios.cmd_bios_snapshot import *
 from .bios.cmd_bios_reset_default import *
+from .bios.cmd_bios_change_password import *
 #
 from .attribute.cmd_attribute import *
 from .attribute.cmd_attribute_clear_pending import *

--- a/redfish_ctl/bios/cmd_bios_change_password.py
+++ b/redfish_ctl/bios/cmd_bios_change_password.py
@@ -1,0 +1,322 @@
+"""Change a BIOS password through the Redfish Bios.ChangePassword action.
+
+    redfish_ctl bios-change-password
+    redfish_ctl bios-change-password --password-name Administrator \
+        --old-password-env OLD_BIOS_PASSWORD --new-password-env NEW_BIOS_PASSWORD
+    redfish_ctl bios-change-password --password-name User \
+        --old-password-file old.txt --new-password-file new.txt --confirm
+
+The command discovers ``#Bios.ChangePassword`` from the host BIOS resource.
+Changing a BIOS password can lock out platform configuration access, so the
+action is DESTRUCTIVE: without ``--confirm`` the command only previews the POST
+and redacts password values from returned data.
+
+Author Mus spyroot@gmail.com
+"""
+import os
+from abc import abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_CHANGE_PASSWORD_ACTION = "#Bios.ChangePassword"
+
+
+class BiosChangePassword(RedfishManagerBase,
+                         scm_type=ApiRequestType.BiosChangePassword,
+                         name="bios_change_password",
+                         metaclass=Singleton):
+    """Change a BIOS password through the discovered ChangePassword action."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the bios-change-password command."""
+        super(BiosChangePassword, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``bios-change-password`` subcommand.
+
+        :param cls: the owning command class, used to build the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--password-name",
+            "--password_name",
+            required=False,
+            dest="password_name",
+            type=str,
+            default=None,
+            help="BIOS password slot to change, such as Administrator or User",
+        )
+        old_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        old_group.add_argument(
+            "--old-password-env",
+            "--old_password_env",
+            required=False,
+            dest="old_password_env",
+            type=str,
+            default=None,
+            help="environment variable containing the current BIOS password",
+        )
+        old_group.add_argument(
+            "--old-password-file",
+            "--old_password_file",
+            required=False,
+            dest="old_password_file",
+            type=str,
+            default=None,
+            help="file containing the current BIOS password",
+        )
+        new_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        new_group.add_argument(
+            "--new-password-env",
+            "--new_password_env",
+            required=False,
+            dest="new_password_env",
+            type=str,
+            default=None,
+            help="environment variable containing the new BIOS password",
+        )
+        new_group.add_argument(
+            "--new-password-file",
+            "--new_password_file",
+            required=False,
+            dest="new_password_file",
+            type=str,
+            default=None,
+            help="file containing the new BIOS password",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the ChangePassword POST; without it the command only previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing",
+        )
+        return (
+            cmd_parser,
+            "bios-change-password",
+            "command change a BIOS password",
+        )
+
+    def _bios_uri(self, do_async: bool) -> str:
+        """Resolve the host BIOS resource URI from the ComputerSystem link.
+
+        :param do_async: issue the host-system query over the async path when True.
+        :return: the linked BIOS resource URI, or the standard ``/Bios`` fallback.
+        """
+        system_uri = self.idrac_manage_servers
+        system = self.base_query(system_uri, do_async=do_async).data or {}
+        bios_link = system.get("Bios") if isinstance(system, dict) else None
+        if isinstance(bios_link, dict) and bios_link.get("@odata.id"):
+            return bios_link["@odata.id"]
+        return self._bios_fallback_uri(system_uri)
+
+    @staticmethod
+    def _bios_fallback_uri(system_uri: str) -> str:
+        """Build the conventional BIOS URI under a ComputerSystem URI.
+
+        :param system_uri: the ComputerSystem resource URI to base the path on.
+        :return: the conventional ``<system_uri>/Bios`` resource URI.
+        """
+        return f"{system_uri.rstrip('/')}/{str(RedfishApi.Bios).strip('/')}"
+
+    def _change_metadata(self, do_async: bool) -> CommandResult:
+        """Return discovered Bios.ChangePassword target metadata.
+
+        :param do_async: issue the BIOS query over the async path when True.
+        :return: CommandResult with target metadata, or an error if absent.
+        """
+        uri = self._bios_uri(do_async)
+        try:
+            bios = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+
+        actions = self.discover_redfish_actions(self, bios)
+        targets = self._flatten_action_targets(bios)
+        target = targets.get(_CHANGE_PASSWORD_ACTION)
+        if target is None:
+            available = sorted(set(list(actions.keys()) + list(targets.keys())))
+            return CommandResult(
+                {"bios": uri, "action": _CHANGE_PASSWORD_ACTION, "available": available},
+                actions,
+                None,
+                f"action '{_CHANGE_PASSWORD_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {"bios": uri, "action": _CHANGE_PASSWORD_ACTION, "target": target},
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _password_from_source(label: str,
+                              env_name: Optional[str] = None,
+                              file_name: Optional[str] = None) -> str:
+        """Read a password value from a named environment variable or file.
+
+        :param label: human-readable source label for error messages.
+        :param env_name: name of the environment variable to read.
+        :param file_name: path to a file containing the password.
+        :return: the password string, including an empty string if the source is
+            intentionally empty.
+        :raises InvalidArgument: when source selection or reading fails.
+        """
+        if env_name and file_name:
+            raise InvalidArgument(
+                f"use only one of --{label}-password-env or --{label}-password-file"
+            )
+        if env_name is not None:
+            name = env_name.strip()
+            if not name:
+                raise InvalidArgument(
+                    f"{label} password environment variable name cannot be empty"
+                )
+            if name not in os.environ:
+                raise InvalidArgument(f"{label} password environment variable '{name}' is not set")
+            return os.environ[name]
+        if file_name is not None:
+            path = Path(file_name).expanduser()
+            try:
+                return path.read_text(encoding="utf-8").rstrip("\r\n")
+            except OSError as exc:
+                raise InvalidArgument(
+                    f"failed to read {label} password file '{path}': {exc}"
+                ) from exc
+        raise InvalidArgument(f"{label} password source is required")
+
+    @staticmethod
+    def _payload(password_name: str, old_password: str, new_password: str) -> dict:
+        """Build a Bios.ChangePassword payload.
+
+        :param password_name: Redfish BIOS password slot name.
+        :param old_password: current BIOS password value.
+        :param new_password: replacement BIOS password value.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when ``password_name`` is empty.
+        """
+        name = (password_name or "").strip()
+        if not name:
+            raise InvalidArgument("password name cannot be empty")
+        return {
+            "PasswordName": name,
+            "OldPassword": old_password,
+            "NewPassword": new_password,
+        }
+
+    @staticmethod
+    def _redact_passwords(result: CommandResult) -> CommandResult:
+        """Mask password fields in dry-run or validation payloads.
+
+        :param result: CommandResult from ``invoke_action``.
+        :return: CommandResult with password fields redacted in returned data.
+        """
+        if not isinstance(result.data, dict):
+            return result
+        data = dict(result.data)
+        payload = data.get("payload")
+        if isinstance(payload, dict):
+            payload = dict(payload)
+            if "OldPassword" in payload:
+                payload["OldPassword"] = "********"
+            if "NewPassword" in payload:
+                payload["NewPassword"] = "********"
+            data["payload"] = payload
+        return CommandResult(data, result.discovered, result.extra, result.error)
+
+    @staticmethod
+    def _has_password_input(password_name: Optional[str],
+                            old_password_env: Optional[str],
+                            old_password_file: Optional[str],
+                            new_password_env: Optional[str],
+                            new_password_file: Optional[str]) -> bool:
+        """Return whether the caller supplied any password-change input.
+
+        :param password_name: requested BIOS password slot.
+        :param old_password_env: old password environment variable name.
+        :param old_password_file: old password file path.
+        :param new_password_env: new password environment variable name.
+        :param new_password_file: new password file path.
+        :return: True when at least one change parameter was supplied.
+        """
+        return any((
+            password_name is not None,
+            old_password_env is not None,
+            old_password_file is not None,
+            new_password_env is not None,
+            new_password_file is not None,
+        ))
+
+    def execute(self,
+                password_name: Optional[str] = None,
+                old_password_env: Optional[str] = None,
+                old_password_file: Optional[str] = None,
+                new_password_env: Optional[str] = None,
+                new_password_file: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke the BIOS ChangePassword action.
+
+        With no password-change inputs the command returns the discovered action
+        target without mutating. With inputs it requires a password name plus old
+        and new password sources, then invokes the DESTRUCTIVE action through the
+        shared dry-run/confirm guard.
+
+        :param password_name: BIOS password slot, for example Administrator or User.
+        :param old_password_env: environment variable containing the old password.
+        :param old_password_file: file containing the old password.
+        :param new_password_env: environment variable containing the new password.
+        :param new_password_file: file containing the new password.
+        :param confirm: authorize the ChangePassword POST to actually fire.
+        :param dry_run: force a dry-run preview even when ``confirm`` is true.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with target metadata, dry-run preview, or POST result.
+        """
+        if not self._has_password_input(
+            password_name,
+            old_password_env,
+            old_password_file,
+            new_password_env,
+            new_password_file,
+        ):
+            return self._change_metadata(bool(do_async))
+
+        payload = self._payload(
+            password_name,
+            self._password_from_source("old", old_password_env, old_password_file),
+            self._password_from_source("new", new_password_env, new_password_file),
+        )
+        result = self.invoke_action(
+            self._bios_uri(bool(do_async)),
+            "ChangePassword",
+            payload=payload,
+            full_action_type=_CHANGE_PASSWORD_ACTION,
+            do_async=do_async,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        return self._redact_passwords(result)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -53,6 +53,7 @@ class ApiRequestType(Enum):
     BootOptions = auto()
     SystemConfigQuery = auto()
     IDracQuery = auto()
+    BiosChangePassword = auto()
 
     # firmware
     FirmwareQuery = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -30,6 +30,7 @@ def test_policy_classifies_known_and_unknown():
     for action in hpe_reversible_actions:
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
+    assert classify("#Bios.ChangePassword") is Destructiveness.DESTRUCTIVE
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)

--- a/tests/test_bios_change_password_dualmode.py
+++ b/tests/test_bios_change_password_dualmode.py
@@ -1,0 +1,252 @@
+"""Dual-mode-style coverage for the guarded BIOS ChangePassword command."""
+
+import copy
+
+import pytest
+
+from redfish_ctl.bios.cmd_bios_change_password import BiosChangePassword
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_bios_change_password_lists_target_without_mutating(
+    redfish_mock_factory,
+) -> None:
+    """No password sources lists the discovered BIOS ChangePassword target."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BiosChangePassword,
+        "bios_change_password",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "bios": "/redfish/v1/Systems/System_0/Bios",
+        "action": "#Bios.ChangePassword",
+        "target": "/redfish/v1/Systems/System_0/Bios/Actions/Bios.ChangePassword",
+    }
+    assert _post_requests(service) == []
+
+
+def test_bios_change_password_without_confirm_previews_and_redacts(
+    redfish_mock_factory,
+    monkeypatch,
+) -> None:
+    """Destructive password changes dry-run by default and mask payload secrets."""
+    manager, service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("OLD_BIOS_PASSWORD", "old-secret")
+    monkeypatch.setenv("NEW_BIOS_PASSWORD", "new-secret")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BiosChangePassword,
+        "bios_change_password",
+        password_name="Administrator",
+        old_password_env="OLD_BIOS_PASSWORD",
+        new_password_env="NEW_BIOS_PASSWORD",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["action"] == "#Bios.ChangePassword"
+    assert result.data["target"] == (
+        "/redfish/v1/Systems/System_0/Bios/Actions/Bios.ChangePassword"
+    )
+    assert result.data["payload"] == {
+        "PasswordName": "Administrator",
+        "OldPassword": "********",
+        "NewPassword": "********",
+    }
+    assert _post_requests(service) == []
+
+
+def test_bios_change_password_confirm_posts_discovered_hpe_target(
+    redfish_mock_factory,
+    tmp_path,
+) -> None:
+    """--confirm POSTs to the vendor-discovered HPE ChangePassword target."""
+    manager, service = redfish_mock_factory("hpe")
+    old_file = tmp_path / "old-password"
+    new_file = tmp_path / "new-password"
+    old_file.write_text("old-secret\n", encoding="utf-8")
+    new_file.write_text("new-secret\n", encoding="utf-8")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BiosChangePassword,
+        "bios_change_password",
+        password_name="Administrator",
+        old_password_file=str(old_file),
+        new_password_file=str(new_file),
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#Bios.ChangePassword"
+    assert result.data["target"] == (
+        "/redfish/v1/systems/1/bios/Actions/Bios.ChangePasswords/"
+    )
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == (
+        "/redfish/v1/systems/1/bios/actions/bios.changepasswords/"
+    )
+    assert posts[0].json() == {
+        "PasswordName": "Administrator",
+        "OldPassword": "old-secret",
+        "NewPassword": "new-secret",
+    }
+
+
+def test_bios_change_password_confirm_dry_run_still_does_not_post(
+    redfish_mock_factory,
+    monkeypatch,
+) -> None:
+    """--dry_run wins over --confirm so operators can preview safely."""
+    manager, service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("OLD_BIOS_PASSWORD", "old-secret")
+    monkeypatch.setenv("NEW_BIOS_PASSWORD", "new-secret")
+
+    result = manager.sync_invoke(
+        ApiRequestType.BiosChangePassword,
+        "bios_change_password",
+        password_name="User",
+        old_password_env="OLD_BIOS_PASSWORD",
+        new_password_env="NEW_BIOS_PASSWORD",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"]["OldPassword"] == "********"
+    assert result.data["payload"]["NewPassword"] == "********"
+    assert _post_requests(service) == []
+
+
+def test_bios_change_password_missing_action_reports_available_without_post(
+    redfish_mock_factory,
+    monkeypatch,
+) -> None:
+    """A BIOS resource without ChangePassword returns an error and never POSTs."""
+    manager, service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("OLD_BIOS_PASSWORD", "old-secret")
+    monkeypatch.setenv("NEW_BIOS_PASSWORD", "new-secret")
+    bios_path = "/redfish/v1/Systems/System_0/Bios"
+    bios = copy.deepcopy(service._state(bios_path))
+    bios["Actions"].pop("#Bios.ChangePassword")
+    service._overlay[bios_path] = bios
+    service._overlay[bios_path.lower()] = bios
+
+    result = manager.sync_invoke(
+        ApiRequestType.BiosChangePassword,
+        "bios_change_password",
+        password_name="Administrator",
+        old_password_env="OLD_BIOS_PASSWORD",
+        new_password_env="NEW_BIOS_PASSWORD",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#Bios.ChangePassword' not found on "
+        "/redfish/v1/Systems/System_0/Bios"
+    )
+    assert result.data["action"] == "#Bios.ChangePassword"
+    assert "ChangePassword" not in result.data["available"]
+    assert "#Bios.ChangePassword" not in result.data["available"]
+    assert _post_requests(service) == []
+
+
+def test_bios_change_password_requires_complete_secret_sources(
+    redfish_mock_factory,
+    monkeypatch,
+) -> None:
+    """Supplying any change input requires password name plus old and new sources."""
+    manager, service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("OLD_BIOS_PASSWORD", "old-secret")
+
+    with pytest.raises(
+        InvalidArgument,
+        match="new password source is required",
+    ):
+        manager.sync_invoke(
+            ApiRequestType.BiosChangePassword,
+            "bios_change_password",
+            password_name="Administrator",
+            old_password_env="OLD_BIOS_PASSWORD",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_bios_change_password_rejects_missing_password_env(
+    redfish_mock_factory,
+    monkeypatch,
+) -> None:
+    """Missing password environment variables fail before any POST."""
+    manager, service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("NEW_BIOS_PASSWORD", "new-secret")
+
+    with pytest.raises(
+        InvalidArgument,
+        match="old password environment variable 'MISSING_OLD_BIOS_PASSWORD'",
+    ):
+        manager.sync_invoke(
+            ApiRequestType.BiosChangePassword,
+            "bios_change_password",
+            password_name="Administrator",
+            old_password_env="MISSING_OLD_BIOS_PASSWORD",
+            new_password_env="NEW_BIOS_PASSWORD",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_bios_change_password_rejects_empty_password_name(
+    redfish_mock_factory,
+    monkeypatch,
+) -> None:
+    """PasswordName is explicit; no default is guessed for a lockout-sensitive action."""
+    manager, service = redfish_mock_factory("supermicro")
+    monkeypatch.setenv("OLD_BIOS_PASSWORD", "old-secret")
+    monkeypatch.setenv("NEW_BIOS_PASSWORD", "new-secret")
+
+    with pytest.raises(InvalidArgument, match="password name cannot be empty"):
+        manager.sync_invoke(
+            ApiRequestType.BiosChangePassword,
+            "bios_change_password",
+            password_name="  ",
+            old_password_env="OLD_BIOS_PASSWORD",
+            new_password_env="NEW_BIOS_PASSWORD",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_bios_change_password_exposes_cli_entrypoint() -> None:
+    """The bios-change-password command is wired into the package registry."""
+    registry = BiosChangePassword.get_registry()
+
+    assert registry[ApiRequestType.BiosChangePassword]["bios_change_password"] is (
+        BiosChangePassword
+    )
+    _, cmd_name, cmd_help = BiosChangePassword.register_subcommand(BiosChangePassword)
+    assert cmd_name == "bios-change-password"
+    assert "password" in cmd_help


### PR DESCRIPTION
## Summary
- add `bios-change-password` for the discovered `#Bios.ChangePassword` action
- require an explicit password name plus old and new password sources before a write
- preview by default, redact password payload values, and cover Supermicro/HPE fixture paths

## Validation
- `git diff --cached --check`
- GitHub Actions CI #630 passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14; the blocking offline tests and docstring gates completed successfully. The workflow's Ruff step is informational per `.github/workflows/ci.yml`.