### PR TITLE
Add HPE Kerberos keytab import command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -132,6 +132,7 @@ Safety labels:
 | `get` | Read an arbitrary Redfish resource URI. | Read |
 | `get_vm` | Read virtual media. | Read |
 | `gpu-metrics` | Read consolidated GPU temperature, compute, throttle, and memory metric rows. | Read |
+| `hpe-kerberos-keytab-import` | Import an HPE iLO Kerberos keytab through `AccountService`; keytab material is read from env/file, previews are redacted, and `--confirm` is required to write. | Guarded |
 | `hpe-test-actions` | List or send HPE iLO directory, SNMP, mail, and syslog test actions; dry-run by default and `--confirm` posts. | Guarded |
 | `identify-led` | Read or set a chassis/system identify LED; requires `--confirm` to write. | Guarded |
 | `insert_vm` | Insert virtual media from a URI. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -122,6 +122,7 @@ from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
+from .oem.cmd_hpe_kerberos_keytab import *
 from .oem.cmd_nvidia_debug_token import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -8,8 +8,8 @@ dry-run unless ``--confirm`` is given, or additionally needs an explicit
 
 Fail-safe by construction: an action not in the table is treated as DESTRUCTIVE,
 so a newly exposed (unclassified) action can never POST without an explicit
-confirm. This module is product-neutral — it names standard DMTF + NVIDIA OEM
-action types only and imports nothing from the Redfish manager layer.
+confirm. This module is product-neutral — it names standard DMTF plus known OEM
+action types and imports nothing from the Redfish manager layer.
 
 Author Mus spyroot@gmail.com
 """
@@ -70,6 +70,7 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#HpeiLOAccountService.ImportKerberosKeytab": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/oem/cmd_hpe_kerberos_keytab.py
+++ b/redfish_ctl/oem/cmd_hpe_kerberos_keytab.py
@@ -1,0 +1,264 @@
+"""Import an HPE iLO Kerberos keytab through AccountService.
+
+    redfish_ctl hpe-kerberos-keytab-import
+    redfish_ctl hpe-kerberos-keytab-import --keytab-file ./krb5.keytab --dry_run
+    redfish_ctl hpe-kerberos-keytab-import --keytab-base64-env HPE_KEYTAB_B64 --confirm
+
+The command discovers ``#HpeiLOAccountService.ImportKerberosKeytab`` from the
+AccountService resource. Keytab material is accepted only from an environment
+variable or file source, and returned previews redact the payload value.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import base64
+import os
+from abc import abstractmethod
+from binascii import Error as BinasciiError
+from pathlib import Path
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_IMPORT_KEYTAB_ACTION = "#HpeiLOAccountService.ImportKerberosKeytab"
+_KEYTAB_FIELD = "KerberosKeytab"
+
+
+class HpeKerberosKeytabImport(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.HpeKerberosKeytabImport,
+    name="hpe-kerberos-keytab-import",
+    metaclass=Singleton,
+):
+    """Import a Kerberos keytab into HPE iLO AccountService."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the hpe-kerberos-keytab-import command."""
+        super(HpeKerberosKeytabImport, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``hpe-kerberos-keytab-import`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        keytab_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        keytab_group.add_argument(
+            "--keytab-base64-env",
+            dest="keytab_base64_env",
+            default=None,
+            help="environment variable containing Base64-encoded keytab material",
+        )
+        keytab_group.add_argument(
+            "--keytab-file",
+            dest="keytab_file",
+            default=None,
+            help="keytab file to read and Base64-encode before import",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the HPE ImportKerberosKeytab POST; otherwise preview only",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show a redacted payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "hpe-kerberos-keytab-import",
+            "command import an HPE iLO Kerberos keytab",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body holding the link.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _account_service_uri(self, do_async):
+        """Resolve AccountService from the service root.
+
+        :param do_async: issue the root query over the async path when True.
+        :return: AccountService URI, with the standard path as fallback.
+        """
+        try:
+            root = self.base_query(RedfishApi.Version, do_async=do_async).data or {}
+        except Exception:
+            root = {}
+        return self._link(root, "AccountService") or f"{RedfishApi.Version}/AccountService"
+
+    def _metadata(self, do_async):
+        """Return the discovered HPE keytab import target metadata.
+
+        :param do_async: issue the AccountService query asynchronously when True.
+        :return: CommandResult with target metadata or a discovery error.
+        """
+        uri = self._account_service_uri(do_async)
+        try:
+            service = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+
+        actions = self.discover_redfish_actions(self, service)
+        target = self._flatten_action_targets(service).get(_IMPORT_KEYTAB_ACTION)
+        if target is None:
+            available = sorted(set(
+                list(actions.keys())
+                + list(self._flatten_action_targets(service).keys())
+            ))
+            return CommandResult(
+                {
+                    "account_service": uri,
+                    "action": _IMPORT_KEYTAB_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_IMPORT_KEYTAB_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "account_service": uri,
+                "action": _IMPORT_KEYTAB_ACTION,
+                "target": target,
+                "payload_field": _KEYTAB_FIELD,
+            },
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _normalize_base64(value, source):
+        """Validate and normalize Base64 keytab text.
+
+        :param value: Base64 text to validate.
+        :param source: human-readable source label for error messages.
+        :return: compact Base64 text.
+        :raises InvalidArgument: when the value is empty or invalid Base64.
+        """
+        normalized = "".join(str(value or "").split())
+        if not normalized:
+            raise InvalidArgument(f"{source} cannot be empty")
+        try:
+            base64.b64decode(normalized.encode("ascii"), validate=True)
+        except (BinasciiError, ValueError, UnicodeEncodeError) as exc:
+            raise InvalidArgument(f"{source} must contain Base64-encoded keytab data") from exc
+        return normalized
+
+    @classmethod
+    def _keytab_from_source(cls, keytab_base64_env=None, keytab_file=None):
+        """Read keytab material from one source and return Base64 text.
+
+        :param keytab_base64_env: env var containing Base64-encoded keytab data.
+        :param keytab_file: file containing raw keytab bytes.
+        :return: Base64-encoded keytab text.
+        :raises InvalidArgument: when no source is supplied or a source is invalid.
+        """
+        if keytab_base64_env and keytab_file:
+            raise InvalidArgument(
+                "use only one of --keytab-base64-env or --keytab-file"
+            )
+        if keytab_base64_env is not None:
+            env_name = keytab_base64_env.strip()
+            if not env_name:
+                raise InvalidArgument("keytab environment variable name cannot be empty")
+            if env_name not in os.environ:
+                raise InvalidArgument(f"keytab environment variable '{env_name}' is not set")
+            return cls._normalize_base64(
+                os.environ[env_name],
+                f"environment variable '{env_name}'",
+            )
+        if keytab_file is not None:
+            path = Path(keytab_file).expanduser()
+            try:
+                raw = path.read_bytes()
+            except OSError as exc:
+                raise InvalidArgument(f"failed to read keytab file '{path}': {exc}") from exc
+            if not raw:
+                raise InvalidArgument(f"keytab file '{path}' cannot be empty")
+            return base64.b64encode(raw).decode("ascii")
+        raise InvalidArgument("one of --keytab-base64-env or --keytab-file is required")
+
+    @staticmethod
+    def _redact_keytab(result):
+        """Mask KerberosKeytab in dry-run payloads before returning.
+
+        :param result: CommandResult returned by ``invoke_action``.
+        :return: CommandResult with any keytab payload value masked.
+        """
+        if not isinstance(result.data, dict):
+            return result
+        payload = result.data.get("payload")
+        if isinstance(payload, dict) and _KEYTAB_FIELD in payload:
+            payload = dict(payload)
+            payload[_KEYTAB_FIELD] = "********"
+            result.data["payload"] = payload
+        return result
+
+    def execute(
+        self,
+        keytab_base64_env: Optional[str] = None,
+        keytab_file: Optional[str] = None,
+        confirm: Optional[bool] = False,
+        dry_run: Optional[bool] = False,
+        filename: Optional[str] = None,
+        data_type: Optional[str] = "json",
+        verbose: Optional[bool] = False,
+        do_async: Optional[bool] = False,
+        **kwargs,
+    ) -> CommandResult:
+        """List the import target, or import a Kerberos keytab.
+
+        With no keytab source the command lists the discovered target without
+        mutating. With a source it resolves the HPE import action and uses the
+        shared action guard, so the POST fires only with ``--confirm``.
+
+        :param keytab_base64_env: env var containing Base64-encoded keytab data.
+        :param keytab_file: raw keytab file to read and Base64-encode.
+        :param confirm: authorize the POST to fire.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying reads/POST over the async path when True.
+        :return: CommandResult with target metadata, preview, execution result, or error.
+        """
+        if keytab_base64_env is None and keytab_file is None:
+            return self._metadata(do_async)
+
+        result = self.invoke_action(
+            self._account_service_uri(do_async),
+            "ImportKerberosKeytab",
+            payload={
+                _KEYTAB_FIELD: self._keytab_from_source(
+                    keytab_base64_env=keytab_base64_env,
+                    keytab_file=keytab_file,
+                )
+            },
+            full_action_type=_IMPORT_KEYTAB_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        return self._redact_keytab(result)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -112,6 +112,7 @@ class ApiRequestType(Enum):
     ActionList = auto()
     EventSubmitTest = auto()
     HpeTestActions = auto()
+    HpeKerberosKeytabImport = auto()
     NvidiaDebugToken = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -31,6 +31,7 @@ def test_policy_classifies_known_and_unknown():
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
+    assert classify("#HpeiLOAccountService.ImportKerberosKeytab") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE

--- a/tests/test_hpe_kerberos_keytab_dualmode.py
+++ b/tests/test_hpe_kerberos_keytab_dualmode.py
@@ -1,0 +1,237 @@
+"""Dual-mode tests for HPE iLO Kerberos keytab import."""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.oem.cmd_hpe_kerberos_keytab import HpeKerberosKeytabImport
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HPE_CORPUS = corpus_dir(REPO_ROOT / "tests" / "hpe_dl360_corpus.tar.gz", "10.43.3.209")
+ACCOUNT_SERVICE = "/redfish/v1/AccountService"
+IMPORT_ACTION = "#HpeiLOAccountService.ImportKerberosKeytab"
+IMPORT_TARGET = (
+    "/redfish/v1/AccountService/Actions/Oem/Hpe/"
+    "HpeiLOAccountService.ImportKerberosKeytab"
+)
+
+
+@pytest.fixture
+def hpe_keytab_mock():
+    """Return a manager and mock service backed by the full HPE DL360 corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-hpe-keytab",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_hpe_keytab_import_lists_target_without_post(hpe_keytab_mock):
+    """With no keytab source, the command lists the target and never POSTs."""
+    manager, service = hpe_keytab_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeKerberosKeytabImport,
+        "hpe-kerberos-keytab-import",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "account_service": ACCOUNT_SERVICE,
+        "action": IMPORT_ACTION,
+        "target": IMPORT_TARGET,
+        "payload_field": "KerberosKeytab",
+    }
+    assert _post_requests(service) == []
+
+
+def test_hpe_keytab_import_file_preview_redacts_payload(
+    hpe_keytab_mock,
+    tmp_path,
+):
+    """A keytab file previews a redacted destructive payload by default."""
+    manager, service = hpe_keytab_mock
+    keytab = tmp_path / "krb5.keytab"
+    keytab.write_bytes(b"\x05\x02placeholder-keytab")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeKerberosKeytabImport,
+        "hpe-kerberos-keytab-import",
+        keytab_file=str(keytab),
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == IMPORT_ACTION
+    assert result.data["target"] == IMPORT_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {"KerberosKeytab": "********"}
+    assert "placeholder-keytab" not in str(result.data)
+    assert _post_requests(service) == []
+
+
+def test_hpe_keytab_import_confirm_posts_encoded_file(
+    hpe_keytab_mock,
+    tmp_path,
+):
+    """--confirm POSTs the Base64-encoded keytab payload to the discovered target."""
+    manager, service = hpe_keytab_mock
+    raw_keytab = b"\x05\x02placeholder-keytab"
+    keytab = tmp_path / "krb5.keytab"
+    keytab.write_bytes(raw_keytab)
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeKerberosKeytabImport,
+        "hpe-kerberos-keytab-import",
+        keytab_file=str(keytab),
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == IMPORT_ACTION
+    assert result.data["target"] == IMPORT_TARGET
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == IMPORT_TARGET.lower()
+    assert posts[0].json() == {
+        "KerberosKeytab": base64.b64encode(raw_keytab).decode("ascii")
+    }
+
+
+def test_hpe_keytab_import_env_preview_redacts_payload(
+    hpe_keytab_mock,
+    monkeypatch,
+):
+    """Base64 keytab text can come from env without echoing the value."""
+    manager, service = hpe_keytab_mock
+    encoded = base64.b64encode(b"env-keytab").decode("ascii")
+    monkeypatch.setenv("HPE_KEYTAB_B64", encoded)
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeKerberosKeytabImport,
+        "hpe-kerberos-keytab-import",
+        keytab_base64_env="HPE_KEYTAB_B64",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["payload"] == {"KerberosKeytab": "********"}
+    assert encoded not in str(result.data)
+    assert _post_requests(service) == []
+
+
+def test_hpe_keytab_import_rejects_missing_env(hpe_keytab_mock):
+    """Missing env source fails before any POST."""
+    manager, service = hpe_keytab_mock
+
+    with pytest.raises(InvalidArgument, match="MISSING_HPE_KEYTAB"):
+        manager.sync_invoke(
+            ApiRequestType.HpeKerberosKeytabImport,
+            "hpe-kerberos-keytab-import",
+            keytab_base64_env="MISSING_HPE_KEYTAB",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_hpe_keytab_import_rejects_invalid_base64_env(
+    hpe_keytab_mock,
+    monkeypatch,
+):
+    """The env path validates that its value is Base64 text."""
+    manager, service = hpe_keytab_mock
+    monkeypatch.setenv("HPE_KEYTAB_B64", "not base64")
+
+    with pytest.raises(InvalidArgument, match="Base64-encoded keytab"):
+        manager.sync_invoke(
+            ApiRequestType.HpeKerberosKeytabImport,
+            "hpe-kerberos-keytab-import",
+            keytab_base64_env="HPE_KEYTAB_B64",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_hpe_keytab_import_missing_target_reports_without_post(
+    redfish_mock_factory,
+    tmp_path,
+):
+    """A non-HPE fixture reports the missing action and does not POST."""
+    manager, service = redfish_mock_factory("generic")
+    keytab = tmp_path / "krb5.keytab"
+    keytab.write_bytes(b"\x05\x02placeholder-keytab")
+
+    result = manager.sync_invoke(
+        ApiRequestType.HpeKerberosKeytabImport,
+        "hpe-kerberos-keytab-import",
+        keytab_file=str(keytab),
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#HpeiLOAccountService.ImportKerberosKeytab' not found on "
+        "/redfish/v1/AccountService"
+    )
+    assert result.data["action"] == IMPORT_ACTION
+    assert _post_requests(service) == []
+
+
+def test_hpe_keytab_import_exposes_cli_entrypoint():
+    """The HPE Kerberos keytab command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.HpeKerberosKeytabImport][
+        "hpe-kerberos-keytab-import"
+    ] is HpeKerberosKeytabImport
+
+    cmd_parser, cmd_name, cmd_help = HpeKerberosKeytabImport.register_subcommand(
+        HpeKerberosKeytabImport
+    )
+
+    help_text = cmd_parser.format_help()
+    assert "--keytab-base64-env" in help_text
+    assert "--keytab-file" in help_text
+    assert cmd_name == "hpe-kerberos-keytab-import"
+    assert "Kerberos" in cmd_help


### PR DESCRIPTION
## Summary
- add a guarded HPE iLO Kerberos keytab import command that discovers the AccountService action target
- read keytab material from an env var or file, Base64-encode file input, and redact previews
- classify the action as destructive and add HPE corpus-backed coverage plus command docs

## Validation
- git diff --check
- git diff --cached --check