### PR TITLE
Add Dell LC SupportAssist status command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-lc-supportassist-status` | Read Dell LC SupportAssist EULA and auto-collect schedule status actions. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_supportassist_status import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -42,6 +42,8 @@ ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DellLCService.SupportAssistGetAutoCollectSchedule": Destructiveness.READ_ONLY,
+    "#DellLCService.SupportAssistGetEULAStatus": Destructiveness.READ_ONLY,
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_status.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_status.py
@@ -1,0 +1,248 @@
+"""Read Dell LC SupportAssist status values exposed as Redfish actions.
+
+    redfish_ctl dell-lc-supportassist-status
+    redfish_ctl dell-lc-supportassist-status --action eula-status
+    redfish_ctl dell-lc-supportassist-status --action auto-collect-schedule --dry_run
+
+The command discovers DellLCService through Manager OEM links and invokes only
+the no-payload status actions listed below. It does not configure
+SupportAssist, accept an EULA, upload collections, export reports, or touch any
+network share.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+
+@dataclass(frozen=True)
+class _SupportAssistStatusSpec:
+    """Static selector metadata for one Dell LC SupportAssist status action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_ACTION_SPECS = {
+    "auto-collect-schedule": _SupportAssistStatusSpec(
+        selector="auto-collect-schedule",
+        full_type="#DellLCService.SupportAssistGetAutoCollectSchedule",
+        action_name="SupportAssistGetAutoCollectSchedule",
+        description="read the configured SupportAssist auto-collect schedule",
+    ),
+    "eula-status": _SupportAssistStatusSpec(
+        selector="eula-status",
+        full_type="#DellLCService.SupportAssistGetEULAStatus",
+        action_name="SupportAssistGetEULAStatus",
+        description="read the SupportAssist EULA acceptance status",
+    ),
+}
+
+
+class DellLcSupportAssistStatus(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellLcSupportAssistStatus,
+    name="dell-lc-supportassist-status",
+    metaclass=Singleton,
+):
+    """Discover and invoke Dell LC SupportAssist status actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-supportassist-status command."""
+        super(DellLcSupportAssistStatus, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-supportassist-status`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="SupportAssist status action to invoke; omit to list targets",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when more than one target is found",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-supportassist-status",
+            "command read Dell LC SupportAssist status actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(data):
+        """Return the ``Links.Oem.Dell`` block from a Manager resource.
+
+        :param data: Redfish Manager resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = data.get("Links") if isinstance(data, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _dell_lc_service_uris(self, do_async):
+        """Return DellLCService URIs discovered from Manager OEM links.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of DellLCService resource URIs.
+        """
+        uris = []
+        for manager_uri in self.discover_manager_ids() or []:
+            manager = self._get(manager_uri, do_async)
+            dell = self._dell_oem_links(manager)
+            service_uri = self._link(dell, "DellLCService")
+            if not service_uri:
+                service_uri = f"{manager_uri.rstrip('/')}/Oem/Dell/DellLCService"
+            if service_uri not in uris:
+                uris.append(service_uri)
+        return uris
+
+    def _target_for(self, resource_uri, spec, do_async):
+        """Return the advertised target URI for a SupportAssist status action.
+
+        :param resource_uri: DellLCService resource URI.
+        :param spec: SupportAssist status selector metadata.
+        :param do_async: run the query asynchronously when True.
+        :return: action target URI, or None when the resource lacks the action.
+        """
+        resource = self._get(resource_uri, do_async)
+        targets = self._flatten_action_targets(resource)
+        return targets.get(spec.full_type)
+
+    def _discover_rows(self, do_async):
+        """Discover available Dell LC SupportAssist status actions.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of available status-action rows.
+        """
+        rows = []
+        for spec in _ACTION_SPECS.values():
+            for resource_uri in self._dell_lc_service_uris(do_async):
+                target = self._target_for(resource_uri, spec, do_async)
+                if target:
+                    rows.append({
+                        "Action": spec.selector,
+                        "FullType": spec.full_type,
+                        "Resource": resource_uri,
+                        "Target": target,
+                        "Description": spec.description,
+                    })
+        return rows
+
+    @staticmethod
+    def _matches(rows, action, resource_uri):
+        """Filter discovered rows by action selector and optional resource URI.
+
+        :param rows: discovered status-action rows.
+        :param action: selected action name.
+        :param resource_uri: optional DellLCService URI selector.
+        :return: matching rows.
+        """
+        matches = [row for row in rows if row["Action"] == action]
+        if resource_uri:
+            normalized = resource_uri.rstrip("/")
+            matches = [
+                row for row in matches
+                if row["Resource"].rstrip("/") == normalized
+            ]
+        return matches
+
+    def execute(self,
+                action: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke Dell LC SupportAssist status actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param resource_uri: optional DellLCService URI to disambiguate targets.
+        :param dry_run: force preview mode without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if action is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = self._matches(rows, action, resource_uri)
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"Dell LC SupportAssist status action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                "multiple Dell LC SupportAssist targets found; pass --resource-uri",
+            )
+
+        row = matches[0]
+        spec = _ACTION_SPECS[action]
+        return self.invoke_action(
+            row["Resource"],
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            dry_run=bool(dry_run),
+            confirm=True,
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -41,6 +41,7 @@ class ApiRequestType(Enum):
 
     RemoteServicesRssAPIStatus = auto()
     RemoteServicesAPIStatus = auto()
+    DellLcSupportAssistStatus = auto()
     TasksList = auto()
 
     ChangeBootOrder = auto()

--- a/tests/test_dell_lc_supportassist_status_dualmode.py
+++ b/tests/test_dell_lc_supportassist_status_dualmode.py
@@ -1,0 +1,187 @@
+"""Dual-mode-style tests for Dell LC SupportAssist status actions."""
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_supportassist_status import (
+    DellLcSupportAssistStatus,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+DELL_LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+EULA_TARGET = (
+    f"{DELL_LC_SERVICE}/Actions/DellLCService.SupportAssistGetEULAStatus"
+)
+SCHEDULE_TARGET = (
+    f"{DELL_LC_SERVICE}/Actions/"
+    "DellLCService.SupportAssistGetAutoCollectSchedule"
+)
+
+
+@pytest.fixture
+def dell_lc_corpus_mock():
+    """Return a manager and mock service backed by the full Dell corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-lc-supportassist",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_supportassist_status_policy_is_read_only():
+    """The two Dell LC status actions are classified as read-only POSTs."""
+    assert (
+        classify("#DellLCService.SupportAssistGetEULAStatus")
+        is Destructiveness.READ_ONLY
+    )
+    assert (
+        classify("#DellLCService.SupportAssistGetAutoCollectSchedule")
+        is Destructiveness.READ_ONLY
+    )
+
+
+def test_dell_lc_supportassist_status_lists_targets_without_post(
+    dell_lc_corpus_mock,
+):
+    """Listing discovers the status actions and never POSTs."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistStatus,
+        "dell-lc-supportassist-status",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    actions = {row["Action"]: row for row in result.data}
+    assert set(actions) == {"auto-collect-schedule", "eula-status"}
+    assert actions["auto-collect-schedule"]["Target"] == SCHEDULE_TARGET
+    assert actions["eula-status"]["Target"] == EULA_TARGET
+    assert actions["eula-status"]["Resource"] == DELL_LC_SERVICE
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_supportassist_status_posts_selected_target(
+    dell_lc_corpus_mock,
+):
+    """A selected status action POSTs an empty payload to the discovered target."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistStatus,
+        "dell-lc-supportassist-status",
+        action="eula-status",
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellLCService.SupportAssistGetEULAStatus"
+    assert result.data["target"] == EULA_TARGET
+    assert result.data["level"] == "read_only"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == EULA_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_lc_supportassist_status_dry_run_does_not_post(
+    dell_lc_corpus_mock,
+):
+    """--dry_run resolves the status action target without sending a POST."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistStatus,
+        "dell-lc-supportassist-status",
+        action="auto-collect-schedule",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == (
+        "#DellLCService.SupportAssistGetAutoCollectSchedule"
+    )
+    assert result.data["target"] == SCHEDULE_TARGET
+    assert result.data["level"] == "read_only"
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {}
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_supportassist_status_missing_target_reports_without_post(
+    redfish_mock_factory,
+):
+    """A non-Dell fixture reports no SupportAssist status target and no POST."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistStatus,
+        "dell-lc-supportassist-status",
+        action="eula-status",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "Dell LC SupportAssist status action not found: eula-status"
+    )
+    assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_supportassist_status_exposes_cli_entrypoint():
+    """The command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellLcSupportAssistStatus][
+            "dell-lc-supportassist-status"
+        ]
+        is DellLcSupportAssistStatus
+    )
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellLcSupportAssistStatus.register_subcommand(DellLcSupportAssistStatus)
+    )
+
+    assert "--action" in cmd_parser.format_help()
+    assert cmd_name == "dell-lc-supportassist-status"
+    assert "SupportAssist" in cmd_help


### PR DESCRIPTION
## Summary
- Add `dell-lc-supportassist-status` to discover DellLCService and read SupportAssist EULA and auto-collect schedule status actions.
- Mark the two status actions as read-only and wire command registration.
- Add Dell corpus-backed coverage for listing, dry-run, POST target selection, missing targets, and registry wiring.

## Validation
- `git diff --cached --check` before commit
- GitHub Actions matrix will run on this PR