### PR TITLE
Add Dell software update query command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-software-update-queries` | Run DellSoftwareInstallationService read-only update schedule and repository-list query actions. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -137,6 +137,7 @@ from .delloem.delloem_disconnect import *
 from .delloem.delloem_get_networkios import *
 from .delloem.delloem_boot_netios import *
 from .delloem.delloem_os_deployment import *
+from .delloem.cmd_dell_software_update_queries import *
 
 
 # tasks

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -42,6 +42,8 @@ ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DellSoftwareInstallationService.GetRepoBasedUpdateList": Destructiveness.READ_ONLY,
+    "#DellSoftwareInstallationService.GetUpdateSchedule": Destructiveness.READ_ONLY,
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/delloem/cmd_dell_software_update_queries.py
+++ b/redfish_ctl/delloem/cmd_dell_software_update_queries.py
@@ -1,0 +1,235 @@
+"""Run Dell SoftwareInstallationService read-only query actions.
+
+    redfish_ctl dell-software-update-queries
+    redfish_ctl dell-software-update-queries --query schedule
+    redfish_ctl dell-software-update-queries --query repo-list --dry_run
+
+Dell carries these query operations over Redfish Actions, so the command
+discovers the target from ``DellSoftwareInstallationService`` and POSTs only the
+read-only query actions named here. Omitting ``--query`` lists available targets
+without POSTing.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SERVICE_FALLBACK = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/"
+    "DellSoftwareInstallationService"
+)
+
+
+@dataclass(frozen=True)
+class _DellSoftwareQuerySpec:
+    """Selector metadata for one Dell software-installation query action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_QUERY_SPECS = {
+    "repo-list": _DellSoftwareQuerySpec(
+        selector="repo-list",
+        full_type="#DellSoftwareInstallationService.GetRepoBasedUpdateList",
+        action_name="GetRepoBasedUpdateList",
+        description="get repository-based update list state",
+    ),
+    "schedule": _DellSoftwareQuerySpec(
+        selector="schedule",
+        full_type="#DellSoftwareInstallationService.GetUpdateSchedule",
+        action_name="GetUpdateSchedule",
+        description="get the configured update schedule",
+    ),
+}
+
+
+class DellSoftwareUpdateQueries(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellSoftwareUpdateQueries,
+    name="dell-software-update-queries",
+    metaclass=Singleton,
+):
+    """Discover and run Dell software-installation read-only query actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-software-update-queries command."""
+        super(DellSoftwareUpdateQueries, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-software-update-queries`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--query",
+            choices=sorted(_QUERY_SPECS),
+            default=None,
+            help="query action to run; omit to list available targets",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-software-update-queries",
+            "command run Dell software installation query actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell(data):
+        """Return the ``Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, treating optional misses as absent.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _system_uris(self, do_async):
+        """Return ComputerSystem member URIs.
+
+        :param do_async: run the query asynchronously when True.
+        :return: list of system resource URIs.
+        """
+        root = self._get(RedfishApi.Version, do_async)
+        systems_uri = self._link(root, "Systems") or f"{RedfishApi.Version}/Systems"
+        systems = self._get(systems_uri, do_async)
+        members = systems.get("Members") if isinstance(systems, dict) else []
+        return [
+            member["@odata.id"]
+            for member in members
+            if isinstance(member, dict) and isinstance(member.get("@odata.id"), str)
+        ]
+
+    def _service_uris(self, do_async):
+        """Discover DellSoftwareInstallationService resource URIs.
+
+        :param do_async: run the query asynchronously when True.
+        :return: ordered list of discovered service URIs.
+        """
+        uris = []
+        for system_uri in self._system_uris(do_async):
+            system = self._get(system_uri, do_async)
+            service_uri = self._link(
+                self._dell(system),
+                "DellSoftwareInstallationService",
+            )
+            if service_uri and service_uri not in uris:
+                uris.append(service_uri)
+        if not uris:
+            uris.append(_SERVICE_FALLBACK)
+        return uris
+
+    def _discover_rows(self, do_async):
+        """Discover available Dell software update query actions.
+
+        :param do_async: run underlying GETs asynchronously when True.
+        :return: list of available query-action rows.
+        """
+        rows = []
+        for service_uri in self._service_uris(do_async):
+            service = self._get(service_uri, do_async)
+            targets = self._flatten_action_targets(service)
+            for spec in _QUERY_SPECS.values():
+                target = targets.get(spec.full_type)
+                if target:
+                    rows.append({
+                        "Query": spec.selector,
+                        "FullType": spec.full_type,
+                        "Resource": service_uri,
+                        "Target": target,
+                        "Description": spec.description,
+                    })
+        return rows
+
+    def execute(self,
+                query: Optional[str] = None,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or run Dell software-installation query actions.
+
+        :param query: selector from ``_QUERY_SPECS``; omit to list targets.
+        :param dry_run: resolve the target and payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if query is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = [row for row in rows if row["Query"] == query]
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"Dell software update query not found: {query}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                f"multiple Dell software update query targets found: {query}",
+            )
+
+        spec = _QUERY_SPECS[query]
+        return self.invoke_action(
+            matches[0]["Resource"],
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=False,
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -59,6 +59,7 @@ class ApiRequestType(Enum):
     FirmwareInventoryQuery = auto()
     UpdateServiceQuery = auto()
     UpdateStart = auto()
+    DellSoftwareUpdateQueries = auto()
     PciDeviceQuery = auto()
     SystemQuery = auto()
     VirtualDiskQuery = auto()

--- a/tests/test_dell_software_update_queries_dualmode.py
+++ b/tests/test_dell_software_update_queries_dualmode.py
@@ -1,0 +1,175 @@
+"""Dual-mode-style coverage for Dell software-installation query actions."""
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.delloem.cmd_dell_software_update_queries import (
+    DellSoftwareUpdateQueries,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+SOFTWARE_SERVICE = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/"
+    "DellSoftwareInstallationService"
+)
+SCHEDULE_TARGET = (
+    f"{SOFTWARE_SERVICE}/Actions/"
+    "DellSoftwareInstallationService.GetUpdateSchedule"
+)
+REPO_LIST_TARGET = (
+    f"{SOFTWARE_SERVICE}/Actions/"
+    "DellSoftwareInstallationService.GetRepoBasedUpdateList"
+)
+
+
+@pytest.fixture
+def dell_software_manager():
+    """Serve the committed Dell XR8620t corpus over requests-mock.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-software",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_dell_software_update_queries_list_targets_without_post(
+    dell_software_manager,
+):
+    """Listing discovers Dell software update query actions without POSTing."""
+    manager, service = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateQueries,
+        "dell-software-update-queries",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    queries = {row["Query"]: row for row in result.data}
+    assert set(queries) == {"repo-list", "schedule"}
+    assert queries["schedule"]["Resource"] == SOFTWARE_SERVICE
+    assert queries["schedule"]["Target"] == SCHEDULE_TARGET
+    assert queries["repo-list"]["Target"] == REPO_LIST_TARGET
+    assert _post_requests(service) == []
+
+
+def test_dell_software_update_query_dry_run_resolves_target_without_post(
+    dell_software_manager,
+):
+    """--dry_run resolves the selected read-only action without POSTing."""
+    manager, service = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateQueries,
+        "dell-software-update-queries",
+        query="repo-list",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == (
+        "#DellSoftwareInstallationService.GetRepoBasedUpdateList"
+    )
+    assert result.data["target"] == REPO_LIST_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "read_only"
+    assert result.data["blocked"] is None
+    assert _post_requests(service) == []
+
+
+def test_dell_software_update_query_posts_read_only_action_by_default(
+    dell_software_manager,
+):
+    """Read-only Dell software query actions do not require a confirm flag."""
+    manager, service = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateQueries,
+        "dell-software-update-queries",
+        query="schedule",
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == (
+        "#DellSoftwareInstallationService.GetUpdateSchedule"
+    )
+    assert result.data["target"] == SCHEDULE_TARGET
+    assert result.data["level"] == "read_only"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SCHEDULE_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_software_update_query_missing_target_reports_without_post(
+    redfish_mock_factory,
+):
+    """A non-Dell fixture reports the missing query action and sends no POST."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateQueries,
+        "dell-software-update-queries",
+        query="schedule",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell software update query not found: schedule"
+    assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_dell_software_update_queries_exposes_cli_entrypoint():
+    """The command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellSoftwareUpdateQueries][
+        "dell-software-update-queries"
+    ] is DellSoftwareUpdateQueries
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellSoftwareUpdateQueries.register_subcommand(DellSoftwareUpdateQueries)
+    )
+
+    assert "--query" in cmd_parser.format_help()
+    assert "--dry_run" in cmd_parser.format_help()
+    assert cmd_name == "dell-software-update-queries"
+    assert "Dell" in cmd_help


### PR DESCRIPTION
## Summary
- add dell-software-update-queries for DellSoftwareInstallationService GetUpdateSchedule and GetRepoBasedUpdateList
- classify those POST-carried query actions as read-only and list discovered targets by default
- cover Dell XR8620t corpus discovery, dry-run, POST, missing-target, and registry wiring

## Validation
- git diff --cached --check
- Not run locally: pytest and ruff; project gates run in CI or remote execution environments.