### PR TITLE
Add Dell RAID query actions

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-raid-queries` | Run read-only DellRaidService query actions for available disks, dedicated hot spares, and RAID levels. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -18,6 +18,7 @@ from .compute.cmd_compute_setting import *
 
 from .redfish_manager_shared import *
 from .raid.cmd_raid_service import *
+from .raid.cmd_dell_raid_queries import *
 #
 # bios commands
 from .bios.cmd_bios import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -8,8 +8,8 @@ dry-run unless ``--confirm`` is given, or additionally needs an explicit
 
 Fail-safe by construction: an action not in the table is treated as DESTRUCTIVE,
 so a newly exposed (unclassified) action can never POST without an explicit
-confirm. This module is product-neutral — it names standard DMTF + NVIDIA OEM
-action types only and imports nothing from the Redfish manager layer.
+confirm. This module is product-neutral — it names standard DMTF and vetted
+OEM action types, and imports nothing from the Redfish manager layer.
 
 Author Mus spyroot@gmail.com
 """
@@ -35,13 +35,15 @@ class Destructiveness(Enum):
     IRREVERSIBLE = "irreversible"
 
 
-# Keyed by the full Redfish action type "#Type.Action" (as discover_redfish_actions
-# reports it in RedfishAction.full_redfish_name). Covers the 25 action types the
-# GB300 NVL exposes plus a couple of standard siblings.
+# Keyed by the full Redfish action type "#Type.Action" as discover_redfish_actions
+# reports it in RedfishAction.full_redfish_name.
 ACTION_POLICY = {
-    # read-only: a signed-measurement fetch carried over POST
+    # read-only: queries carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DellRaidService.GetAvailableDisks": Destructiveness.READ_ONLY,
+    "#DellRaidService.GetDHSDisks": Destructiveness.READ_ONLY,
+    "#DellRaidService.GetRAIDLevels": Destructiveness.READ_ONLY,
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/raid/cmd_dell_raid_queries.py
+++ b/redfish_ctl/raid/cmd_dell_raid_queries.py
@@ -1,0 +1,384 @@
+"""Run read-only DellRaidService query actions.
+
+    redfish_ctl dell-raid-queries
+    redfish_ctl dell-raid-queries --query raid-levels
+    redfish_ctl dell-raid-queries --query available-disks --disk-type SSD
+
+Dell exposes some inventory-style RAID lookups as Redfish actions on
+``DellRaidService``. These POST actions return information instead of changing
+storage state, so this command only wires the captured query actions and leaves
+mutating RAID operations to their own guarded commands.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, RedfishApiRespond, Singleton
+from ..redfish_shared import RedfishApi
+
+
+@dataclass(frozen=True)
+class _DellRaidQuerySpec:
+    """Static selector metadata for one DellRaidService query action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+    payload_keys: tuple[str, ...]
+
+
+_COMMON_FILTERS = (
+    "BlockSizeInBytes",
+    "DiskEncrypt",
+    "DiskType",
+    "Diskprotocol",
+    "FormFactor",
+    "T10PIStatus",
+)
+
+_QUERY_SPECS = {
+    "available-disks": _DellRaidQuerySpec(
+        selector="available-disks",
+        full_type="#DellRaidService.GetAvailableDisks",
+        action_name="GetAvailableDisks",
+        description="return disks matching RAID capability filters",
+        payload_keys=_COMMON_FILTERS + ("RaidLevel",),
+    ),
+    "dhs-disks": _DellRaidQuerySpec(
+        selector="dhs-disks",
+        full_type="#DellRaidService.GetDHSDisks",
+        action_name="GetDHSDisks",
+        description="return Dell dedicated-hot-spare disk candidates",
+        payload_keys=(),
+    ),
+    "raid-levels": _DellRaidQuerySpec(
+        selector="raid-levels",
+        full_type="#DellRaidService.GetRAIDLevels",
+        action_name="GetRAIDLevels",
+        description="return RAID levels matching disk capability filters",
+        payload_keys=_COMMON_FILTERS,
+    ),
+}
+
+_CLI_PAYLOAD_KEYS = {
+    "block_size": "BlockSizeInBytes",
+    "disk_encrypt": "DiskEncrypt",
+    "disk_type": "DiskType",
+    "disk_protocol": "Diskprotocol",
+    "form_factor": "FormFactor",
+    "raid_level": "RaidLevel",
+    "t10_pi_status": "T10PIStatus",
+}
+
+
+class DellRaidQueries(RedfishManagerBase,
+                      scm_type=ApiRequestType.DellRaidQueries,
+                      name="dell-raid-queries",
+                      metaclass=Singleton):
+    """Discover and invoke read-only DellRaidService query actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-raid-queries command."""
+        super(DellRaidQueries, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-raid-queries`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--query",
+            choices=sorted(_QUERY_SPECS),
+            default=None,
+            help="Dell RAID query action to run; omit to list available targets",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        cmd_parser.add_argument("--block-size", dest="block_size", default=None)
+        cmd_parser.add_argument("--disk-encrypt", dest="disk_encrypt", default=None)
+        cmd_parser.add_argument("--disk-type", dest="disk_type", default=None)
+        cmd_parser.add_argument("--disk-protocol", dest="disk_protocol", default=None)
+        cmd_parser.add_argument("--form-factor", dest="form_factor", default=None)
+        cmd_parser.add_argument("--raid-level", dest="raid_level", default=None)
+        cmd_parser.add_argument("--t10-pi-status", dest="t10_pi_status", default=None)
+        return (
+            cmd_parser,
+            "dell-raid-queries",
+            "command run read-only Dell RAID service query actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_links(resource):
+        """Return the ``Links.Oem.Dell`` block from a resource.
+
+        :param resource: Redfish resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = resource.get("Links") if isinstance(resource, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _system_uri(self):
+        """Return the selected ComputerSystem URI.
+
+        :return: discovered ComputerSystem URI.
+        """
+        return self.idrac_manage_servers
+
+    def _raid_service_uri(self, do_async):
+        """Resolve the DellRaidService URI from the ComputerSystem OEM links.
+
+        :param do_async: run the system query asynchronously when True.
+        :return: DellRaidService URI.
+        """
+        system_uri = self._system_uri()
+        system = self._get(system_uri, do_async)
+        dell_links = self._dell_links(system)
+        linked = self._link(dell_links, "DellRaidService")
+        if linked:
+            return linked
+        system_id = system_uri.rstrip("/").rsplit("/", 1)[-1]
+        return f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellRaidService"
+
+    @staticmethod
+    def _allowable(action, key):
+        """Return sorted allowable values advertised for one action parameter.
+
+        :param action: discovered RedfishAction.
+        :param key: action payload key.
+        :return: sorted allowable values.
+        """
+        args = getattr(action, "args", {}) or {}
+        return sorted(args.get(key, []) or [])
+
+    def _discover_rows(self, do_async):
+        """Discover available DellRaidService query actions.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: tuple of service URI, action map, and available rows.
+        """
+        service_uri = self._raid_service_uri(do_async)
+        service = self._get(service_uri, do_async)
+        actions = self.discover_redfish_actions(self, service)
+        targets = self._flatten_action_targets(service)
+        rows = []
+        for spec in _QUERY_SPECS.values():
+            target = targets.get(spec.full_type)
+            action = actions.get(spec.action_name)
+            if not target:
+                continue
+            rows.append({
+                "Action": spec.selector,
+                "FullType": spec.full_type,
+                "Resource": service_uri,
+                "Target": target,
+                "Description": spec.description,
+                "Parameters": {
+                    key: self._allowable(action, key)
+                    for key in spec.payload_keys
+                },
+            })
+        return service_uri, actions, rows
+
+    @staticmethod
+    def _payload_from_args(spec, values):
+        """Build the selected query payload from CLI filter values.
+
+        :param spec: selected query metadata.
+        :param values: mapping of CLI option names to values.
+        :return: action payload.
+        :raises InvalidArgument: when a filter is not supported by the query.
+        """
+        payload = {}
+        unsupported = []
+        for cli_key, payload_key in _CLI_PAYLOAD_KEYS.items():
+            value = values.get(cli_key)
+            if value is None:
+                continue
+            if payload_key not in spec.payload_keys:
+                unsupported.append(payload_key)
+                continue
+            payload[payload_key] = value
+        if unsupported:
+            raise InvalidArgument(
+                f"{spec.selector} does not accept: {', '.join(sorted(unsupported))}"
+            )
+        return payload
+
+    def _invoke_query_action(self, row, spec, payload, do_async, dry_run):
+        """Invoke a selected read-only query action and preserve JSON bodies.
+
+        :param row: discovered query-action row.
+        :param spec: selected query metadata.
+        :param payload: action payload.
+        :param do_async: use the async Redfish transport when True.
+        :param dry_run: resolve and validate without POSTing when True.
+        :return: CommandResult for dry-run, validation, task, or JSON response.
+        """
+        preview = self.invoke_action(
+            row["Resource"],
+            spec.action_name,
+            payload=payload,
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            expected_status=200,
+            dry_run=True,
+        )
+        if preview.error or dry_run:
+            return preview
+        if not isinstance(preview.data, dict):
+            return preview
+        if preview.data.get("level") != "read_only":
+            return CommandResult(
+                preview.data,
+                preview.discovered,
+                None,
+                f"{spec.full_type} is not classified as read-only",
+            )
+        if do_async:
+            return self.invoke_action(
+                row["Resource"],
+                spec.action_name,
+                payload=payload,
+                full_action_type=spec.full_type,
+                do_async=True,
+                expected_status=200,
+            )
+
+        target = preview.data["target"]
+        response = self.api_post_call(
+            f"{self._default_method}{self.redfish_ip}{target}",
+            json.dumps(payload),
+            self.json_content_type,
+        )
+        api_resp = self.default_post_success(response, expected=200)
+        data = {
+            "executed": True,
+            "action": spec.full_type,
+            "target": target,
+            "payload": payload,
+            "level": "read_only",
+        }
+        data.update(self.api_success_msg(api_resp))
+        if api_resp == RedfishApiRespond.AcceptedTaskGenerated:
+            data["task_id"] = self.job_id_from_header(response)
+        else:
+            try:
+                body = response.json()
+            except ValueError:
+                body = None
+            if body is not None:
+                data["response"] = body
+        return CommandResult(data, preview.discovered, None, None)
+
+    def execute(self,
+                query: Optional[str] = None,
+                dry_run: Optional[bool] = False,
+                block_size: Optional[str] = None,
+                disk_encrypt: Optional[str] = None,
+                disk_type: Optional[str] = None,
+                disk_protocol: Optional[str] = None,
+                form_factor: Optional[str] = None,
+                raid_level: Optional[str] = None,
+                t10_pi_status: Optional[str] = None,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or run DellRaidService read-only query actions.
+
+        :param query: selector from ``_QUERY_SPECS``; omit to list targets.
+        :param dry_run: resolve the target and payload without POSTing.
+        :param block_size: optional BlockSizeInBytes filter.
+        :param disk_encrypt: optional DiskEncrypt filter.
+        :param disk_type: optional DiskType filter.
+        :param disk_protocol: optional Diskprotocol filter.
+        :param form_factor: optional FormFactor filter.
+        :param raid_level: optional RaidLevel filter for available-disk queries.
+        :param t10_pi_status: optional T10PIStatus filter.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, dry-run preview, execution result,
+            or missing-action error.
+        """
+        service_uri, actions, rows = self._discover_rows(bool(do_async))
+        if query is None:
+            return CommandResult(rows, actions, None, None)
+
+        spec = _QUERY_SPECS[query]
+        row = next((item for item in rows if item["Action"] == query), None)
+        if row is None:
+            return CommandResult(
+                {
+                    "raid_service": service_uri,
+                    "action": spec.full_type,
+                    "available": rows,
+                },
+                actions,
+                None,
+                f"Dell RAID query action not found: {query}",
+            )
+
+        payload = self._payload_from_args(
+            spec,
+            {
+                "block_size": block_size,
+                "disk_encrypt": disk_encrypt,
+                "disk_type": disk_type,
+                "disk_protocol": disk_protocol,
+                "form_factor": form_factor,
+                "raid_level": raid_level,
+                "t10_pi_status": t10_pi_status,
+            },
+        )
+        return self._invoke_query_action(
+            row,
+            spec,
+            payload,
+            do_async=do_async,
+            dry_run=bool(dry_run),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -63,6 +63,7 @@ class ApiRequestType(Enum):
     SystemQuery = auto()
     VirtualDiskQuery = auto()
     RaidServiceQuery = auto()
+    DellRaidQueries = auto()
     StorageQuery = auto()
     Tasks = auto()
     GetTask = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -30,6 +30,9 @@ def test_policy_classifies_known_and_unknown():
     for action in hpe_reversible_actions:
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
+    assert classify("#DellRaidService.GetAvailableDisks") is Destructiveness.READ_ONLY
+    assert classify("#DellRaidService.GetDHSDisks") is Destructiveness.READ_ONLY
+    assert classify("#DellRaidService.GetRAIDLevels") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)

--- a/tests/test_dell_raid_queries_dualmode.py
+++ b/tests/test_dell_raid_queries_dualmode.py
@@ -1,0 +1,261 @@
+"""Dual-mode tests for DellRaidService query actions."""
+import json
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.raid.cmd_dell_raid_queries import DellRaidQueries
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+RAID_SERVICE = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+AVAILABLE_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.GetAvailableDisks"
+RAID_LEVELS_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.GetRAIDLevels"
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-xr8620t",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _replace_post_response(service, status_code, body):
+    """Replace the mock POST handler with a fixed response.
+
+    :param service: mock Redfish service.
+    :param status_code: HTTP status to return.
+    :param body: JSON body to return.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+
+    def post_cb(request, context):
+        service.requests.append(request)
+        context.status_code = status_code
+        return json.dumps(body)
+
+    service.mocker.post(requests_mock.ANY, text=post_cb)
+
+
+def test_dell_raid_queries_list_corpus_targets_without_post(dell_corpus_mock):
+    """Listing discovers read-only DellRaidService query actions."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidQueries,
+        "dell-raid-queries",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    actions = {row["Action"]: row for row in result.data}
+    assert set(actions) == {"available-disks", "dhs-disks", "raid-levels"}
+    assert actions["available-disks"]["Resource"] == RAID_SERVICE
+    assert actions["available-disks"]["Target"] == AVAILABLE_TARGET
+    assert actions["available-disks"]["Parameters"]["DiskType"] == [
+        "All",
+        "HDD",
+        "SSD",
+    ]
+    assert actions["raid-levels"]["Parameters"]["T10PIStatus"] == [
+        "All",
+        "T10PICapable",
+        "T10PIIncapable",
+    ]
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_query_dry_run_resolves_payload_without_post(dell_corpus_mock):
+    """--dry_run resolves the target and validates the payload without POSTing."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidQueries,
+        "dell-raid-queries",
+        query="available-disks",
+        disk_type="SSD",
+        disk_protocol="NVMe",
+        raid_level="RAID1",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellRaidService.GetAvailableDisks"
+    assert result.data["level"] == "read_only"
+    assert result.data["target"] == AVAILABLE_TARGET
+    assert result.data["payload"] == {
+        "DiskType": "SSD",
+        "Diskprotocol": "NVMe",
+        "RaidLevel": "RAID1",
+    }
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_query_posts_read_only_action_by_default(dell_corpus_mock):
+    """DellRaidService query actions are read-only, so selected queries POST."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidQueries,
+        "dell-raid-queries",
+        query="raid-levels",
+        disk_type="SSD",
+        disk_protocol="SAS",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.GetRAIDLevels"
+    assert result.data["level"] == "read_only"
+    assert result.data["target"] == RAID_LEVELS_TARGET
+
+    posts = _post_requests(service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == RAID_LEVELS_TARGET.lower()
+    assert posts[0].json() == {
+        "DiskType": "SSD",
+        "Diskprotocol": "SAS",
+    }
+
+
+def test_dell_raid_query_preserves_sync_json_response(dell_corpus_mock):
+    """A synchronous Dell query action body is returned to callers."""
+    manager, service = dell_corpus_mock
+    _replace_post_response(
+        service,
+        200,
+        {"RAIDLevels": ["RAID0", "RAID1"]},
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidQueries,
+        "dell-raid-queries",
+        query="raid-levels",
+        disk_type="SSD",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["Status"] == "ok"
+    assert result.data["response"] == {"RAIDLevels": ["RAID0", "RAID1"]}
+
+    posts = _post_requests(service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == RAID_LEVELS_TARGET.lower()
+    assert posts[0].json() == {"DiskType": "SSD"}
+
+
+def test_dell_raid_query_rejects_invalid_allowable_value(dell_corpus_mock):
+    """Advertised allowable values are enforced before any POST."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidQueries,
+        "dell-raid-queries",
+        query="raid-levels",
+        disk_type="Tape",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellRaidService.GetRAIDLevels DiskType: Tape; "
+        "allowed: All, HDD, SSD"
+    )
+    assert result.data["validation_errors"][0]["parameter"] == "DiskType"
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_query_rejects_unsupported_filter(dell_corpus_mock):
+    """Query-specific payload keys are checked before transport validation."""
+    manager, service = dell_corpus_mock
+
+    with pytest.raises(InvalidArgument, match="dhs-disks does not accept: DiskType"):
+        manager.sync_invoke(
+            ApiRequestType.DellRaidQueries,
+            "dell-raid-queries",
+            query="dhs-disks",
+            disk_type="SSD",
+        )
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_query_missing_target_reports_without_post(dell_corpus_mock):
+    """A service missing the selected action reports available targets."""
+    manager, service = dell_corpus_mock
+    service._overlay[RAID_SERVICE.lower()] = {
+        "@odata.id": RAID_SERVICE,
+        "Actions": {
+            "#DellRaidService.GetDHSDisks": {
+                "target": f"{RAID_SERVICE}/Actions/DellRaidService.GetDHSDisks"
+            }
+        },
+    }
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidQueries,
+        "dell-raid-queries",
+        query="available-disks",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell RAID query action not found: available-disks"
+    assert result.data["action"] == "#DellRaidService.GetAvailableDisks"
+    assert [row["Action"] for row in result.data["available"]] == ["dhs-disks"]
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_queries_exposes_cli_entrypoint():
+    """The dell-raid-queries command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellRaidQueries]["dell-raid-queries"] is (
+        DellRaidQueries
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellRaidQueries.register_subcommand(
+        DellRaidQueries
+    )
+
+    assert "--query" in cmd_parser.format_help()
+    assert cmd_name == "dell-raid-queries"
+    assert "RAID" in cmd_help


### PR DESCRIPTION
## Summary
- add `dell-raid-queries` for DellRaidService `GetAvailableDisks`, `GetDHSDisks`, and `GetRAIDLevels`
- classify those POST-backed query actions as read-only and preserve synchronous JSON response bodies
- add Dell XR8620t corpus-backed tests and command reference coverage

## Validation
- `git diff --cached --check`
- GitHub Actions pending