### PR TITLE
Add Dell OS driver-pack query command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-os-driver-pack` | Query Dell OS deployment driver-pack information through `DellOSDeploymentService.GetDriverPackInfo`. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -137,6 +137,7 @@ from .delloem.delloem_disconnect import *
 from .delloem.delloem_get_networkios import *
 from .delloem.delloem_boot_netios import *
 from .delloem.delloem_os_deployment import *
+from .delloem.cmd_os_deployment_driver_pack import *
 
 
 # tasks

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -42,6 +42,7 @@ ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DellOSDeploymentService.GetDriverPackInfo": Destructiveness.READ_ONLY,
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/delloem/cmd_os_deployment_driver_pack.py
+++ b/redfish_ctl/delloem/cmd_os_deployment_driver_pack.py
@@ -1,0 +1,233 @@
+"""Dell OS deployment driver-pack query action.
+
+    redfish_ctl dell-os-driver-pack
+    redfish_ctl dell-os-driver-pack --dry_run
+
+``#DellOSDeploymentService.GetDriverPackInfo`` is a Dell OEM query carried over
+POST. The command discovers the DellOSDeploymentService resource from the
+ComputerSystem OEM links and returns the advertised driver-pack information.
+
+Author Mus spyroot@gmail.com
+"""
+import asyncio
+import json
+from abc import abstractmethod
+from typing import Optional
+
+from ..actions.action_policy import classify
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, RedfishApiRespond, Singleton
+
+_DRIVER_PACK_ACTION = "#DellOSDeploymentService.GetDriverPackInfo"
+_LEGACY_OS_DEPLOYMENT_SERVICE = (
+    "/redfish/v1/Dell/Systems/System.Embedded.1/DellOSDeploymentService"
+)
+_STANDARD_OS_DEPLOYMENT_SERVICE = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService"
+)
+
+
+class DellOsDeploymentDriverPack(
+        RedfishManagerBase,
+        scm_type=ApiRequestType.DellOsDeploymentDriverPack,
+        name="dell-os-driver-pack",
+        metaclass=Singleton):
+    """Query Dell OS deployment driver-pack information."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-os-driver-pack command."""
+        super(DellOsDeploymentDriverPack, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-os-driver-pack`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the Dell action target without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-os-driver-pack",
+            "command query Dell OS deployment driver-pack info",
+        )
+
+    @staticmethod
+    def _link(data, *path):
+        """Return a nested Redfish ``@odata.id`` link.
+
+        :param data: resource body to inspect.
+        :param path: nested mapping keys leading to a link object.
+        :return: linked URI, or None when absent.
+        """
+        node = data or {}
+        for key in path:
+            if not isinstance(node, dict):
+                return None
+            node = node.get(key)
+        return node.get("@odata.id") if isinstance(node, dict) else None
+
+    def _os_deployment_service_uri(self, do_async):
+        """Resolve the DellOSDeploymentService resource URI.
+
+        The XR8620t corpus advertises the service through
+        ``ComputerSystem.Links.Oem.Dell.DellOSDeploymentService``. Older
+        fixtures used the legacy ``/redfish/v1/Dell/Systems/...`` path, so keep
+        that as the final fallback.
+
+        :param do_async: issue the ComputerSystem query over the async path.
+        :return: the discovered DellOSDeploymentService URI.
+        """
+        candidates = []
+        try:
+            system = self.base_query(self.idrac_manage_servers, do_async=do_async).data
+        except Exception:
+            system = {}
+        link = self._link(
+            system,
+            "Links",
+            "Oem",
+            "Dell",
+            "DellOSDeploymentService",
+        )
+        if link:
+            candidates.append(link)
+        candidates.extend([
+            _STANDARD_OS_DEPLOYMENT_SERVICE,
+            _LEGACY_OS_DEPLOYMENT_SERVICE,
+        ])
+        for candidate in candidates:
+            try:
+                result = self.base_query(candidate, do_async=do_async)
+            except Exception:
+                continue
+            if result.error is None and isinstance(result.data, dict):
+                return candidate
+        return candidates[0]
+
+    def _resolve_driver_pack_action(self, service_uri, do_async):
+        """Read the service resource and resolve the driver-pack action target.
+
+        :param service_uri: DellOSDeploymentService resource URI.
+        :param do_async: issue the service query over the async path.
+        :return: tuple of (actions, target, error).
+        """
+        try:
+            resource = self.base_query(service_uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return {}, None, f"failed to read {service_uri}: {exc}"
+        actions = self.discover_redfish_actions(self, resource)
+        full_targets = self._flatten_action_targets(resource)
+        target = full_targets.get(_DRIVER_PACK_ACTION)
+        if target is None:
+            action = actions.get("GetDriverPackInfo")
+            target = getattr(action, "target", None)
+        if target is None:
+            available = sorted(set(list(actions.keys()) + list(full_targets.keys())))
+            return actions, None, {
+                "action": _DRIVER_PACK_ACTION,
+                "available": available,
+            }
+        return actions, target, None
+
+    def execute(self,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Resolve and invoke ``#DellOSDeploymentService.GetDriverPackInfo``.
+
+        :param dry_run: resolve the target and show it without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying reads/POSTs on the async path when True.
+        :return: CommandResult with driver-pack data, dry-run preview, or an error.
+        """
+        service_uri = self._os_deployment_service_uri(do_async)
+        actions, target, error = self._resolve_driver_pack_action(
+            service_uri, do_async
+        )
+        if error is not None:
+            if isinstance(error, dict):
+                return CommandResult(
+                    error,
+                    actions,
+                    None,
+                    f"action '{_DRIVER_PACK_ACTION}' not found on {service_uri}",
+                )
+            return CommandResult(None, actions, None, error)
+
+        level = classify(_DRIVER_PACK_ACTION)
+        payload = {}
+        if dry_run:
+            return CommandResult({
+                "dry_run": True,
+                "action": _DRIVER_PACK_ACTION,
+                "target": target,
+                "payload": payload,
+                "level": level.value,
+                "blocked": None,
+            }, actions, None, None)
+
+        headers = {}
+        if data_type == "json":
+            headers.update(self.json_content_type)
+        try:
+            request_uri = f"{self._default_method}{self.redfish_ip}{target}"
+            if do_async:
+                loop = asyncio.get_event_loop()
+                response, api_resp = loop.run_until_complete(
+                    self.api_async_post_until_complete(
+                        request_uri,
+                        json.dumps(payload),
+                        headers,
+                        expected=200,
+                    )
+                )
+            else:
+                response = self.api_post_call(
+                    request_uri,
+                    json.dumps(payload),
+                    headers,
+                )
+                api_resp = self.default_post_success(response, expected=200)
+        except Exception as exc:
+            return CommandResult(
+                {"action": _DRIVER_PACK_ACTION, "target": target},
+                actions,
+                None,
+                str(exc),
+            )
+
+        if api_resp == RedfishApiRespond.AcceptedTaskGenerated:
+            return CommandResult({
+                "executed": True,
+                "action": _DRIVER_PACK_ACTION,
+                "target": target,
+                "level": level.value,
+                "task_id": self.job_id_from_header(response, strict=False),
+            }, actions, None, None)
+
+        try:
+            response_data = response.json()
+        except ValueError:
+            response_data = {}
+        return CommandResult({
+            "executed": True,
+            "action": _DRIVER_PACK_ACTION,
+            "target": target,
+            "level": level.value,
+            "response": response_data,
+        }, actions, None, None)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -36,6 +36,7 @@ class ApiRequestType(Enum):
 
     # dell oem
     DellOemTask = auto()
+    DellOsDeploymentDriverPack = auto()
     DellLcQuery = auto()
     DellOemDisconnect = auto()
 

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -30,6 +30,7 @@ def test_policy_classifies_known_and_unknown():
     for action in hpe_reversible_actions:
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
+    assert classify("#DellOSDeploymentService.GetDriverPackInfo") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)

--- a/tests/test_dell_os_driver_pack_dualmode.py
+++ b/tests/test_dell_os_driver_pack_dualmode.py
@@ -1,0 +1,173 @@
+"""Dual-mode tests for Dell OS deployment driver-pack query action."""
+import json
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.delloem.cmd_os_deployment_driver_pack import (
+    DellOsDeploymentDriverPack,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+OS_DEPLOYMENT = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService"
+)
+DRIVER_PACK_TARGET = (
+    f"{OS_DEPLOYMENT}/Actions/DellOSDeploymentService.GetDriverPackInfo"
+)
+
+
+@pytest.fixture
+def dell_os_deployment_mock():
+    """Return a manager and Dell XR8620t corpus-backed mock service.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+
+    def post_cb(request, context):
+        service.requests.append(request)
+        if request.path.lower() == DRIVER_PACK_TARGET.lower():
+            context.status_code = 200
+            return json.dumps({
+                "DriverPackVersion": "42.7.9",
+                "DriverPackStatus": "Available",
+            })
+        context.status_code = 404
+        return json.dumps({"error": f"unexpected POST {request.path}"})
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-xr8620t",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_dell_os_driver_pack_posts_query_and_preserves_response(
+        dell_os_deployment_mock):
+    """The read-only driver-pack action POSTs and returns the JSON body."""
+    manager, service = dell_os_deployment_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellOsDeploymentDriverPack,
+        "dell-os-driver-pack",
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellOSDeploymentService.GetDriverPackInfo"
+    assert result.data["target"] == DRIVER_PACK_TARGET
+    assert result.data["level"] == "read_only"
+    assert result.data["response"] == {
+        "DriverPackVersion": "42.7.9",
+        "DriverPackStatus": "Available",
+    }
+    assert len(posts) == 1
+    assert posts[0].path.lower() == DRIVER_PACK_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_os_driver_pack_dry_run_does_not_post(dell_os_deployment_mock):
+    """--dry_run resolves the target and returns a no-POST preview."""
+    manager, service = dell_os_deployment_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellOsDeploymentDriverPack,
+        "dell-os-driver-pack",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellOSDeploymentService.GetDriverPackInfo",
+        "target": DRIVER_PACK_TARGET,
+        "payload": {},
+        "level": "read_only",
+        "blocked": None,
+    }
+    assert _post_requests(service) == []
+
+
+def test_dell_os_driver_pack_missing_action_reports_available(
+        dell_os_deployment_mock):
+    """A service without GetDriverPackInfo returns a structured error."""
+    manager, service = dell_os_deployment_mock
+    service._overlay[OS_DEPLOYMENT] = {
+        "@odata.id": OS_DEPLOYMENT,
+        "Actions": {
+            "#DellOSDeploymentService.GetAttachStatus": {
+                "target": (
+                    f"{OS_DEPLOYMENT}/Actions/"
+                    "DellOSDeploymentService.GetAttachStatus"
+                )
+            }
+        },
+    }
+    service._overlay[OS_DEPLOYMENT.lower()] = service._overlay[OS_DEPLOYMENT]
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellOsDeploymentDriverPack,
+        "dell-os-driver-pack",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#DellOSDeploymentService.GetDriverPackInfo' not found on "
+        f"{OS_DEPLOYMENT}"
+    )
+    assert result.data["action"] == "#DellOSDeploymentService.GetDriverPackInfo"
+    assert result.data["available"] == [
+        "#DellOSDeploymentService.GetAttachStatus",
+        "GetAttachStatus",
+    ]
+    assert _post_requests(service) == []
+
+
+def test_dell_os_driver_pack_exposes_cli_entrypoint():
+    """The dell-os-driver-pack command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellOsDeploymentDriverPack]["dell-os-driver-pack"]
+        is DellOsDeploymentDriverPack
+    )
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellOsDeploymentDriverPack.register_subcommand(
+            DellOsDeploymentDriverPack
+        )
+    )
+
+    assert "--dry_run" in cmd_parser.format_help()
+    assert cmd_name == "dell-os-driver-pack"
+    assert "driver-pack" in cmd_help


### PR DESCRIPTION
## Summary
- add `dell-os-driver-pack` for DellOSDeploymentService.GetDriverPackInfo
- discover the Dell OS deployment service through ComputerSystem OEM links with legacy fallback
- preserve the read-only action response body and add Dell XR8620t corpus-backed coverage

## Validation
- `git diff --cached --check`
- GitHub CI pending