### PR TITLE
Add Dell job cleanup timeout command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -137,6 +137,7 @@ Safety labels:
 | `insert_vm` | Insert virtual media from a URI. | Write |
 | `job` | Read one Dell job. | Read |
 | `job-apply` | Apply pending jobs. | Write |
+| `job-delete-timeout` | Set Dell JobService completed-job cleanup timeout; lists the target when no timeout is supplied and requires `--confirm` to write. | Guarded |
 | `job-rm` | Delete one job. | Write |
 | `job-rm-all` | Delete all jobs. | Write |
 | `job-watch` | Watch a job until it reaches a terminal state. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -43,6 +43,7 @@ from .jobs.cmd_job_watch import *
 from .jobs.cmd_job_del import *
 from .jobs.cmd_job_dell_services import *
 from .jobs.cmd_job_delete_all import *
+from .jobs.cmd_job_delete_timeout import *
 from .jobs.cmd_job_apply import *
 #
 # # firmwares cmds

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,7 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellJobService.SetDeleteOnCompletionTimeout": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/jobs/cmd_job_delete_timeout.py
+++ b/redfish_ctl/jobs/cmd_job_delete_timeout.py
@@ -1,0 +1,230 @@
+"""Set Dell JobService delete-on-completion timeout.
+
+    redfish_ctl job-delete-timeout
+    redfish_ctl job-delete-timeout --minutes 2880
+    redfish_ctl job-delete-timeout --minutes 2880 --confirm
+
+The command discovers DellJobService from the Manager OEM Dell links and invokes
+``#DellJobService.SetDeleteOnCompletionTimeout``. It lists the discovered target
+when no timeout is supplied, and it previews by default when a timeout is given.
+Use ``--confirm`` to POST the new timeout.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_DELL_JOB_TIMEOUT_ACTION = "#DellJobService.SetDeleteOnCompletionTimeout"
+_DELL_JOB_SERVICE_FALLBACK = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService"
+)
+
+
+class JobDeleteTimeout(RedfishManagerBase,
+                       scm_type=ApiRequestType.JobDeleteTimeout,
+                       name="job-delete-timeout",
+                       metaclass=Singleton):
+    """Set DellJobService automatic completed-job cleanup timeout."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the job-delete-timeout command."""
+        super(JobDeleteTimeout, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``job-delete-timeout`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--minutes",
+            required=False,
+            dest="minutes",
+            type=int,
+            default=None,
+            help="DeleteOnCompletionTimeoutMinutes value to set; omit to list "
+                 "the discovered DellJobService action target",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the SetDeleteOnCompletionTimeout POST; without it the "
+                 "command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show the payload without POSTing; "
+                 "overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "job-delete-timeout",
+            "command set Dell JobService completed-job cleanup timeout",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _dell_oem_link(cls, manager, key):
+        """Return an OEM Dell link from a Manager resource.
+
+        :param manager: Manager resource body.
+        :param key: OEM Dell link name, such as ``DellJobService``.
+        :return: the linked URI, or None when absent.
+        """
+        links = (manager or {}).get("Links", {})
+        if not isinstance(links, dict):
+            return None
+        oem_links = links.get("Oem", {})
+        if not isinstance(oem_links, dict):
+            return None
+        dell_links = oem_links.get("Dell", {})
+        if not isinstance(dell_links, dict):
+            return None
+        return cls._link(dell_links, key)
+
+    def _job_service_uri(self, do_async):
+        """Resolve the DellJobService URI from Manager OEM links.
+
+        :param do_async: issue Manager queries over the async Redfish path.
+        :return: discovered DellJobService URI, or the legacy Dell fallback.
+        """
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            try:
+                manager = self.base_query(
+                    manager_uri.rstrip("/"),
+                    do_async=do_async,
+                ).data or {}
+            except Exception:
+                continue
+            target = self._dell_oem_link(manager, "DellJobService")
+            if target:
+                return target
+        return _DELL_JOB_SERVICE_FALLBACK
+
+    def _job_service(self, do_async):
+        """Read the DellJobService resource.
+
+        :param do_async: issue the query over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or ``(uri, CommandResult)`` on error.
+        """
+        uri = self._job_service_uri(do_async)
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return uri, CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+        return uri, data
+
+    def _timeout_metadata(self, do_async):
+        """Return discovered timeout action metadata.
+
+        :param do_async: issue the DellJobService query over the async Redfish path.
+        :return: CommandResult with service and action target metadata.
+        """
+        uri, service = self._job_service(do_async)
+        if isinstance(service, CommandResult):
+            return service
+        actions = self.discover_redfish_actions(self, service)
+        target = self._flatten_action_targets(service).get(_DELL_JOB_TIMEOUT_ACTION)
+        if target is None:
+            available = sorted(set(list(actions.keys())
+                                   + list(self._flatten_action_targets(service).keys())))
+            return CommandResult(
+                {
+                    "job_service": uri,
+                    "action": _DELL_JOB_TIMEOUT_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_DELL_JOB_TIMEOUT_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "job_service": uri,
+                "action": _DELL_JOB_TIMEOUT_ACTION,
+                "target": target,
+                "current_minutes": service.get("DeleteOnCompletionTimeoutMinutes"),
+                "current_jobs": service.get("CurrentNumberOfJobs"),
+                "maximum_jobs": service.get("MaximumNumberOfJobs"),
+            },
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _payload(minutes):
+        """Build a SetDeleteOnCompletionTimeout payload.
+
+        :param minutes: timeout value in minutes.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when minutes is negative.
+        """
+        if minutes is None:
+            return None
+        if minutes < 0:
+            raise InvalidArgument("minutes must be zero or greater")
+        return {"DeleteOnCompletionTimeoutMinutes": minutes}
+
+    def execute(self,
+                minutes: Optional[int] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or set DellJobService completed-job cleanup timeout.
+
+        :param minutes: timeout value in minutes; None lists target metadata.
+        :param confirm: authorize the timeout POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with target metadata, dry-run preview, or POST result.
+        """
+        payload = self._payload(minutes)
+        if payload is None:
+            return self._timeout_metadata(do_async)
+
+        return self.invoke_action(
+            self._job_service_uri(do_async),
+            "SetDeleteOnCompletionTimeout",
+            payload=payload,
+            full_action_type=_DELL_JOB_TIMEOUT_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -194,6 +194,7 @@ class ApiRequestType(Enum):
     #  dell services
     JobRmDellServices = auto()
     JobDellServices = auto()
+    JobDeleteTimeout = auto()
 
     Discovery = auto()
     FleetInventory = auto()

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DellJobService.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DellJobService.json
@@ -6,6 +6,9 @@
   "Name": "Dell Job Service",
   "Description": "Dell OEM job queue service",
   "ServiceEnabled": true,
+  "CurrentNumberOfJobs": 106,
+  "DeleteOnCompletionTimeoutMinutes": 2880,
+  "MaximumNumberOfJobs": 256,
   "Jobs": {
     "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Jobs"
   },
@@ -24,6 +27,9 @@
         "JID_CLEARALL",
         "JID_CLEARALL_FORCE"
       ]
+    },
+    "#DellJobService.SetDeleteOnCompletionTimeout": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService/Actions/DellJobService.SetDeleteOnCompletionTimeout"
     }
   }
 }

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -31,6 +31,7 @@ def test_policy_classifies_known_and_unknown():
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
+    assert classify("#DellJobService.SetDeleteOnCompletionTimeout") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE

--- a/tests/test_jobs_tasks_dualmode.py
+++ b/tests/test_jobs_tasks_dualmode.py
@@ -4,7 +4,11 @@ import json
 import pytest
 
 import redfish_ctl.tasks.cmd_task_svc  # noqa: F401
-from redfish_ctl.cmd_exceptions import AuthenticationFailed, InvalidArgumentFormat
+from redfish_ctl.cmd_exceptions import (
+    AuthenticationFailed,
+    InvalidArgument,
+    InvalidArgumentFormat,
+)
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.jobs.cmd_jobs import JobList
@@ -113,6 +117,107 @@ def test_dell_job_service_returns_delete_queue_action(redfish_api):
         "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService/"
         "Actions/DellJobService.DeleteJobQueue"
     )
+
+
+def _job_timeout_post_count(service):
+    """Return the number of Dell timeout action POSTs sent to the mock."""
+    return sum(
+        1 for request in service.requests
+        if request.method == "POST"
+        and request.path.lower().endswith(
+            "/actions/delljobservice.setdeleteoncompletiontimeout"
+        )
+    )
+
+
+def test_job_delete_timeout_lists_discovered_target(redfish_api):
+    """job-delete-timeout lists DellJobService timeout metadata by default."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.JobDeleteTimeout,
+        "job-delete-timeout",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["job_service"] == (
+        "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService"
+    )
+    assert result.data["action"] == "#DellJobService.SetDeleteOnCompletionTimeout"
+    assert result.data["target"] == (
+        "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService/"
+        "Actions/DellJobService.SetDeleteOnCompletionTimeout"
+    )
+    assert result.data["current_minutes"] == 2880
+    assert result.data["maximum_jobs"] == 256
+
+
+def test_job_delete_timeout_previews_without_confirm(redfish_mock, redfish_service):
+    """job-delete-timeout does not POST a timeout update without --confirm."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.JobDeleteTimeout,
+        "job-delete-timeout",
+        minutes=1440,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {"DeleteOnCompletionTimeoutMinutes": 1440}
+    assert result.data["target"].endswith(
+        "/Actions/DellJobService.SetDeleteOnCompletionTimeout"
+    )
+    assert _job_timeout_post_count(redfish_service) == 0
+
+
+def test_job_delete_timeout_posts_when_confirmed(redfish_mock, redfish_service):
+    """job-delete-timeout POSTs the timeout payload only with --confirm."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.JobDeleteTimeout,
+        "job-delete-timeout",
+        minutes=1440,
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellJobService.SetDeleteOnCompletionTimeout"
+    assert _job_timeout_post_count(redfish_service) == 1
+    assert redfish_service.last_request.json() == {
+        "DeleteOnCompletionTimeoutMinutes": 1440,
+    }
+
+
+def test_job_delete_timeout_dry_run_overrides_confirm(redfish_mock, redfish_service):
+    """Explicit dry-run prevents POST even if --confirm is also supplied."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.JobDeleteTimeout,
+        "job-delete-timeout",
+        minutes=1440,
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert _job_timeout_post_count(redfish_service) == 0
+
+
+def test_job_delete_timeout_rejects_negative_minutes(
+    redfish_mock, redfish_service
+):
+    """Negative cleanup timeouts are rejected before any Redfish POST."""
+    with pytest.raises(InvalidArgument, match="minutes must be zero or greater"):
+        redfish_mock.sync_invoke(
+            ApiRequestType.JobDeleteTimeout,
+            "job-delete-timeout",
+            minutes=-1,
+            confirm=True,
+        )
+
+    assert _job_timeout_post_count(redfish_service) == 0
 
 
 def test_task_service_root_query_returns_task_links(redfish_api):


### PR DESCRIPTION
## Summary
- add job-delete-timeout for DellJobService.SetDeleteOnCompletionTimeout
- discover DellJobService from Manager OEM links with a legacy fallback
- preview by default, require --confirm to post, and cover target listing, dry-run, confirm, override, and invalid timeout paths

## Validation
- git diff --cached --check
- GitHub CI pending