### PR TITLE
Add Dell KVM session query command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-kvm-session` | Fetch Dell iDRAC KVM session state through the DelliDRACCardService `GetKVMSession` action. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -121,6 +121,7 @@ from .firmware.cmd_firmware_update import *
 from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
+from .oem.cmd_dell_kvm_session import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
 from .manager.cmd_console_info import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -42,6 +42,7 @@ ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DelliDRACCardService.GetKVMSession": Destructiveness.READ_ONLY,
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/oem/cmd_dell_kvm_session.py
+++ b/redfish_ctl/oem/cmd_dell_kvm_session.py
@@ -1,0 +1,259 @@
+"""Fetch Dell iDRAC KVM session status through DelliDRACCardService.
+
+    redfish_ctl dell-kvm-session
+    redfish_ctl dell-kvm-session --query
+    redfish_ctl dell-kvm-session --query --dry_run
+
+The command discovers ``#DelliDRACCardService.GetKVMSession`` from the Manager
+OEM Dell card-service link. With no query flag it lists the discovered target.
+The selected action is a read-only status query carried over POST.
+
+Author Mus spyroot@gmail.com
+"""
+import asyncio
+import json
+from abc import abstractmethod
+from typing import Optional
+
+from ..actions.action_policy import classify
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_DELL_KVM_SESSION_ACTION = "#DelliDRACCardService.GetKVMSession"
+_DELL_CARD_SERVICE_FALLBACK = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+)
+
+
+class DellKvmSession(RedfishManagerBase,
+                     scm_type=ApiRequestType.DellKvmSession,
+                     name="dell-kvm-session",
+                     metaclass=Singleton):
+    """Discover and query Dell iDRAC KVM session state."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-kvm-session command."""
+        super(DellKvmSession, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-kvm-session`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--query",
+            action="store_true",
+            dest="query",
+            default=False,
+            help="POST the read-only GetKVMSession query; omit to list target metadata",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-kvm-session",
+            "command fetch Dell iDRAC KVM session status",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _dell_oem_link(cls, manager, key):
+        """Return an OEM Dell link from a Manager resource.
+
+        :param manager: Manager resource body.
+        :param key: OEM Dell link name, such as ``DelliDRACCardService``.
+        :return: the linked URI, or None when absent.
+        """
+        links = (manager or {}).get("Links", {})
+        if not isinstance(links, dict):
+            return None
+        oem_links = links.get("Oem", {})
+        if not isinstance(oem_links, dict):
+            return None
+        dell_links = oem_links.get("Dell", {})
+        if not isinstance(dell_links, dict):
+            return None
+        return cls._link(dell_links, key)
+
+    def _card_service_uri(self, do_async):
+        """Resolve the DelliDRACCardService URI from Manager OEM links.
+
+        :param do_async: issue Manager queries over the async Redfish path.
+        :return: discovered DelliDRACCardService URI, or the legacy Dell fallback.
+        """
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            try:
+                manager = self.base_query(
+                    manager_uri.rstrip("/"),
+                    do_async=do_async,
+                ).data or {}
+            except Exception:
+                continue
+            target = self._dell_oem_link(manager, "DelliDRACCardService")
+            if target:
+                return target
+        return _DELL_CARD_SERVICE_FALLBACK
+
+    def _card_service(self, do_async):
+        """Read the DelliDRACCardService resource.
+
+        :param do_async: issue the query over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or ``(uri, CommandResult)`` on error.
+        """
+        uri = self._card_service_uri(do_async)
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return uri, CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+        return uri, data
+
+    def _session_metadata(self, do_async):
+        """Return discovered GetKVMSession action metadata.
+
+        :param do_async: issue the card-service query over the async Redfish path.
+        :return: CommandResult with service and action target metadata.
+        """
+        uri, service = self._card_service(do_async)
+        if isinstance(service, CommandResult):
+            return service
+        actions = self.discover_redfish_actions(self, service)
+        target = self._flatten_action_targets(service).get(_DELL_KVM_SESSION_ACTION)
+        if target is None:
+            available = sorted(set(list(actions.keys())
+                                   + list(self._flatten_action_targets(service).keys())))
+            return CommandResult(
+                {
+                    "card_service": uri,
+                    "action": _DELL_KVM_SESSION_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_DELL_KVM_SESSION_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "card_service": uri,
+                "action": _DELL_KVM_SESSION_ACTION,
+                "target": target,
+            },
+            actions,
+            None,
+            None,
+        )
+
+    def _post_session_query(self, target, do_async):
+        """POST the read-only KVM session query and keep the response body.
+
+        :param target: discovered GetKVMSession action target.
+        :param do_async: issue the POST over the async Redfish path.
+        :return: CommandResult with the response payload and action metadata.
+        """
+        headers = dict(self.json_content_type)
+        url = f"{self._default_method}{self.redfish_ip}{target}"
+        try:
+            if do_async:
+                loop = asyncio.get_event_loop()
+                api_resp, response = loop.run_until_complete(
+                    self.api_async_post_until_complete(
+                        url,
+                        json.dumps({}),
+                        headers,
+                        expected=200,
+                    )
+                )
+            else:
+                response = self.api_post_call(url, json.dumps({}), headers)
+                api_resp = self.default_post_success(response, expected=200)
+        except Exception as exc:
+            return CommandResult(
+                {
+                    "action": _DELL_KVM_SESSION_ACTION,
+                    "target": target,
+                    "payload": {},
+                    "level": classify(_DELL_KVM_SESSION_ACTION).value,
+                },
+                None,
+                None,
+                f"failed to POST {target}: {exc}",
+            )
+
+        try:
+            response_body = response.json()
+        except Exception:
+            response_body = {}
+        data = response_body if isinstance(response_body, dict) else {
+            "response": response_body,
+        }
+        data.setdefault("Status", self.api_success_msg(api_resp)["Status"])
+        data.setdefault("executed", True)
+        data.setdefault("method", "POST")
+        data.setdefault("action", _DELL_KVM_SESSION_ACTION)
+        data.setdefault("target", target)
+        data.setdefault("level", classify(_DELL_KVM_SESSION_ACTION).value)
+        return CommandResult(data, None, None, None)
+
+    def execute(self,
+                query: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or query Dell iDRAC KVM session state.
+
+        :param query: when True, POST the read-only GetKVMSession query.
+        :param dry_run: resolve the target without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with target metadata, dry-run preview, or POST result.
+        """
+        metadata = self._session_metadata(do_async)
+        if not query or metadata.error:
+            return metadata
+
+        target = metadata.data["target"]
+        if dry_run:
+            return CommandResult(
+                {
+                    "dry_run": True,
+                    "action": _DELL_KVM_SESSION_ACTION,
+                    "target": target,
+                    "payload": {},
+                    "level": classify(_DELL_KVM_SESSION_ACTION).value,
+                    "blocked": None,
+                },
+                metadata.discovered,
+                None,
+                None,
+            )
+        result = self._post_session_query(target, bool(do_async))
+        return CommandResult(result.data, metadata.discovered, None, result.error)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -129,6 +129,7 @@ class ApiRequestType(Enum):
     Triggers = auto()
     NetworkPorts = auto()
     OemInfo = auto()
+    DellKvmSession = auto()
     ConsoleInfo = auto()
     SerialConsoleConfig = auto()
     BiosSnapshot = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -30,6 +30,7 @@ def test_policy_classifies_known_and_unknown():
     for action in hpe_reversible_actions:
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
+    assert classify("#DelliDRACCardService.GetKVMSession") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)

--- a/tests/test_dell_kvm_session_dualmode.py
+++ b/tests/test_dell_kvm_session_dualmode.py
@@ -1,0 +1,193 @@
+"""Dual-mode-style coverage for Dell iDRAC KVM session status."""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.oem.cmd_dell_kvm_session import DellKvmSession
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+CARD_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+)
+KVM_ACTION = "#DelliDRACCardService.GetKVMSession"
+KVM_TARGET = f"{CARD_SERVICE}/Actions/DelliDRACCardService.GetKVMSession"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@contextmanager
+def _mock_dell_kvm(card_service_transform=None):
+    """Serve the committed Dell corpus over requests-mock.
+
+    :param card_service_transform: optional mutator for the card-service fixture.
+    :return: context yielding RedfishManagerBase and recorded requests.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        data = json.loads(fixture.read_text())
+        if request.path.rstrip("/") == CARD_SERVICE and card_service_transform:
+            data = card_service_transform(data)
+        context.status_code = 200
+        return json.dumps(data)
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 200
+        return json.dumps({
+            "Name": "KVM session status",
+            "KVMSession": {
+                "Active": False,
+                "SessionCount": 0,
+            },
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-kvm",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_kvm_session_lists_target_without_posting():
+    """With no query flag, the command lists the KVM action target only."""
+    with _mock_dell_kvm() as (manager, requests):
+        result = manager.sync_invoke(ApiRequestType.DellKvmSession, "dell-kvm-session")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "card_service": CARD_SERVICE,
+        "action": KVM_ACTION,
+        "target": KVM_TARGET,
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_kvm_session_dry_run_resolves_without_posting():
+    """--query --dry_run reports the read-only POST target without firing it."""
+    with _mock_dell_kvm() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellKvmSession,
+            "dell-kvm-session",
+            query=True,
+            dry_run=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": KVM_ACTION,
+        "target": KVM_TARGET,
+        "payload": {},
+        "level": "read_only",
+        "blocked": None,
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_kvm_session_query_posts_and_preserves_response():
+    """--query POSTs an empty body and returns the KVM session response body."""
+    with _mock_dell_kvm() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellKvmSession,
+            "dell-kvm-session",
+            query=True,
+        )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["Name"] == "KVM session status"
+    assert result.data["KVMSession"] == {
+        "Active": False,
+        "SessionCount": 0,
+    }
+    assert result.data["Status"] == "ok"
+    assert result.data["executed"] is True
+    assert result.data["method"] == "POST"
+    assert result.data["action"] == KVM_ACTION
+    assert result.data["target"] == KVM_TARGET
+    assert result.data["level"] == "read_only"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == KVM_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_kvm_session_reports_missing_action_without_posting():
+    """A card-service resource without GetKVMSession reports available actions."""
+
+    def without_kvm_action(data):
+        actions = data.get("Actions", {})
+        actions.pop(KVM_ACTION, None)
+        return data
+
+    with _mock_dell_kvm(without_kvm_action) as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellKvmSession,
+            "dell-kvm-session",
+            query=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == f"action '{KVM_ACTION}' not found on {CARD_SERVICE}"
+    assert KVM_ACTION not in result.data["available"]
+    assert "DeleteGroup" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_kvm_session_exposes_cli_entrypoint():
+    """The dell-kvm-session command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellKvmSession]["dell-kvm-session"] is (
+        DellKvmSession
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellKvmSession.register_subcommand(
+        DellKvmSession
+    )
+
+    assert "--query" in cmd_parser.format_help()
+    assert "--dry_run" in cmd_parser.format_help()
+    assert cmd_name == "dell-kvm-session"
+    assert "KVM" in cmd_help

--- a/tests/test_dell_kvm_session_dualmode.py
+++ b/tests/test_dell_kvm_session_dualmode.py
@@ -50,7 +50,8 @@ def _mock_dell_kvm(card_service_transform=None):
             context.status_code = 404
             return json.dumps({"error": f"no fixture for {request.path}"})
         data = json.loads(fixture.read_text())
-        if request.path.rstrip("/") == CARD_SERVICE and card_service_transform:
+        is_card_service = request.path.rstrip("/").lower() == CARD_SERVICE.lower()
+        if is_card_service and card_service_transform:
             data = card_service_transform(data)
         context.status_code = 200
         return json.dumps(data)
@@ -158,8 +159,11 @@ def test_dell_kvm_session_reports_missing_action_without_posting():
     """A card-service resource without GetKVMSession reports available actions."""
 
     def without_kvm_action(data):
-        actions = data.get("Actions", {})
-        actions.pop(KVM_ACTION, None)
+        for actions in (
+            data.get("Actions", {}),
+            data.get("Oem", {}).get("Dell", {}).get("Actions", {}),
+        ):
+            actions.pop(KVM_ACTION, None)
         return data
 
     with _mock_dell_kvm(without_kvm_action) as (manager, requests):


### PR DESCRIPTION
Summary:
- Add read-only dell-kvm-session for DelliDRACCardService.GetKVMSession.
- Discover DelliDRACCardService through Manager OEM Dell links and list the target by default.
- Add action policy, command docs, and Dell XR8620t corpus-backed coverage for listing, dry-run, query response, missing action, and registry wiring.

Validation:
- git diff --cached --check
- GitHub CI will run the full test matrix.