### PR TITLE
Add Dell vFlash state command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-vflash-state` | Enable or disable Dell vFlash through `DellPersistentStorageService.VFlashStateChange`; dry-run by default and `--confirm` posts. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -121,6 +121,7 @@ from .firmware.cmd_firmware_update import *
 from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
+from .oem.cmd_dell_vflash_state import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
 from .manager.cmd_console_info import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -8,8 +8,8 @@ dry-run unless ``--confirm`` is given, or additionally needs an explicit
 
 Fail-safe by construction: an action not in the table is treated as DESTRUCTIVE,
 so a newly exposed (unclassified) action can never POST without an explicit
-confirm. This module is product-neutral — it names standard DMTF + NVIDIA OEM
-action types only and imports nothing from the Redfish manager layer.
+confirm. This module is product-neutral — it names standard DMTF actions and
+selected vendor OEM action types without importing the Redfish manager layer.
 
 Author Mus spyroot@gmail.com
 """
@@ -69,6 +69,7 @@ ACTION_POLICY = {
     "#Control.ResetToDefaults": Destructiveness.DESTRUCTIVE,
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.VFlashStateChange": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE

--- a/redfish_ctl/oem/cmd_dell_vflash_state.py
+++ b/redfish_ctl/oem/cmd_dell_vflash_state.py
@@ -1,0 +1,239 @@
+"""Change Dell vFlash state through DellPersistentStorageService.
+
+    redfish_ctl dell-vflash-state
+    redfish_ctl dell-vflash-state --requested-state Enable --dry_run
+    redfish_ctl dell-vflash-state --requested-state Disable --confirm
+
+The command discovers ``#DellPersistentStorageService.VFlashStateChange`` from
+the Manager OEM Dell persistent-storage link. With no requested state it lists
+the discovered target and advertised states. Changing vFlash state rewrites BMC
+configuration, so the action previews by default and only POSTs with
+``--confirm``.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_VFLASH_STATE_ACTION = "#DellPersistentStorageService.VFlashStateChange"
+_PERSISTENT_STORAGE_FALLBACK = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DellPersistentStorageService"
+)
+
+
+class DellVFlashStateChange(RedfishManagerBase,
+                            scm_type=ApiRequestType.DellVFlashStateChange,
+                            name="dell-vflash-state",
+                            metaclass=Singleton):
+    """Discover and change Dell vFlash state."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-vflash-state command."""
+        super(DellVFlashStateChange, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-vflash-state`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--requested-state",
+            required=False,
+            dest="requested_state",
+            type=str,
+            default=None,
+            help="Dell vFlash state to request, such as Enable or Disable; "
+                 "omit to list the discovered action target",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the VFlashStateChange POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-vflash-state",
+            "command change Dell vFlash state",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _dell_oem_link(cls, manager, key):
+        """Return an OEM Dell link from a Manager resource.
+
+        :param manager: Manager resource body.
+        :param key: OEM Dell link name, such as ``DellPersistentStorageService``.
+        :return: the linked URI, or None when absent.
+        """
+        links = (manager or {}).get("Links", {})
+        if not isinstance(links, dict):
+            return None
+        oem_links = links.get("Oem", {})
+        if not isinstance(oem_links, dict):
+            return None
+        dell_links = oem_links.get("Dell", {})
+        if not isinstance(dell_links, dict):
+            return None
+        return cls._link(dell_links, key)
+
+    def _persistent_storage_uri(self, do_async):
+        """Resolve DellPersistentStorageService from Manager OEM links.
+
+        :param do_async: issue Manager queries over the async Redfish path.
+        :return: discovered persistent-storage service URI, or the legacy fallback.
+        """
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            try:
+                manager = self.base_query(
+                    manager_uri.rstrip("/"),
+                    do_async=do_async,
+                ).data or {}
+            except Exception:
+                continue
+            target = self._dell_oem_link(manager, "DellPersistentStorageService")
+            if target:
+                return target
+        return _PERSISTENT_STORAGE_FALLBACK
+
+    def _persistent_storage_service(self, do_async):
+        """Read the DellPersistentStorageService resource.
+
+        :param do_async: issue the query over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or ``(uri, CommandResult)`` on error.
+        """
+        uri = self._persistent_storage_uri(do_async)
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return uri, CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+        return uri, data
+
+    def _state_metadata(self, do_async):
+        """Return discovered VFlashStateChange target metadata.
+
+        :param do_async: issue the persistent-storage query over the async Redfish path.
+        :return: CommandResult with service, action target, and advertised states.
+        """
+        uri, service = self._persistent_storage_service(do_async)
+        if isinstance(service, CommandResult):
+            return service
+        actions = self.discover_redfish_actions(self, service)
+        action = actions.get("VFlashStateChange")
+        requested_states = sorted((getattr(action, "args", {}) or {}).get(
+            "RequestedState", []
+        ))
+        target = self._flatten_action_targets(service).get(_VFLASH_STATE_ACTION)
+        if target is None:
+            available = sorted(set(list(actions.keys())
+                                   + list(self._flatten_action_targets(service).keys())))
+            return CommandResult(
+                {
+                    "persistent_storage_service": uri,
+                    "action": _VFLASH_STATE_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_VFLASH_STATE_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "persistent_storage_service": uri,
+                "action": _VFLASH_STATE_ACTION,
+                "target": target,
+                "requested_states": requested_states,
+            },
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _payload(requested_state):
+        """Build a VFlashStateChange payload.
+
+        :param requested_state: requested Dell vFlash state.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when ``requested_state`` is empty.
+        """
+        state = (requested_state or "").strip()
+        if not state:
+            raise InvalidArgument("requested state cannot be empty")
+        return {"RequestedState": state}
+
+    def execute(self,
+                requested_state: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List the Dell vFlash target, or change the requested state.
+
+        With no ``--requested-state`` the command returns discovered
+        VFlashStateChange metadata without mutating. With a requested state it
+        resolves and invokes the action; because this rewrites BMC
+        configuration, the POST only fires with ``--confirm``. ``--dry_run``
+        remains a no-POST override even when ``--confirm`` is also set.
+
+        :param requested_state: requested Dell vFlash state; None lists target
+            metadata.
+        :param confirm: authorize the VFlashStateChange POST to actually fire.
+        :param dry_run: resolve the target and payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path.
+        :return: a CommandResult with target metadata, dry-run preview, or POST
+            result.
+        :raises InvalidArgument: when ``requested_state`` is empty after trimming.
+        """
+        if requested_state is None:
+            return self._state_metadata(do_async)
+
+        return self.invoke_action(
+            self._persistent_storage_uri(do_async),
+            "VFlashStateChange",
+            payload=self._payload(requested_state),
+            full_action_type=_VFLASH_STATE_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -129,6 +129,7 @@ class ApiRequestType(Enum):
     Triggers = auto()
     NetworkPorts = auto()
     OemInfo = auto()
+    DellVFlashStateChange = auto()
     ConsoleInfo = auto()
     SerialConsoleConfig = auto()
     BiosSnapshot = auto()

--- a/tests/test_dell_vflash_state_dualmode.py
+++ b/tests/test_dell_vflash_state_dualmode.py
@@ -1,0 +1,230 @@
+"""Dual-mode-style coverage for Dell vFlash state changes."""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.oem.cmd_dell_vflash_state import DellVFlashStateChange
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+PERSISTENT_STORAGE_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DellPersistentStorageService"
+)
+VFLASH_ACTION = "#DellPersistentStorageService.VFlashStateChange"
+VFLASH_TARGET = (
+    f"{PERSISTENT_STORAGE_SERVICE}/Actions/"
+    "DellPersistentStorageService.VFlashStateChange"
+)
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@contextmanager
+def _mock_dell_vflash(persistent_storage_transform=None):
+    """Serve the committed Dell corpus over requests-mock.
+
+    :param persistent_storage_transform: optional mutator for the service fixture.
+    :return: context yielding RedfishManagerBase and recorded requests.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        data = json.loads(fixture.read_text())
+        is_service = request.path.rstrip("/").lower() == (
+            PERSISTENT_STORAGE_SERVICE.lower()
+        )
+        if is_service and persistent_storage_transform:
+            data = persistent_storage_transform(data)
+        context.status_code = 200
+        return json.dumps(data)
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/vflash-1"
+        return json.dumps({
+            "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/vflash-1"}
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-vflash",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_vflash_state_lists_target_without_posting():
+    """With no requested state, the command lists the VFlash target only."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "persistent_storage_service": PERSISTENT_STORAGE_SERVICE,
+        "action": VFLASH_ACTION,
+        "target": VFLASH_TARGET,
+        "requested_states": ["Disable", "Enable"],
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_without_confirm_is_preview_only():
+    """VFlashStateChange resolves the target but does not POST without confirm."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Enable",
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == VFLASH_ACTION
+    assert result.data["target"] == VFLASH_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {"RequestedState": "Enable"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_confirm_posts_requested_state():
+    """--confirm POSTs the requested state to the discovered action target."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Disable",
+            confirm=True,
+        )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == VFLASH_ACTION
+    assert result.data["target"] == VFLASH_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "vflash-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == VFLASH_TARGET.lower()
+    assert posts[0].json() == {"RequestedState": "Disable"}
+
+
+def test_dell_vflash_state_rejects_invalid_requested_state():
+    """Inline allowable values reject an unsupported RequestedState before POST."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Suspend",
+            confirm=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellPersistentStorageService.VFlashStateChange "
+        "RequestedState: Suspend; allowed: Disable, Enable"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "RequestedState",
+            "value": "Suspend",
+            "allowed": ["Disable", "Enable"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_reports_missing_action_without_posting():
+    """A persistent-storage resource without VFlashStateChange fails closed."""
+
+    def without_vflash_action(data):
+        data.get("Actions", {}).pop(VFLASH_ACTION, None)
+        return data
+
+    with _mock_dell_vflash(without_vflash_action) as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Enable",
+            confirm=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        f"action '{VFLASH_ACTION}' not found on {PERSISTENT_STORAGE_SERVICE}"
+    )
+    assert VFLASH_ACTION not in result.data["available"]
+    assert "AttachPartition" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_exposes_cli_entrypoint_and_policy():
+    """The command is registered and classified as a guarded state change."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellVFlashStateChange][
+        "dell-vflash-state"
+    ] is DellVFlashStateChange
+    assert classify(VFLASH_ACTION) is Destructiveness.DESTRUCTIVE
+
+    cmd_parser, cmd_name, cmd_help = DellVFlashStateChange.register_subcommand(
+        DellVFlashStateChange
+    )
+
+    assert "--requested-state" in cmd_parser.format_help()
+    assert "--confirm" in cmd_parser.format_help()
+    assert "--dry_run" in cmd_parser.format_help()
+    assert cmd_name == "dell-vflash-state"
+    assert "vFlash" in cmd_help
+
+
+def test_dell_vflash_state_rejects_blank_requested_state():
+    """Blank requested-state input is rejected before any POST can be made."""
+    with pytest.raises(InvalidArgument, match="requested state cannot be empty"):
+        DellVFlashStateChange._payload("  ")


### PR DESCRIPTION
## Summary
- add guarded dell-vflash-state for DellPersistentStorageService.VFlashStateChange
- discover the service from Manager OEM Dell links and list the target/states by default
- validate RequestedState, require --confirm for POST, and add Dell corpus-backed tests plus command docs

## Validation
- git diff --cached --check
- GitHub Actions will run the full test matrix