### PR TITLE
Add Dell time management command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-time-manage` | Query or set Dell service-processor time through `DellTimeService.ManageTime`; queries by default, and `--set-time` requires `--confirm`. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -126,6 +126,7 @@ from .oem.cmd_nvidia_debug_token import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *
+from .manager.cmd_dell_time_manage import *
 from .chassis.cmd_chassis_query import *
 
 # dell oem attach

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,7 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellTimeService.ManageTime": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/manager/cmd_dell_time_manage.py
+++ b/redfish_ctl/manager/cmd_dell_time_manage.py
@@ -1,0 +1,314 @@
+"""Query or set Dell service-processor time through DellTimeService.ManageTime.
+
+    redfish_ctl dell-time-manage
+    redfish_ctl dell-time-manage --dry_run
+    redfish_ctl dell-time-manage --set-time 2026-07-18T03:00:00+00:00
+    redfish_ctl dell-time-manage --set-time 2026-07-18T03:00:00+00:00 --confirm
+
+``#DellTimeService.ManageTime`` uses POST for both a read-style query and a
+volatile time write. This command sends the read payload by default and requires
+``--confirm`` before it sends a set-time payload.
+
+Author Mus spyroot@gmail.com
+"""
+import datetime
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_DELL_TIME_ACTION = "#DellTimeService.ManageTime"
+_DELL_TIME_FALLBACK = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/DellTimeService"
+)
+
+
+class DellTimeManage(RedfishManagerBase,
+                     scm_type=ApiRequestType.DellTimeManage,
+                     name="dell-time-manage",
+                     metaclass=Singleton):
+    """Query or set Dell service-processor time via DellTimeService."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-time-manage command."""
+        super(DellTimeManage, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-time-manage`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--manager",
+            default=None,
+            help="manager Id or URI when more than one Dell manager advertises "
+                 "DellTimeService",
+        )
+        cmd_parser.add_argument(
+            "--set-time",
+            dest="set_time",
+            default=None,
+            help="ISO-8601 DateTime to set through DellTimeService.ManageTime",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="send the set-time POST; reads do not require confirmation",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-time-manage",
+            "command query or set Dell service-processor time",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish ``@odata.id`` link value from a resource body.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: link URI, or None when absent.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _oem_dell(data):
+        """Return the ``Links.Oem.Dell`` block from a Manager resource.
+
+        :param data: Manager resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = data.get("Links") if isinstance(data, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async, optional=False):
+        """GET a Redfish resource body.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the GET over the async path when True.
+        :param optional: return an empty object instead of failing on read errors.
+        :return: parsed Redfish object body.
+        :raises InvalidArgument: when a required read fails or is not an object.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            if optional:
+                return {}
+            raise InvalidArgument(f"failed to read {uri}: {exc}") from exc
+        if not isinstance(data, dict):
+            if optional:
+                return {}
+            raise InvalidArgument(f"unexpected response from {uri}: expected object")
+        return data
+
+    def _service_uri_for_manager(self, manager_uri, do_async):
+        """Resolve a manager's DellTimeService URI.
+
+        :param manager_uri: Manager resource URI.
+        :param do_async: issue the Manager GET over the async path when True.
+        :return: DellTimeService URI.
+        """
+        manager = self._get(manager_uri, do_async, optional=True)
+        service_uri = self._link(self._oem_dell(manager), "DellTimeService")
+        if service_uri:
+            return service_uri
+        if manager_uri.rstrip("/").endswith("/iDRAC.Embedded.1"):
+            return _DELL_TIME_FALLBACK
+        return None
+
+    def _discover_rows(self, do_async):
+        """Discover managers that advertise DellTimeService.ManageTime.
+
+        :param do_async: issue discovery reads over the async path when True.
+        :return: list of target rows.
+        """
+        rows = []
+        for manager_uri in self.discover_manager_ids() or []:
+            manager_uri = manager_uri.rstrip("/")
+            service_uri = self._service_uri_for_manager(manager_uri, do_async)
+            if not service_uri:
+                continue
+            service = self._get(service_uri, do_async, optional=True)
+            target = self._flatten_action_targets(service).get(_DELL_TIME_ACTION)
+            if not target:
+                continue
+            rows.append({
+                "Manager": manager_uri.rsplit("/", 1)[-1],
+                "ManagerUri": manager_uri,
+                "Service": service_uri,
+                "Target": target,
+            })
+        return rows
+
+    @staticmethod
+    def _select_rows(rows, manager):
+        """Filter target rows by manager selector.
+
+        :param rows: discovered DellTimeService target rows.
+        :param manager: optional manager Id or URI.
+        :return: matching rows.
+        :raises InvalidArgument: when the selector does not match.
+        """
+        if not manager:
+            return rows
+        selector = manager.strip()
+        if not selector:
+            raise InvalidArgument("manager selector cannot be empty")
+        folded = selector.lower()
+        matches = [
+            row for row in rows
+            if folded in {row["Manager"].lower(), row["ManagerUri"].lower()}
+        ]
+        if not matches:
+            available = [row["Manager"] for row in rows]
+            raise InvalidArgument(
+                f"no DellTimeService target for manager '{manager}'; "
+                f"available: {available}"
+            )
+        return matches
+
+    @staticmethod
+    def _validate_time_data(value):
+        """Validate and normalize a requested Redfish DateTime string.
+
+        :param value: user-supplied DateTime.
+        :return: stripped DateTime string.
+        :raises InvalidArgument: when the value is empty or not ISO-8601-like.
+        """
+        text = str(value or "").strip()
+        if not text:
+            raise InvalidArgument("set-time cannot be empty")
+        parse_text = f"{text[:-1]}+00:00" if text.endswith("Z") else text
+        try:
+            datetime.datetime.fromisoformat(parse_text)
+        except ValueError as exc:
+            raise InvalidArgument(
+                f"set-time must be an ISO-8601 DateTime: {text}"
+            ) from exc
+        return text
+
+    @staticmethod
+    def _payload(set_time):
+        """Build a DellTimeService.ManageTime payload.
+
+        :param set_time: DateTime string to set, or None to query.
+        :return: tuple of (payload, level).
+        """
+        if set_time is None:
+            return {"GetRequest": True}, "read_only"
+        return {
+            "GetRequest": False,
+            "TimeData": DellTimeManage._validate_time_data(set_time),
+        }, "destructive"
+
+    def _preview(self, rows, payload, level, blocked):
+        """Return a no-POST command preview.
+
+        :param rows: selected target rows.
+        :param payload: payload that would be posted.
+        :param level: risk level for the selected mode.
+        :param blocked: optional reason the POST is blocked.
+        :return: preview CommandResult.
+        """
+        return CommandResult({
+            "dry_run": True,
+            "action": _DELL_TIME_ACTION,
+            "targets": rows,
+            "payload": payload,
+            "level": level,
+            "blocked": blocked,
+        }, None, None, None)
+
+    def execute(self,
+                manager: Optional[str] = None,
+                set_time: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Query or set Dell service-processor time.
+
+        :param manager: optional manager Id or URI selector.
+        :param set_time: ISO-8601 DateTime to set; None queries current time.
+        :param confirm: allow a set-time POST to be sent.
+        :param dry_run: resolve target and payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying reads/POSTs over the async path when True.
+        :return: CommandResult containing preview data or POST results.
+        """
+        rows = self._select_rows(self._discover_rows(do_async), manager)
+        if not rows:
+            return CommandResult(
+                {"action": _DELL_TIME_ACTION, "available": []},
+                None,
+                None,
+                "DellTimeService.ManageTime action not found",
+            )
+        if set_time is not None and manager is None and len(rows) > 1:
+            managers = [row["Manager"] for row in rows]
+            raise InvalidArgument(
+                f"--manager is required when setting time on multiple managers: "
+                f"{managers}"
+            )
+
+        payload, level = self._payload(set_time)
+        if dry_run:
+            return self._preview(rows, payload, level, None)
+        if set_time is not None and not confirm:
+            return self._preview(
+                rows,
+                payload,
+                level,
+                "DellTimeService.ManageTime set requires --confirm",
+            )
+
+        results = []
+        first_error = None
+        for row in rows:
+            result, status = self.base_post(
+                row["Target"],
+                payload=payload,
+                do_async=do_async,
+                expected_status=200,
+            )
+            entry = dict(row)
+            entry["status"] = str(status)
+            entry["response"] = result.data
+            if result.error:
+                entry["error"] = result.error
+                first_error = first_error or result.error
+            results.append(entry)
+
+        data = {
+            "action": _DELL_TIME_ACTION,
+            "payload": payload,
+            "level": level,
+            "executed": True,
+            "results": results,
+        }
+        return CommandResult(data, None, None, first_error)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -135,6 +135,7 @@ class ApiRequestType(Enum):
     BootState = auto()
     BmcScan = auto()
     ManagerTime = auto()
+    DellTimeManage = auto()
     WaitReady = auto()
 
     # boot sources

--- a/tests/test_dell_time_manage_dualmode.py
+++ b/tests/test_dell_time_manage_dualmode.py
@@ -1,0 +1,222 @@
+"""Dual-mode-style coverage for DellTimeService.ManageTime."""
+
+import json
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.manager.cmd_dell_time_manage import DellTimeManage
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_TIME_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellTimeService"
+)
+MANAGE_TARGET = f"{DELL_TIME_SERVICE}/Actions/DellTimeService.ManageTime"
+QUERY_TIME = "2023-06-02T11:03:14-05:00"
+SET_TIME = "2026-07-18T03:00:00+00:00"
+
+
+@pytest.fixture
+def dell_time_manager():
+    """Serve the committed Dell corpus with a ManageTime POST response."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+
+    def post_cb(request, context):
+        if request.path.lower() == MANAGE_TARGET.lower():
+            service.requests.append(request)
+            payload = request.json() if request.text else {}
+            context.status_code = 200
+            if payload.get("GetRequest") is True:
+                return json.dumps({"TimeData": QUERY_TIME})
+            return json.dumps({"TimeData": payload.get("TimeData")})
+        return service.post_cb(request, context)
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-time",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_dell_time_manage_queries_time_by_default(dell_time_manager):
+    """The default query sends the read-style ManageTime payload."""
+    manager, service = dell_time_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellTimeManage,
+        "dell-time-manage",
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["action"] == "#DellTimeService.ManageTime"
+    assert result.data["payload"] == {"GetRequest": True}
+    assert result.data["level"] == "read_only"
+    assert result.data["executed"] is True
+    assert result.data["results"][0]["response"] == {"Status": "ok"}
+    assert len(posts) == 1
+    assert posts[0].path.lower() == MANAGE_TARGET.lower()
+    assert posts[0].json() == {"GetRequest": True}
+
+
+def test_dell_time_manage_dry_run_suppresses_query_post(dell_time_manager):
+    """--dry_run resolves the Dell target without POSTing."""
+    manager, service = dell_time_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellTimeManage,
+        "dell-time-manage",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellTimeService.ManageTime"
+    assert result.data["payload"] == {"GetRequest": True}
+    assert result.data["level"] == "read_only"
+    assert result.data["blocked"] is None
+    assert result.data["targets"] == [{
+        "Manager": "iDRAC.Embedded.1",
+        "ManagerUri": "/redfish/v1/Managers/iDRAC.Embedded.1",
+        "Service": DELL_TIME_SERVICE,
+        "Target": MANAGE_TARGET,
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_time_manage_set_requires_confirm(dell_time_manager):
+    """A set-time payload is previewed unless --confirm is present."""
+    manager, service = dell_time_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellTimeManage,
+        "dell-time-manage",
+        set_time=SET_TIME,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["level"] == "destructive"
+    assert result.data["payload"] == {
+        "GetRequest": False,
+        "TimeData": SET_TIME,
+    }
+    assert result.data["blocked"] == (
+        "DellTimeService.ManageTime set requires --confirm"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_time_manage_confirm_posts_set_payload(dell_time_manager):
+    """--confirm sends exactly one set-time POST to the discovered Dell target."""
+    manager, service = dell_time_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellTimeManage,
+        "dell-time-manage",
+        set_time=SET_TIME,
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "destructive"
+    assert result.data["results"][0]["response"] == {"Status": "ok"}
+    assert len(posts) == 1
+    assert posts[0].path.lower() == MANAGE_TARGET.lower()
+    assert posts[0].json() == {
+        "GetRequest": False,
+        "TimeData": SET_TIME,
+    }
+
+
+def test_dell_time_manage_reports_missing_action_without_post(redfish_mock_factory):
+    """A fixture without DellTimeService reports an error and never POSTs."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellTimeManage,
+        "dell-time-manage",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data == {
+        "action": "#DellTimeService.ManageTime",
+        "available": [],
+    }
+    assert result.error == "DellTimeService.ManageTime action not found"
+    assert _post_requests(service) == []
+
+
+def test_dell_time_manage_rejects_invalid_set_time(dell_time_manager):
+    """Invalid set-time values fail before POST."""
+    manager, service = dell_time_manager
+
+    with pytest.raises(InvalidArgument):
+        manager.sync_invoke(
+            ApiRequestType.DellTimeManage,
+            "dell-time-manage",
+            set_time="not-a-date",
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_dell_time_manage_is_registered():
+    """The dell-time-manage command is wired into the command registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellTimeManage]["dell-time-manage"] is (
+        DellTimeManage
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellTimeManage.register_subcommand(
+        DellTimeManage
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-time-manage"
+    assert "Dell service-processor time" in cmd_help
+    assert "--set-time" in help_text
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text
+
+
+def test_dell_time_manage_policy_is_destructive():
+    """Generic action listings classify ManageTime as guarded by default."""
+    assert classify("#DellTimeService.ManageTime") is Destructiveness.DESTRUCTIVE


### PR DESCRIPTION
## Summary
- add a dell-time-manage command for DellTimeService.ManageTime discovery
- support default time query, dry-run previews, and confirmed set-time payloads
- add Dell corpus-backed command coverage and command-table documentation

## Validation
- git diff --check
- not run: off-laptop pytest/ruff gate unavailable from current environment