### PR TITLE
Add Dell LC log comment command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-log-comment` | Insert a Dell Lifecycle Controller log comment; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -9,6 +9,7 @@ from .system.cmd_system_import import *
 #
 from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
+from .dell_lc.cmd_dell_lc_log_comment import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
 #

--- a/redfish_ctl/dell_lc/cmd_dell_lc_log_comment.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_log_comment.py
@@ -1,0 +1,257 @@
+"""Insert a comment or worknote into the Dell Lifecycle Controller log.
+
+    redfish_ctl dell-lc-log-comment
+    redfish_ctl dell-lc-log-comment --comment "maintenance note"
+    redfish_ctl dell-lc-log-comment --comment "follow-up" --log-sequence-number 123 --confirm
+
+The command resolves ``#DellLCService.InsertCommentInLCLog`` from the Dell LC
+service. With no comment it lists the discovered action target. With a comment it
+previews by default; ``--confirm`` is required before the POST is sent.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_LC_LOG_COMMENT_ACTION = "#DellLCService.InsertCommentInLCLog"
+_STANDARD_LC_SERVICE = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+_LEGACY_LC_SERVICE = f"{RedfishApi.Version}/Dell/Managers/iDRAC.Embedded.1/DellLCService"
+
+
+class DellLcLogComment(RedfishManagerBase,
+                       scm_type=ApiRequestType.DellLcLogComment,
+                       name="dell-lc-log-comment",
+                       metaclass=Singleton):
+    """Preview or insert a Dell Lifecycle Controller log comment."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-log-comment command."""
+        super(DellLcLogComment, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-lc-log-comment`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--comment",
+            required=False,
+            dest="comment",
+            type=str,
+            default=None,
+            help="comment/worknote text to insert into the Lifecycle Controller log",
+        )
+        cmd_parser.add_argument(
+            "--log-sequence-number",
+            required=False,
+            dest="log_sequence_number",
+            type=str,
+            default=None,
+            help="optional LC log sequence number to attach the comment to",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the InsertCommentInLCLog POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-log-comment",
+            "command insert a Dell Lifecycle Controller log comment",
+        )
+
+    @staticmethod
+    def _nested_link(data, *keys):
+        """Return an ``@odata.id`` nested under ``keys``.
+
+        :param data: resource body to inspect.
+        :param keys: dictionary path ending at a Redfish link object.
+        :return: link target URI, or None when absent or malformed.
+        """
+        node = data or {}
+        for key in keys:
+            if not isinstance(node, dict):
+                return None
+            node = node.get(key)
+        return node.get("@odata.id") if isinstance(node, dict) else None
+
+    def _linked_lc_service_uri(self, do_async):
+        """Resolve DellLCService from Manager Links/Oem/Dell when available.
+
+        :param do_async: issue manager reads over the async Redfish path.
+        :return: linked DellLCService URI, or None when no manager exposes it.
+        """
+        try:
+            manager_ids = self.discover_manager_ids()
+        except Exception:
+            manager_ids = []
+        for manager_uri in manager_ids:
+            try:
+                manager = self.base_query(manager_uri, do_async=do_async).data or {}
+            except Exception:
+                continue
+            linked = self._nested_link(
+                manager, "Links", "Oem", "Dell", "DellLCService"
+            )
+            if linked:
+                return linked
+        return None
+
+    def _service_candidates(self, do_async):
+        """Return candidate DellLCService URIs in preferred order.
+
+        :param do_async: issue discovery reads over the async Redfish path.
+        :return: tuple of unique candidate service URIs.
+        """
+        candidates = [
+            self._linked_lc_service_uri(do_async),
+            _STANDARD_LC_SERVICE,
+            _LEGACY_LC_SERVICE,
+        ]
+        result = []
+        for uri in candidates:
+            if uri and uri not in result:
+                result.append(uri)
+        return tuple(result)
+
+    def _read_lc_service(self, do_async):
+        """Read DellLCService using linked and legacy path candidates.
+
+        :param do_async: issue queries over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or a CommandResult error.
+        """
+        errors = []
+        for uri in self._service_candidates(do_async):
+            try:
+                result = self.base_query(uri, do_async=do_async)
+            except Exception as exc:
+                errors.append(f"{uri}: {exc}")
+                continue
+            if result.error is not None:
+                errors.append(f"{uri}: {result.error}")
+                continue
+            data = result.data or {}
+            if isinstance(data, dict) and data:
+                return uri, data
+        error = "; ".join(errors) if errors else "no DellLCService candidate URI"
+        return CommandResult(None, None, None, f"failed to read DellLCService: {error}")
+
+    def _comment_metadata(self, do_async):
+        """Return discovered InsertCommentInLCLog target metadata.
+
+        :param do_async: issue the DellLCService query over the async path.
+        :return: CommandResult with target metadata, or an error if absent.
+        """
+        service_info = self._read_lc_service(do_async)
+        if isinstance(service_info, CommandResult):
+            return service_info
+        uri, service = service_info
+        actions = self.discover_redfish_actions(self, service)
+        target = self._flatten_action_targets(service).get(_LC_LOG_COMMENT_ACTION)
+        if target is None:
+            available = sorted(set(list(actions.keys())
+                                   + list(self._flatten_action_targets(service).keys())))
+            return CommandResult(
+                {
+                    "lc_service": uri,
+                    "action": _LC_LOG_COMMENT_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_LC_LOG_COMMENT_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "lc_service": uri,
+                "action": _LC_LOG_COMMENT_ACTION,
+                "target": target,
+            },
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _payload(comment, log_sequence_number=None):
+        """Build the InsertCommentInLCLog payload.
+
+        :param comment: worknote/comment text.
+        :param log_sequence_number: optional LC log sequence number.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when ``comment`` is empty after trimming.
+        """
+        text = (comment or "").strip()
+        if not text:
+            raise InvalidArgument("Lifecycle Controller log comment cannot be empty")
+        payload = {"Comment": text}
+        sequence = (log_sequence_number or "").strip()
+        if sequence:
+            payload["LogSequenceNumber"] = sequence
+        return payload
+
+    def execute(self,
+                comment: Optional[str] = None,
+                log_sequence_number: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke the Dell LC log-comment action.
+
+        With no ``--comment`` this command only reports the discovered
+        InsertCommentInLCLog target. With a comment it resolves the target and
+        previews the POST unless ``--confirm`` is passed. ``--dry_run`` remains a
+        no-POST override even with ``--confirm``.
+
+        :param comment: worknote/comment text to insert; None lists target metadata.
+        :param log_sequence_number: optional LC log sequence number to annotate.
+        :param confirm: authorize the action POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with target metadata, the action outcome, or a
+            blocked/dry-run preview.
+        :raises InvalidArgument: when ``comment`` is empty after trimming.
+        """
+        metadata = self._comment_metadata(do_async)
+        if comment is None or metadata.error is not None:
+            return metadata
+
+        service_uri = metadata.data["lc_service"]
+        return self.invoke_action(
+            service_uri,
+            "InsertCommentInLCLog",
+            payload=self._payload(comment, log_sequence_number),
+            full_action_type=_LC_LOG_COMMENT_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcLogComment = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/tests/test_dell_lc_log_comment_dualmode.py
+++ b/tests/test_dell_lc_log_comment_dualmode.py
@@ -1,0 +1,214 @@
+"""Dual-mode-style coverage for DellLCService.InsertCommentInLCLog."""
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.dell_lc.cmd_dell_lc_log_comment import DellLcLogComment
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+LC_SERVICE = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+INSERT_TARGET = f"{LC_SERVICE}/Actions/DellLCService.InsertCommentInLCLog"
+INSERT_ACTION = "#DellLCService.InsertCommentInLCLog"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_lc_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase and recorded requests list.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/lclog-comment-1"
+        return json.dumps({
+            "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/lclog-comment-1"}
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-lc",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_lc_log_comment_lists_target_without_mutating(dell_lc_manager):
+    """Without a comment, the command lists the target and never POSTs."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "lc_service": LC_SERVICE,
+        "action": INSERT_ACTION,
+        "target": INSERT_TARGET,
+    }
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_without_confirm_is_preview_only(dell_lc_manager):
+    """InsertCommentInLCLog resolves the target but does not POST by default."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment=" maintenance note ",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == INSERT_ACTION
+    assert result.data["target"] == INSERT_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {"Comment": "maintenance note"}
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_confirm_posts_payload(dell_lc_manager):
+    """--confirm POSTs the comment payload to the discovered action target."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment="Investigated PSU event",
+        log_sequence_number="42",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == INSERT_ACTION
+    assert result.data["target"] == INSERT_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "lclog-comment-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == INSERT_TARGET.lower()
+    assert posts[0].json() == {
+        "Comment": "Investigated PSU event",
+        "LogSequenceNumber": "42",
+    }
+
+
+def test_lc_log_comment_confirm_dry_run_still_does_not_post(dell_lc_manager):
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment="do not send",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"Comment": "do not send"}
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_rejects_empty_comment(dell_lc_manager):
+    """A blank comment is rejected before any action POST can fire."""
+    manager, requests = dell_lc_manager
+
+    with pytest.raises(InvalidArgument, match="comment cannot be empty"):
+        manager.sync_invoke(
+            ApiRequestType.DellLcLogComment,
+            "dell-lc-log-comment",
+            comment="   ",
+            confirm=True,
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_reports_missing_action_without_post(redfish_mock):
+    """Older Dell fixtures without InsertCommentInLCLog return a target error."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment="maintenance note",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#DellLCService.InsertCommentInLCLog' not found on "
+        "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService"
+    )
+    assert result.data["action"] == INSERT_ACTION
+    assert "GetRSStatus" in result.data["available"]
+
+
+def test_lc_log_comment_exposes_cli_entrypoint():
+    """The dell-lc-log-comment command is wired into the package registry."""
+    registry = RedfishManagerBase._registry
+    assert registry[ApiRequestType.DellLcLogComment]["dell-lc-log-comment"] is (
+        DellLcLogComment
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellLcLogComment.register_subcommand(
+        DellLcLogComment
+    )
+
+    assert cmd_name == "dell-lc-log-comment"
+    assert "comment" in cmd_help
+    assert any(action.dest == "comment" for action in cmd_parser._actions)


### PR DESCRIPTION
## Summary
- add `dell-lc-log-comment` for `DellLCService.InsertCommentInLCLog`
- discover the LC service from Dell manager links with standard and legacy path fallback
- add XR8620t corpus-backed coverage and the command reference row

## Validation
- `git diff --check`
- GitHub CI will run the offline matrix after push