### PR TITLE
Add Dell Lifecycle Controller export command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-export` | Export Dell LC data; preview unless confirmed. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -9,6 +9,7 @@ from .system.cmd_system_import import *
 #
 from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
+from .dell_lc.cmd_dell_lc_export import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
 #

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -8,8 +8,8 @@ dry-run unless ``--confirm`` is given, or additionally needs an explicit
 
 Fail-safe by construction: an action not in the table is treated as DESTRUCTIVE,
 so a newly exposed (unclassified) action can never POST without an explicit
-confirm. This module is product-neutral — it names standard DMTF + NVIDIA OEM
-action types only and imports nothing from the Redfish manager layer.
+confirm. This module is product-neutral — it names standard DMTF and vendor OEM
+action types and imports nothing from the Redfish manager layer.
 
 Author Mus spyroot@gmail.com
 """
@@ -36,8 +36,7 @@ class Destructiveness(Enum):
 
 
 # Keyed by the full Redfish action type "#Type.Action" (as discover_redfish_actions
-# reports it in RedfishAction.full_redfish_name). Covers the 25 action types the
-# GB300 NVL exposes plus a couple of standard siblings.
+# reports it in RedfishAction.full_redfish_name).
 ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
@@ -70,6 +69,15 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportCompleteLCLog": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportFactoryConfiguration": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportHWInventory": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportLCLog": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportSVGFile": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportServerScreenShot": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportTechSupportReport": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportVideoLog": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExportePSADiagnosticsResult": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/dell_lc/cmd_dell_lc_export.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_export.py
@@ -1,0 +1,541 @@
+"""Export Dell Lifecycle Controller data through DellLCService actions.
+
+    redfish_ctl dell-lc-export
+    redfish_ctl dell-lc-export --export lc-log --share-type NFS \
+        --share-name /exports/lc --dry_run
+    redfish_ctl dell-lc-export --export hw-inventory --share-type HTTPS \
+        --share-name reports --confirm
+
+The command resolves DellLCService from the Manager OEM path and falls back to
+the older Dell fixture path. Export actions can write potentially sensitive
+support data to a local or network target, so selected exports preview by default
+and only POST when ``--confirm`` is supplied.
+
+Author Mus spyroot@gmail.com
+"""
+import os
+from abc import abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_DELL_LC_EXPORTS = {
+    "complete-lc-log": "#DellLCService.ExportCompleteLCLog",
+    "epsa-diagnostics": "#DellLCService.ExportePSADiagnosticsResult",
+    "factory-configuration": "#DellLCService.ExportFactoryConfiguration",
+    "hw-inventory": "#DellLCService.ExportHWInventory",
+    "lc-log": "#DellLCService.ExportLCLog",
+    "server-screenshot": "#DellLCService.ExportServerScreenShot",
+    "svg": "#DellLCService.ExportSVGFile",
+    "tech-support-report": "#DellLCService.ExportTechSupportReport",
+    "video-log": "#DellLCService.ExportVideoLog",
+}
+
+
+class DellLcExport(RedfishManagerBase,
+                   scm_type=ApiRequestType.DellLcExport,
+                   name="dell-lc-export",
+                   metaclass=Singleton):
+    """Export Dell Lifecycle Controller data through discovered DellLCService actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-export command."""
+        super(DellLcExport, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-lc-export`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--export",
+            required=False,
+            dest="export_name",
+            choices=tuple(sorted(_DELL_LC_EXPORTS)),
+            default=None,
+            help="LC export action to run; omit to list discovered export targets",
+        )
+        cmd_parser.add_argument(
+            "--share-type",
+            required=False,
+            dest="share_type",
+            type=str,
+            default=None,
+            help="ShareType value for export actions that write to a share",
+        )
+        cmd_parser.add_argument(
+            "--ip-address",
+            required=False,
+            dest="ip_address",
+            type=str,
+            default=None,
+            help="network share host or address for actions that require IPAddress",
+        )
+        cmd_parser.add_argument(
+            "--share-name",
+            required=False,
+            dest="share_name",
+            type=str,
+            default=None,
+            help="network share name or local export destination",
+        )
+        cmd_parser.add_argument(
+            "--file-name",
+            required=False,
+            dest="file_name",
+            type=str,
+            default=None,
+            help="optional output file name for the export payload",
+        )
+        cmd_parser.add_argument(
+            "--username",
+            required=False,
+            dest="share_username",
+            type=str,
+            default=None,
+            help="optional network share username",
+        )
+        password_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        password_group.add_argument(
+            "--password-env",
+            required=False,
+            dest="share_password_env",
+            type=str,
+            default=None,
+            help="environment variable containing the share password",
+        )
+        password_group.add_argument(
+            "--password-file",
+            required=False,
+            dest="share_password_file",
+            type=str,
+            default=None,
+            help="file containing the share password",
+        )
+        cmd_parser.add_argument(
+            "--workgroup",
+            required=False,
+            dest="workgroup",
+            type=str,
+            default=None,
+            help="optional CIFS workgroup",
+        )
+        cmd_parser.add_argument(
+            "--ignore-cert-warning",
+            required=False,
+            dest="ignore_cert_warning",
+            type=str,
+            default=None,
+            help="IgnoreCertWarning value when the export action advertises it",
+        )
+        cmd_parser.add_argument(
+            "--proxy-support",
+            required=False,
+            dest="proxy_support",
+            type=str,
+            default=None,
+            help="ProxySupport value when the export action advertises it",
+        )
+        cmd_parser.add_argument(
+            "--proxy-type",
+            required=False,
+            dest="proxy_type",
+            type=str,
+            default=None,
+            help="ProxyType value when the export action advertises it",
+        )
+        cmd_parser.add_argument(
+            "--xml-schema",
+            required=False,
+            dest="xml_schema",
+            type=str,
+            default=None,
+            help="XMLSchema value for HW inventory export",
+        )
+        cmd_parser.add_argument(
+            "--file-type",
+            required=False,
+            dest="file_type",
+            type=str,
+            default=None,
+            help="FileType value for screenshot or video export",
+        )
+        cmd_parser.add_argument(
+            "--data-selector",
+            action="append",
+            required=False,
+            dest="data_selectors",
+            default=None,
+            help="DataSelectorArrayIn entry; repeat for multiple selectors",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the selected DellLCService export POST",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-export",
+            "command export Dell Lifecycle Controller data",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body holding the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: link target URI, or None when absent.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _manager_id(manager_uri):
+        """Return the Manager id from a Manager URI.
+
+        :param manager_uri: Manager resource URI.
+        :return: last path segment, or None when malformed.
+        """
+        value = (manager_uri or "").rstrip("/")
+        return value.rsplit("/", 1)[-1] if value else None
+
+    def _get(self, uri, do_async):
+        """Read a Redfish resource, returning None when the GET is not usable.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the read through the async path when True.
+        :return: parsed JSON object or None.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+
+    @staticmethod
+    def _append_unique(items, value):
+        """Append a non-empty value to ``items`` once.
+
+        :param items: list being built.
+        :param value: candidate string value.
+        :return: None.
+        """
+        if value and value not in items:
+            items.append(value)
+
+    def _candidate_lc_uris(self, do_async):
+        """Return candidate DellLCService URIs for modern and legacy layouts.
+
+        :param do_async: issue discovery reads through the async path when True.
+        :return: ordered list of candidate DellLCService URIs.
+        """
+        candidates = []
+        try:
+            managers = self.discover_manager_ids() or []
+        except Exception:
+            managers = []
+        for manager_uri in managers:
+            manager = self._get(manager_uri, do_async) or {}
+            oem_dell = (manager.get("Oem") or {}).get("Dell")
+            if isinstance(oem_dell, dict):
+                self._append_unique(
+                    candidates, self._link(oem_dell, "DellLCService"))
+            manager_id = self._manager_id(manager_uri)
+            if manager_id:
+                self._append_unique(
+                    candidates,
+                    f"{manager_uri.rstrip('/')}/Oem/Dell/DellLCService",
+                )
+                self._append_unique(
+                    candidates,
+                    f"/redfish/v1/Dell/Managers/{manager_id}/DellLCService",
+                )
+        self._append_unique(
+            candidates,
+            "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService",
+        )
+        self._append_unique(
+            candidates, "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService")
+        return candidates
+
+    def _lc_service(self, do_async):
+        """Read the first available DellLCService resource.
+
+        :param do_async: issue discovery reads through the async path when True.
+        :return: tuple of ``(uri, body)`` or ``(None, CommandResult)`` on error.
+        """
+        candidates = self._candidate_lc_uris(do_async)
+        for uri in candidates:
+            service = self._get(uri, do_async)
+            actions = service.get("Actions") if isinstance(service, dict) else None
+            if isinstance(actions, dict) and any(
+                    name.startswith("#DellLCService.") for name in actions):
+                return uri, service
+        return None, CommandResult(
+            {"candidates": candidates}, None, None,
+            "DellLCService is not available on this Redfish endpoint")
+
+    @staticmethod
+    def _allowed_args(action):
+        """Return advertised allowable values for an action.
+
+        :param action: discovered RedfishAction.
+        :return: dict of argument name to sorted allowable values.
+        """
+        args = getattr(action, "args", None) or {}
+        return {key: sorted(values or []) for key, values in sorted(args.items())}
+
+    def _export_metadata(self, do_async):
+        """Return discovered LC export target metadata.
+
+        :param do_async: issue the service query through the async path when True.
+        :return: CommandResult containing the export action table or an error.
+        """
+        uri, service = self._lc_service(do_async)
+        if isinstance(service, CommandResult):
+            return service
+        actions = self.discover_redfish_actions(self, service)
+        full_targets = self._flatten_action_targets(service)
+        exports = []
+        for export_name, full_type in _DELL_LC_EXPORTS.items():
+            target = full_targets.get(full_type)
+            if target is None:
+                continue
+            action_name = full_type.rsplit(".", 1)[-1]
+            exports.append({
+                "export": export_name,
+                "action": full_type,
+                "target": target,
+                "allowed": self._allowed_args(actions.get(action_name)),
+            })
+        return CommandResult({
+            "lc_service": uri,
+            "export_actions": exports,
+        }, actions, None, None)
+
+    @staticmethod
+    def _optional_payload_value(value):
+        """Strip optional string payload values and drop empty values.
+
+        :param value: optional Redfish action payload value.
+        :return: stripped string, original non-string value, or None.
+        """
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    @staticmethod
+    def _password_from_source(password_env=None, password_file=None):
+        """Read a share password from a named environment variable or file.
+
+        :param password_env: environment variable name to read.
+        :param password_file: path to a file containing the password.
+        :return: password string, or None when no source is provided.
+        :raises InvalidArgument: when the source is invalid or unavailable.
+        """
+        if password_env and password_file:
+            raise InvalidArgument(
+                "use only one of --password-env or --password-file"
+            )
+        if password_env is not None:
+            env_name = password_env.strip()
+            if not env_name:
+                raise InvalidArgument("password environment variable name cannot be empty")
+            if env_name not in os.environ:
+                raise InvalidArgument(f"password environment variable '{env_name}' is not set")
+            return os.environ[env_name]
+        if password_file is not None:
+            path = Path(password_file).expanduser()
+            try:
+                return path.read_text(encoding="utf-8").rstrip("\r\n")
+            except OSError as exc:
+                raise InvalidArgument(
+                    f"failed to read password file '{path}': {exc}"
+                ) from exc
+        return None
+
+    @staticmethod
+    def _payload(**kwargs):
+        """Build a DellLCService export payload from supplied optional fields.
+
+        :param kwargs: normalized command arguments.
+        :return: JSON-serializable action payload.
+        """
+        fields = {
+            "ShareType": kwargs.get("share_type"),
+            "IPAddress": kwargs.get("ip_address"),
+            "ShareName": kwargs.get("share_name"),
+            "FileName": kwargs.get("file_name"),
+            "UserName": kwargs.get("share_username"),
+            "Password": kwargs.get("share_password"),
+            "Workgroup": kwargs.get("workgroup"),
+            "IgnoreCertWarning": kwargs.get("ignore_cert_warning"),
+            "ProxySupport": kwargs.get("proxy_support"),
+            "ProxyType": kwargs.get("proxy_type"),
+            "XMLSchema": kwargs.get("xml_schema"),
+            "FileType": kwargs.get("file_type"),
+        }
+        payload = {
+            key: DellLcExport._optional_payload_value(value)
+            for key, value in fields.items()
+        }
+        selectors = [
+            selector.strip() for selector in kwargs.get("data_selectors") or []
+            if isinstance(selector, str) and selector.strip()
+        ]
+        if selectors:
+            payload["DataSelectorArrayIn"] = selectors
+        return {key: value for key, value in payload.items() if value is not None}
+
+    @staticmethod
+    def _selected_export(export_name, exports):
+        """Resolve an export choice to its discovered action metadata.
+
+        :param export_name: requested export choice.
+        :param exports: discovered export metadata rows.
+        :return: selected metadata row.
+        :raises InvalidArgument: when the export is unavailable.
+        """
+        selected = next(
+            (item for item in exports if item["export"] == export_name),
+            None,
+        )
+        if selected is None:
+            available = [item["export"] for item in exports]
+            raise InvalidArgument(
+                f"DellLCService export '{export_name}' is not available; "
+                f"available: {available}")
+        return selected
+
+    @staticmethod
+    def _redact_password(result):
+        """Mask a share password in returned preview payloads.
+
+        :param result: CommandResult from ``invoke_action``.
+        :return: CommandResult with any payload password redacted.
+        """
+        if not isinstance(result.data, dict):
+            return result
+        payload = result.data.get("payload")
+        if isinstance(payload, dict) and "Password" in payload:
+            payload = dict(payload)
+            payload["Password"] = "********"
+            result.data["payload"] = payload
+        return result
+
+    def execute(self,
+                export_name: Optional[str] = None,
+                share_type: Optional[str] = None,
+                ip_address: Optional[str] = None,
+                share_name: Optional[str] = None,
+                file_name: Optional[str] = None,
+                share_username: Optional[str] = None,
+                share_password_env: Optional[str] = None,
+                share_password_file: Optional[str] = None,
+                workgroup: Optional[str] = None,
+                ignore_cert_warning: Optional[str] = None,
+                proxy_support: Optional[str] = None,
+                proxy_type: Optional[str] = None,
+                xml_schema: Optional[str] = None,
+                file_type: Optional[str] = None,
+                data_selectors: Optional[list[str]] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List export targets, preview a selected export, or fire it.
+
+        With no ``--export`` the command lists discovered LC export actions
+        WITHOUT mutating. With an export choice it invokes the advertised action;
+        because LC exports can write support data to a target, the POST only
+        fires with ``--confirm``. ``--dry_run`` overrides confirmation.
+
+        :param export_name: export action choice; None lists discovered targets.
+        :param share_type: optional ShareType payload value.
+        :param ip_address: optional IPAddress payload value.
+        :param share_name: optional ShareName payload value.
+        :param file_name: optional FileName payload value.
+        :param share_username: optional UserName payload value.
+        :param share_password_env: environment variable holding an optional share password.
+        :param share_password_file: file holding an optional share password.
+        :param workgroup: optional Workgroup payload value.
+        :param ignore_cert_warning: optional IgnoreCertWarning payload value.
+        :param proxy_support: optional ProxySupport payload value.
+        :param proxy_type: optional ProxyType payload value.
+        :param xml_schema: optional XMLSchema payload value.
+        :param file_type: optional FileType payload value.
+        :param data_selectors: optional DataSelectorArrayIn entries.
+        :param confirm: authorize the selected export POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST through the async path.
+        :return: CommandResult with target metadata, a blocked/dry-run preview,
+            or the POST result.
+        """
+        metadata = self._export_metadata(do_async)
+        if metadata.error or export_name is None:
+            return metadata
+        exports = metadata.data.get("export_actions", [])
+        selected = self._selected_export(export_name, exports)
+        full_action = selected["action"]
+        action_name = full_action.rsplit(".", 1)[-1]
+        payload = self._payload(
+            share_type=share_type,
+            ip_address=ip_address,
+            share_name=share_name,
+            file_name=file_name,
+            share_username=share_username,
+            share_password=self._password_from_source(
+                share_password_env,
+                share_password_file,
+            ),
+            workgroup=workgroup,
+            ignore_cert_warning=ignore_cert_warning,
+            proxy_support=proxy_support,
+            proxy_type=proxy_type,
+            xml_schema=xml_schema,
+            file_type=file_type,
+            data_selectors=data_selectors,
+        )
+        preview_only = bool(dry_run) or not bool(confirm)
+        result = self.invoke_action(
+            metadata.data["lc_service"],
+            action_name,
+            payload=payload,
+            full_action_type=full_action,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=preview_only,
+            confirm=True,
+        )
+        if (
+                not confirm
+                and not dry_run
+                and result.error is None
+                and isinstance(result.data, dict)):
+            result.data["blocked"] = "DellLCService export requires --confirm"
+        return self._redact_password(result)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcExport = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -31,6 +31,7 @@ def test_policy_classifies_known_and_unknown():
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
+    assert classify("#DellLCService.ExportLCLog") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE

--- a/tests/test_dell_lc_export_dualmode.py
+++ b/tests/test_dell_lc_export_dualmode.py
@@ -1,0 +1,331 @@
+"""Dual-mode-style coverage for DellLCService export actions."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.dell_lc.cmd_dell_lc_export import DellLcExport
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+LC_SERVICE = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+LC_ACTIONS = f"{LC_SERVICE}/Actions/DellLCService"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_lc_export_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase and recorded requests list.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/lc-export-1"
+        return json.dumps({
+            "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/lc-export-1"}
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-lc-export",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def _export_rows(result):
+    """Return export metadata rows keyed by export choice.
+
+    :param result: dell-lc-export metadata CommandResult.
+    :return: dict of export choice to metadata row.
+    """
+    return {item["export"]: item for item in result.data["export_actions"]}
+
+
+def test_dell_lc_export_lists_corpus_targets_without_mutating(
+    dell_lc_export_manager,
+):
+    """No export choice lists corpus-advertised LC export actions and never POSTs."""
+    manager, requests = dell_lc_export_manager
+
+    result = manager.sync_invoke(ApiRequestType.DellLcExport, "dell-lc-export")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["lc_service"] == LC_SERVICE
+    rows = _export_rows(result)
+    assert rows["lc-log"]["target"] == f"{LC_ACTIONS}.ExportLCLog"
+    assert rows["hw-inventory"]["allowed"]["ShareType"] == [
+        "CIFS",
+        "HTTP",
+        "HTTPS",
+        "Local",
+        "NFS",
+    ]
+    assert rows["tech-support-report"]["allowed"]["DataSelectorArrayIn"] == [
+        "HWData",
+        "OSAppData",
+        "OSAppDataWithoutPII",
+        "TTYLogs",
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_export_without_confirm_previews_payload_only(
+    dell_lc_export_manager,
+):
+    """DellLCService.ExportLCLog resolves the target but does not POST by default."""
+    manager, requests = dell_lc_export_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcExport,
+        "dell-lc-export",
+        export_name="lc-log",
+        share_type="NFS",
+        ip_address="192.0.2.10",
+        share_name="/exports/lc",
+        file_name="lc.log",
+        ignore_cert_warning="On",
+        proxy_support="Off",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.ExportLCLog"
+    assert result.data["target"] == f"{LC_ACTIONS}.ExportLCLog"
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "DellLCService export requires --confirm"
+    assert result.data["payload"] == {
+        "ShareType": "NFS",
+        "IPAddress": "192.0.2.10",
+        "ShareName": "/exports/lc",
+        "FileName": "lc.log",
+        "IgnoreCertWarning": "On",
+        "ProxySupport": "Off",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_export_confirm_posts_hw_inventory_payload(
+    dell_lc_export_manager,
+):
+    """--confirm POSTs the selected export payload to the discovered target."""
+    manager, requests = dell_lc_export_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcExport,
+        "dell-lc-export",
+        export_name="hw-inventory",
+        share_type="HTTPS",
+        ip_address="192.0.2.20",
+        share_name="reports",
+        file_name="hw.json",
+        xml_schema="JSON",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellLCService.ExportHWInventory"
+    assert result.data["target"] == f"{LC_ACTIONS}.ExportHWInventory"
+    assert result.data["task_id"] == "lc-export-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == f"{LC_ACTIONS}.ExportHWInventory".lower()
+    assert posts[0].json() == {
+        "ShareType": "HTTPS",
+        "IPAddress": "192.0.2.20",
+        "ShareName": "reports",
+        "FileName": "hw.json",
+        "XMLSchema": "JSON",
+    }
+
+
+def test_dell_lc_export_dry_run_overrides_confirm(dell_lc_export_manager):
+    """--dry_run remains a no-POST preview even when --confirm is also supplied."""
+    manager, requests = dell_lc_export_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcExport,
+        "dell-lc-export",
+        export_name="lc-log",
+        share_type="Local",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"ShareType": "Local"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_export_rejects_invalid_share_type(dell_lc_export_manager):
+    """Inline allowable values reject an unsupported ShareType before POST."""
+    manager, requests = dell_lc_export_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcExport,
+        "dell-lc-export",
+        export_name="lc-log",
+        share_type="FTP",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.ExportLCLog ShareType: FTP; "
+        "allowed: CIFS, HTTP, HTTPS, Local, NFS"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "ShareType",
+            "value": "FTP",
+            "allowed": ["CIFS", "HTTP", "HTTPS", "Local", "NFS"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_export_rejects_invalid_data_selector(dell_lc_export_manager):
+    """Inline allowable values reject unsupported support-report selectors."""
+    manager, requests = dell_lc_export_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcExport,
+        "dell-lc-export",
+        export_name="tech-support-report",
+        data_selectors=["HWData", "DebugLogs"],
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.ExportTechSupportReport "
+        "DataSelectorArrayIn: DebugLogs; allowed: HWData, OSAppData, "
+        "OSAppDataWithoutPII, TTYLogs"
+    )
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_export_redacts_password_from_env(
+    dell_lc_export_manager,
+    monkeypatch,
+):
+    """Dry-run output does not echo a share password read from env."""
+    manager, requests = dell_lc_export_manager
+    monkeypatch.setenv("LC_EXPORT_PASSWORD", "placeholder-value")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcExport,
+        "dell-lc-export",
+        export_name="lc-log",
+        share_type="CIFS",
+        share_username="share-user",
+        share_password_env="LC_EXPORT_PASSWORD",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["payload"]["UserName"] == "share-user"
+    assert result.data["payload"]["Password"] == "********"
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_export_rejects_missing_password_env(dell_lc_export_manager):
+    """Missing password environment variables fail before any POST."""
+    manager, requests = dell_lc_export_manager
+
+    with pytest.raises(
+        InvalidArgument,
+        match="environment variable 'MISSING_LC_EXPORT_PASSWORD'",
+    ):
+        manager.sync_invoke(
+            ApiRequestType.DellLcExport,
+            "dell-lc-export",
+            export_name="lc-log",
+            share_password_env="MISSING_LC_EXPORT_PASSWORD",
+            confirm=True,
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_export_legacy_fixture_reports_missing_export(redfish_api):
+    """The legacy small fixture is discovered but reports no LC export actions."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellLcExport,
+        "dell-lc-export",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "lc_service": "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService",
+        "export_actions": [],
+    }
+
+
+def test_dell_lc_export_registers_cli_help():
+    """The command registry exposes dell-lc-export and its safety flags."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellLcExport]["dell-lc-export"] is DellLcExport
+
+    parser, command_name, help_text = DellLcExport.register_subcommand(DellLcExport)
+
+    assert command_name == "dell-lc-export"
+    assert "export Dell Lifecycle Controller" in help_text
+    cmd_help = parser.format_help()
+    assert "--export" in cmd_help
+    assert "--confirm" in cmd_help
+    assert "--dry_run" in cmd_help


### PR DESCRIPTION
## Summary
- add a guarded `dell-lc-export` command for DellLCService export actions
- discover modern Manager OEM and legacy DellLCService URI layouts
- list export targets by default and preview selected payloads unless `--confirm` is supplied
- validate advertised allowable values and redact share passwords in previews

## Validation
- `git diff --check`
- CI run 29635508624 passed Python 3.10, 3.11, 3.12, 3.13, and 3.14 jobs