### PR TITLE
Add Dell JobService queue setup command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-job-queue-setup` | Start Dell JobService `SetupJobQueue`; previews unless `--confirm` is given. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -44,6 +44,7 @@ from .jobs.cmd_job_del import *
 from .jobs.cmd_job_dell_services import *
 from .jobs.cmd_job_delete_all import *
 from .jobs.cmd_job_apply import *
+from .jobs.cmd_job_queue_setup import *
 #
 # # firmwares cmds
 from .firmware.cmd_firmware import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -76,6 +76,7 @@ ACTION_POLICY = {
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
+    "#DellJobService.SetupJobQueue": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/jobs/cmd_job_queue_setup.py
+++ b/redfish_ctl/jobs/cmd_job_queue_setup.py
@@ -1,0 +1,82 @@
+"""Guarded Dell JobService SetupJobQueue action command.
+
+Examples:
+    redfish_ctl dell-job-queue-setup
+    redfish_ctl dell-job-queue-setup --confirm
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_DELL_JOB_SERVICE = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService"
+_SETUP_JOB_QUEUE_ACTION = "#DellJobService.SetupJobQueue"
+
+
+class DellJobQueueSetup(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellJobQueueSetup,
+    name="dell-job-queue-setup",
+    metaclass=Singleton,
+):
+    """Run DellJobService.SetupJobQueue behind the action safety gate."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-job-queue-setup command."""
+        super(DellJobQueueSetup, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the dell-job-queue-setup command and flags.
+
+        :param cls: the CLI manager class providing the base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="actually run SetupJobQueue; otherwise preview only",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="force a preview even when --confirm is present",
+        )
+        return (
+            cmd_parser,
+            "dell-job-queue-setup",
+            "run Dell JobService SetupJobQueue (guarded)",
+        )
+
+    def execute(
+            self,
+            confirm: Optional[bool] = False,
+            dry_run: Optional[bool] = False,
+            do_async: Optional[bool] = False,
+            **kwargs) -> CommandResult:
+        """Run DellJobService.SetupJobQueue, previewing unless confirmed.
+
+        :param confirm: if set (and not dry_run), actually start the setup action.
+        :param dry_run: force a preview even when confirm is present.
+        :param do_async: note async will subscribe to an event loop.
+        :param kwargs: accepted for CLI compatibility; not used by this command.
+        :return: CommandResult with the preview or action result.
+        """
+        return self.invoke_action(
+            _DELL_JOB_SERVICE,
+            "SetupJobQueue",
+            payload={},
+            full_action_type=_SETUP_JOB_QUEUE_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -194,6 +194,7 @@ class ApiRequestType(Enum):
     #  dell services
     JobRmDellServices = auto()
     JobDellServices = auto()
+    DellJobQueueSetup = auto()
 
     Discovery = auto()
     FleetInventory = auto()

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DellJobService.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DellJobService.json
@@ -24,6 +24,9 @@
         "JID_CLEARALL",
         "JID_CLEARALL_FORCE"
       ]
+    },
+    "#DellJobService.SetupJobQueue": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService/Actions/DellJobService.SetupJobQueue"
     }
   }
 }

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -32,6 +32,7 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
+    assert classify("#DellJobService.SetupJobQueue") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE

--- a/tests/test_jobs_tasks_dualmode.py
+++ b/tests/test_jobs_tasks_dualmode.py
@@ -12,6 +12,13 @@ from redfish_ctl.redfish_manager import CommandResult
 from tests.test_utils import create_json_resp
 
 JOB_ID = "JID_000000000001"
+DELL_JOB_SERVICE = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService"
+SETUP_JOB_QUEUE = f"{DELL_JOB_SERVICE}/Actions/DellJobService.SetupJobQueue"
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
 
 
 def test_jobs_list_returns_expanded_job_members(redfish_api):
@@ -113,6 +120,77 @@ def test_dell_job_service_returns_delete_queue_action(redfish_api):
         "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellJobService/"
         "Actions/DellJobService.DeleteJobQueue"
     )
+    assert "SetupJobQueue" in result.extra
+    assert result.extra["SetupJobQueue"].target == SETUP_JOB_QUEUE
+
+
+def test_dell_job_queue_setup_dry_run_resolves_action_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """dell-job-queue-setup previews SetupJobQueue without POSTing."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellJobQueueSetup,
+        "dell-job-queue-setup",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellJobService.SetupJobQueue",
+        "target": SETUP_JOB_QUEUE,
+        "payload": {},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_job_queue_setup_confirm_posts_empty_payload(
+    redfish_mock,
+    redfish_service,
+):
+    """dell-job-queue-setup --confirm POSTs to the discovered target."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellJobQueueSetup,
+        "dell-job-queue-setup",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellJobService.SetupJobQueue"
+    posts = _post_requests(redfish_service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SETUP_JOB_QUEUE.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_job_queue_setup_missing_action_fails_closed_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """dell-job-queue-setup reports a missing action without POSTing."""
+    service = dict(redfish_service._state(DELL_JOB_SERVICE.lower()))
+    service["Actions"] = {
+        name: metadata
+        for name, metadata in service.get("Actions", {}).items()
+        if name != "#DellJobService.SetupJobQueue"
+    }
+    redfish_service._overlay[DELL_JOB_SERVICE.lower()] = service
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellJobQueueSetup,
+        "dell-job-queue-setup",
+        confirm=True,
+    )
+
+    assert result.error == (
+        f"action '#DellJobService.SetupJobQueue' not found on {DELL_JOB_SERVICE}"
+    )
+    assert _post_requests(redfish_service) == []
 
 
 def test_task_service_root_query_returns_task_links(redfish_api):


### PR DESCRIPTION
## Summary
- add guarded `dell-job-queue-setup` for `DellJobService.SetupJobQueue`
- classify the action as destructive so it previews by default and requires `--confirm`
- extend the Dell JobService fixture and cover dry-run, confirmed POST, and missing-action paths

## Validation
- `git diff --cached --check`
- GitHub CI will run the Python matrix for this branch