### PR TITLE
Add Dell SystemManagement LCD errors command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-system-lcd-errors` | Show Dell system errors on the chassis LCD through `DellSystemManagementService.ShowErrorsOnLCD`; dry-run by default and `--confirm` posts. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -6,6 +6,7 @@ from .redfish_shared import *
 from .system.cmd_system import *
 from .system.cmd_system_config import *
 from .system.cmd_system_import import *
+from .system.cmd_dell_system_lcd_errors import *
 #
 from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -76,6 +76,7 @@ ACTION_POLICY = {
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
+    "#DellSystemManagementService.ShowErrorsOnLCD": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -105,6 +105,7 @@ class ApiRequestType(Enum):
     TelemetryClearReports = auto()
     ComponentIntegrity = auto()
     SpdmMeasurements = auto()
+    DellSystemLcdErrors = auto()
     NetworkAdapters = auto()
     NicFirmware = auto()
     NvLinkPorts = auto()

--- a/redfish_ctl/system/cmd_dell_system_lcd_errors.py
+++ b/redfish_ctl/system/cmd_dell_system_lcd_errors.py
@@ -1,0 +1,226 @@
+"""Show Dell system errors on the chassis LCD.
+
+    redfish_ctl dell-system-lcd-errors
+    redfish_ctl dell-system-lcd-errors --system-uri /redfish/v1/Systems/System.Embedded.1
+    redfish_ctl dell-system-lcd-errors --confirm
+
+The command resolves ``#DellSystemManagementService.ShowErrorsOnLCD`` from the
+Dell SystemManagementService resource beneath a ComputerSystem. The action is
+treated as destructive by the shared policy, so the default invocation previews
+the target and payload without POSTing.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_SHOW_ERRORS_ON_LCD_ACTION = "#DellSystemManagementService.ShowErrorsOnLCD"
+_DELL_SYSTEM_MANAGEMENT_SERVICE = "Oem/Dell/DellSystemManagementService"
+
+
+class DellSystemLcdErrors(RedfishManagerBase,
+                          scm_type=ApiRequestType.DellSystemLcdErrors,
+                          name="dell-system-lcd-errors",
+                          metaclass=Singleton):
+    """Preview or invoke DellSystemManagementService.ShowErrorsOnLCD."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-system-lcd-errors command."""
+        super(DellSystemLcdErrors, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-system-lcd-errors`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--system-uri",
+            required=False,
+            dest="system_uri",
+            type=str,
+            default=None,
+            help="ComputerSystem URI that owns DellSystemManagementService; "
+                 "omitted value probes discovered systems",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the ShowErrorsOnLCD POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-system-lcd-errors",
+            "command show Dell system errors on the chassis LCD",
+        )
+
+    @staticmethod
+    def _normalize_uri(uri):
+        """Return a Redfish URI without a trailing slash.
+
+        :param uri: Redfish resource URI.
+        :return: normalized URI, or None for a blank value.
+        """
+        if uri is None:
+            return None
+        normalized = uri.strip().rstrip("/")
+        return normalized or None
+
+    @classmethod
+    def _service_uri(cls, system_uri):
+        """Return the DellSystemManagementService URI below a ComputerSystem.
+
+        :param system_uri: normalized ComputerSystem URI.
+        :return: SystemManagementService URI.
+        """
+        return f"{system_uri}/{_DELL_SYSTEM_MANAGEMENT_SERVICE}"
+
+    def _candidate_systems(self, system_uri=None):
+        """Return ComputerSystem URIs to probe for the Dell service.
+
+        :param system_uri: optional explicit ComputerSystem URI.
+        :return: de-duplicated list of normalized system URIs.
+        """
+        explicit = self._normalize_uri(system_uri)
+        if explicit is not None:
+            return [explicit]
+
+        candidates = []
+        try:
+            candidates.extend(self.discover_computer_system_ids())
+        except Exception:
+            pass
+        try:
+            candidates.append(self.idrac_manage_servers)
+        except Exception:
+            pass
+
+        seen = set()
+        normalized = []
+        for candidate in candidates:
+            value = self._normalize_uri(candidate)
+            if value is not None and value not in seen:
+                normalized.append(value)
+                seen.add(value)
+        return normalized
+
+    def _show_errors_metadata(self, do_async, system_uri=None):
+        """Resolve the Dell ShowErrorsOnLCD action target.
+
+        :param do_async: issue Redfish queries on the async path.
+        :param system_uri: optional explicit ComputerSystem URI.
+        :return: CommandResult with target metadata, or an error.
+        """
+        candidates = self._candidate_systems(system_uri)
+        if not candidates:
+            return CommandResult(
+                {
+                    "action": _SHOW_ERRORS_ON_LCD_ACTION,
+                    "available": [],
+                },
+                None,
+                None,
+                "no ComputerSystem URI available for DellSystemManagementService",
+            )
+
+        attempts = []
+        last_actions = None
+        for candidate in candidates:
+            service_uri = self._service_uri(candidate)
+            attempts.append(service_uri)
+            try:
+                service = self.base_query(service_uri, do_async=do_async).data or {}
+            except Exception:
+                continue
+            actions = self.discover_redfish_actions(self, service)
+            targets = self._flatten_action_targets(service)
+            target = targets.get(_SHOW_ERRORS_ON_LCD_ACTION)
+            if target is None:
+                last_actions = actions
+                continue
+            return CommandResult(
+                {
+                    "system": candidate,
+                    "system_management_service": service_uri,
+                    "action": _SHOW_ERRORS_ON_LCD_ACTION,
+                    "target": target,
+                },
+                actions,
+                None,
+                None,
+            )
+
+        available = []
+        if last_actions is not None:
+            available = sorted(
+                set(list(last_actions.keys()) + list(targets.keys()))
+            )
+        return CommandResult(
+            {
+                "action": _SHOW_ERRORS_ON_LCD_ACTION,
+                "attempted": attempts,
+                "available": available,
+            },
+            last_actions,
+            None,
+            (
+                f"action '{_SHOW_ERRORS_ON_LCD_ACTION}' not found on "
+                "DellSystemManagementService"
+            ),
+        )
+
+    def execute(self,
+                system_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or run DellSystemManagementService.ShowErrorsOnLCD.
+
+        :param system_uri: optional ComputerSystem URI owning the Dell service.
+        :param confirm: authorize the ShowErrorsOnLCD POST to actually fire.
+        :param dry_run: resolve the target and show it without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: CommandResult with target metadata, preview, or POST result.
+        """
+        metadata = self._show_errors_metadata(do_async, system_uri=system_uri)
+        if metadata.error is not None:
+            return metadata
+
+        result = self.invoke_action(
+            metadata.data["system_management_service"],
+            "ShowErrorsOnLCD",
+            payload={},
+            full_action_type=_SHOW_ERRORS_ON_LCD_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        if isinstance(result.data, dict):
+            result.data.setdefault("system", metadata.data["system"])
+            result.data.setdefault(
+                "system_management_service",
+                metadata.data["system_management_service"],
+            )
+        return result

--- a/tests/test_dell_system_lcd_errors_dualmode.py
+++ b/tests/test_dell_system_lcd_errors_dualmode.py
@@ -1,0 +1,183 @@
+"""Dual-mode-style coverage for DellSystemManagementService.ShowErrorsOnLCD."""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+from redfish_ctl.system.cmd_dell_system_lcd_errors import DellSystemLcdErrors
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+SYSTEM = "/redfish/v1/Systems/System.Embedded.1"
+SERVICE = f"{SYSTEM}/Oem/Dell/DellSystemManagementService"
+ACTION = "#DellSystemManagementService.ShowErrorsOnLCD"
+TARGET = f"{SERVICE}/Actions/DellSystemManagementService.ShowErrorsOnLCD"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@contextmanager
+def _dell_system_lcd_manager(remove_action=False):
+    """Serve the Dell corpus over requests-mock.
+
+    :param remove_action: drop ShowErrorsOnLCD from the service fixture.
+    :return: tuple of RedfishManagerBase and recorded requests.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        data = json.loads(fixture.read_text())
+        if remove_action and request.path.lower() == SERVICE.lower():
+            data["Actions"].pop(ACTION, None)
+        return json.dumps(data)
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/lcd-1"
+        return json.dumps(
+            {"Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/lcd-1"}}
+        )
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-system-lcd",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_system_lcd_errors_without_confirm_is_preview_only():
+    """ShowErrorsOnLCD resolves its target but does not POST without --confirm."""
+    with _dell_system_lcd_manager() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == ACTION
+    assert result.data["target"] == TARGET
+    assert result.data["system"] == SYSTEM
+    assert result.data["system_management_service"] == SERVICE
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {}
+    assert _post_requests(requests) == []
+
+
+def test_dell_system_lcd_errors_confirm_posts_empty_payload():
+    """--confirm POSTs the empty ShowErrorsOnLCD payload to the action target."""
+    with _dell_system_lcd_manager() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+            confirm=True,
+        )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == ACTION
+    assert result.data["target"] == TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "lcd-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_system_lcd_errors_confirm_dry_run_still_does_not_post():
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    with _dell_system_lcd_manager() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+            confirm=True,
+            dry_run=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == TARGET
+    assert _post_requests(requests) == []
+
+
+def test_dell_system_lcd_errors_reports_missing_action_without_post():
+    """A Dell service without ShowErrorsOnLCD reports the absent action."""
+    with _dell_system_lcd_manager(remove_action=True) as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+            system_uri=SYSTEM,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        f"action '{ACTION}' not found on DellSystemManagementService"
+    )
+    assert result.data["action"] == ACTION
+    assert result.data["attempted"] == [SERVICE]
+    assert "RebootChassisManager" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_system_lcd_errors_policy_is_destructive():
+    """ShowErrorsOnLCD cannot fire unless explicitly confirmed."""
+    assert classify(ACTION) is Destructiveness.DESTRUCTIVE
+
+
+def test_dell_system_lcd_errors_exposes_cli_entrypoint():
+    """The dell-system-lcd-errors command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellSystemLcdErrors]["dell-system-lcd-errors"] is (
+        DellSystemLcdErrors
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellSystemLcdErrors.register_subcommand(
+        DellSystemLcdErrors
+    )
+
+    assert "--system-uri" in cmd_parser.format_help()
+    assert "--confirm" in cmd_parser.format_help()
+    assert cmd_name == "dell-system-lcd-errors"
+    assert "Dell" in cmd_help


### PR DESCRIPTION
## Summary
- add guarded dell-system-lcd-errors for DellSystemManagementService.ShowErrorsOnLCD
- resolve the action from the Dell SystemManagement service and preview unless --confirm is supplied
- document the command and cover dry-run, confirmed POST, missing-action, policy, and registry paths

## Validation
- Not run locally; remote CI is expected to run the test suite and lint gates.