### PR TITLE
Add Dell SEKM server test command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-card-sekm-test` | Test Dell SEKM server connectivity through `DelliDRACCardService`; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -121,6 +121,7 @@ from .firmware.cmd_firmware_update import *
 from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
+from .oem.cmd_dell_card_sekm_test import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
 from .manager.cmd_console_info import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -45,6 +45,7 @@ ACTION_POLICY = {
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,
+    "#DelliDRACCardService.TestSEKMServerConnection": Destructiveness.REVERSIBLE,
     "#HpeDirectoryTest.StartTest": Destructiveness.REVERSIBLE,
     "#HpeDirectoryTest.StopTest": Destructiveness.REVERSIBLE,
     "#HpeiLOSnmpService.SendSNMPTestAlert": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/oem/cmd_dell_card_sekm_test.py
+++ b/redfish_ctl/oem/cmd_dell_card_sekm_test.py
@@ -1,0 +1,271 @@
+"""Preview or run the Dell SEKM server connectivity test action.
+
+    redfish_ctl dell-card-sekm-test
+    redfish_ctl dell-card-sekm-test --server-type Primary
+    redfish_ctl dell-card-sekm-test --server-type Secondary --confirm
+
+The command discovers the Dell ``DelliDRACCardService`` link from Manager OEM
+metadata and resolves the advertised
+``#DelliDRACCardService.TestSEKMServerConnection`` target from that resource.
+Selected tests preview by default; ``--confirm`` is required before POSTing.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_ACTION_TYPE = "#DelliDRACCardService.TestSEKMServerConnection"
+_ACTION_NAME = "TestSEKMServerConnection"
+_SERVICE_NAME = "DelliDRACCardService"
+_DEFAULT_SERVICE_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+)
+_DEFAULT_ALLOWED_SERVER_TYPES = ("Primary", "Secondary")
+
+
+class DellCardSekmTest(RedfishManagerBase,
+                       scm_type=ApiRequestType.DellCardSekmTest,
+                       name="dell-card-sekm-test",
+                       metaclass=Singleton):
+    """Discover and invoke the Dell SEKM server connectivity test."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-card-sekm-test command."""
+        super(DellCardSekmTest, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-card-sekm-test`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--server-type",
+            dest="server_type",
+            choices=_DEFAULT_ALLOWED_SERVER_TYPES,
+            default=None,
+            help="SEKM server endpoint to test; omit to list available targets",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DelliDRACCardService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the selected connectivity test instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-card-sekm-test",
+            "command test Dell SEKM server connectivity",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the Dell block under ``Manager.Links.Oem``.
+
+        :param manager: Manager resource body.
+        :return: Dell OEM links dict, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    @staticmethod
+    def _dell_oem_body(manager):
+        """Return the Dell block under ``Manager.Oem``.
+
+        :param manager: Manager resource body.
+        :return: Dell OEM body dict, or an empty dict.
+        """
+        oem = manager.get("Oem") if isinstance(manager, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DelliDRACCardService resource URIs.
+
+        :param do_async: issue manager queries on the async path when True.
+        :return: list of candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(
+                self._dell_oem_links(manager),
+                _SERVICE_NAME,
+            )
+            if not service_uri:
+                service_uri = self._link(
+                    self._dell_oem_body(manager),
+                    _SERVICE_NAME,
+                )
+            if service_uri:
+                uris.append(service_uri)
+        if not uris:
+            uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uris))
+
+    @staticmethod
+    def _allowed_server_types(service, actions):
+        """Return allowed ``ServerType`` values for the SEKM test action.
+
+        :param service: DelliDRACCardService resource body.
+        :param actions: discovered Redfish action map for ``service``.
+        :return: sorted list of allowed server type strings.
+        """
+        action = actions.get(_ACTION_NAME)
+        allowed = tuple(getattr(action, "args", {}).get("ServerType", ()) or ())
+        if not allowed:
+            raw_actions = service.get("Actions") if isinstance(service, dict) else None
+            raw_action = (
+                raw_actions.get(_ACTION_TYPE)
+                if isinstance(raw_actions, dict)
+                else None
+            )
+            if isinstance(raw_action, dict):
+                allowed = tuple(
+                    raw_action.get("ServerType@Redfish.AllowableValues", ()) or ()
+                )
+        if not allowed:
+            allowed = _DEFAULT_ALLOWED_SERVER_TYPES
+        return sorted(allowed)
+
+    def _row_for(self, resource_uri, do_async):
+        """Build a discovered action row for one DelliDRACCardService URI.
+
+        :param resource_uri: candidate service URI.
+        :param do_async: issue the service query on the async path when True.
+        :return: discovered row, or None when the action is absent.
+        """
+        service = self._get(resource_uri, do_async)
+        if not service:
+            return None
+        target = self._flatten_action_targets(service).get(_ACTION_TYPE)
+        if not target:
+            return None
+        actions = self.discover_redfish_actions(self, service)
+        return {
+            "Resource": resource_uri,
+            "Action": _ACTION_TYPE,
+            "Target": target,
+            "AllowedServerTypes": self._allowed_server_types(service, actions),
+        }
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Discover Dell SEKM server test targets.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DelliDRACCardService URI.
+        :return: list of discovered target rows.
+        """
+        uris = [resource_uri] if resource_uri else self._service_uris(do_async)
+        rows = []
+        for uri in dict.fromkeys(uris):
+            row = self._row_for(uri, do_async)
+            if row:
+                rows.append(row)
+        return rows
+
+    def execute(self,
+                server_type: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke the Dell SEKM server connectivity test.
+
+        :param server_type: optional ``ServerType`` value, usually Primary or Secondary.
+        :param resource_uri: optional DelliDRACCardService URI override.
+        :param confirm: authorize a POST. Without this the selected test previews.
+        :param dry_run: force a preview even with ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish calls on the async path.
+        :return: CommandResult with discovered targets, preview, or POST result.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri=resource_uri)
+        if server_type is None:
+            return CommandResult({"sekm_test_targets": rows}, None, None, None)
+
+        if not rows:
+            return CommandResult(
+                {"action": _ACTION_TYPE, "available": []},
+                None,
+                None,
+                "Dell card SEKM test action not found",
+            )
+        if len(rows) > 1:
+            return CommandResult(
+                {"matches": rows},
+                None,
+                None,
+                "multiple Dell card SEKM test targets found; pass --resource-uri",
+            )
+
+        result = self.invoke_action(
+            rows[0]["Resource"],
+            _ACTION_NAME,
+            payload={"ServerType": server_type},
+            full_action_type=_ACTION_TYPE,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        if not confirm and isinstance(result.data, dict):
+            result.data["requires_confirm"] = True
+            result.data["blocked"] = "Dell SEKM server test requires --confirm"
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -38,6 +38,7 @@ class ApiRequestType(Enum):
     DellOemTask = auto()
     DellLcQuery = auto()
     DellOemDisconnect = auto()
+    DellCardSekmTest = auto()
 
     RemoteServicesRssAPIStatus = auto()
     RemoteServicesAPIStatus = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -20,6 +20,9 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComputerSystem.Reset") is Destructiveness.DESTRUCTIVE
     assert classify("#Drive.SecureErase") is Destructiveness.IRREVERSIBLE
     assert classify("#EventService.SubmitTestEvent") is Destructiveness.REVERSIBLE
+    assert classify("#DelliDRACCardService.TestSEKMServerConnection") is (
+        Destructiveness.REVERSIBLE
+    )
     hpe_reversible_actions = (
         "#HpeDirectoryTest.StartTest",
         "#HpeDirectoryTest.StopTest",

--- a/tests/test_dell_card_sekm_test_dualmode.py
+++ b/tests/test_dell_card_sekm_test_dualmode.py
@@ -1,0 +1,237 @@
+"""Dual-mode-style tests for the Dell SEKM server connectivity test command."""
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.oem.cmd_dell_card_sekm_test import DellCardSekmTest
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+GENERIC_MANAGER_URI = "/redfish/v1/Managers/BMC"
+SERVICE_URI = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+TARGET_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/"
+    "Actions/DelliDRACCardService.TestSEKMServerConnection"
+)
+ACTION_TYPE = "#DelliDRACCardService.TestSEKMServerConnection"
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-xr8620t",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(redfish_service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [
+        request
+        for request in redfish_service.requests
+        if request.method == "POST"
+    ]
+
+
+def _seed_card_service(redfish_service, include_action=True):
+    """Overlay a Dell card service link and optional SEKM test action."""
+    manager = deepcopy(redfish_service._state(GENERIC_MANAGER_URI))
+    manager.setdefault("Links", {}).setdefault("Oem", {}).setdefault("Dell", {})[
+        "DelliDRACCardService"
+    ] = {"@odata.id": SERVICE_URI}
+
+    service = {
+        "@odata.id": SERVICE_URI,
+        "@odata.type": "#DelliDRACCardService.v1_0_0.DelliDRACCardService",
+        "Id": "DelliDRACCardService",
+        "Name": "Dell iDRAC Card Service",
+        "Actions": {},
+    }
+    if include_action:
+        service["Actions"][ACTION_TYPE] = {
+            "target": TARGET_URI,
+            "ServerType@Redfish.AllowableValues": ["Primary", "Secondary"],
+        }
+
+    for path, body in (
+        (GENERIC_MANAGER_URI, manager),
+        (SERVICE_URI, service),
+    ):
+        redfish_service._overlay[path] = body
+        redfish_service._overlay[path.lower()] = body
+
+
+def test_dell_card_sekm_test_lists_corpus_target(dell_corpus_mock):
+    """Listing discovers the Dell corpus card-service SEKM test action."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardSekmTest,
+        "dell-card-sekm-test",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["sekm_test_targets"] == [{
+        "Resource": SERVICE_URI,
+        "Action": ACTION_TYPE,
+        "Target": TARGET_URI,
+        "AllowedServerTypes": ["Primary", "Secondary"],
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_card_sekm_test_previews_primary_by_default(
+    dell_corpus_mock,
+):
+    """A selected SEKM test previews unless --confirm is supplied."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardSekmTest,
+        "dell-card-sekm-test",
+        server_type="Primary",
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == ACTION_TYPE
+    assert result.data["level"] == "reversible"
+    assert result.data["target"] == TARGET_URI
+    assert result.data["payload"] == {"ServerType": "Primary"}
+    assert result.data["requires_confirm"] is True
+    assert result.data["blocked"] == "Dell SEKM server test requires --confirm"
+    assert _post_requests(service) == []
+
+
+def test_dell_card_sekm_test_confirm_posts_secondary(
+    dell_corpus_mock,
+):
+    """--confirm POSTs exactly one selected Dell SEKM server test."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardSekmTest,
+        "dell-card-sekm-test",
+        server_type="Secondary",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == ACTION_TYPE
+    assert result.data["level"] == "reversible"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == TARGET_URI.lower()
+    assert posts[0].json() == {"ServerType": "Secondary"}
+
+
+def test_dell_card_sekm_test_dry_run_overrides_confirm(
+    dell_corpus_mock,
+):
+    """--dry_run remains a preview even when --confirm is also passed."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardSekmTest,
+        "dell-card-sekm-test",
+        server_type="Primary",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"ServerType": "Primary"}
+    assert _post_requests(service) == []
+
+
+def test_dell_card_sekm_test_rejects_invalid_server_type(
+    dell_corpus_mock,
+):
+    """Inline Redfish metadata rejects unsupported ServerType values."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardSekmTest,
+        "dell-card-sekm-test",
+        server_type="Tertiary",
+        confirm=True,
+    )
+
+    assert result.error == (
+        "invalid value for DelliDRACCardService.TestSEKMServerConnection "
+        "ServerType: Tertiary; allowed: Primary, Secondary"
+    )
+    assert result.data["validation_errors"] == [{
+        "parameter": "ServerType",
+        "value": "Tertiary",
+        "allowed": ["Primary", "Secondary"],
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_card_sekm_test_missing_action_reports_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """A card-service resource without the SEKM action returns a target error."""
+    _seed_card_service(redfish_service, include_action=False)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellCardSekmTest,
+        "dell-card-sekm-test",
+        server_type="Primary",
+        confirm=True,
+    )
+
+    assert result.error == "Dell card SEKM test action not found"
+    assert result.data == {"action": ACTION_TYPE, "available": []}
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_card_sekm_test_exposes_cli_entrypoint():
+    """The dell-card-sekm-test command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellCardSekmTest]["dell-card-sekm-test"] is (
+        DellCardSekmTest
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellCardSekmTest.register_subcommand(
+        DellCardSekmTest
+    )
+    help_text = cmd_parser.format_help()
+
+    assert "--server-type" in help_text
+    assert "--resource-uri" in help_text
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text
+    assert cmd_name == "dell-card-sekm-test"
+    assert "SEKM" in cmd_help


### PR DESCRIPTION
## Summary
- add a guarded dell-card-sekm-test command for DelliDRACCardService.TestSEKMServerConnection
- classify the SEKM server test action as reversible and wire the command into the CLI registry
- cover Dell XR8620t corpus discovery plus preview, confirm, dry-run, validation, and missing-action paths

## Validation
- Not run locally; CI runs the offline pytest and Ruff gates.