### PR TITLE
Add Dell LC OS health update command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-lc-os-health-update` | Update Dell Lifecycle Controller OS application health data; dry-run by default and `--confirm` posts. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_os_health_update import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -60,6 +60,7 @@ ACTION_POLICY = {
     "#NvidiaWorkloadPower.DisableProfiles": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.GenerateToken": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.DisableToken": Destructiveness.REVERSIBLE,
+    "#DellLCService.UpdateOSAppHealthData": Destructiveness.REVERSIBLE,
 
     # destructive: service disruption / config rewrite — dry-run unless --confirm
     "#ComputerSystem.Reset": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/dell_lc/cmd_dell_lc_os_health_update.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_os_health_update.py
@@ -1,0 +1,246 @@
+"""Preview or update Dell Lifecycle Controller OS application health data.
+
+    redfish_ctl dell-lc-os-health-update
+    redfish_ctl dell-lc-os-health-update --update-type Automatic
+    redfish_ctl dell-lc-os-health-update --update-type Automatic --confirm
+
+The command resolves ``#DellLCService.UpdateOSAppHealthData`` from the Dell
+Lifecycle Controller service. With no update type it lists the discovered action
+target. With an update type it previews by default; ``--confirm`` is required
+before the POST is sent.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_ACTION_TYPE = "#DellLCService.UpdateOSAppHealthData"
+_ACTION_NAME = "UpdateOSAppHealthData"
+_SERVICE_NAME = "DellLCService"
+_DEFAULT_SERVICE_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+_DEFAULT_UPDATE_TYPES = ("Automatic",)
+
+
+class DellLcOsHealthUpdate(RedfishManagerBase,
+                           scm_type=ApiRequestType.DellLcOsHealthUpdate,
+                           name="dell-lc-os-health-update",
+                           metaclass=Singleton):
+    """Discover and invoke DellLCService.UpdateOSAppHealthData."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-os-health-update command."""
+        super(DellLcOsHealthUpdate, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-os-health-update`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--update-type",
+            dest="update_type",
+            default=None,
+            help="DellLCService.UpdateOSAppHealthData UpdateType; omit to list target",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the OS health update instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-os-health-update",
+            "command update Dell Lifecycle Controller OS application health data",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the Dell block under ``Manager.Links.Oem``.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM links dict, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional-resource misses.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: issue manager queries on the async path when True.
+        :return: de-duplicated candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(self._dell_oem_links(manager), _SERVICE_NAME)
+            if service_uri:
+                uris.append(service_uri)
+            uris.append(manager_uri.rstrip("/") + f"/Oem/Dell/{_SERVICE_NAME}")
+        uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uri for uri in uris if uri))
+
+    @staticmethod
+    def _allowed_update_types(service, actions):
+        """Return advertised ``UpdateType`` values for the OS-health action.
+
+        :param service: DellLCService resource body.
+        :param actions: discovered Redfish action map for ``service``.
+        :return: sorted list of allowed update type strings.
+        """
+        action = actions.get(_ACTION_NAME)
+        allowed = tuple(getattr(action, "args", {}).get("UpdateType", ()) or ())
+        if not allowed:
+            raw_actions = service.get("Actions") if isinstance(service, dict) else None
+            raw_action = (
+                raw_actions.get(_ACTION_TYPE)
+                if isinstance(raw_actions, dict)
+                else None
+            )
+            if isinstance(raw_action, dict):
+                allowed = tuple(
+                    raw_action.get("UpdateType@Redfish.AllowableValues", ()) or ()
+                )
+        if not allowed:
+            allowed = _DEFAULT_UPDATE_TYPES
+        return sorted(allowed)
+
+    def _row_for(self, resource_uri, do_async):
+        """Build a discovered UpdateOSAppHealthData row for one service URI.
+
+        :param resource_uri: candidate DellLCService URI.
+        :param do_async: issue the service query on the async path when True.
+        :return: discovered row, or None when the action is absent.
+        """
+        service = self._get(resource_uri, do_async)
+        if not service:
+            return None
+        target = self._flatten_action_targets(service).get(_ACTION_TYPE)
+        if not target:
+            return None
+        actions = self.discover_redfish_actions(self, service)
+        return {
+            "Resource": resource_uri,
+            "Action": _ACTION_TYPE,
+            "Target": target,
+            "AllowedUpdateTypes": self._allowed_update_types(service, actions),
+        }
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Discover Dell LC OS-health update targets.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DellLCService URI.
+        :return: list of discovered target rows.
+        """
+        uris = [resource_uri] if resource_uri else self._service_uris(do_async)
+        rows = []
+        for uri in dict.fromkeys(uris):
+            row = self._row_for(uri, do_async)
+            if row:
+                rows.append(row)
+        return rows
+
+    def execute(self,
+                update_type: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke DellLCService.UpdateOSAppHealthData.
+
+        :param update_type: optional ``UpdateType`` value; omitted means list metadata.
+        :param resource_uri: optional DellLCService URI override.
+        :param confirm: authorize the action POST.
+        :param dry_run: force a preview even when ``confirm`` is true.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish calls on the async path.
+        :return: CommandResult with discovered targets, preview, or POST result.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri=resource_uri)
+        if update_type is None:
+            return CommandResult({"os_health_update_targets": rows}, None, None, None)
+
+        if not rows:
+            return CommandResult(
+                {"action": _ACTION_TYPE, "available": []},
+                None,
+                None,
+                "Dell LC OS health update action not found",
+            )
+        if len(rows) > 1:
+            return CommandResult(
+                {"matches": rows},
+                None,
+                None,
+                "multiple Dell LC OS health update targets found; pass --resource-uri",
+            )
+
+        return self.invoke_action(
+            rows[0]["Resource"],
+            _ACTION_NAME,
+            payload={"UpdateType": update_type},
+            full_action_type=_ACTION_TYPE,
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -41,6 +41,7 @@ class ApiRequestType(Enum):
 
     RemoteServicesRssAPIStatus = auto()
     RemoteServicesAPIStatus = auto()
+    DellLcOsHealthUpdate = auto()
     TasksList = auto()
 
     ChangeBootOrder = auto()

--- a/tests/test_dell_lc_os_health_update_dualmode.py
+++ b/tests/test_dell_lc_os_health_update_dualmode.py
@@ -1,0 +1,219 @@
+"""Dual-mode-style tests for DellLCService.UpdateOSAppHealthData."""
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_os_health_update import (
+    DellLcOsHealthUpdate,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+DELL_LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+TARGET_URI = f"{DELL_LC_SERVICE}/Actions/DellLCService.UpdateOSAppHealthData"
+
+
+@pytest.fixture
+def dell_lc_corpus_mock():
+    """Return a manager and mock service backed by the full Dell corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-lc-os-health",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_dell_lc_os_health_update_policy_is_reversible():
+    """The Dell LC OS-health refresh action is classified as reversible."""
+    assert (
+        classify("#DellLCService.UpdateOSAppHealthData")
+        is Destructiveness.REVERSIBLE
+    )
+
+
+def test_dell_lc_os_health_update_lists_target_without_post(dell_lc_corpus_mock):
+    """Listing discovers the action target and does not POST."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcOsHealthUpdate,
+        "dell-lc-os-health-update",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    rows = result.data["os_health_update_targets"]
+    assert rows == [{
+        "Resource": DELL_LC_SERVICE,
+        "Action": "#DellLCService.UpdateOSAppHealthData",
+        "Target": TARGET_URI,
+        "AllowedUpdateTypes": ["Automatic"],
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_os_health_update_without_confirm_is_preview_only(
+    dell_lc_corpus_mock,
+):
+    """An update type is resolved but not POSTed unless --confirm is present."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcOsHealthUpdate,
+        "dell-lc-os-health-update",
+        update_type="Automatic",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.UpdateOSAppHealthData"
+    assert result.data["target"] == TARGET_URI
+    assert result.data["level"] == "reversible"
+    assert result.data["payload"] == {"UpdateType": "Automatic"}
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_os_health_update_confirm_posts_payload(dell_lc_corpus_mock):
+    """--confirm POSTs UpdateOSAppHealthData to the discovered action target."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcOsHealthUpdate,
+        "dell-lc-os-health-update",
+        update_type="Automatic",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellLCService.UpdateOSAppHealthData"
+    assert result.data["target"] == TARGET_URI
+    assert result.data["level"] == "reversible"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == TARGET_URI.lower()
+    assert posts[0].json() == {"UpdateType": "Automatic"}
+
+
+def test_dell_lc_os_health_update_dry_run_overrides_confirm(dell_lc_corpus_mock):
+    """--dry_run keeps the command preview-only even with --confirm."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcOsHealthUpdate,
+        "dell-lc-os-health-update",
+        update_type="Automatic",
+        dry_run=True,
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"UpdateType": "Automatic"}
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_os_health_update_rejects_invalid_update_type(
+    dell_lc_corpus_mock,
+):
+    """Inline allowable values reject an unsupported UpdateType before POST."""
+    manager, service = dell_lc_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcOsHealthUpdate,
+        "dell-lc-os-health-update",
+        update_type="Manual",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.UpdateOSAppHealthData UpdateType: "
+        "Manual; allowed: Automatic"
+    )
+    assert result.data["validation_errors"] == [{
+        "parameter": "UpdateType",
+        "value": "Manual",
+        "allowed": ["Automatic"],
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_os_health_update_missing_action_does_not_post(
+    redfish_mock_factory,
+):
+    """A non-Dell fixture reports no OS-health target and no POST."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcOsHealthUpdate,
+        "dell-lc-os-health-update",
+        update_type="Automatic",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell LC OS health update action not found"
+    assert result.data == {
+        "action": "#DellLCService.UpdateOSAppHealthData",
+        "available": [],
+    }
+    assert _post_requests(service) == []
+
+
+def test_dell_lc_os_health_update_exposes_cli_entrypoint():
+    """The command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellLcOsHealthUpdate][
+            "dell-lc-os-health-update"
+        ]
+        is DellLcOsHealthUpdate
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellLcOsHealthUpdate.register_subcommand(
+        DellLcOsHealthUpdate
+    )
+
+    assert "--update-type" in cmd_parser.format_help()
+    assert cmd_name == "dell-lc-os-health-update"
+    assert "OS application health" in cmd_help


### PR DESCRIPTION
## Summary
- add a guarded DellLCService.UpdateOSAppHealthData command
- discover DellLCService targets from Manager OEM links and show target metadata when no update type is supplied
- add Dell XR8620t corpus-backed coverage and command docs

## Validation
- git diff --cached --check