### PR TITLE
Add Dell SupportAssist schedule command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-supportassist-schedule` | Manage Dell LC SupportAssist auto-collection schedules; previews by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_supportassist_schedule import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -60,6 +60,8 @@ ACTION_POLICY = {
     "#NvidiaWorkloadPower.DisableProfiles": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.GenerateToken": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.DisableToken": Destructiveness.REVERSIBLE,
+    "#DellLCService.SupportAssistClearAutoCollectSchedule": Destructiveness.REVERSIBLE,
+    "#DellLCService.SupportAssistSetAutoCollectSchedule": Destructiveness.REVERSIBLE,
 
     # destructive: service disruption / config rewrite — dry-run unless --confirm
     "#ComputerSystem.Reset": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_schedule.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_schedule.py
@@ -1,0 +1,280 @@
+"""Preview or update Dell Lifecycle Controller SupportAssist schedules.
+
+    redfish_ctl dell-lc-supportassist-schedule
+    redfish_ctl dell-lc-supportassist-schedule --action set --recurrence Weekly
+    redfish_ctl dell-lc-supportassist-schedule --action clear --confirm
+
+The command resolves the SupportAssist auto-collection schedule actions from
+the Dell Lifecycle Controller service. Without ``--action`` it lists available
+targets. Set and clear operations preview by default; ``--confirm`` is required
+before a POST is sent.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_SERVICE_NAME = "DellLCService"
+_DEFAULT_SERVICE_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+_ACTION_SPECS = {
+    "clear": {
+        "type": "#DellLCService.SupportAssistClearAutoCollectSchedule",
+        "name": "SupportAssistClearAutoCollectSchedule",
+    },
+    "set": {
+        "type": "#DellLCService.SupportAssistSetAutoCollectSchedule",
+        "name": "SupportAssistSetAutoCollectSchedule",
+    },
+}
+
+
+class DellLcSupportAssistSchedule(
+        RedfishManagerBase,
+        scm_type=ApiRequestType.DellLcSupportAssistSchedule,
+        name="dell-lc-supportassist-schedule",
+        metaclass=Singleton):
+    """Discover and invoke DellLCService SupportAssist schedule actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-supportassist-schedule command."""
+        super(DellLcSupportAssistSchedule, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-supportassist-schedule`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=tuple(_ACTION_SPECS),
+            default=None,
+            help="SupportAssist schedule action to preview or run",
+        )
+        cmd_parser.add_argument(
+            "--recurrence",
+            default=None,
+            help="recurrence for --action set; allowed values come from Redfish",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the schedule action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-supportassist-schedule",
+            "command update Dell Lifecycle Controller SupportAssist schedule",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the Dell block under ``Manager.Links.Oem``.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM links dict, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional-resource misses.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: issue manager queries on the async path when True.
+        :return: de-duplicated candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(self._dell_oem_links(manager), _SERVICE_NAME)
+            if service_uri:
+                uris.append(service_uri)
+            uris.append(manager_uri.rstrip("/") + f"/Oem/Dell/{_SERVICE_NAME}")
+        uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uri for uri in uris if uri))
+
+    @staticmethod
+    def _allowed_recurrences(actions):
+        """Return advertised SupportAssist schedule recurrence values.
+
+        :param actions: discovered Redfish action map for a DellLCService body.
+        :return: sorted list of allowed recurrence strings.
+        """
+        action = actions.get(_ACTION_SPECS["set"]["name"])
+        allowed = tuple(getattr(action, "args", {}).get("Recurrence", ()) or ())
+        return sorted(allowed)
+
+    def _rows_for(self, resource_uri, do_async):
+        """Build discovered SupportAssist schedule rows for one service URI.
+
+        :param resource_uri: candidate DellLCService URI.
+        :param do_async: issue the service query on the async path when True.
+        :return: discovered rows, possibly empty when actions are absent.
+        """
+        service = self._get(resource_uri, do_async)
+        if not service:
+            return []
+        targets = self._flatten_action_targets(service)
+        actions = self.discover_redfish_actions(self, service)
+        allowed_recurrences = self._allowed_recurrences(actions)
+        rows = []
+        for selector, spec in _ACTION_SPECS.items():
+            target = targets.get(spec["type"])
+            if not target:
+                continue
+            row = {
+                "Resource": resource_uri,
+                "Selector": selector,
+                "Action": spec["type"],
+                "Target": target,
+            }
+            if selector == "set":
+                row["AllowedRecurrences"] = allowed_recurrences
+            rows.append(row)
+        return rows
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Discover Dell LC SupportAssist schedule action targets.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DellLCService URI.
+        :return: list of discovered target rows.
+        """
+        uris = [resource_uri] if resource_uri else self._service_uris(do_async)
+        rows = []
+        for uri in dict.fromkeys(uris):
+            rows.extend(self._rows_for(uri, do_async))
+        return rows
+
+    @staticmethod
+    def _select_row(rows, action):
+        """Return the discovered row for a requested schedule action.
+
+        :param rows: discovered SupportAssist schedule rows.
+        :param action: requested action selector.
+        :return: row dict, or None when absent.
+        """
+        for row in rows:
+            if row["Selector"] == action:
+                return row
+        return None
+
+    def execute(self,
+                action: Optional[str] = None,
+                recurrence: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke SupportAssist schedule actions.
+
+        :param action: optional action selector, ``set`` or ``clear``.
+        :param recurrence: recurrence value required by ``--action set``.
+        :param resource_uri: optional DellLCService URI override.
+        :param confirm: authorize the action POST.
+        :param dry_run: force a preview even when ``confirm`` is true.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish calls on the async path.
+        :return: CommandResult with discovered targets, preview, or POST result.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri=resource_uri)
+        if action is None:
+            return CommandResult(
+                {"supportassist_schedule_targets": rows},
+                None,
+                None,
+                None,
+            )
+        if action not in _ACTION_SPECS:
+            return CommandResult(
+                {"valid_actions": sorted(_ACTION_SPECS)},
+                None,
+                None,
+                f"invalid SupportAssist schedule action: {action}",
+            )
+        row = self._select_row(rows, action)
+        if row is None:
+            return CommandResult(
+                {"action": _ACTION_SPECS[action]["type"], "available": rows},
+                None,
+                None,
+                "Dell LC SupportAssist schedule action not found",
+            )
+        if action == "set" and not recurrence:
+            return CommandResult(
+                {"required": ["Recurrence"], "action": row["Action"]},
+                None,
+                None,
+                "SupportAssist schedule set requires --recurrence",
+            )
+
+        payload = {"Recurrence": recurrence} if action == "set" else {}
+        spec = _ACTION_SPECS[action]
+        return self.invoke_action(
+            row["Resource"],
+            spec["name"],
+            payload=payload,
+            full_action_type=spec["type"],
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcSupportAssistSchedule = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/tests/test_dell_lc_supportassist_schedule_dualmode.py
+++ b/tests/test_dell_lc_supportassist_schedule_dualmode.py
@@ -1,0 +1,343 @@
+"""Dual-mode-style coverage for DellLCService SupportAssist schedules."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_supportassist_schedule import (
+    DellLcSupportAssistSchedule,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+DELL_LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+CLEAR_TARGET = (
+    f"{DELL_LC_SERVICE}/Actions/"
+    "DellLCService.SupportAssistClearAutoCollectSchedule"
+)
+SET_TARGET = (
+    f"{DELL_LC_SERVICE}/Actions/"
+    "DellLCService.SupportAssistSetAutoCollectSchedule"
+)
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_lc_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase and recorded requests list.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/supportassist-1"
+        return json.dumps(
+            {"Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/supportassist-1"}}
+        )
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-lc-supportassist",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_lc_supportassist_schedule_policy_is_reversible():
+    """The SupportAssist schedule actions are classified as reversible."""
+    assert (
+        classify("#DellLCService.SupportAssistClearAutoCollectSchedule")
+        is Destructiveness.REVERSIBLE
+    )
+    assert (
+        classify("#DellLCService.SupportAssistSetAutoCollectSchedule")
+        is Destructiveness.REVERSIBLE
+    )
+
+
+def test_dell_lc_supportassist_schedule_lists_targets_without_post(
+    dell_lc_manager,
+):
+    """Listing discovers schedule actions and does not POST."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["supportassist_schedule_targets"] == [
+        {
+            "Resource": DELL_LC_SERVICE,
+            "Selector": "clear",
+            "Action": "#DellLCService.SupportAssistClearAutoCollectSchedule",
+            "Target": CLEAR_TARGET,
+        },
+        {
+            "Resource": DELL_LC_SERVICE,
+            "Selector": "set",
+            "Action": "#DellLCService.SupportAssistSetAutoCollectSchedule",
+            "Target": SET_TARGET,
+            "AllowedRecurrences": ["Monthly", "Quarterly", "Weekly"],
+        },
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_set_previews_by_default(
+    dell_lc_manager,
+):
+    """Setting a recurrence does not POST unless --confirm is present."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Weekly",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.SupportAssistSetAutoCollectSchedule"
+    assert result.data["target"] == SET_TARGET
+    assert result.data["level"] == "reversible"
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"Recurrence": "Weekly"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_set_confirm_posts_payload(
+    dell_lc_manager,
+):
+    """--confirm POSTs the recurrence payload to the set action target."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Weekly",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellLCService.SupportAssistSetAutoCollectSchedule"
+    assert result.data["target"] == SET_TARGET
+    assert result.data["level"] == "reversible"
+    assert result.data["task_id"] == "supportassist-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SET_TARGET.lower()
+    assert posts[0].json() == {"Recurrence": "Weekly"}
+
+
+def test_dell_lc_supportassist_schedule_clear_previews_by_default(
+    dell_lc_manager,
+):
+    """Clearing the schedule resolves the target but does not POST by default."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="clear",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.SupportAssistClearAutoCollectSchedule"
+    assert result.data["target"] == CLEAR_TARGET
+    assert result.data["payload"] == {}
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_clear_confirm_posts_empty_payload(
+    dell_lc_manager,
+):
+    """--confirm POSTs an empty payload to the clear action target."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="clear",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["target"] == CLEAR_TARGET
+    assert len(posts) == 1
+    assert posts[0].path.lower() == CLEAR_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_lc_supportassist_schedule_dry_run_overrides_confirm(
+    dell_lc_manager,
+):
+    """--dry_run keeps the command preview-only even with --confirm."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Monthly",
+        dry_run=True,
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"Recurrence": "Monthly"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_rejects_invalid_recurrence(
+    dell_lc_manager,
+):
+    """Inline allowable values reject unsupported recurrences before POST."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Yearly",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.SupportAssistSetAutoCollectSchedule "
+        "Recurrence: Yearly; allowed: Monthly, Quarterly, Weekly"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "Recurrence",
+            "value": "Yearly",
+            "allowed": ["Monthly", "Quarterly", "Weekly"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_set_requires_recurrence(
+    dell_lc_manager,
+):
+    """The set action fails closed when Recurrence is omitted."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "SupportAssist schedule set requires --recurrence"
+    assert result.data == {
+        "required": ["Recurrence"],
+        "action": "#DellLCService.SupportAssistSetAutoCollectSchedule",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_missing_action_does_not_post(
+    redfish_mock_factory,
+):
+    """A non-Dell fixture reports no schedule target and no POST."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="clear",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell LC SupportAssist schedule action not found"
+    assert result.data == {
+        "action": "#DellLCService.SupportAssistClearAutoCollectSchedule",
+        "available": [],
+    }
+    assert _post_requests(service.requests) == []
+
+
+def test_dell_lc_supportassist_schedule_exposes_cli_entrypoint():
+    """The command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellLcSupportAssistSchedule][
+            "dell-lc-supportassist-schedule"
+        ]
+        is DellLcSupportAssistSchedule
+    )
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellLcSupportAssistSchedule.register_subcommand(
+            DellLcSupportAssistSchedule
+        )
+    )
+
+    assert "--recurrence" in cmd_parser.format_help()
+    assert cmd_name == "dell-lc-supportassist-schedule"
+    assert "SupportAssist schedule" in cmd_help


### PR DESCRIPTION
## Summary
- add dell-lc-supportassist-schedule for DellLCService SupportAssist auto-collection schedule set/clear actions
- preview by default and require --confirm before POSTing
- validate Recurrence from Redfish allowable values and cover the Dell corpus path

## Validation
- git diff --cached --check
- Not run locally; GitHub Actions will run on the pull request