### PR TITLE
Add Dell software update schedule command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-software-update-schedule` | Manage Dell software update schedules; writes require `--confirm`. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -137,6 +137,7 @@ from .delloem.delloem_disconnect import *
 from .delloem.delloem_get_networkios import *
 from .delloem.delloem_boot_netios import *
 from .delloem.delloem_os_deployment import *
+from .delloem.cmd_dell_software_update_schedule import *
 
 
 # tasks

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,8 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellSoftwareInstallationService.ClearUpdateSchedule": Destructiveness.DESTRUCTIVE,
+    "#DellSoftwareInstallationService.SetUpdateSchedule": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/delloem/cmd_dell_software_update_schedule.py
+++ b/redfish_ctl/delloem/cmd_dell_software_update_schedule.py
@@ -1,0 +1,413 @@
+"""Manage Dell SoftwareInstallationService update schedules.
+
+    redfish_ctl dell-software-update-schedule
+    redfish_ctl dell-software-update-schedule --action set --payload-json '{"ShareType":"HTTP"}'
+    redfish_ctl dell-software-update-schedule --action clear --confirm
+
+The Dell OEM ``DellSoftwareInstallationService`` advertises schedule mutation
+actions in the ComputerSystem OEM links. This command discovers those targets,
+lists them by default, and previews schedule set/clear payloads unless
+``--confirm`` is supplied.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SERVICE_FALLBACK = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/"
+    "DellSoftwareInstallationService"
+)
+_REDACTED = "********"
+
+
+@dataclass(frozen=True)
+class _DellSoftwareScheduleSpec:
+    """Selector metadata for one Dell software update schedule action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_ACTION_SPECS = {
+    "set": _DellSoftwareScheduleSpec(
+        selector="set",
+        full_type="#DellSoftwareInstallationService.SetUpdateSchedule",
+        action_name="SetUpdateSchedule",
+        description="set the Dell software update schedule",
+    ),
+    "clear": _DellSoftwareScheduleSpec(
+        selector="clear",
+        full_type="#DellSoftwareInstallationService.ClearUpdateSchedule",
+        action_name="ClearUpdateSchedule",
+        description="clear the Dell software update schedule",
+    ),
+}
+
+
+class DellSoftwareUpdateSchedule(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellSoftwareUpdateSchedule,
+    name="dell-software-update-schedule",
+    metaclass=Singleton,
+):
+    """Discover and invoke Dell software update schedule actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-software-update-schedule command."""
+        super(DellSoftwareUpdateSchedule, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-software-update-schedule`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="schedule action to run; omit to list available targets",
+        )
+        cmd_parser.add_argument(
+            "--software-service-uri",
+            dest="software_service_uri",
+            type=str,
+            default=None,
+            help="specific DellSoftwareInstallationService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--payload-json",
+            dest="payload_json",
+            type=str,
+            default=None,
+            help="JSON object payload for SetUpdateSchedule vendor fields",
+        )
+        cmd_parser.add_argument(
+            "--share-type",
+            dest="share_type",
+            type=str,
+            default=None,
+            help="SetUpdateSchedule ShareType value advertised by the BMC",
+        )
+        cmd_parser.add_argument(
+            "--apply-reboot",
+            dest="apply_reboot",
+            type=str,
+            default=None,
+            help="SetUpdateSchedule ApplyReboot value, such as NoReboot",
+        )
+        cmd_parser.add_argument(
+            "--ignore-cert-warning",
+            dest="ignore_cert_warning",
+            type=str,
+            default=None,
+            help="SetUpdateSchedule IgnoreCertWarning value, such as Off or On",
+        )
+        cmd_parser.add_argument(
+            "--proxy-support",
+            dest="proxy_support",
+            type=str,
+            default=None,
+            help="SetUpdateSchedule ProxySupport value advertised by the BMC",
+        )
+        cmd_parser.add_argument(
+            "--proxy-type",
+            dest="proxy_type",
+            type=str,
+            default=None,
+            help="SetUpdateSchedule ProxyType value advertised by the BMC",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the schedule action POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-software-update-schedule",
+            "command manage Dell software update schedules",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell(data):
+        """Return the ``Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    @staticmethod
+    def _clean(value):
+        """Strip optional string values and omit blank strings.
+
+        :param value: candidate payload value.
+        :return: stripped string, original value, or None when blank.
+        """
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    @staticmethod
+    def _payload_from_json(payload_json):
+        """Parse a JSON object payload.
+
+        :param payload_json: JSON object text, or None.
+        :return: parsed payload dict.
+        :raises InvalidArgument: when the JSON is invalid or not an object.
+        """
+        if payload_json is None:
+            return {}
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError as exc:
+            raise InvalidArgument(f"invalid --payload-json: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise InvalidArgument("--payload-json must be a JSON object")
+        return dict(payload)
+
+    @staticmethod
+    def _redact_payload(payload):
+        """Return a copy of a payload with password-like fields masked.
+
+        :param payload: action payload dict.
+        :return: redacted payload copy.
+        """
+        redacted = {}
+        for key, value in payload.items():
+            if "password" in key.lower():
+                redacted[key] = _REDACTED
+            else:
+                redacted[key] = value
+        return redacted
+
+    @classmethod
+    def _payload(cls,
+                 payload_json=None,
+                 share_type=None,
+                 apply_reboot=None,
+                 ignore_cert_warning=None,
+                 proxy_support=None,
+                 proxy_type=None):
+        """Build a SetUpdateSchedule payload from JSON plus typed overrides.
+
+        :param payload_json: JSON object text with vendor-specific schedule fields.
+        :param share_type: optional ShareType value.
+        :param apply_reboot: optional ApplyReboot value.
+        :param ignore_cert_warning: optional IgnoreCertWarning value.
+        :param proxy_support: optional ProxySupport value.
+        :param proxy_type: optional ProxyType value.
+        :return: JSON-serializable payload dict.
+        """
+        payload = cls._payload_from_json(payload_json)
+        updates = {
+            "ShareType": cls._clean(share_type),
+            "ApplyReboot": cls._clean(apply_reboot),
+            "IgnoreCertWarning": cls._clean(ignore_cert_warning),
+            "ProxySupport": cls._clean(proxy_support),
+            "ProxyType": cls._clean(proxy_type),
+        }
+        payload.update({key: value for key, value in updates.items()
+                        if value is not None})
+        return payload
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, treating optional misses as absent.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _system_uris(self, do_async):
+        """Return ComputerSystem member URIs.
+
+        :param do_async: run the query asynchronously when True.
+        :return: list of system resource URIs.
+        """
+        root = self._get(RedfishApi.Version, do_async)
+        systems_uri = self._link(root, "Systems") or f"{RedfishApi.Version}/Systems"
+        systems = self._get(systems_uri, do_async)
+        members = systems.get("Members") if isinstance(systems, dict) else []
+        return [
+            member["@odata.id"]
+            for member in members
+            if isinstance(member, dict) and isinstance(member.get("@odata.id"), str)
+        ]
+
+    def _service_uris(self, do_async, service_uri=None):
+        """Discover DellSoftwareInstallationService resource URIs.
+
+        :param do_async: run the query asynchronously when True.
+        :param service_uri: optional caller-supplied service URI.
+        :return: ordered list of discovered service URIs.
+        """
+        if service_uri:
+            return [service_uri]
+
+        uris = []
+        for system_uri in self._system_uris(do_async):
+            system = self._get(system_uri, do_async)
+            discovered = self._link(
+                self._dell(system),
+                "DellSoftwareInstallationService",
+            )
+            if discovered and discovered not in uris:
+                uris.append(discovered)
+        if not uris:
+            uris.append(_SERVICE_FALLBACK)
+        return uris
+
+    def _discover_rows(self, do_async, service_uri=None):
+        """Discover available Dell software update schedule actions.
+
+        :param do_async: run underlying GETs asynchronously when True.
+        :param service_uri: optional caller-supplied service URI.
+        :return: list of available schedule-action rows.
+        """
+        rows = []
+        for candidate_uri in self._service_uris(do_async, service_uri):
+            service = self._get(candidate_uri, do_async)
+            actions = self.discover_redfish_actions(self, service)
+            targets = self._flatten_action_targets(service)
+            for spec in _ACTION_SPECS.values():
+                target = targets.get(spec.full_type)
+                if not target:
+                    continue
+                action = actions.get(spec.action_name)
+                rows.append({
+                    "Action": spec.selector,
+                    "FullType": spec.full_type,
+                    "Resource": candidate_uri,
+                    "Target": target,
+                    "Description": spec.description,
+                    "AllowableValues": getattr(action, "args", None) or {},
+                })
+        return rows
+
+    def execute(self,
+                action: Optional[str] = None,
+                software_service_uri: Optional[str] = None,
+                payload_json: Optional[str] = None,
+                share_type: Optional[str] = None,
+                apply_reboot: Optional[str] = None,
+                ignore_cert_warning: Optional[str] = None,
+                proxy_support: Optional[str] = None,
+                proxy_type: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or run Dell software update schedule actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param software_service_uri: optional direct service resource URI.
+        :param payload_json: JSON object payload for SetUpdateSchedule.
+        :param share_type: optional ShareType override.
+        :param apply_reboot: optional ApplyReboot override.
+        :param ignore_cert_warning: optional IgnoreCertWarning override.
+        :param proxy_support: optional ProxySupport override.
+        :param proxy_type: optional ProxyType override.
+        :param confirm: authorize the schedule action POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        :raises InvalidArgument: when ``--action set`` has no payload fields.
+        """
+        rows = self._discover_rows(bool(do_async), software_service_uri)
+        if action is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = [row for row in rows if row["Action"] == action]
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"Dell software update schedule action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                f"multiple Dell software update schedule targets found: {action}",
+            )
+
+        spec = _ACTION_SPECS[action]
+        payload = {}
+        if action == "set":
+            payload = self._payload(
+                payload_json=payload_json,
+                share_type=share_type,
+                apply_reboot=apply_reboot,
+                ignore_cert_warning=ignore_cert_warning,
+                proxy_support=proxy_support,
+                proxy_type=proxy_type,
+            )
+            if not payload:
+                raise InvalidArgument(
+                    "--action set requires --payload-json or a schedule option"
+                )
+
+        result = self.invoke_action(
+            matches[0]["Resource"],
+            spec.action_name,
+            payload=payload,
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        if isinstance(result.data, dict) and "payload" in result.data:
+            result.data["payload"] = self._redact_payload(result.data["payload"])
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -147,6 +147,7 @@ class ApiRequestType(Enum):
     GetAttachStatus = auto()
     DellOemNetIsoBoot = auto()
     DellOemDetach = auto()
+    DellSoftwareUpdateSchedule = auto()
     TaskGet = auto()
 
     # attribute

--- a/tests/test_dell_software_update_schedule_dualmode.py
+++ b/tests/test_dell_software_update_schedule_dualmode.py
@@ -1,0 +1,361 @@
+"""Dual-mode-style coverage for Dell software update schedule actions."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.delloem.cmd_dell_software_update_schedule import (
+    DellSoftwareUpdateSchedule,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+SERVICE = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/"
+    "DellSoftwareInstallationService"
+)
+SET_TARGET = f"{SERVICE}/Actions/DellSoftwareInstallationService.SetUpdateSchedule"
+CLEAR_TARGET = f"{SERVICE}/Actions/DellSoftwareInstallationService.ClearUpdateSchedule"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+def _service_body():
+    """Return the DellSoftwareInstallationService fixture body.
+
+    :return: parsed DellSoftwareInstallationService JSON.
+    """
+    return json.loads(_fixture_for_path(SERVICE).read_text())
+
+
+@pytest.fixture
+def dell_software_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase, recorded requests, and GET overrides.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+    overrides = {}
+
+    def get_cb(request, context):
+        requests.append(request)
+        override = overrides.get(request.path.lower())
+        if override is not None:
+            context.status_code = 200
+            return json.dumps(override)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/software-schedule-1"
+        return json.dumps({
+            "Task": {
+                "@odata.id": "/redfish/v1/TaskService/Tasks/software-schedule-1"
+            }
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-software",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests, overrides
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_software_update_schedule_lists_targets(dell_software_manager):
+    """Omitting --action lists set/clear targets without POSTing."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert {
+        (row["Action"], row["Target"])
+        for row in result.data
+    } == {
+        ("set", SET_TARGET),
+        ("clear", CLEAR_TARGET),
+    }
+    set_row = next(row for row in result.data if row["Action"] == "set")
+    assert set_row["AllowableValues"]["ShareType"] == [
+        "CIFS",
+        "FTP",
+        "HTTP",
+        "HTTPS",
+        "NFS",
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_set_previews_payload(dell_software_manager):
+    """SetUpdateSchedule resolves and previews payloads by default."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+        action="set",
+        payload_json='{"ShareName": "/repo", "Password": "secret"}',
+        share_type="HTTP",
+        apply_reboot="NoReboot",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellSoftwareInstallationService.SetUpdateSchedule"
+    assert result.data["target"] == SET_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {
+        "ShareName": "/repo",
+        "Password": "********",
+        "ShareType": "HTTP",
+        "ApplyReboot": "NoReboot",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_set_confirm_posts(dell_software_manager):
+    """--confirm POSTs a SetUpdateSchedule payload to the discovered target."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+        action="set",
+        payload_json='{"ShareName": "/repo"}',
+        share_type="HTTPS",
+        apply_reboot="RebootRequired",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellSoftwareInstallationService.SetUpdateSchedule"
+    assert result.data["target"] == SET_TARGET
+    assert result.data["task_id"] == "software-schedule-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SET_TARGET.lower()
+    assert posts[0].json() == {
+        "ShareName": "/repo",
+        "ShareType": "HTTPS",
+        "ApplyReboot": "RebootRequired",
+    }
+
+
+def test_dell_software_update_schedule_set_dry_run_overrides_confirm(
+    dell_software_manager,
+):
+    """--dry_run keeps SetUpdateSchedule from POSTing even with --confirm."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+        action="set",
+        share_type="NFS",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == SET_TARGET
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_rejects_invalid_allowable(
+    dell_software_manager,
+):
+    """Inline allowable values reject invalid SetUpdateSchedule enum values."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+        action="set",
+        share_type="TFTP",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellSoftwareInstallationService.SetUpdateSchedule "
+        "ShareType: TFTP; allowed: CIFS, FTP, HTTP, HTTPS, NFS"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "ShareType",
+            "value": "TFTP",
+            "allowed": ["CIFS", "FTP", "HTTP", "HTTPS", "NFS"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_clear_previews(dell_software_manager):
+    """ClearUpdateSchedule previews by default without POSTing."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+        action="clear",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellSoftwareInstallationService.ClearUpdateSchedule"
+    assert result.data["target"] == CLEAR_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_clear_confirm_posts_empty_payload(
+    dell_software_manager,
+):
+    """--confirm POSTs an empty ClearUpdateSchedule body."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+        action="clear",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellSoftwareInstallationService.ClearUpdateSchedule"
+    assert result.data["target"] == CLEAR_TARGET
+    assert len(posts) == 1
+    assert posts[0].path.lower() == CLEAR_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_software_update_schedule_reports_missing_action(
+    dell_software_manager,
+):
+    """A service without SetUpdateSchedule reports the available schedule action."""
+    manager, requests, overrides = dell_software_manager
+    body = _service_body()
+    body["Actions"].pop("#DellSoftwareInstallationService.SetUpdateSchedule")
+    overrides[SERVICE.lower()] = body
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateSchedule,
+        "dell-software-update-schedule",
+        action="set",
+        share_type="HTTP",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell software update schedule action not found: set"
+    assert [row["Action"] for row in result.data["available"]] == ["clear"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_rejects_empty_set_payload(
+    dell_software_manager,
+):
+    """SetUpdateSchedule requires at least one payload field."""
+    manager, requests, _ = dell_software_manager
+
+    with pytest.raises(InvalidArgument, match="--action set requires"):
+        manager.sync_invoke(
+            ApiRequestType.DellSoftwareUpdateSchedule,
+            "dell-software-update-schedule",
+            action="set",
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_rejects_non_object_json(
+    dell_software_manager,
+):
+    """The payload JSON must be an object."""
+    manager, requests, _ = dell_software_manager
+
+    with pytest.raises(InvalidArgument, match="JSON object"):
+        manager.sync_invoke(
+            ApiRequestType.DellSoftwareUpdateSchedule,
+            "dell-software-update-schedule",
+            action="set",
+            payload_json='["not-object"]',
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_schedule_is_registered():
+    """The command is wired into the command registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellSoftwareUpdateSchedule][
+            "dell-software-update-schedule"
+        ]
+        is DellSoftwareUpdateSchedule
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellSoftwareUpdateSchedule.register_subcommand(
+        DellSoftwareUpdateSchedule
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-software-update-schedule"
+    assert "schedule" in cmd_help
+    assert "--action" in help_text
+    assert "--payload-json" in help_text
+    assert "--confirm" in help_text


### PR DESCRIPTION
## Summary
- add dell-software-update-schedule for DellSoftwareInstallationService SetUpdateSchedule and ClearUpdateSchedule
- discover the schedule actions from ComputerSystem Dell OEM links and list targets by default
- preview writes by default, require --confirm before POSTing, validate advertised allowable values, and redact password-like dry-run payload fields

## Validation
- git diff --cached --check
- Not run locally; GitHub Actions will run on the pull request