### PR TITLE
Add Dell software update install command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-software-update-install` | Run DellSoftwareInstallationService repository or URI install actions; `--dry_run` previews, `--confirm` writes. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -137,6 +137,7 @@ from .delloem.delloem_disconnect import *
 from .delloem.delloem_get_networkios import *
 from .delloem.delloem_boot_netios import *
 from .delloem.delloem_os_deployment import *
+from .delloem.cmd_dell_software_update_install import *
 
 
 # tasks

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,8 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellSoftwareInstallationService.InstallFromRepository": Destructiveness.DESTRUCTIVE,
+    "#DellSoftwareInstallationService.InstallFromURI": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/delloem/cmd_dell_software_update_install.py
+++ b/redfish_ctl/delloem/cmd_dell_software_update_install.py
@@ -1,0 +1,550 @@
+"""Run Dell SoftwareInstallationService install actions.
+
+    redfish_ctl dell-software-update-install
+    redfish_ctl dell-software-update-install --action repository --share-name /repo
+    redfish_ctl dell-software-update-install --action uri --uri https://repo.example/fw.exe \
+        --confirm
+
+The Dell OEM ``DellSoftwareInstallationService`` advertises software install
+actions from the ComputerSystem OEM links. These actions can install firmware
+or software, so the command discovers and previews the target by default and
+only POSTs when ``--confirm`` is supplied.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+import os
+from abc import abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SERVICE_FALLBACK = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/"
+    "DellSoftwareInstallationService"
+)
+_REDACTED = "********"
+
+
+@dataclass(frozen=True)
+class _DellSoftwareInstallSpec:
+    """Selector metadata for one Dell software-installation action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_ACTION_SPECS = {
+    "repository": _DellSoftwareInstallSpec(
+        selector="repository",
+        full_type="#DellSoftwareInstallationService.InstallFromRepository",
+        action_name="InstallFromRepository",
+        description="install updates from a repository share",
+    ),
+    "uri": _DellSoftwareInstallSpec(
+        selector="uri",
+        full_type="#DellSoftwareInstallationService.InstallFromURI",
+        action_name="InstallFromURI",
+        description="install an update from a specific URI",
+    ),
+}
+
+
+class DellSoftwareUpdateInstall(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellSoftwareUpdateInstall,
+    name="dell-software-update-install",
+    metaclass=Singleton,
+):
+    """Discover and invoke Dell software-installation update actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-software-update-install command."""
+        super(DellSoftwareUpdateInstall, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-software-update-install`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="install action to run; omit to list available targets",
+        )
+        cmd_parser.add_argument(
+            "--software-service-uri",
+            dest="software_service_uri",
+            type=str,
+            default=None,
+            help="specific DellSoftwareInstallationService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--payload-json",
+            dest="payload_json",
+            type=str,
+            default=None,
+            help="JSON object payload for vendor-specific install fields",
+        )
+        cmd_parser.add_argument(
+            "--uri",
+            dest="install_uri",
+            type=str,
+            default=None,
+            help="InstallFromURI URI value",
+        )
+        cmd_parser.add_argument(
+            "--share-name",
+            dest="share_name",
+            type=str,
+            default=None,
+            help="repository share name for InstallFromRepository",
+        )
+        cmd_parser.add_argument(
+            "--share-type",
+            dest="share_type",
+            type=str,
+            default=None,
+            help="repository ShareType value advertised by the BMC",
+        )
+        cmd_parser.add_argument(
+            "--catalog-file",
+            dest="catalog_file",
+            type=str,
+            default=None,
+            help="optional repository catalog file name",
+        )
+        cmd_parser.add_argument(
+            "--apply-update",
+            dest="apply_update",
+            type=str,
+            default=None,
+            help="InstallFromRepository ApplyUpdate value, usually True or False",
+        )
+        cmd_parser.add_argument(
+            "--ignore-cert-warning",
+            dest="ignore_cert_warning",
+            type=str,
+            default=None,
+            help="IgnoreCertWarning value advertised by the BMC",
+        )
+        cmd_parser.add_argument(
+            "--proxy-support",
+            dest="proxy_support",
+            type=str,
+            default=None,
+            help="ProxySupport value advertised by the BMC",
+        )
+        cmd_parser.add_argument(
+            "--proxy-type",
+            dest="proxy_type",
+            type=str,
+            default=None,
+            help="ProxyType value advertised by the BMC",
+        )
+        cmd_parser.add_argument(
+            "--username",
+            dest="software_username",
+            type=str,
+            default=None,
+            help="optional repository or URI username",
+        )
+        password_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        password_group.add_argument(
+            "--password-env",
+            dest="software_password_env",
+            type=str,
+            default=None,
+            help="environment variable containing the repository or URI password",
+        )
+        password_group.add_argument(
+            "--password-file",
+            dest="software_password_file",
+            type=str,
+            default=None,
+            help="file containing the repository or URI password",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the install action POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-software-update-install",
+            "command run Dell software installation actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell(data):
+        """Return the ``Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    @staticmethod
+    def _clean(value):
+        """Strip optional string values and omit blank strings.
+
+        :param value: candidate payload value.
+        :return: stripped string, original value, or None when blank.
+        """
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    @staticmethod
+    def _payload_from_json(payload_json):
+        """Parse a JSON object payload.
+
+        :param payload_json: JSON object text, or None.
+        :return: parsed payload dict.
+        :raises InvalidArgument: when the JSON is invalid or not an object.
+        """
+        if payload_json is None:
+            return {}
+        try:
+            payload = json.loads(payload_json)
+        except json.JSONDecodeError as exc:
+            raise InvalidArgument(f"invalid --payload-json: {exc}") from exc
+        if not isinstance(payload, dict):
+            raise InvalidArgument("--payload-json must be a JSON object")
+        return dict(payload)
+
+    @staticmethod
+    def _password_from_source(password_env=None, password_file=None):
+        """Read an optional repository password from an env var or file.
+
+        :param password_env: name of the environment variable to read.
+        :param password_file: path to a file containing the password.
+        :return: password string, or None when no source was provided.
+        :raises InvalidArgument: when the source cannot be read.
+        """
+        if password_env and password_file:
+            raise InvalidArgument(
+                "use only one of --password-env or --password-file"
+            )
+        if password_env is not None:
+            env_name = password_env.strip()
+            if not env_name:
+                raise InvalidArgument("password environment variable name cannot be empty")
+            if env_name not in os.environ:
+                raise InvalidArgument(f"password environment variable '{env_name}' is not set")
+            return os.environ[env_name]
+        if password_file is not None:
+            path = Path(password_file).expanduser()
+            try:
+                return path.read_text(encoding="utf-8").rstrip("\r\n")
+            except OSError as exc:
+                raise InvalidArgument(
+                    f"failed to read password file '{path}': {exc}"
+                ) from exc
+        return None
+
+    @staticmethod
+    def _is_sensitive_key(key):
+        """Return True for payload keys whose values should not be echoed.
+
+        :param key: payload key name.
+        :return: True when the key is credential-like.
+        """
+        lowered = key.lower()
+        return (
+            "password" in lowered
+            or "secret" in lowered
+            or "token" in lowered
+            or lowered in {"apikey", "api_key", "accesskey", "access_key"}
+        )
+
+    @classmethod
+    def _redact_payload(cls, payload):
+        """Return a copy of a payload with credential-like fields masked.
+
+        :param payload: action payload dict.
+        :return: redacted payload copy.
+        """
+        return {
+            key: _REDACTED if cls._is_sensitive_key(key) else value
+            for key, value in payload.items()
+        }
+
+    @classmethod
+    def _redact_result(cls, result):
+        """Mask credential-like fields in returned dry-run/error payloads.
+
+        :param result: CommandResult returned by ``invoke_action``.
+        :return: CommandResult with any payload credentials redacted.
+        """
+        if isinstance(result.data, dict) and isinstance(result.data.get("payload"), dict):
+            result.data["payload"] = cls._redact_payload(result.data["payload"])
+        return result
+
+    @classmethod
+    def _payload(cls,
+                 action,
+                 payload_json=None,
+                 install_uri=None,
+                 share_name=None,
+                 share_type=None,
+                 catalog_file=None,
+                 apply_update=None,
+                 ignore_cert_warning=None,
+                 proxy_support=None,
+                 proxy_type=None,
+                 software_username=None,
+                 software_password=None):
+        """Build an action payload from JSON plus typed CLI fields.
+
+        :param action: selected install action.
+        :param payload_json: JSON object text with vendor-specific fields.
+        :param install_uri: optional InstallFromURI URI.
+        :param share_name: optional repository share name.
+        :param share_type: optional repository ShareType value.
+        :param catalog_file: optional repository catalog file.
+        :param apply_update: optional ApplyUpdate value.
+        :param ignore_cert_warning: optional IgnoreCertWarning value.
+        :param proxy_support: optional ProxySupport value.
+        :param proxy_type: optional ProxyType value.
+        :param software_username: optional username for the repository or URI.
+        :param software_password: optional password read from a safe source.
+        :return: JSON-serializable payload dict.
+        """
+        payload = cls._payload_from_json(payload_json)
+        updates = {
+            "IgnoreCertWarning": cls._clean(ignore_cert_warning),
+            "ProxySupport": cls._clean(proxy_support),
+            "ProxyType": cls._clean(proxy_type),
+            "UserName": cls._clean(software_username),
+            "Password": cls._clean(software_password),
+        }
+        if action == "uri":
+            updates["URI"] = cls._clean(install_uri)
+        else:
+            updates.update({
+                "ShareName": cls._clean(share_name),
+                "ShareType": cls._clean(share_type),
+                "CatalogFile": cls._clean(catalog_file),
+                "ApplyUpdate": cls._clean(apply_update),
+            })
+        payload.update({key: value for key, value in updates.items()
+                        if value is not None})
+        return payload
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, treating optional misses as absent.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _system_uris(self, do_async):
+        """Return ComputerSystem member URIs.
+
+        :param do_async: run the query asynchronously when True.
+        :return: list of system resource URIs.
+        """
+        root = self._get(RedfishApi.Version, do_async)
+        systems_uri = self._link(root, "Systems") or f"{RedfishApi.Version}/Systems"
+        systems = self._get(systems_uri, do_async)
+        members = systems.get("Members") if isinstance(systems, dict) else []
+        return [
+            member["@odata.id"]
+            for member in members
+            if isinstance(member, dict) and isinstance(member.get("@odata.id"), str)
+        ]
+
+    def _service_uris(self, do_async, service_uri=None):
+        """Discover DellSoftwareInstallationService resource URIs.
+
+        :param do_async: run the query asynchronously when True.
+        :param service_uri: optional caller-supplied service URI.
+        :return: ordered list of discovered service URIs.
+        """
+        if service_uri:
+            return [service_uri]
+
+        uris = []
+        for system_uri in self._system_uris(do_async):
+            system = self._get(system_uri, do_async)
+            discovered = self._link(
+                self._dell(system),
+                "DellSoftwareInstallationService",
+            )
+            if discovered and discovered not in uris:
+                uris.append(discovered)
+        if not uris:
+            uris.append(_SERVICE_FALLBACK)
+        return uris
+
+    def _discover_rows(self, do_async, service_uri=None):
+        """Discover available Dell software installation actions.
+
+        :param do_async: run underlying GETs asynchronously when True.
+        :param service_uri: optional caller-supplied service URI.
+        :return: list of available install-action rows.
+        """
+        rows = []
+        for candidate_uri in self._service_uris(do_async, service_uri):
+            service = self._get(candidate_uri, do_async)
+            actions = self.discover_redfish_actions(self, service)
+            targets = self._flatten_action_targets(service)
+            for spec in _ACTION_SPECS.values():
+                target = targets.get(spec.full_type)
+                if not target:
+                    continue
+                action = actions.get(spec.action_name)
+                rows.append({
+                    "Action": spec.selector,
+                    "FullType": spec.full_type,
+                    "Resource": candidate_uri,
+                    "Target": target,
+                    "Description": spec.description,
+                    "AllowableValues": getattr(action, "args", None) or {},
+                })
+        return rows
+
+    def execute(self,
+                action: Optional[str] = None,
+                software_service_uri: Optional[str] = None,
+                payload_json: Optional[str] = None,
+                install_uri: Optional[str] = None,
+                share_name: Optional[str] = None,
+                share_type: Optional[str] = None,
+                catalog_file: Optional[str] = None,
+                apply_update: Optional[str] = None,
+                ignore_cert_warning: Optional[str] = None,
+                proxy_support: Optional[str] = None,
+                proxy_type: Optional[str] = None,
+                software_username: Optional[str] = None,
+                software_password_env: Optional[str] = None,
+                software_password_file: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or run Dell software update install actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param software_service_uri: optional direct service resource URI.
+        :param payload_json: JSON object payload for vendor-specific fields.
+        :param install_uri: optional InstallFromURI URI value.
+        :param share_name: optional repository share name.
+        :param share_type: optional repository ShareType value.
+        :param catalog_file: optional repository catalog file.
+        :param apply_update: optional repository ApplyUpdate value.
+        :param ignore_cert_warning: optional IgnoreCertWarning value.
+        :param proxy_support: optional ProxySupport value.
+        :param proxy_type: optional ProxyType value.
+        :param software_username: optional username for the repository or URI.
+        :param software_password_env: environment variable containing a password.
+        :param software_password_file: file containing a password.
+        :param confirm: authorize the install action POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        :raises InvalidArgument: when an action has no payload fields.
+        """
+        rows = self._discover_rows(bool(do_async), software_service_uri)
+        if action is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = [row for row in rows if row["Action"] == action]
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"Dell software update install action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                f"multiple Dell software update install targets found: {action}",
+            )
+
+        spec = _ACTION_SPECS[action]
+        payload = self._payload(
+            action,
+            payload_json=payload_json,
+            install_uri=install_uri,
+            share_name=share_name,
+            share_type=share_type,
+            catalog_file=catalog_file,
+            apply_update=apply_update,
+            ignore_cert_warning=ignore_cert_warning,
+            proxy_support=proxy_support,
+            proxy_type=proxy_type,
+            software_username=software_username,
+            software_password=self._password_from_source(
+                software_password_env,
+                software_password_file,
+            ),
+        )
+        if not payload:
+            raise InvalidArgument(
+                f"--action {action} requires --payload-json or an install option"
+            )
+
+        result = self.invoke_action(
+            matches[0]["Resource"],
+            spec.action_name,
+            payload=payload,
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        return self._redact_result(result)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -59,6 +59,7 @@ class ApiRequestType(Enum):
     FirmwareInventoryQuery = auto()
     UpdateServiceQuery = auto()
     UpdateStart = auto()
+    DellSoftwareUpdateInstall = auto()
     PciDeviceQuery = auto()
     SystemQuery = auto()
     VirtualDiskQuery = auto()

--- a/tests/test_dell_software_update_install_dualmode.py
+++ b/tests/test_dell_software_update_install_dualmode.py
@@ -1,0 +1,398 @@
+"""Dual-mode-style coverage for Dell software update install actions."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.delloem.cmd_dell_software_update_install import (
+    DellSoftwareUpdateInstall,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+SERVICE = (
+    "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/"
+    "DellSoftwareInstallationService"
+)
+REPOSITORY_TARGET = (
+    f"{SERVICE}/Actions/"
+    "DellSoftwareInstallationService.InstallFromRepository"
+)
+URI_TARGET = (
+    f"{SERVICE}/Actions/"
+    "DellSoftwareInstallationService.InstallFromURI"
+)
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+def _service_body():
+    """Return the DellSoftwareInstallationService fixture body.
+
+    :return: parsed DellSoftwareInstallationService JSON.
+    """
+    return json.loads(_fixture_for_path(SERVICE).read_text())
+
+
+@pytest.fixture
+def dell_software_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase, recorded requests, and GET overrides.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+    overrides = {}
+
+    def get_cb(request, context):
+        requests.append(request)
+        override = overrides.get(request.path.lower())
+        if override is not None:
+            context.status_code = 200
+            return json.dumps(override)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/software-install-1"
+        return json.dumps({
+            "Task": {
+                "@odata.id": "/redfish/v1/TaskService/Tasks/software-install-1"
+            }
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-software-install",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests, overrides
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_software_update_install_lists_targets(dell_software_manager):
+    """Omitting --action lists install targets without POSTing."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateInstall,
+        "dell-software-update-install",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert {
+        (row["Action"], row["Target"])
+        for row in result.data
+    } == {
+        ("repository", REPOSITORY_TARGET),
+        ("uri", URI_TARGET),
+    }
+    repository = next(row for row in result.data if row["Action"] == "repository")
+    uri = next(row for row in result.data if row["Action"] == "uri")
+    assert repository["AllowableValues"]["ShareType"] == [
+        "CIFS",
+        "FTP",
+        "HTTP",
+        "HTTPS",
+        "NFS",
+        "TFTP",
+    ]
+    assert uri["AllowableValues"]["ProxyType"] == ["HTTP", "SOCKS"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_repository_previews_payload(
+    dell_software_manager,
+):
+    """InstallFromRepository resolves and previews payloads by default."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateInstall,
+        "dell-software-update-install",
+        action="repository",
+        payload_json='{"Password": "placeholder-value"}',
+        share_name="/repo/catalog",
+        share_type="HTTP",
+        apply_update="True",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert (
+        result.data["action"]
+        == "#DellSoftwareInstallationService.InstallFromRepository"
+    )
+    assert result.data["target"] == REPOSITORY_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {
+        "Password": "********",
+        "ShareName": "/repo/catalog",
+        "ShareType": "HTTP",
+        "ApplyUpdate": "True",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_repository_confirm_posts(
+    dell_software_manager,
+):
+    """--confirm POSTs InstallFromRepository to the discovered target."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateInstall,
+        "dell-software-update-install",
+        action="repository",
+        share_name="/repo/catalog",
+        share_type="HTTPS",
+        apply_update="False",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert (
+        result.data["action"]
+        == "#DellSoftwareInstallationService.InstallFromRepository"
+    )
+    assert result.data["target"] == REPOSITORY_TARGET
+    assert result.data["task_id"] == "software-install-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == REPOSITORY_TARGET.lower()
+    assert posts[0].json() == {
+        "ShareName": "/repo/catalog",
+        "ShareType": "HTTPS",
+        "ApplyUpdate": "False",
+    }
+
+
+def test_dell_software_update_install_uri_confirm_posts(dell_software_manager):
+    """--confirm POSTs InstallFromURI to the discovered target."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateInstall,
+        "dell-software-update-install",
+        action="uri",
+        install_uri="https://repo.example.test/firmware.exe",
+        ignore_cert_warning="On",
+        proxy_support="Off",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellSoftwareInstallationService.InstallFromURI"
+    assert result.data["target"] == URI_TARGET
+    assert len(posts) == 1
+    assert posts[0].path.lower() == URI_TARGET.lower()
+    assert posts[0].json() == {
+        "URI": "https://repo.example.test/firmware.exe",
+        "IgnoreCertWarning": "On",
+        "ProxySupport": "Off",
+    }
+
+
+def test_dell_software_update_install_dry_run_overrides_confirm(
+    dell_software_manager,
+):
+    """--dry_run keeps InstallFromURI from POSTing even with --confirm."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateInstall,
+        "dell-software-update-install",
+        action="uri",
+        install_uri="https://repo.example.test/firmware.exe",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == URI_TARGET
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_rejects_invalid_allowable(
+    dell_software_manager,
+):
+    """Inline allowable values reject invalid repository enum values."""
+    manager, requests, _ = dell_software_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateInstall,
+        "dell-software-update-install",
+        action="repository",
+        share_name="/repo/catalog",
+        share_type="SFTP",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellSoftwareInstallationService.InstallFromRepository "
+        "ShareType: SFTP; allowed: CIFS, FTP, HTTP, HTTPS, NFS, TFTP"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "ShareType",
+            "value": "SFTP",
+            "allowed": ["CIFS", "FTP", "HTTP", "HTTPS", "NFS", "TFTP"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_reports_missing_action(
+    dell_software_manager,
+):
+    """A service without InstallFromURI reports the remaining install action."""
+    manager, requests, overrides = dell_software_manager
+    body = _service_body()
+    body["Actions"].pop("#DellSoftwareInstallationService.InstallFromURI")
+    overrides[SERVICE.lower()] = body
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellSoftwareUpdateInstall,
+        "dell-software-update-install",
+        action="uri",
+        install_uri="https://repo.example.test/firmware.exe",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell software update install action not found: uri"
+    assert [row["Action"] for row in result.data["available"]] == ["repository"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_rejects_empty_payload(
+    dell_software_manager,
+):
+    """Selected install actions require at least one payload field."""
+    manager, requests, _ = dell_software_manager
+
+    with pytest.raises(InvalidArgument, match="--action uri requires"):
+        manager.sync_invoke(
+            ApiRequestType.DellSoftwareUpdateInstall,
+            "dell-software-update-install",
+            action="uri",
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_rejects_non_object_json(
+    dell_software_manager,
+):
+    """The payload JSON must be an object."""
+    manager, requests, _ = dell_software_manager
+
+    with pytest.raises(InvalidArgument, match="JSON object"):
+        manager.sync_invoke(
+            ApiRequestType.DellSoftwareUpdateInstall,
+            "dell-software-update-install",
+            action="repository",
+            payload_json='["not-object"]',
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_rejects_missing_password_env(
+    dell_software_manager,
+):
+    """Missing password environment variables fail before any POST."""
+    manager, requests, _ = dell_software_manager
+
+    with pytest.raises(
+        InvalidArgument,
+        match="environment variable 'MISSING_SOFTWARE_PASSWORD'",
+    ):
+        manager.sync_invoke(
+            ApiRequestType.DellSoftwareUpdateInstall,
+            "dell-software-update-install",
+            action="repository",
+            share_name="/repo/catalog",
+            software_password_env="MISSING_SOFTWARE_PASSWORD",
+            confirm=True,
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_software_update_install_is_registered():
+    """The command is wired into the command registry and policy table."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellSoftwareUpdateInstall][
+            "dell-software-update-install"
+        ]
+        is DellSoftwareUpdateInstall
+    )
+    assert (
+        classify("#DellSoftwareInstallationService.InstallFromRepository")
+        == Destructiveness.DESTRUCTIVE
+    )
+    assert (
+        classify("#DellSoftwareInstallationService.InstallFromURI")
+        == Destructiveness.DESTRUCTIVE
+    )
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellSoftwareUpdateInstall.register_subcommand(DellSoftwareUpdateInstall)
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-software-update-install"
+    assert "software installation" in cmd_help
+    assert "--action" in help_text
+    assert "--payload-json" in help_text
+    assert "--confirm" in help_text


### PR DESCRIPTION
## Summary
- add a guarded DellSoftwareInstallationService install command for repository and URI install actions
- discover the Dell OEM service from ComputerSystem links and list targets by default
- add destructive action policies, docs, and Dell XR8620t corpus-backed coverage

## Testing
- Not run locally; validation is covered by GitHub CI for this branch.