### PR TITLE
Add Dell OS deployment VFlash action command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-os-vflash-actions` | List or invoke Dell OS deployment VFlash boot/delete/detach actions; previews by default and `--confirm` posts. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -137,6 +137,7 @@ from .delloem.delloem_disconnect import *
 from .delloem.delloem_get_networkios import *
 from .delloem.delloem_boot_netios import *
 from .delloem.delloem_os_deployment import *
+from .delloem.cmd_dell_os_vflash_actions import *
 
 
 # tasks

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,12 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellOSDeploymentService.BootToHD": Destructiveness.DESTRUCTIVE,
+    "#DellOSDeploymentService.BootToISOFromVFlash": Destructiveness.DESTRUCTIVE,
+    "#DellOSDeploymentService.DeleteISOFromVFlash": Destructiveness.DESTRUCTIVE,
+    "#DellOSDeploymentService.DetachDrivers": Destructiveness.DESTRUCTIVE,
+    "#DellOSDeploymentService.DetachISOFromVFlash": Destructiveness.DESTRUCTIVE,
+    "#DellOSDeploymentService.SkipISOImageBoot": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/delloem/cmd_dell_os_vflash_actions.py
+++ b/redfish_ctl/delloem/cmd_dell_os_vflash_actions.py
@@ -1,0 +1,340 @@
+"""Preview or invoke Dell OS deployment VFlash actions.
+
+    redfish_ctl dell-os-vflash-actions
+    redfish_ctl dell-os-vflash-actions --action detach-vflash-iso
+    redfish_ctl dell-os-vflash-actions --action skip-iso-boot --confirm
+
+The command discovers the Dell OEM ``DellOSDeploymentService`` from ComputerSystem
+links or the standard per-system OEM path. Selected actions preview by default,
+and ``--confirm`` is required before any POST is sent.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+
+@dataclass(frozen=True)
+class _OsDeploymentAction:
+    """Selector metadata for one Dell OS deployment action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_ACTION_SPECS = {
+    "boot-hd": _OsDeploymentAction(
+        selector="boot-hd",
+        full_type="#DellOSDeploymentService.BootToHD",
+        action_name="BootToHD",
+        description="boot back to the local hard disk path",
+    ),
+    "boot-vflash-iso": _OsDeploymentAction(
+        selector="boot-vflash-iso",
+        full_type="#DellOSDeploymentService.BootToISOFromVFlash",
+        action_name="BootToISOFromVFlash",
+        description="boot from the ISO currently staged on VFlash",
+    ),
+    "delete-vflash-iso": _OsDeploymentAction(
+        selector="delete-vflash-iso",
+        full_type="#DellOSDeploymentService.DeleteISOFromVFlash",
+        action_name="DeleteISOFromVFlash",
+        description="delete the ISO image currently staged on VFlash",
+    ),
+    "detach-drivers": _OsDeploymentAction(
+        selector="detach-drivers",
+        full_type="#DellOSDeploymentService.DetachDrivers",
+        action_name="DetachDrivers",
+        description="detach drivers exposed through OS deployment",
+    ),
+    "detach-vflash-iso": _OsDeploymentAction(
+        selector="detach-vflash-iso",
+        full_type="#DellOSDeploymentService.DetachISOFromVFlash",
+        action_name="DetachISOFromVFlash",
+        description="detach the VFlash ISO image from the host",
+    ),
+    "skip-iso-boot": _OsDeploymentAction(
+        selector="skip-iso-boot",
+        full_type="#DellOSDeploymentService.SkipISOImageBoot",
+        action_name="SkipISOImageBoot",
+        description="skip the pending ISO-image boot",
+    ),
+}
+
+
+class DellOsVflashActions(RedfishManagerBase,
+                          scm_type=ApiRequestType.DellOsVflashActions,
+                          name="dell-os-vflash-actions",
+                          metaclass=Singleton):
+    """Discover and invoke Dell OS deployment VFlash actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-os-vflash-actions command."""
+        super(DellOsVflashActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-os-vflash-actions`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="OS deployment action to preview or invoke; omit to list targets",
+        )
+        cmd_parser.add_argument(
+            "--system",
+            default=None,
+            help="ComputerSystem Id or URI when multiple systems expose the service",
+        )
+        cmd_parser.add_argument(
+            "--service-uri",
+            dest="service_uri",
+            default=None,
+            help="specific DellOSDeploymentService URI to target",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the selected action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-os-vflash-actions",
+            "command run Dell OS deployment VFlash actions",
+        )
+
+    @staticmethod
+    def _members(data):
+        """Return collection member URIs from a Redfish collection.
+
+        :param data: Redfish collection body.
+        :return: list of member ``@odata.id`` strings.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` from a linked Redfish property.
+
+        :param data: resource body that may carry the link.
+        :param key: property name to inspect.
+        :return: linked URI, or None when absent.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _nested_link(data, *keys):
+        """Follow nested dict keys and return the final ``@odata.id``.
+
+        :param data: resource body to walk.
+        :param keys: nested dict keys to follow.
+        :return: linked URI, or None when any step is absent.
+        """
+        value = data
+        for key in keys:
+            if not isinstance(value, dict):
+                return None
+            value = value.get(key)
+        return DellOsVflashActions._link({"value": value}, "value")
+
+    @staticmethod
+    def _resource_id(uri):
+        """Return the trailing Redfish URI segment.
+
+        :param uri: Redfish resource URI.
+        :return: trailing URI segment.
+        """
+        return uri.rstrip("/").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _service_candidates(system_uri, system):
+        """Return candidate DellOSDeploymentService URIs for one system.
+
+        :param system_uri: ComputerSystem URI.
+        :param system: ComputerSystem resource body.
+        :return: ordered list of candidate service URIs.
+        """
+        linked = DellOsVflashActions._nested_link(
+            system,
+            "Links",
+            "Oem",
+            "Dell",
+            "DellOSDeploymentService",
+        )
+        system_id = DellOsVflashActions._resource_id(system_uri)
+        candidates = [
+            linked,
+            f"{system_uri.rstrip('/')}/Oem/Dell/DellOSDeploymentService",
+            f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellOSDeploymentService",
+        ]
+        seen = set()
+        result = []
+        for uri in candidates:
+            if uri and uri not in seen:
+                seen.add(uri)
+                result.append(uri)
+        return result
+
+    def _get(self, uri, do_async, optional=False):
+        """GET a Redfish resource body.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async path when True.
+        :param optional: treat a failed read as an empty object when True.
+        :return: parsed resource body.
+        :raises InvalidArgument: when a required read fails or is not an object.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            if optional:
+                return {}
+            raise InvalidArgument(f"failed to read {uri}: {exc}") from exc
+        if not isinstance(data, dict):
+            if optional:
+                return {}
+            raise InvalidArgument(f"unexpected response from {uri}: expected object")
+        return data
+
+    def _discover_rows(self, do_async):
+        """Discover DellOSDeploymentService resources and supported actions.
+
+        :param do_async: issue GET requests on the async path when True.
+        :return: list of discovered service rows.
+        """
+        systems = self._get(f"{RedfishApi.Version}/Systems", do_async)
+        rows = []
+        seen_services = set()
+        for system_uri in self._members(systems):
+            system = self._get(system_uri, do_async, optional=True)
+            for service_uri in self._service_candidates(system_uri, system):
+                if service_uri in seen_services:
+                    continue
+                seen_services.add(service_uri)
+                service = self._get(service_uri, do_async, optional=True)
+                targets = self._flatten_action_targets(service)
+                actions = []
+                for spec in _ACTION_SPECS.values():
+                    target = targets.get(spec.full_type)
+                    if target:
+                        actions.append({
+                            "Action": spec.selector,
+                            "FullType": spec.full_type,
+                            "Target": target,
+                            "Description": spec.description,
+                        })
+                if actions:
+                    rows.append({
+                        "System": system.get("Id") or self._resource_id(system_uri),
+                        "SystemUri": system_uri,
+                        "Id": service.get("Id") or self._resource_id(service_uri),
+                        "Name": service.get("Name"),
+                        "Uri": service_uri,
+                        "Actions": actions,
+                    })
+        return rows
+
+    @staticmethod
+    def _resolve_row(rows, system=None, service_uri=None):
+        """Resolve a selected OS deployment service row.
+
+        :param rows: discovered rows from :meth:`_discover_rows`.
+        :param system: optional ComputerSystem Id or URI selector.
+        :param service_uri: optional DellOSDeploymentService URI selector.
+        :return: matching row.
+        :raises InvalidArgument: when selection is missing or ambiguous.
+        """
+        matches = list(rows)
+        if service_uri:
+            wanted = service_uri.rstrip("/")
+            matches = [row for row in rows if row["Uri"].rstrip("/") == wanted]
+        elif system:
+            wanted = system.rstrip("/")
+            folded = wanted.lower()
+            matches = [
+                row for row in rows
+                if row["SystemUri"].rstrip("/") == wanted
+                or str(row["System"]).lower() == folded
+            ]
+        if not matches:
+            raise InvalidArgument("DellOSDeploymentService resource not found")
+        if len(matches) > 1:
+            systems = [row["System"] for row in matches]
+            raise InvalidArgument(
+                "multiple DellOSDeploymentService resources found; pass --system "
+                f"or --service-uri: {systems}"
+            )
+        return matches[0]
+
+    def execute(self,
+                action: Optional[str] = None,
+                system: Optional[str] = None,
+                service_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke Dell OS deployment VFlash actions.
+
+        :param action: optional action selector; None lists discovered targets.
+        :param system: optional ComputerSystem Id or URI selector.
+        :param service_uri: optional DellOSDeploymentService URI selector.
+        :param confirm: authorize a POST. Without this every selected action previews.
+        :param dry_run: force a preview even with ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish calls on the async path.
+        :return: CommandResult with discovered targets, preview, or POST result.
+        :raises InvalidArgument: when selection arguments are invalid.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if action is None:
+            return CommandResult({"os_deployment_targets": rows}, None, None, None)
+
+        spec = _ACTION_SPECS[action]
+        row = self._resolve_row(rows, system=system, service_uri=service_uri)
+        return self.invoke_action(
+            row["Uri"],
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -147,6 +147,7 @@ class ApiRequestType(Enum):
     GetAttachStatus = auto()
     DellOemNetIsoBoot = auto()
     DellOemDetach = auto()
+    DellOsVflashActions = auto()
     TaskGet = auto()
 
     # attribute

--- a/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Oem_Dell_DellOSDeploymentService.json
+++ b/tests/idrac_fixtures/_redfish_v1_Systems_System.Embedded.1_Oem_Dell_DellOSDeploymentService.json
@@ -1,0 +1,103 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#DellOSDeploymentService.DellOSDeploymentService",
+  "@odata.id": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService",
+  "@odata.type": "#DellOSDeploymentService.v1_1_0.DellOSDeploymentService",
+  "Actions": {
+    "#DellOSDeploymentService.BootToHD": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.BootToHD"
+    },
+    "#DellOSDeploymentService.BootToISOFromVFlash": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.BootToISOFromVFlash"
+    },
+    "#DellOSDeploymentService.BootToNetworkISO": {
+      "HashType@Redfish.AllowableValues": [
+        "MD5",
+        "SHA1"
+      ],
+      "ShareType@Redfish.AllowableValues": [
+        "CIFS",
+        "NFS"
+      ],
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.BootToNetworkISO"
+    },
+    "#DellOSDeploymentService.ConfigurableBootToNetworkISO": {
+      "HashType@Redfish.AllowableValues": [
+        "MD5",
+        "SHA1"
+      ],
+      "ResetType@Redfish.AllowableValues": [
+        "ColdReset",
+        "NoReset",
+        "WarmReset"
+      ],
+      "ShareType@Redfish.AllowableValues": [
+        "CIFS",
+        "NFS"
+      ],
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.ConfigurableBootToNetworkISO"
+    },
+    "#DellOSDeploymentService.ConnectNetworkISOImage": {
+      "HashType@Redfish.AllowableValues": [
+        "MD5",
+        "SHA1"
+      ],
+      "ShareType@Redfish.AllowableValues": [
+        "CIFS",
+        "NFS"
+      ],
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.ConnectNetworkISOImage"
+    },
+    "#DellOSDeploymentService.DeleteISOFromVFlash": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.DeleteISOFromVFlash"
+    },
+    "#DellOSDeploymentService.DetachDrivers": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.DetachDrivers"
+    },
+    "#DellOSDeploymentService.DetachISOFromVFlash": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.DetachISOFromVFlash"
+    },
+    "#DellOSDeploymentService.DetachISOImage": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.DetachISOImage"
+    },
+    "#DellOSDeploymentService.DisconnectNetworkISOImage": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.DisconnectNetworkISOImage"
+    },
+    "#DellOSDeploymentService.DownloadISOToVFlash": {
+      "HashType@Redfish.AllowableValues": [
+        "MD5",
+        "SHA1"
+      ],
+      "ShareType@Redfish.AllowableValues": [
+        "CIFS",
+        "NFS",
+        "TFTP"
+      ],
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.DownloadISOToVFlash"
+    },
+    "#DellOSDeploymentService.GetAttachStatus": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.GetAttachStatus"
+    },
+    "#DellOSDeploymentService.GetDriverPackInfo": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.GetDriverPackInfo"
+    },
+    "#DellOSDeploymentService.GetNetworkISOImageConnectionInfo": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.GetNetworkISOImageConnectionInfo"
+    },
+    "#DellOSDeploymentService.SkipISOImageBoot": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.SkipISOImageBoot"
+    },
+    "#DellOSDeploymentService.UnpackAndAttach": {
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.UnpackAndAttach"
+    },
+    "#DellOSDeploymentService.UnpackAndShare": {
+      "ShareType@Redfish.AllowableValues": [
+        "CIFS",
+        "NFS"
+      ],
+      "target": "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService/Actions/DellOSDeploymentService.UnpackAndShare"
+    }
+  },
+  "Description": "The DellOSDeploymentService resource provides some actions to support OS deployment configurations.",
+  "Id": "DellOSDeploymentService",
+  "Name": "DellOSDeploymentService"
+}

--- a/tests/test_dell_os_vflash_actions_dualmode.py
+++ b/tests/test_dell_os_vflash_actions_dualmode.py
@@ -1,0 +1,168 @@
+"""Dual-mode coverage for Dell OS deployment VFlash actions."""
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.delloem.cmd_dell_os_vflash_actions import DellOsVflashActions
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+OS_DEPLOYMENT = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellOSDeploymentService"
+ACTION_PREFIX = f"{OS_DEPLOYMENT}/Actions/DellOSDeploymentService"
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the offline mock service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _service_body(service):
+    """Return a mutable DellOSDeploymentService body from fixture-backed state."""
+    return dict(service._state(OS_DEPLOYMENT))
+
+
+def _set_os_deployment(service, body):
+    """Overlay DellOSDeploymentService under both path casings used by requests-mock."""
+    service._overlay[OS_DEPLOYMENT] = body
+    service._overlay[OS_DEPLOYMENT.lower()] = body
+
+
+def test_dell_os_vflash_actions_lists_corpus_backed_targets(redfish_api):
+    """The command lists VFlash-related actions from DellOSDeploymentService."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellOsVflashActions,
+        "dell-os-vflash-actions",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    rows = result.data["os_deployment_targets"]
+    assert len(rows) == 1
+    assert rows[0]["System"] == "System.Embedded.1"
+    assert rows[0]["Uri"] == OS_DEPLOYMENT
+    actions = {action["Action"]: action for action in rows[0]["Actions"]}
+    assert set(actions) == {
+        "boot-hd",
+        "boot-vflash-iso",
+        "delete-vflash-iso",
+        "detach-drivers",
+        "detach-vflash-iso",
+        "skip-iso-boot",
+    }
+    assert actions["detach-vflash-iso"]["Target"] == (
+        f"{ACTION_PREFIX}.DetachISOFromVFlash"
+    )
+
+
+def test_dell_os_vflash_action_defaults_to_dry_run(redfish_api, redfish_service):
+    """A selected action previews by default and does not POST."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellOsVflashActions,
+        "dell-os-vflash-actions",
+        action="detach-vflash-iso",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellOSDeploymentService.DetachISOFromVFlash",
+        "target": f"{ACTION_PREFIX}.DetachISOFromVFlash",
+        "payload": {},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_os_vflash_action_confirm_posts_empty_payload(
+        redfish_api, redfish_service):
+    """With --confirm the command POSTs to the discovered action target."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellOsVflashActions,
+        "dell-os-vflash-actions",
+        action="skip-iso-boot",
+        confirm=True,
+    )
+
+    posts = [
+        request
+        for request in _post_requests(redfish_service)
+        if request.path.lower() == f"{ACTION_PREFIX}.SkipISOImageBoot".lower()
+    ]
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellOSDeploymentService.SkipISOImageBoot"
+    assert result.data["target"] == f"{ACTION_PREFIX}.SkipISOImageBoot"
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].json() == {}
+
+
+def test_dell_os_vflash_action_dry_run_overrides_confirm(
+        redfish_api, redfish_service):
+    """--dry_run keeps the command in preview mode even with --confirm."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellOsVflashActions,
+        "dell-os-vflash-actions",
+        action="delete-vflash-iso",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["action"] == "#DellOSDeploymentService.DeleteISOFromVFlash"
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_os_vflash_action_reports_missing_action(
+        redfish_api, redfish_service):
+    """A service missing the selected action returns an actionable error."""
+    body = _service_body(redfish_service)
+    body["Actions"] = dict(body["Actions"])
+    del body["Actions"]["#DellOSDeploymentService.BootToHD"]
+    _set_os_deployment(redfish_service, body)
+
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellOsVflashActions,
+        "dell-os-vflash-actions",
+        action="boot-hd",
+        confirm=True,
+    )
+
+    assert result.error == (
+        "action '#DellOSDeploymentService.BootToHD' not found on "
+        f"{OS_DEPLOYMENT}"
+    )
+    assert "#DellOSDeploymentService.SkipISOImageBoot" in result.data["available"]
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_os_vflash_actions_are_registered_and_guarded():
+    """The command is registered and its selected actions are destructive."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellOsVflashActions][
+        "dell-os-vflash-actions"
+    ] is DellOsVflashActions
+
+    for action in (
+        "#DellOSDeploymentService.BootToHD",
+        "#DellOSDeploymentService.BootToISOFromVFlash",
+        "#DellOSDeploymentService.DeleteISOFromVFlash",
+        "#DellOSDeploymentService.DetachDrivers",
+        "#DellOSDeploymentService.DetachISOFromVFlash",
+        "#DellOSDeploymentService.SkipISOImageBoot",
+    ):
+        assert classify(action) is Destructiveness.DESTRUCTIVE
+
+    cmd_parser, cmd_name, cmd_help = DellOsVflashActions.register_subcommand(
+        DellOsVflashActions
+    )
+    help_text = cmd_parser.format_help()
+    assert cmd_name == "dell-os-vflash-actions"
+    assert "VFlash" in cmd_help
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text


### PR DESCRIPTION
## Summary
- add a guarded `dell-os-vflash-actions` command for DellOSDeploymentService VFlash boot/delete/detach actions
- list discovered targets by default and require `--confirm` before POSTing selected actions
- add Dell fixture coverage, action policy entries, registration, and the command reference row

## Testing
- `git diff --cached --check`
- Not run locally: pytest/Ruff; GitHub CI runs the project gate for this repository
