### PR TITLE
Reject blank asset tag targets

### DIFF
--- a/redfish_ctl/chassis/cmd_asset_tag_set.py
+++ b/redfish_ctl/chassis/cmd_asset_tag_set.py
@@ -3,7 +3,7 @@
     redfish_ctl asset-tag-set --resource chassis --target-id Chassis_0 --asset-tag lab-01 --confirm
 """
 
-from abc import abstractmethod
+import argparse
 from typing import Optional
 
 from ..cmd_exceptions import InvalidArgument
@@ -18,6 +18,19 @@ _COLLECTIONS = {
 }
 
 
+def _target_id_arg(value: str) -> str:
+    """Normalize and validate the CLI target identifier.
+
+    :param value: raw ``--target-id`` argument value from argparse.
+    :return: stripped resource Id or ``@odata.id`` URI.
+    :raises argparse.ArgumentTypeError: when the value is empty after trimming.
+    """
+    target_id = str(value).strip()
+    if not target_id:
+        raise argparse.ArgumentTypeError("target id cannot be empty")
+    return target_id
+
+
 class AssetTagSet(RedfishManagerBase,
                   scm_type=ApiRequestType.AssetTagSet,
                   name="asset-tag-set",
@@ -29,7 +42,6 @@ class AssetTagSet(RedfishManagerBase,
         super(AssetTagSet, self).__init__(*args, **kwargs)
 
     @staticmethod
-    @abstractmethod
     def register_subcommand(cls):
         """Register the guarded ``asset-tag-set`` subcommand.
 
@@ -46,6 +58,7 @@ class AssetTagSet(RedfishManagerBase,
             "--target-id",
             required=True,
             dest="target_id",
+            type=_target_id_arg,
             help="resource Id or @odata.id URI to read or patch",
         )
         cmd_parser.add_argument(
@@ -116,6 +129,7 @@ class AssetTagSet(RedfishManagerBase,
         """
         if resource not in _COLLECTIONS:
             raise InvalidArgument(f"unsupported AssetTag resource {resource!r}")
+        target_id = str(target_id).strip() if target_id is not None else ""
         if not target_id:
             raise InvalidArgument("target_id is required")
 

--- a/tests/test_asset_tag_set_dualmode.py
+++ b/tests/test_asset_tag_set_dualmode.py
@@ -145,6 +145,35 @@ def test_asset_tag_set_patch_error_does_not_reread_target(
     assert state["get_count"] > 0
 
 
+def test_asset_tag_set_rejects_blank_target_without_requests(
+    redfish_mock_factory,
+):
+    """A blank target id fails before any Redfish collection read."""
+    manager, service = redfish_mock_factory("supermicro")
+
+    with pytest.raises(InvalidArgument, match="target_id is required"):
+        manager.sync_invoke(
+            _request_type(),
+            "asset-tag-set",
+            resource="chassis",
+            target_id="   ",
+            asset_tag="restored-tag",
+            confirm=True,
+        )
+
+    assert service.requests == []
+
+
+def test_asset_tag_set_parser_rejects_blank_target_id():
+    """The CLI parser rejects whitespace-only --target-id values."""
+    parser, name, _help = AssetTagSet.register_subcommand(AssetTagSet)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--target-id", "   "])
+
+    assert name == "asset-tag-set"
+
+
 def test_asset_tag_set_allows_empty_restore_value(redfish_mock_factory):
     """An empty AssetTag is a valid restore value for vendors that start blank."""
     manager, service = redfish_mock_factory("supermicro")


### PR DESCRIPTION
## Summary
- Reject whitespace-only `asset-tag-set --target-id` values before resolving Redfish collections.
- Validate the CLI `--target-id` argument through argparse and keep the command registration concrete.
- Cover direct invocation and parser rejection cases in the dual-mode tests.

## Validation
- `git diff --check`
- `git diff --cached --check`