### PR TITLE
Add Dell card certificate export command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-card-cert-export` | Export Dell iDRAC card-service certificates; lists targets by default and `--query` posts the selected read-only action. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_dell_card_cert_export import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -42,6 +42,11 @@ ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DelliDRACCardService.ExportCertificate": Destructiveness.READ_ONLY,
+    "#DelliDRACCardService.ExportSSLCertificate": Destructiveness.READ_ONLY,
+    "#DelliDRACCardService.FactoryIdentityExportCertificate": (
+        Destructiveness.READ_ONLY
+    ),
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/oem/cmd_dell_card_cert_export.py
+++ b/redfish_ctl/oem/cmd_dell_card_cert_export.py
@@ -1,0 +1,314 @@
+"""Discover and query Dell iDRAC card certificate export actions.
+
+    redfish_ctl dell-card-cert-export
+    redfish_ctl dell-card-cert-export --action factory-identity --query
+    redfish_ctl dell-card-cert-export --action export-cert \\
+        --certificate-type KMS_SERVER_CA --query
+
+The command discovers certificate export targets from
+``Links.Oem.Dell.DelliDRACCardService`` on Manager resources. A selected action
+previews by default; ``--query`` is required before the read-only POST is sent.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+
+@dataclass(frozen=True)
+class _DellCardCertExportSpec:
+    """Static selector metadata for one Dell card certificate export action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+    payload_field: Optional[str] = None
+    cli_arg: Optional[str] = None
+
+
+_ACTION_SPECS = {
+    "export-cert": _DellCardCertExportSpec(
+        selector="export-cert",
+        full_type="#DelliDRACCardService.ExportCertificate",
+        action_name="ExportCertificate",
+        description="export a Dell card-service certificate by certificate type",
+        payload_field="CertificateType",
+        cli_arg="--certificate-type",
+    ),
+    "export-ssl-cert": _DellCardCertExportSpec(
+        selector="export-ssl-cert",
+        full_type="#DelliDRACCardService.ExportSSLCertificate",
+        action_name="ExportSSLCertificate",
+        description="export an iDRAC SSL certificate by SSL certificate type",
+        payload_field="SSLCertType",
+        cli_arg="--ssl-cert-type",
+    ),
+    "factory-identity": _DellCardCertExportSpec(
+        selector="factory-identity",
+        full_type="#DelliDRACCardService.FactoryIdentityExportCertificate",
+        action_name="FactoryIdentityExportCertificate",
+        description="export the factory identity certificate",
+    ),
+}
+
+
+class DellCardCertExport(RedfishManagerBase,
+                         scm_type=ApiRequestType.DellCardCertExport,
+                         name="dell-card-cert-export",
+                         metaclass=Singleton):
+    """Discover and query Dell iDRAC card certificate export actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-card-cert-export command."""
+        super(DellCardCertExport, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-card-cert-export`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help=(
+                "Dell card certificate export action to preview or query; "
+                "omit to list"
+            ),
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DelliDRACCardService URI when more than one target exists",
+        )
+        cmd_parser.add_argument(
+            "--certificate-type",
+            dest="certificate_type",
+            default=None,
+            help="CertificateType payload for export-cert",
+        )
+        cmd_parser.add_argument(
+            "--ssl-cert-type",
+            dest="ssl_cert_type",
+            default=None,
+            help="SSLCertType payload for export-ssl-cert",
+        )
+        cmd_parser.add_argument(
+            "--query",
+            action="store_true",
+            default=False,
+            help="POST the selected read-only export action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-card-cert-export",
+            "command export Dell iDRAC card certificates",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _oem_dell(data):
+        """Return the ``Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    @staticmethod
+    def _links_oem_dell(data):
+        """Return the ``Links.Oem.Dell`` block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = data.get("Links") if isinstance(data, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _card_service_uris(self, do_async):
+        """Return DelliDRACCardService resource URIs for every manager.
+
+        :param do_async: run manager queries asynchronously when True.
+        :return: list of DelliDRACCardService URIs.
+        """
+        uris = []
+        for manager_uri in self.discover_manager_ids() or []:
+            manager = self._get(manager_uri, do_async)
+            links_dell = self._links_oem_dell(manager)
+            service_uri = self._link(links_dell, "DelliDRACCardService")
+            if not service_uri:
+                oem_dell = self._oem_dell(manager)
+                service_uri = self._link(oem_dell, "DelliDRACCardService")
+            if not service_uri:
+                service_uri = f"{manager_uri.rstrip('/')}/Oem/Dell/DelliDRACCardService"
+            uris.append(service_uri)
+        return uris
+
+    def _discover_rows(self, do_async):
+        """Discover available Dell card certificate export actions.
+
+        :param do_async: run underlying queries asynchronously when True.
+        :return: list of available export-action rows.
+        """
+        rows = []
+        for service_uri in self._card_service_uris(do_async):
+            service = self._get(service_uri, do_async)
+            targets = self._flatten_action_targets(service)
+            for spec in _ACTION_SPECS.values():
+                target = targets.get(spec.full_type)
+                if target:
+                    rows.append({
+                        "Action": spec.selector,
+                        "FullType": spec.full_type,
+                        "Resource": service_uri,
+                        "Target": target,
+                        "Description": spec.description,
+                    })
+        return rows
+
+    @staticmethod
+    def _matches(rows, action, resource_uri):
+        """Filter discovered rows by action selector and optional resource URI.
+
+        :param rows: discovered Dell card export-action rows.
+        :param action: selected action name.
+        :param resource_uri: optional resource URI selector.
+        :return: matching rows.
+        """
+        matches = [row for row in rows if row["Action"] == action]
+        if resource_uri:
+            normalized = resource_uri.rstrip("/")
+            matches = [
+                row for row in matches
+                if row["Resource"].rstrip("/") == normalized
+            ]
+        return matches
+
+    @staticmethod
+    def _payload_for(spec, certificate_type, ssl_cert_type):
+        """Build the selected action payload.
+
+        :param spec: selected action metadata.
+        :param certificate_type: CertificateType value for export-cert.
+        :param ssl_cert_type: SSLCertType value for export-ssl-cert.
+        :return: JSON payload for the action.
+        """
+        if spec.payload_field is None:
+            return {}
+        value = (
+            certificate_type
+            if spec.payload_field == "CertificateType"
+            else ssl_cert_type
+        )
+        if not value:
+            raise ValueError(f"{spec.selector} requires {spec.cli_arg}")
+        return {spec.payload_field: value}
+
+    def execute(self,
+                action: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                certificate_type: Optional[str] = None,
+                ssl_cert_type: Optional[str] = None,
+                query: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or query Dell card certificate export actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param resource_uri: optional service URI to disambiguate multiple targets.
+        :param certificate_type: CertificateType payload for ``export-cert``.
+        :param ssl_cert_type: SSLCertType payload for ``export-ssl-cert``.
+        :param query: POST the selected read-only export action when True.
+        :param dry_run: force preview mode even when ``query`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        rows = self._discover_rows(bool(do_async))
+        if action is None:
+            return CommandResult(rows, None, None, None)
+
+        matches = self._matches(rows, action, resource_uri)
+        if not matches:
+            return CommandResult(
+                {"available": rows},
+                None,
+                None,
+                f"Dell iDRAC card certificate export action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                "multiple Dell iDRAC card certificate export targets found; "
+                "pass --resource-uri",
+            )
+
+        spec = _ACTION_SPECS[action]
+        try:
+            payload = self._payload_for(spec, certificate_type, ssl_cert_type)
+        except ValueError as exc:
+            return CommandResult({"available": rows}, None, None, str(exc))
+
+        row = matches[0]
+        return self.invoke_action(
+            row["Resource"],
+            spec.action_name,
+            payload=payload,
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(query),
+            confirm=False,
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -113,6 +113,7 @@ class ApiRequestType(Enum):
     EventSubmitTest = auto()
     HpeTestActions = auto()
     NvidiaDebugToken = auto()
+    DellCardCertExport = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()
     SubscriptionDelete = auto()

--- a/tests/test_dell_card_cert_export_dualmode.py
+++ b/tests/test_dell_card_cert_export_dualmode.py
@@ -1,0 +1,223 @@
+"""Dual-mode tests for Dell iDRAC card certificate export actions."""
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.oem.cmd_dell_card_cert_export import DellCardCertExport
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+CARD_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+)
+ACTION_BASE = f"{CARD_SERVICE}/Actions/DelliDRACCardService"
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-xr8620t",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def test_dell_card_cert_export_lists_corpus_targets_without_post(dell_corpus_mock):
+    """Listing discovers Dell card certificate export actions."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardCertExport,
+        "dell-card-cert-export",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    actions = {row["Action"]: row for row in result.data}
+    assert set(actions) == {
+        "export-cert",
+        "export-ssl-cert",
+        "factory-identity",
+    }
+    assert actions["export-cert"]["Resource"] == CARD_SERVICE
+    assert actions["export-cert"]["Target"] == (
+        f"{ACTION_BASE}.ExportCertificate"
+    )
+    assert actions["export-ssl-cert"]["Target"] == (
+        f"{ACTION_BASE}.ExportSSLCertificate"
+    )
+    assert actions["factory-identity"]["Target"] == (
+        f"{ACTION_BASE}.FactoryIdentityExportCertificate"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_card_cert_export_previews_selected_action(dell_corpus_mock):
+    """A selected export action resolves target and payload without POSTing."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardCertExport,
+        "dell-card-cert-export",
+        action="export-cert",
+        certificate_type="KMS_SERVER_CA",
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DelliDRACCardService.ExportCertificate"
+    assert result.data["level"] == "read_only"
+    assert result.data["target"] == f"{ACTION_BASE}.ExportCertificate"
+    assert result.data["payload"] == {"CertificateType": "KMS_SERVER_CA"}
+    assert result.data["blocked"] is None
+    assert _post_requests(service) == []
+
+
+def test_dell_card_cert_export_query_posts_selected_target(dell_corpus_mock):
+    """--query POSTs exactly one selected read-only export action."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardCertExport,
+        "dell-card-cert-export",
+        action="export-ssl-cert",
+        ssl_cert_type="Server",
+        query=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DelliDRACCardService.ExportSSLCertificate"
+    assert result.data["level"] == "read_only"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == f"{ACTION_BASE}.ExportSSLCertificate".lower()
+    assert posts[0].json() == {"SSLCertType": "Server"}
+
+
+def test_dell_card_cert_export_requires_payload_selector(dell_corpus_mock):
+    """Actions with typed payloads report the missing CLI selector."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardCertExport,
+        "dell-card-cert-export",
+        action="export-cert",
+        query=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "export-cert requires --certificate-type"
+    assert _post_requests(service) == []
+
+
+def test_dell_card_cert_export_validates_allowable_values(dell_corpus_mock):
+    """Invalid certificate type values are rejected before POST."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardCertExport,
+        "dell-card-cert-export",
+        action="export-cert",
+        certificate_type="Server",
+        query=True,
+    )
+
+    assert result.error == (
+        "invalid value for DelliDRACCardService.ExportCertificate "
+        "CertificateType: Server; allowed: KMS_SERVER_CA, SEKM_SSL_CERT"
+    )
+    assert result.data["validation_errors"][0]["parameter"] == "CertificateType"
+    assert _post_requests(service) == []
+
+
+def test_dell_card_cert_export_factory_identity_has_empty_payload(dell_corpus_mock):
+    """The factory identity export action has no payload selector."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardCertExport,
+        "dell-card-cert-export",
+        action="factory-identity",
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["payload"] == {}
+    assert result.data["target"] == (
+        f"{ACTION_BASE}.FactoryIdentityExportCertificate"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_card_cert_export_missing_target_reports_without_post(
+    redfish_mock_factory,
+):
+    """A fixture without Dell card export resources reports an error."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardCertExport,
+        "dell-card-cert-export",
+        action="factory-identity",
+        query=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "Dell iDRAC card certificate export action not found: factory-identity"
+    )
+    assert result.data == {"available": []}
+    assert _post_requests(service) == []
+
+
+def test_dell_card_cert_export_exposes_cli_entrypoint():
+    """The dell-card-cert-export command is wired into the command registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellCardCertExport][
+        "dell-card-cert-export"
+    ] is DellCardCertExport
+
+    cmd_parser, cmd_name, cmd_help = DellCardCertExport.register_subcommand(
+        DellCardCertExport
+    )
+    help_text = cmd_parser.format_help()
+
+    assert classify(
+        "#DelliDRACCardService.FactoryIdentityExportCertificate"
+    ) is Destructiveness.READ_ONLY
+    assert "--action" in help_text
+    assert "--query" in help_text
+    assert "--certificate-type" in help_text
+    assert "--ssl-cert-type" in help_text
+    assert cmd_name == "dell-card-cert-export"
+    assert "Dell" in cmd_help


### PR DESCRIPTION
## Summary
- Add `dell-card-cert-export` for Dell card-service certificate export actions.
- Discover targets from Manager OEM Dell links and list them by default.
- Require `--query` before sending read-only export POSTs, with dry-run previews and allowable-value validation.

## Validation
- `git diff --cached --check`
- GitHub Actions will run the offline test matrix.