### PR TITLE
Add Dell card CSR command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-card-csr` | Generate Dell card-service factory-identity or SEKM CSRs; lists targets by default and requires `--confirm` to POST. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_dell_card_csr import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -53,6 +53,8 @@ ACTION_POLICY = {
     "#VirtualMedia.InsertMedia": Destructiveness.REVERSIBLE,
     "#VirtualMedia.EjectMedia": Destructiveness.REVERSIBLE,
     "#CertificateService.GenerateCSR": Destructiveness.REVERSIBLE,
+    "#DelliDRACCardService.FactoryIdentityCertificateGenerateCSR": Destructiveness.REVERSIBLE,
+    "#DelliDRACCardService.GenerateSEKMCSR": Destructiveness.REVERSIBLE,
     "#LogService.CollectDiagnosticData": Destructiveness.REVERSIBLE,
     "#NvidiaPowerSmoothing.ActivatePresetProfile": Destructiveness.REVERSIBLE,
     "#NvidiaPowerSmoothing.ApplyAdminOverrides": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/oem/cmd_dell_card_csr.py
+++ b/redfish_ctl/oem/cmd_dell_card_csr.py
@@ -1,0 +1,283 @@
+"""Generate Dell iDRAC card-service certificate signing requests.
+
+    redfish_ctl dell-card-csr
+    redfish_ctl dell-card-csr --action factory-identity --confirm
+    redfish_ctl dell-card-csr --action sekm --dry_run
+
+The command discovers ``DelliDRACCardService`` from Manager OEM links when the
+manager exposes them, otherwise it falls back to the standard Dell manager OEM
+resource path. Selected CSR actions preview by default; ``--confirm`` is
+required before POSTing.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SERVICE_NAME = "DelliDRACCardService"
+_DEFAULT_SERVICE_URI = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/{_SERVICE_NAME}"
+)
+
+
+@dataclass(frozen=True)
+class _DellCardCsrSpec:
+    """Static selector metadata for one Dell card-service CSR action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+
+
+_ACTION_SPECS = {
+    "factory-identity": _DellCardCsrSpec(
+        selector="factory-identity",
+        full_type="#DelliDRACCardService.FactoryIdentityCertificateGenerateCSR",
+        action_name="FactoryIdentityCertificateGenerateCSR",
+        description="generate a CSR for the Dell factory identity certificate",
+    ),
+    "sekm": _DellCardCsrSpec(
+        selector="sekm",
+        full_type="#DelliDRACCardService.GenerateSEKMCSR",
+        action_name="GenerateSEKMCSR",
+        description="generate a CSR for Dell SEKM certificate enrollment",
+    ),
+}
+
+
+class DellCardCsr(RedfishManagerBase,
+                  scm_type=ApiRequestType.DellCardCsr,
+                  name="dell-card-csr",
+                  metaclass=Singleton):
+    """Discover and generate Dell card-service CSRs."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-card-csr command."""
+        super(DellCardCsr, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-card-csr`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="Dell card-service CSR action to preview or run; omit to list",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DelliDRACCardService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the selected CSR action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-card-csr",
+            "command generate Dell iDRAC card-service CSRs",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _oem_dell(data):
+        """Return the ``Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    @staticmethod
+    def _links_oem_dell(data):
+        """Return the ``Links.Oem.Dell`` block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = data.get("Links") if isinstance(data, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DelliDRACCardService resource URIs.
+
+        :param do_async: issue Manager queries on the async path when True.
+        :return: ordered list of candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(
+                self._links_oem_dell(manager),
+                _SERVICE_NAME,
+            )
+            if not service_uri:
+                service_uri = self._link(self._oem_dell(manager), _SERVICE_NAME)
+            if service_uri:
+                uris.append(service_uri)
+        if not uris:
+            uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uri.rstrip("/") for uri in uris))
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Discover Dell card-service CSR action targets.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DelliDRACCardService URI.
+        :return: list of discovered CSR target rows.
+        """
+        uris = [resource_uri.rstrip("/")] if resource_uri else self._service_uris(
+            do_async
+        )
+        rows = []
+        for service_uri in dict.fromkeys(uris):
+            service = self._get(service_uri, do_async)
+            targets = self._flatten_action_targets(service)
+            for spec in _ACTION_SPECS.values():
+                target = targets.get(spec.full_type)
+                if target:
+                    rows.append({
+                        "Action": spec.selector,
+                        "FullType": spec.full_type,
+                        "Resource": service_uri,
+                        "Target": target,
+                        "Description": spec.description,
+                    })
+        return rows
+
+    @staticmethod
+    def _matches(rows, action, resource_uri):
+        """Filter discovered rows by action selector and optional resource URI.
+
+        :param rows: discovered Dell card-service CSR rows.
+        :param action: selected action name.
+        :param resource_uri: optional resource URI selector.
+        :return: matching rows.
+        """
+        matches = [row for row in rows if row["Action"] == action]
+        if resource_uri:
+            normalized = resource_uri.rstrip("/")
+            matches = [
+                row for row in matches
+                if row["Resource"].rstrip("/") == normalized
+            ]
+        return matches
+
+    def execute(self,
+                action: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or invoke Dell card-service CSR actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param resource_uri: optional service URI to disambiguate multiple targets.
+        :param confirm: authorize a POST. Without this the selected action previews.
+        :param dry_run: force a preview even with ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish reads/POST on the async path.
+        :return: CommandResult with discovered targets, preview, POST result, or error.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri=resource_uri)
+        if action is None:
+            return CommandResult({"csr_targets": rows}, None, None, None)
+        if action not in _ACTION_SPECS:
+            return CommandResult(
+                {"available": sorted(_ACTION_SPECS)},
+                None,
+                None,
+                f"unknown Dell card-service CSR action: {action}",
+            )
+
+        matches = self._matches(rows, action, resource_uri)
+        if not matches:
+            return CommandResult(
+                {"action": _ACTION_SPECS[action].full_type, "available": rows},
+                None,
+                None,
+                f"Dell card-service CSR action not found: {action}",
+            )
+        if len(matches) > 1:
+            return CommandResult(
+                {"matches": matches},
+                None,
+                None,
+                "multiple Dell card-service CSR targets found; pass --resource-uri",
+            )
+
+        spec = _ACTION_SPECS[action]
+        result = self.invoke_action(
+            matches[0]["Resource"],
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        if not confirm and isinstance(result.data, dict):
+            result.data["requires_confirm"] = True
+            result.data["blocked"] = "Dell card-service CSR generation requires --confirm"
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -125,6 +125,7 @@ class ApiRequestType(Enum):
     SecureBoot = auto()
     CertificatesQuery = auto()
     CertificateGenerateCSR = auto()
+    DellCardCsr = auto()
     FirmwareUpdate = auto()
     Triggers = auto()
     NetworkPorts = auto()

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DelliDRACCardService.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DelliDRACCardService.json
@@ -1,0 +1,152 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#DelliDRACCardService.DelliDRACCardService",
+  "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService",
+  "@odata.type": "#DelliDRACCardService.v1_6_0.DelliDRACCardService",
+  "Id": "DelliDRACCardService",
+  "Name": "Dell iDRAC Card Service",
+  "Actions": {
+    "#DelliDRACCardService.DeleteCertificate": {
+      "CertificateType@Redfish.AllowableValues": [
+        "KMS_SERVER_CA",
+        "SEKM_SSL_CERT"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.DeleteCertificate"
+    },
+    "#DelliDRACCardService.DeleteGroup": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.DeleteGroup"
+    },
+    "#DelliDRACCardService.DisableSEKM": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.DisableSEKM"
+    },
+    "#DelliDRACCardService.DisableiLKM": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.DisableiLKM"
+    },
+    "#DelliDRACCardService.EnableSEKM": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.EnableSEKM"
+    },
+    "#DelliDRACCardService.EnableiLKM": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.EnableiLKM"
+    },
+    "#DelliDRACCardService.ExportCertificate": {
+      "CertificateType@Redfish.AllowableValues": [
+        "KMS_SERVER_CA",
+        "SEKM_SSL_CERT"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.ExportCertificate"
+    },
+    "#DelliDRACCardService.ExportSSLCertificate": {
+      "SSLCertType@Redfish.AllowableValues": [
+        "CA",
+        "CSC",
+        "ClientTrustCertificate",
+        "Server"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.ExportSSLCertificate"
+    },
+    "#DelliDRACCardService.FactoryIdentityCertificateGenerateCSR": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.FactoryIdentityCertificateGenerateCSR"
+    },
+    "#DelliDRACCardService.FactoryIdentityExportCertificate": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.FactoryIdentityExportCertificate"
+    },
+    "#DelliDRACCardService.FactoryIdentityImportCertificate": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.FactoryIdentityImportCertificate"
+    },
+    "#DelliDRACCardService.GenerateSEKMCSR": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.GenerateSEKMCSR"
+    },
+    "#DelliDRACCardService.GetKVMSession": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.GetKVMSession"
+    },
+    "#DelliDRACCardService.ImportCertificate": {
+      "CertificateType@Redfish.AllowableValues": [
+        "IEEE8021xCSC",
+        "IEEE8021xClient",
+        "KMS_SERVER_CA",
+        "RSYSLOG_SERVER_CA",
+        "SEKM_SSL_CERT"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.ImportCertificate"
+    },
+    "#DelliDRACCardService.ImportSSLCertificate": {
+      "CertificateType@Redfish.AllowableValues": [
+        "CA",
+        "CSC",
+        "ClientTrustCertificate",
+        "CustomCertificate",
+        "Server"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.ImportSSLCertificate"
+    },
+    "#DelliDRACCardService.JoinGroup": {
+      "CloneConfiguration@Redfish.AllowableValues": [
+        "Disable",
+        "Enable"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.JoinGroup"
+    },
+    "#DelliDRACCardService.Rekey": {
+      "Mode@Redfish.AllowableValues": [
+        "SEKM",
+        "iLKM"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.Rekey"
+    },
+    "#DelliDRACCardService.RemoveSelf": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.RemoveSelf"
+    },
+    "#DelliDRACCardService.SSLResetCfg": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.SSLResetCfg"
+    },
+    "#DelliDRACCardService.SendTestEmailAlert": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.SendTestEmailAlert"
+    },
+    "#DelliDRACCardService.SendTestSNMPTrap": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.SendTestSNMPTrap"
+    },
+    "#DelliDRACCardService.TestRsyslogServerConnection": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.TestRsyslogServerConnection"
+    },
+    "#DelliDRACCardService.TestSEKMServerConnection": {
+      "ServerType@Redfish.AllowableValues": [
+        "Primary",
+        "Secondary"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.TestSEKMServerConnection"
+    },
+    "#DelliDRACCardService.UploadSSLKey": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.UploadSSLKey"
+    },
+    "#DelliDRACCardService.VerifyHWProofOfPossession": {
+      "Algorithm@Redfish.AllowableValues": [
+        "AES128CBC"
+      ],
+      "KeyDerivationFunction@Redfish.AllowableValues": [
+        "DellSHA256"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.VerifyHWProofOfPossession"
+    },
+    "#DelliDRACCardService.iDRACReset": {
+      "Force@Redfish.AllowableValues": [
+        "Force",
+        "Graceful"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.iDRACReset"
+    },
+    "#DelliDRACCardService.iDRACResetCfg": {
+      "Force@Redfish.AllowableValues": [
+        "Force",
+        "Graceful"
+      ],
+      "Preserve@Redfish.AllowableValues": [
+        "All",
+        "Default",
+        "ResetAllWithRootDefaults"
+      ],
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.iDRACResetCfg"
+    },
+    "#DelliDRACCardService.iLKMToSEKMTransition": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/Actions/DelliDRACCardService.iLKMToSEKMTransition"
+    }
+  }
+}

--- a/tests/test_dell_card_csr_dualmode.py
+++ b/tests/test_dell_card_csr_dualmode.py
@@ -1,0 +1,172 @@
+"""Dual-mode tests for Dell card-service CSR generation actions."""
+
+from redfish_ctl.actions.action_policy import classify
+from redfish_ctl.oem.cmd_dell_card_csr import DellCardCsr
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+SERVICE_URI = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+FACTORY_ACTION = "#DelliDRACCardService.FactoryIdentityCertificateGenerateCSR"
+FACTORY_TARGET = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DelliDRACCardService/Actions/"
+    "DelliDRACCardService.FactoryIdentityCertificateGenerateCSR"
+)
+SEKM_ACTION = "#DelliDRACCardService.GenerateSEKMCSR"
+SEKM_TARGET = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DelliDRACCardService/Actions/DelliDRACCardService.GenerateSEKMCSR"
+)
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the offline mock service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _set_card_service(service, body):
+    """Overlay the Dell card-service fixture under canonical and lowercase paths."""
+    service._overlay[SERVICE_URI] = body
+    service._overlay[SERVICE_URI.lower()] = body
+
+
+def test_dell_card_csr_lists_corpus_backed_targets(redfish_api, redfish_service):
+    """dell-card-csr lists CSR targets from the Dell card-service fixture."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellCardCsr,
+        "dell-card-csr",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["csr_targets"] == [
+        {
+            "Action": "factory-identity",
+            "FullType": FACTORY_ACTION,
+            "Resource": SERVICE_URI,
+            "Target": FACTORY_TARGET,
+            "Description": (
+                "generate a CSR for the Dell factory identity certificate"
+            ),
+        },
+        {
+            "Action": "sekm",
+            "FullType": SEKM_ACTION,
+            "Resource": SERVICE_URI,
+            "Target": SEKM_TARGET,
+            "Description": "generate a CSR for Dell SEKM certificate enrollment",
+        },
+    ]
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_card_csr_defaults_to_preview(redfish_api, redfish_service):
+    """A selected CSR action does not POST unless --confirm is supplied."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellCardCsr,
+        "dell-card-csr",
+        action="sekm",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == SEKM_ACTION
+    assert result.data["target"] == SEKM_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "reversible"
+    assert result.data["requires_confirm"] is True
+    assert result.data["blocked"] == (
+        "Dell card-service CSR generation requires --confirm"
+    )
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_card_csr_confirm_posts_empty_payload(redfish_api, redfish_service):
+    """With --confirm the command POSTs to the discovered CSR action target."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellCardCsr,
+        "dell-card-csr",
+        action="factory-identity",
+        confirm=True,
+    )
+
+    posts = _post_requests(redfish_service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == FACTORY_ACTION
+    assert result.data["target"] == FACTORY_TARGET
+    assert result.data["level"] == "reversible"
+    assert len(posts) == 1
+    assert posts[0].path == FACTORY_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_card_csr_dry_run_overrides_confirm(redfish_api, redfish_service):
+    """--dry_run suppresses POST even when --confirm is also supplied."""
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellCardCsr,
+        "dell-card-csr",
+        action="factory-identity",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_card_csr_reports_missing_action(redfish_api, redfish_service):
+    """A card-service resource without the selected CSR action reports available rows."""
+    body = dict(redfish_service._state(SERVICE_URI))
+    body["Actions"] = {
+        FACTORY_ACTION: {
+            "target": FACTORY_TARGET,
+        },
+    }
+    _set_card_service(redfish_service, body)
+
+    result = redfish_api.sync_invoke(
+        ApiRequestType.DellCardCsr,
+        "dell-card-csr",
+        action="sekm",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell card-service CSR action not found: sekm"
+    assert result.data["action"] == SEKM_ACTION
+    assert result.data["available"] == [
+        {
+            "Action": "factory-identity",
+            "FullType": FACTORY_ACTION,
+            "Resource": SERVICE_URI,
+            "Target": FACTORY_TARGET,
+            "Description": (
+                "generate a CSR for the Dell factory identity certificate"
+            ),
+        },
+    ]
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_card_csr_registration_and_policy():
+    """The command is registered and the CSR actions are reversible."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellCardCsr]["dell-card-csr"] is DellCardCsr
+    assert classify(FACTORY_ACTION).value == "reversible"
+    assert classify(SEKM_ACTION).value == "reversible"
+
+    cmd_parser, cmd_name, cmd_help = DellCardCsr.register_subcommand(DellCardCsr)
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-card-csr"
+    assert "card-service CSRs" in cmd_help
+    assert "--action" in help_text
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text


### PR DESCRIPTION
## Summary

- Add a guarded `dell-card-csr` command for DelliDRACCardService factory-identity and SEKM CSR actions.
- Register the request type, reversible action-policy entries, Dell card-service fixture, and command docs row.
- Add dual-mode coverage for listing, default preview, confirmed POST, dry-run precedence, missing action handling, and registry/policy wiring.

## Validation

- `git diff --cached --check`
- Not run locally: pytest/ruff. GitHub CI is expected to run the full validation matrix.
