### PR TITLE
Refresh telemetry documentation from exporter mapping

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,8 +4,8 @@ Author: Mus <spyroot@gmail.com>
 
 `redfish_ctl` emits OpenTelemetry **metrics** and **traces** over OTLP, so a fleet of server BMCs —
 and the operations run against them — become visible in Splunk Observability APM (or any OTLP
-backend: Grafana Tempo/Mimir, an OpenTelemetry Collector, etc.). No agent on the host, no code in the
-firmware; everything is read out-of-band over the Redfish API and shipped as standard telemetry.
+backend: Grafana Tempo/Mimir, an OpenTelemetry Collector, etc.). No host-side daemon and no code in
+the firmware; everything is read out-of-band over the Redfish API and shipped as standard telemetry.
 
 ## What problem this addresses
 
@@ -13,8 +13,9 @@ At fleet scale (hundreds to thousands of servers, each with a different tuning p
 team mutates BMCs constantly — tuning BIOS, upgrading firmware, setting boot order, remediating
 drift — usually through a k8s operator. Without telemetry, that activity is invisible: which node's
 BIOS apply failed, which vendor's firmware flash is slow, which reconcile is stuck waiting on a
-reboot. `redfish_ctl` turns every read and every mutation into a span, so that activity shows up as a
-normal APM service map + trace waterfall + per-operation error/latency breakdown.
+reboot. `redfish_ctl` wraps command executions in operation spans and traced Redfish request helpers
+in client spans, so covered activity shows up as a normal APM service map, trace waterfall, and
+per-operation error/latency breakdown.
 
 ## Who it is for
 
@@ -44,13 +45,14 @@ flowchart LR
 Two signals, one pipeline:
 
 - **Traces.** Each command run through the engine opens an **operation span** named by the command
-  (`firmware-update`, `bios-change`, `reboot`). Every BMC HTTP call inside it opens a `SpanKind.CLIENT`
-  span (`redfish.bmc.request`) carrying `peer.service="bmc"`. Because the BMC is uninstrumented, Splunk
+  (`firmware-update`, `bios-change`, `reboot`). BMC calls routed through the manager HTTP verbs, the
+  Redfish action primitive, and the firmware upload helper open `SpanKind.CLIENT` spans
+  (`redfish.bmc.request`) carrying `peer.service="bmc"`. Because the BMC is uninstrumented, Splunk
   infers it as a single downstream service node — so a whole fleet renders as `redfish-ctl → bmc`, not
   one node per address. Failures set the span to ERROR (from the HTTP status or `CommandResult.error`),
-  which drives the red edges, error rate, and Root Cause in APM. See the span model in
-  [`.internal/design-notes/splunk-apm-traces/`] (design notes) and the code in
-  `redfish_ctl/telemetry/tracing.py`.
+  which drives the red edges, error rate, and Root Cause in APM. The public span contract lives in
+  `specs/telemetry/span_contract.yaml`; the merge-gate coverage requirements live in
+  `specs/telemetry/gates.md`, and the implementation is in `redfish_ctl/telemetry/tracing.py`.
 - **Metrics.** The exporter samples hardware state (power, thermal, fans, GPU, leak detection, fabric)
   into the stable `hw.*` metric family. Traces say *what operation ran and whether it failed*; metrics
   say *what the hardware did* — a firmware-update span sits next to the `hw.power` spike it caused,
@@ -63,7 +65,7 @@ within the Troubleshooting MetricSet cardinality budget.
 
 ## Quick start — stream to Splunk in three commands
 
-Install with the OTLP extra, point at your collector (or Splunk OTLP endpoint), and run any command
+Install with the OTLP extra, point at your collector (or Splunk OTLP endpoint), and run a command
 with tracing on:
 
 ```bash
@@ -93,6 +95,6 @@ to an in-cluster Collector), see the [Kubernetes guide](../k8s/README.md) and th
 
 ## Try it with zero hardware
 
-The mock BMC serves the committed GB300 corpus over HTTP and can replay mutations, so the full
-read-and-mutate path — and the traces it produces — can be exercised with no real BMC. See
+The mock BMC serves the committed GB300 corpus over HTTP and can replay captured mutations, so
+supported read paths and replay-backed mutation paths can be exercised with no real BMC. See
 [Simulation and replay](simulation-and-replay.md).

--- a/docs/telemetry-metrics.md
+++ b/docs/telemetry-metrics.md
@@ -6,6 +6,10 @@ This reference is generated from the Supermicro GB300 fixture files packed in
 `tests/supermicro_gb300_corpus.tar.gz`, the captured Redfish JSON corpus used by
 the offline tests, so this page does not require a live BMC or private endpoint.
 
+Regenerate it with `python tools/generate_telemetry_metrics_doc.py`; use
+`python tools/generate_telemetry_metrics_doc.py --check` in gates to verify
+that the checked-in copy matches the exporter mapper.
+
 ## How To Read This
 
 `MetricReports`, the Redfish collection represented by the fixture files named
@@ -23,11 +27,13 @@ operator guidance, not schema-declared units.
 `Context` is the parent Redfish fragment or path segment that disambiguates
 repeated source metric names without copying the full fixture path.
 
-`redfish_ctl exporter`, defined in `redfish_ctl/telemetry/cmd_exporter.py`, emits
-numeric `MetricValue` rows only. Known fabric counters use curated
-`hw.fabric.*` names. GPU temperature, processor, throttle, clock, and memory
-rows use curated `hw.gpu.*` names. Remaining numeric rows become generated
-`hw.gb300.*` metric names derived from the source metric name.
+`redfish_ctl exporter`, defined in `redfish_ctl/telemetry/cmd_exporter.py`,
+emits the metrics shown in the `Exporter metric` column. Fabric properties use
+curated `hw.fabric.*` names. GPU temperature, processor, throttle, clock, and
+memory rows use curated `hw.gpu.*` names. Bounded categorical rows use
+`hw.component.*`, `hw.fabric.link_down_reason`, or `hw.power.*` state gauges.
+Remaining numeric rows become generated `hw.gb300.*` metric names derived from
+the source metric name.
 
 ## Safe Consumption
 
@@ -55,10 +61,11 @@ without posting externally.
 ## Checking Live Data In Splunk
 
 SignalFx is Splunk Observability Cloud, so the exporter's `signalfx` output pushes
-these metrics straight into Splunk Observability — no extra bridge.
+these metrics straight into Splunk Observability; no extra bridge is required.
 
-1. Push to your org (realm ingest URL + an access token). `SPLUNK_INGEST_URL` and
-   `SPLUNK_ACCESS_TOKEN` are read from the environment by `redfish_ctl exporter`:
+1. Push to your org. `SPLUNK_INGEST_URL`, the SignalFx `/v2/datapoint` ingest
+   URL read by the exporter, and `SPLUNK_ACCESS_TOKEN`, the org access token
+   read by the exporter, must come from the environment:
 
 ```bash
 export SPLUNK_ACCESS_TOKEN='<org access token>'
@@ -66,39 +73,41 @@ export SPLUNK_INGEST_URL='https://ingest.<realm>.signalfx.com/v2/datapoint'
 redfish_ctl exporter --vendor supermicro --output signalfx --push-signalfx
 ```
 
-2. Find the data in Splunk Observability. Under **Metrics -> Metric Finder**, search the
-   metric names this exporter emits: `hw.fabric.*` (NVLink/port link state, BER, RX/TX
-   throughput and errors), `hw.gpu.*` (GPU temperature, processor, clock, throttle,
-   and memory gauges), `hw.gb300.*` (remaining GB300-specific numeric rows), and
-   `hw.temperature`, `hw.energy_kwh`, `hw.component_integrity.enabled`. Every datapoint
-   carries these **dimensions** for filtering/grouping: `host.name`, `chassis`, `gpu`,
-   `port`, `sensor`, `vendor`, `report`.
+2. Find the data in Splunk Observability. Under **Metrics -> Metric Finder**,
+   search the metric names this exporter emits: `hw.fabric.*` (NVLink/port
+   link state, BER, RX/TX throughput and errors), `hw.gpu.*` (GPU temperature,
+   processor, clock, throttle, and memory gauges), `hw.component.*` and
+   `hw.power.*` state gauges, `hw.gb300.*` (remaining GB300-specific numeric
+   rows), plus `hw.temperature`, `hw.energy_kwh`, and `hw.leak.state` from
+   the non-MetricReport samplers. Every datapoint carries these dimensions
+   for filtering/grouping: `host.name`, `node`, `server.address`, `bmc.ip`,
+   and `vendor`; report-derived datapoints also carry `report` and any
+   applicable `gpu`, `port`, `sensor`, `memory`, or state label.
 
-3. Confirm points are arriving with a chart or SignalFlow query, e.g. fabric receive rate
-   per port on one host:
+3. Confirm points are arriving with a chart or SignalFlow query, for example
+   fabric receive rate per port on one host:
 
 ```
-data('hw.fabric.raw_rx_gbps', filter=filter('host', '<bmc-host>')).publish()
+data('hw.fabric.raw_rx_gbps', filter=filter('host.name', '<bmc-host>')).publish()
 ```
 
-Datapoints land within a few seconds of the push; when the Metric Finder shows the `hw.*`
-names carrying your `host`/`vendor` dimensions, live data is flowing.
+Datapoints land within a few seconds of the push; when the Metric Finder shows
+the `hw.*` names carrying your `host.name` and `vendor` dimensions, live data
+is flowing.
 
 For **Splunk Enterprise/Cloud (HEC)** rather than Observability: run the Prometheus
-listener (`redfish_ctl exporter --output prometheus`, no `--once`) and point a Splunk
-OpenTelemetry Collector (prometheus receiver -> `splunk_hec` exporter) at it, which lands
-the same metrics in a HEC index.
+listener (`redfish_ctl exporter --output prometheus`, no `--once`) and point a
+Splunk OpenTelemetry Collector (prometheus receiver -> `splunk_hec` exporter) at
+it, which lands the same metrics in a HEC index.
 
-For a **native OTLP** pipeline (no Collector hop for the BMC data), use
-`redfish_ctl exporter --output otlp` — it pushes these same `hw.*` series over OTLP and honors the
-standard `OTEL_EXPORTER_OTLP_*` environment so it behaves like any other OTLP producer. The identity
-dimensions become OTel resource attributes and the per-metric dimensions become datapoint attributes;
-monotonic counters are emitted as OTLP Sum and instantaneous readings as Gauge. Needs the
-`redfish_ctl[otlp]` extra. See [Telemetry exporter](telemetry-exporter.md#otlp-opentelemetry).
+For a **native OTLP** pipeline, use `redfish_ctl exporter --output otlp` to push
+these same `hw.*` series over OTLP. It honors the standard
+`OTEL_EXPORTER_OTLP_*` environment variables and needs the `redfish_ctl[otlp]`
+extra. See [Telemetry exporter](telemetry-exporter.md#otlp-opentelemetry).
 
-> Live verification of the push needs a real `SPLUNK_ACCESS_TOKEN` and your realm's
-> `SPLUNK_INGEST_URL`; without them, use `--once --output signalfx` to validate the
-> datapoint envelope offline.
+> Live verification of the push needs a real `SPLUNK_ACCESS_TOKEN` and your
+> realm's `SPLUNK_INGEST_URL`; without them, use `--once --output signalfx`
+> to validate the datapoint envelope offline.
 
 ## Report Inventory
 
@@ -126,52 +135,52 @@ definition exists but the current fixture did not include a matching sample.
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
 | `ProcessorModule_{ProcessorId}_CPU_{CpuId}_CoreUtil_{CoreId}` | Chassis/HGX_CPU_{CpuId}/Sensors | not declared | number:144 | 144 | `hw.gb300.processor_module_processor_id_cpu_cpu_id_core_util_core_id` |
-| `ProcessorModule_{ProcessorId}_MemCntl_0_Freq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_processor_id_mem_cntl_0_freq_0` |
-| `ProcessorModule_{ProcessorId}_CPU_0_CpuFreq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_processor_id_cpu_0_cpu_freq_0` |
+| `ProcessorModule_{ProcessorId}_MemCntl_0_Freq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: MHz | number:2 | 2 | `hw.gb300.processor_module_processor_id_mem_cntl_0_freq_0` |
+| `ProcessorModule_{ProcessorId}_CPU_0_CpuFreq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: MHz | number:2 | 2 | `hw.gb300.processor_module_processor_id_cpu_0_cpu_freq_0` |
 | `ProcessorModule_{ProcessorId}_Vreg_0_CpuVoltage_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: voltage | number:2 | 2 | `hw.gb300.processor_module_processor_id_vreg_0_cpu_voltage_0` |
 | `ProcessorModule_{ProcessorId}_Vreg_0_SocVoltage_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: voltage | number:2 | 2 | `hw.gb300.processor_module_processor_id_vreg_0_soc_voltage_0` |
 | `MemoryPageRetirementCount` | Oem/Nvidia | name hint: count | number:2 | 2 | `hw.gb300.memory_page_retirement_count` |
-| `EDPViolationState` | Oem/Nvidia | not declared | string:2 | 2 | `not exported by exporter` |
-| `PowerBreakPerformanceState` | Oem/Nvidia | name hint: power | string:2 | 2 | `not exported by exporter` |
-| `MemorySpareChannelPresence` | Oem/Nvidia | not declared | boolean:2 | 2 | `not exported by exporter` |
-| `State` | Status | not declared | string:20 | 20 | `not exported by exporter` |
-| `State` | Status | not declared | string:4 | 4 | `not exported by exporter` |
+| `EDPViolationState` | Oem/Nvidia | not declared | string:2 | 2 | `hw.power.edp_violation_state` |
+| `PowerBreakPerformanceState` | Oem/Nvidia | name hint: power | string:2 | 2 | `hw.power.break_performance_state` |
+| `MemorySpareChannelPresence` | Oem/Nvidia | not declared | boolean:2 | 2 | `hw.gb300.memory_spare_channel_presence` |
+| `State` | Status | not declared | string:20 | 20 | `hw.component.state` |
+| `State` | Status | not declared | string:4 | 4 | `hw.component.state` |
 
 ### `HGX_HealthMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `Health` | Status | not declared | string:2 | 2 | `not exported by exporter` |
-| `HealthRollup` | Status | not declared | string:2 | 2 | `not exported by exporter` |
-| `Health` | Status | not declared | string:4 | 4 | `not exported by exporter` |
-| `HealthRollup` | Status | not declared | string:4 | 4 | `not exported by exporter` |
-| `Health` | Status | not declared | string:1 | 1 | `not exported by exporter` |
-| `HealthRollup` | Status | not declared | string:1 | 1 | `not exported by exporter` |
+| `Health` | Status | not declared | string:2 | 2 | `hw.component.health` |
+| `HealthRollup` | Status | not declared | string:2 | 2 | `hw.component.health_rollup` |
+| `Health` | Status | not declared | string:4 | 4 | `hw.component.health` |
+| `HealthRollup` | Status | not declared | string:4 | 4 | `hw.component.health_rollup` |
+| `Health` | Status | not declared | string:1 | 1 | `hw.component.health` |
+| `HealthRollup` | Status | not declared | string:1 | 1 | `hw.component.health_rollup` |
 
 ### `HGX_MemoryMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `RowRemappingFailed` | Oem/Nvidia | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `OperatingSpeedMHz` | OperatingSpeedMHz | name hint: MHz | number:4 | 4 | `hw.gb300.operating_speed_mhz` |
-| `BandwidthPercent` | BandwidthPercent | name hint: percent | number:4 | 4 | `hw.gb300.bandwidth_percent` |
-| `CapacityUtilizationPercent` | CapacityUtilizationPercent | name hint: percent | number:4 | 4 | `hw.gb300.capacity_utilization_percent` |
-| `CorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gb300.correctable_eccerror_count` |
-| `UncorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gb300.uncorrectable_eccerror_count` |
-| `CorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.correctable_row_remapping_count` |
-| `UncorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.uncorrectable_row_remapping_count` |
-| `MaxAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.max_availability_bank_count` |
-| `HighAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.high_availability_bank_count` |
-| `PartialAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.partial_availability_bank_count` |
-| `LowAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.low_availability_bank_count` |
-| `NoAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.no_availability_bank_count` |
+| `RowRemappingFailed` | Oem/Nvidia | not declared | boolean:4 | 4 | `hw.gpu.memory.row_remapping_failed` |
+| `OperatingSpeedMHz` | Systems/HGX_Baseboard_0/Memory/GPU_{GpuId}_DRAM_0 | MHz | number:4 | 4 | `hw.gpu.memory.clock_mhz` |
+| `BandwidthPercent` | Systems/HGX_Baseboard_0/Memory/GPU_{GpuId}_DRAM_0 | % | number:4 | 4 | `hw.gpu.memory.bandwidth_utilization` |
+| `CapacityUtilizationPercent` | Systems/HGX_Baseboard_0/Memory/GPU_{GpuId}_DRAM_0 | % | number:4 | 4 | `hw.gpu.memory.capacity_utilization` |
+| `CorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gpu.memory.ecc_errors` |
+| `UncorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gpu.memory.ecc_errors` |
+| `CorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `UncorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `MaxAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `HighAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `PartialAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `LowAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `NoAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
 
 ### `HGX_PlatformEnvironmentMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
 | `HGX_BMC_0_Temp_0` | Chassis/HGX_BMC_0/Sensors | name hint: temperature | number:1 | 1 | `hw.gb300.hgx_bmc_0_temp_0` |
-| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | varies by resolved sensor | number:1 | 1 | `hw.gb300.<resolved_metric_property>` |
+| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | not declared | number:1 | 1 | `hw.gb300.<resolved_metric_property>` |
 | `ProcessorModule_{PMWild}_CPU_0_Energy_0` | Chassis/HGX_CPU_{PMWild}/Sensors | name hint: energy | number:2 | 2 | `hw.gb300.processor_module_pmwild_cpu_0_energy_0` |
 | `ProcessorModule_{PMWild}_CPU_0_EnforcedEDPc_0` | Chassis/HGX_CPU_{PMWild}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_pmwild_cpu_0_enforced_edpc_0` |
 | `ProcessorModule_{PMWild}_CPU_0_EnforcedEDPp_0` | Chassis/HGX_CPU_{PMWild}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_pmwild_cpu_0_enforced_edpp_0` |
@@ -181,11 +190,11 @@ definition exists but the current fixture did not include a matching sample.
 | `ProcessorModule_{PMWild}_Vreg_0_CpuPower_0` | Chassis/HGX_CPU_{PMWild}/Sensors | name hint: power | number:2 | 2 | `hw.gb300.processor_module_pmwild_vreg_0_cpu_power_0` |
 | `ProcessorModule_{PMWild}_Vreg_0_SocPower_0` | Chassis/HGX_CPU_{PMWild}/Sensors | name hint: power | number:2 | 2 | `hw.gb300.processor_module_pmwild_vreg_0_soc_power_0` |
 | `HGX_GPU_{GWild}_DRAM_0_Power_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: power | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_dram_0_power_0` |
-| `HGX_GPU_{GWild}_DRAM_0_Temp_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: temperature | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_dram_0_temp_0` |
+| `HGX_GPU_{GWild}_DRAM_0_Temp_0` | Chassis/HGX_GPU_{GWild}/Sensors | Cel | number:4 | 4 | `hw.gpu.temperature` |
 | `HGX_GPU_{GWild}_Energy_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: energy | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_energy_0` |
 | `HGX_GPU_{GWild}_Power_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: power | number:8 | 8 | `hw.gb300.hgx_gpu_gwild_power_0` |
-| `HGX_GPU_{GWild}_TEMP_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: temperature | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_temp_0` |
-| `HGX_GPU_{GWild}_TEMP_1` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: temperature | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_temp_1` |
+| `HGX_GPU_{GWild}_TEMP_0` | Chassis/HGX_GPU_{GWild}/Sensors | Cel | number:4 | 4 | `hw.gpu.temperature` |
+| `HGX_GPU_{GWild}_TEMP_1` | Chassis/HGX_GPU_{GWild}/Sensors | Cel | number:4 | 4 | `hw.gpu.temperature` |
 | `HGX_ProcessorModule_{PMWild}_Exhaust_Temp_0` | Chassis/HGX_ProcessorModule_{PMWild}/Sensors | name hint: temperature | number:2 | 2 | `hw.gb300.hgx_processor_module_pmwild_exhaust_temp_0` |
 | `HGX_ProcessorModule_{PMWild}_Inlet_Temp_0` | Chassis/HGX_ProcessorModule_{PMWild}/Sensors | name hint: temperature | number:2 | 2 | `hw.gb300.hgx_processor_module_pmwild_inlet_temp_0` |
 | `HGX_ProcessorModule_{PMWild}_Inlet_Temp_1` | Chassis/HGX_ProcessorModule_{PMWild}/Sensors | name hint: temperature | number:2 | 2 | `hw.gb300.hgx_processor_module_pmwild_inlet_temp_1` |
@@ -194,40 +203,40 @@ definition exists but the current fixture did not include a matching sample.
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `TensorCoreActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.tensor_core_activity_percent` |
-| `SMOccupancyPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.smoccupancy_percent` |
-| `SMActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.smactivity_percent` |
+| `TensorCoreActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `SMOccupancyPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `SMActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 | `PCIeRawTxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.gb300.pcie_raw_tx_bandwidth_gbps` |
 | `PCIeRawRxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.gb300.pcie_raw_rx_bandwidth_gbps` |
-| `NVOfaUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.nvofa_utilization_percent` |
+| `NVOfaUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 | `NVLinkRawTxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.raw_tx_gbps` |
 | `NVLinkRawRxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.raw_rx_gbps` |
 | `NVLinkDataTxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.tx_gbps` |
 | `NVLinkDataRxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.rx_gbps` |
-| `NVJpgUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.nvjpg_utilization_percent` |
-| `{InstanceId}` | Oem/Nvidia/NVJpgInstanceUtilizationPercent | varies by resolved sensor | number:32 | 32 | `hw.gb300.<resolved_metric_property>` |
-| `{InstanceId}` | Oem/Nvidia/NVDecInstanceUtilizationPercent | varies by resolved sensor | number:32 | 32 | `hw.gb300.<resolved_metric_property>` |
-| `NVDecUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.nvdec_utilization_percent` |
-| `IntegerActivityUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.integer_activity_utilization_percent` |
-| `IMMAUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.immautilization_percent` |
-| `HMMAUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.hmmautilization_percent` |
-| `GraphicsEngineActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.graphics_engine_activity_percent` |
-| `FP64ActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.fp64_activity_percent` |
-| `FP32ActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.fp32_activity_percent` |
-| `FP16ActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.fp16_activity_percent` |
-| `DMMAUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.dmmautilization_percent` |
+| `NVJpgUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `{InstanceId}` | Oem/Nvidia/NVJpgInstanceUtilizationPercent | % | number:32 | 32 | `hw.gpu.compute.utilization` |
+| `{InstanceId}` | Oem/Nvidia/NVDecInstanceUtilizationPercent | % | number:32 | 32 | `hw.gpu.compute.utilization` |
+| `NVDecUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `IntegerActivityUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `IMMAUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `HMMAUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `GraphicsEngineActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `FP64ActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `FP32ActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `FP16ActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `DMMAUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 
 ### `HGX_ProcessorMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `State` | Status | not declared | not observed | 0 | `not exported by exporter` |
-| `PCIeType` | PCIeInterface | not declared | string:4 | 4 | `not exported by exporter` |
+| `State` | Status | not declared | - | 0 | not observed in fixture |
+| `PCIeType` | PCIeInterface | not declared | string:4 | 4 | not exported by exporter |
 | `MaxLanes` | PCIeInterface | not declared | number:4 | 4 | `hw.gb300.max_lanes` |
 | `LanesInUse` | PCIeInterface | not declared | number:4 | 4 | `hw.gb300.lanes_in_use` |
-| `OperatingSpeedMHz` | OperatingSpeedMHz | name hint: MHz | number:4 | 4 | `hw.gb300.operating_speed_mhz` |
-| `BandwidthPercent` | BandwidthPercent | name hint: percent | number:4 | 4 | `hw.gb300.bandwidth_percent` |
-| `SMUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.smutilization_percent` |
+| `OperatingSpeedMHz` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | MHz | number:4 | 4 | `hw.gpu.clock_mhz` |
+| `BandwidthPercent` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | name hint: percent | number:4 | 4 | `hw.gb300.bandwidth_percent` |
+| `SMUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 | `CorrectableECCErrorCount` | CacheMetricsTotal/LifeTime | name hint: count | number:4 | 4 | `hw.gb300.correctable_eccerror_count` |
 | `UncorrectableECCErrorCount` | CacheMetricsTotal/LifeTime | name hint: count | number:4 | 4 | `hw.gb300.uncorrectable_eccerror_count` |
 | `CorrectableErrorCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.correctable_error_count` |
@@ -238,166 +247,166 @@ definition exists but the current fixture did not include a matching sample.
 | `ReplayRolloverCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.replay_rollover_count` |
 | `NAKSentCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.naksent_count` |
 | `NAKReceivedCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.nakreceived_count` |
-| `ThrottleReasons` | Oem/Nvidia | not declared | not observed | 0 | `not exported by exporter` |
-| `PCIeTXBytes` | Oem/Nvidia | name hint: bytes | number:4 | 4 | `hw.gb300.pcie_txbytes` |
-| `PCIeRXBytes` | Oem/Nvidia | name hint: bytes | number:4 | 4 | `hw.gb300.pcie_rxbytes` |
-| `PowerLimitThrottleDuration` | PowerLimitThrottleDuration | name hint: power | string:4 | 4 | `not exported by exporter` |
-| `ThermalLimitThrottleDuration` | ThermalLimitThrottleDuration | not declared | string:4 | 4 | `not exported by exporter` |
-| `HardwareViolationThrottleDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `GlobalSoftwareViolationThrottleDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `AccumulatedGPUContextUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `AccumulatedSMUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `RampDownWattsPerSecond` | RampDownWattsPerSecond | not declared | number:4 | 4 | `hw.gb300.ramp_down_watts_per_second` |
-| `RampDownHysteresisSeconds` | RampDownHysteresisSeconds | not declared | number:4 | 4 | `hw.gb300.ramp_down_hysteresis_seconds` |
-| `RampUpWattsPerSecond` | RampUpWattsPerSecond | not declared | number:4 | 4 | `hw.gb300.ramp_up_watts_per_second` |
-| `TMPFloorPercent` | TMPFloorPercent | name hint: percent | number:4 | 4 | `hw.gb300.tmpfloor_percent` |
-| `ImmediateRampDown` | ImmediateRampDown | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `RemainingLifetimeCircuitryPercent` | RemainingLifetimeCircuitryPercent | name hint: percent | number:4 | 4 | `hw.gb300.remaining_lifetime_circuitry_percent` |
-| `Enabled` | Enabled | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
+| `ThrottleReasons` | Oem/Nvidia | not declared | - | 0 | not observed in fixture |
+| `PCIeTXBytes` | Oem/Nvidia | By | number:4 | 4 | `hw.gb300.pcie_txbytes` |
+| `PCIeRXBytes` | Oem/Nvidia | By | number:4 | 4 | `hw.gb300.pcie_rxbytes` |
+| `PowerLimitThrottleDuration` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `ThermalLimitThrottleDuration` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `HardwareViolationThrottleDuration` | Oem/Nvidia | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `GlobalSoftwareViolationThrottleDuration` | Oem/Nvidia | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `AccumulatedGPUContextUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | not exported by exporter |
+| `AccumulatedSMUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | not exported by exporter |
+| `RampDownWattsPerSecond` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | number:4 | 4 | `hw.gb300.ramp_down_watts_per_second` |
+| `RampDownHysteresisSeconds` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | number:4 | 4 | `hw.gb300.ramp_down_hysteresis_seconds` |
+| `RampUpWattsPerSecond` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | number:4 | 4 | `hw.gb300.ramp_up_watts_per_second` |
+| `TMPFloorPercent` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.tmpfloor_percent` |
+| `ImmediateRampDown` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | boolean:4 | 4 | `hw.gb300.immediate_ramp_down` |
+| `RemainingLifetimeCircuitryPercent` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.remaining_lifetime_circuitry_percent` |
+| `Enabled` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | boolean:4 | 4 | `hw.gb300.enabled` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
 
 ### `HGX_ProcessorPortGPMMetrics_0`
 
@@ -412,30 +421,30 @@ definition exists but the current fixture did not include a matching sample.
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `CurrentSpeedGbps` | CurrentSpeedGbps | Gbps | number:72 | 72 | `hw.fabric.port_speed` |
-| `TXBytes` | TXBytes | By | number:72 | 72 | `hw.fabric.tx_bytes` |
-| `RXBytes` | RXBytes | By | number:72 | 72 | `hw.fabric.rx_bytes` |
-| `RXErrors` | RXErrors | name hint: count | number:72 | 72 | `hw.fabric.rx_errors` |
-| `RXFrames` | Networking | name hint: count | number:72 | 72 | `hw.fabric.rx_frames` |
-| `TXFrames` | Networking | name hint: count | number:72 | 72 | `hw.fabric.tx_frames` |
+| `CurrentSpeedGbps` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports | Gbps | number:72 | 72 | `hw.fabric.port_speed` |
+| `TXBytes` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports/NVLink_{NvlinkId} | By | number:72 | 72 | `hw.fabric.tx_bytes` |
+| `RXBytes` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports/NVLink_{NvlinkId} | By | number:72 | 72 | `hw.fabric.rx_bytes` |
+| `RXErrors` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports/NVLink_{NvlinkId} | name hint: count | number:72 | 72 | `hw.fabric.rx_errors` |
+| `RXFrames` | Networking | not declared | number:72 | 72 | `hw.fabric.rx_frames` |
+| `TXFrames` | Networking | not declared | number:72 | 72 | `hw.fabric.tx_frames` |
 | `TXDiscards` | Networking | not declared | number:72 | 72 | `hw.fabric.tx_discards` |
-| `MalformedPackets` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.malformed_packets` |
-| `VL15Dropped` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.vl15_dropped` |
-| `VL15TXPackets` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.vl15_tx_packets` |
+| `MalformedPackets` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.malformed_packets` |
+| `VL15Dropped` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.vl15_dropped` |
+| `VL15TXPackets` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.vl15_tx_packets` |
 | `VL15TXBytes` | Oem/Nvidia | By | number:72 | 72 | `hw.fabric.vl15_tx_bytes` |
 | `NeighborMTUDiscards` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.neighbor_mtudiscards` |
 | `LinkErrorRecoveryCount` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.link_error_recovery_count` |
 | `LinkDownedCount` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.link_down_count` |
 | `RXRemotePhysicalErrors` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.rx_remote_physical_errors` |
 | `RXSwitchRelayErrors` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.rx_switch_relay_errors` |
-| `QP1Dropped` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.gb300.qp1_dropped` |
+| `QP1Dropped` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.qp1_dropped` |
 | `TXWait` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.tx_wait` |
 | `BitErrorRate` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.bit_error_rate` |
 | `TXNoProtocolBytes` | Oem/Nvidia | By | number:72 | 72 | `hw.fabric.tx_no_protocol_bytes` |
 | `RXNoProtocolBytes` | Oem/Nvidia | By | number:72 | 72 | `hw.fabric.rx_no_protocol_bytes` |
-| `RuntimeError` | Oem/Nvidia/NVLinkErrors | name hint: count | number:72 | 72 | `hw.gb300.runtime_error` |
-| `TrainingError` | Oem/Nvidia/NVLinkErrors | name hint: count | number:72 | 72 | `hw.gb300.training_error` |
-| `LinkDownReasonCode` | Oem/Nvidia | not declared | string:72 | 72 | `not exported by exporter` |
+| `RuntimeError` | Oem/Nvidia/NVLinkErrors | not declared | number:72 | 72 | `hw.gb300.runtime_error` |
+| `TrainingError` | Oem/Nvidia/NVLinkErrors | not declared | number:72 | 72 | `hw.gb300.training_error` |
+| `LinkDownReasonCode` | Oem/Nvidia | not declared | string:72 | 72 | `hw.fabric.link_down_reason` |
 | `EffectiveBER` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.effective_ber` |
 | `SymbolErrors` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.symbol_errors` |
 | `TotalRawBER` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.raw_ber` |
@@ -443,30 +452,30 @@ definition exists but the current fixture did not include a matching sample.
 | `UnintentionalLinkDownCount` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.unintentional_link_down_count` |
 | `RXWidth` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.rxwidth` |
 | `TXWidth` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.txwidth` |
-| `CurrentSpeedGbps` | CurrentSpeedGbps | Gbps | number:4 | 4 | `hw.fabric.port_speed` |
+| `CurrentSpeedGbps` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports | Gbps | number:4 | 4 | `hw.fabric.port_speed` |
 
 ### `HGX_ProcessorResetMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `PF_FLR_ResetEntryCount` | PF_FLR_ResetEntryCount | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_entry_count` |
-| `PF_FLR_ResetExitCount` | PF_FLR_ResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_exit_count` |
-| `ConventionalResetEntryCount` | ConventionalResetEntryCount | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_entry_count` |
-| `ConventionalResetExitCount` | ConventionalResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_exit_count` |
-| `FundamentalResetEntryCount` | FundamentalResetEntryCount | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_entry_count` |
-| `FundamentalResetExitCount` | FundamentalResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_exit_count` |
-| `IRoTResetExitCount` | IRoTResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.iro_treset_exit_count` |
-| `LastResetType` | LastResetType | not declared | string:4 | 4 | `not exported by exporter` |
+| `PF_FLR_ResetEntryCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_entry_count` |
+| `PF_FLR_ResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_exit_count` |
+| `ConventionalResetEntryCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_entry_count` |
+| `ConventionalResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_exit_count` |
+| `FundamentalResetEntryCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_entry_count` |
+| `FundamentalResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_exit_count` |
+| `IRoTResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.iro_treset_exit_count` |
+| `LastResetType` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | string:4 | 4 | `hw.component.last_reset_type` |
 
 ### `PlatformEnvironmentMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
 | `BMC_0_DCSCM_Temp_0` | Chassis/BMC_0/Sensors | name hint: temperature | number:1 | 1 | `hw.gb300.bmc_0_dcscm_temp_0` |
-| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | varies by resolved sensor | not observed | 0 | `not exported by exporter` |
-| `IO_Board_{IWild}_CX7_0_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | not observed | 0 | `not exported by exporter` |
-| `IO_Board_{IWild}_CX7_1_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | not observed | 0 | `not exported by exporter` |
+| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | not declared | - | 0 | not observed in fixture |
+| `IO_Board_{IWild}_CX7_0_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | - | 0 | not observed in fixture |
+| `IO_Board_{IWild}_CX7_1_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | - | 0 | not observed in fixture |
 | `NVME_M2_0_Temp_0` | Chassis/NVME_M2_0/Sensors | name hint: temperature | number:1 | 1 | `hw.gb300.nvme_m2_0_temp_0` |
-| `{PDBWild}` | Chassis/PDB_0/Sensors | varies by resolved sensor | number:13 | 13 | `hw.gb300.<resolved_metric_property>` |
-| `{BFSWild}` | Chassis/Riser_Slot{BFWild}_BlueField_3_SmartNIC_Main_Card/Sensors | varies by resolved sensor | not observed | 0 | `not exported by exporter` |
-| `StorageBackplane_{SBWild}_SSD_{SBDWild}_Temp_0` | Chassis/StorageBackplane_{SBWild}/Sensors | name hint: temperature | number:8 | 8 | `hw.gb300.storage_backplane_sbwild_ssd_sbdwild_temp_0` |
+| `{PDBWild}` | Chassis/PDB_0/Sensors | not declared | number:13 | 13 | `hw.gb300.<resolved_metric_property>` |
+| `{BFSWild}` | Chassis/Riser_Slot{BFWild}_BlueField_3_SmartNIC_Main_Card/Sensors | not declared | - | 0 | not observed in fixture |
+| `StorageBackplane_{SBWild}_SSD_{SBDWild}_Temp_0` | Chassis/StorageBackplane_{SBWild}/Sensors | name hint: temperature | number:8 | 8 | not exported by exporter |

--- a/tools/generate_telemetry_metrics_doc.py
+++ b/tools/generate_telemetry_metrics_doc.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Generate the GB300 telemetry metric catalog markdown.
+
+Audience: both humans and scripted callers. The tool is non-interactive and deterministic:
+it reads the committed GB300 corpus tarball, asks the exporter mapper which
+metric each observed MetricReport row emits, and either rewrites the catalog or
+checks that the checked-in catalog is current.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+import tarfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from redfish_ctl.telemetry import exporter  # noqa: E402
+
+DEFAULT_CORPUS = REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "telemetry-metrics.md"
+DEFAULT_LEAF = "172.25.230.37"
+IDENTITY = exporter.build_identity_dimensions(DEFAULT_LEAF, vendor="supermicro")
+
+
+@dataclass(frozen=True)
+class ReportDefinition:
+    """One MetricReportDefinition from the corpus."""
+
+    report: str
+    definition_type: str
+    metric_properties: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReportData:
+    """One MetricReport from the corpus."""
+
+    report: str
+    values: tuple[Mapping[str, object], ...]
+
+
+@dataclass(frozen=True)
+class CatalogRow:
+    """One rendered catalog row."""
+
+    metric_name: str
+    context: str
+    unit: str
+    observed_type: str
+    expanded_rows: int
+    exporter_metric: str
+
+
+def _load_json_members(tarball: Path, leaf: str) -> dict[str, Mapping[str, object]]:
+    """Return JSON payloads under ``leaf`` from ``tarball``, keyed by basename."""
+    payloads: dict[str, Mapping[str, object]] = {}
+    with tarfile.open(tarball) as tar:
+        for member in tar.getmembers():
+            if not member.isfile() or not member.name.endswith(".json"):
+                continue
+            if not member.name.startswith(f"{leaf}/"):
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            payloads[Path(member.name).name] = json.load(extracted)
+    return payloads
+
+
+def _report_name_from_payload(payload: Mapping[str, object], fallback: str) -> str:
+    """Return the report id/name from a MetricReport or MetricReportDefinition."""
+    for key in ("Id", "Name"):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return fallback
+
+
+def _load_definitions(payloads: Mapping[str, Mapping[str, object]]) -> list[ReportDefinition]:
+    """Load concrete MetricReportDefinition payloads."""
+    prefix = "_redfish_v1_TelemetryService_MetricReportDefinitions_"
+    definitions = []
+    for name, payload in sorted(payloads.items()):
+        if not name.startswith(prefix):
+            continue
+        report = _report_name_from_payload(payload, name.removeprefix(prefix).removesuffix(".json"))
+        metric_properties = tuple(str(item) for item in payload.get("MetricProperties", []) or [])
+        definitions.append(
+            ReportDefinition(
+                report=report,
+                definition_type=str(payload.get("MetricReportDefinitionType") or "unknown"),
+                metric_properties=metric_properties,
+            )
+        )
+    return definitions
+
+
+def _load_reports(payloads: Mapping[str, Mapping[str, object]]) -> dict[str, ReportData]:
+    """Load concrete MetricReport payloads."""
+    prefix = "_redfish_v1_TelemetryService_MetricReports_"
+    reports = {}
+    for name, payload in sorted(payloads.items()):
+        if not name.startswith(prefix):
+            continue
+        report = _report_name_from_payload(payload, name.removeprefix(prefix).removesuffix(".json"))
+        values = []
+        for value in payload.get("MetricValues", []) or []:
+            if isinstance(value, Mapping):
+                values.append(dict(value) | {"Report": report})
+        reports[report] = ReportData(report=report, values=tuple(values))
+    return reports
+
+
+def _value_type(value: object) -> str:
+    """Classify a Redfish MetricValue string for the catalog."""
+    if isinstance(value, bool):
+        return "boolean"
+    text = str(value).strip()
+    if text.lower() in {"true", "false"}:
+        return "boolean"
+    try:
+        float(text)
+    except ValueError:
+        return "string"
+    return "number"
+
+
+def _value_type_summary(values: Iterable[Mapping[str, object]]) -> str:
+    """Return a compact type-count summary."""
+    counts = Counter(_value_type(row.get("MetricValue")) for row in values)
+    if not counts:
+        return "-"
+    order = ("boolean", "number", "string")
+    return ", ".join(f"{name}:{counts[name]}" for name in order if counts[name])
+
+
+def _template_regex(template: str) -> re.Pattern[str]:
+    """Compile a MetricProperty template with ``{Wildcards}`` into a full regex."""
+    pieces = []
+    cursor = 0
+    for match in re.finditer(r"\{[^}]+\}", template):
+        pieces.append(re.escape(template[cursor:match.start()]))
+        pieces.append(r"[^/#]+")
+        cursor = match.end()
+    pieces.append(re.escape(template[cursor:]))
+    return re.compile("^" + "".join(pieces) + "$")
+
+
+def _matching_values(
+    template: str,
+    rows: Iterable[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    """Return MetricReport rows whose MetricProperty matches a definition template."""
+    pattern = _template_regex(template)
+    return [
+        row for row in rows
+        if pattern.match(str(row.get("MetricProperty") or ""))
+    ]
+
+
+def _property_parts(metric_property: str) -> tuple[list[str], list[str]]:
+    """Split a MetricProperty into path and fragment parts."""
+    path, _, fragment = metric_property.partition("#")
+    path_parts = [part for part in path.strip("/").split("/") if part]
+    fragment_parts = [part for part in fragment.strip("/").split("/") if part]
+    return path_parts, fragment_parts
+
+
+def _metric_name(metric_property: str) -> str:
+    """Return the display metric name from a MetricProperty template."""
+    path_parts, fragment_parts = _property_parts(metric_property)
+    parts = fragment_parts or path_parts
+    if not parts:
+        return "metric"
+    if parts[-1].isdigit() and len(parts) > 1:
+        return parts[-2]
+    return parts[-1]
+
+
+def _context(metric_property: str) -> str:
+    """Return a compact context for a MetricProperty template."""
+    path_parts, fragment_parts = _property_parts(metric_property)
+    if fragment_parts:
+        context_parts = fragment_parts[:-1]
+        if context_parts and context_parts[-1].isdigit():
+            context_parts = context_parts[:-1]
+        if context_parts:
+            return "/".join(context_parts)
+    if "redfish" in path_parts:
+        path_parts = path_parts[path_parts.index("redfish") + 2:]
+    return "/".join(path_parts[:-1]) or "-"
+
+
+def _unit_hint(metric_name: str) -> str:
+    """Return a human-readable unit hint when Redfish omits a declared unit."""
+    lowered = metric_name.lower()
+    if "gbps" in lowered:
+        return "Gbps"
+    if lowered.endswith("bytes") or lowered.endswith("txbytes") or lowered.endswith("rxbytes"):
+        return "By"
+    if "mhz" in lowered or "freq" in lowered:
+        return "name hint: MHz"
+    if "percent" in lowered:
+        return "name hint: percent"
+    if "temp" in lowered or "temperature" in lowered:
+        return "name hint: temperature"
+    if "power" in lowered:
+        return "name hint: power"
+    if "energy" in lowered:
+        return "name hint: energy"
+    if "voltage" in lowered:
+        return "name hint: voltage"
+    if "count" in lowered or "errors" in lowered:
+        return "name hint: count"
+    return "not declared"
+
+
+def _generic_exporter_name(metric_name: str) -> str:
+    """Return the stable generated-metric display name for a definition row."""
+    if metric_name.startswith("{") and metric_name.endswith("}"):
+        return "`hw.gb300.<resolved_metric_property>`"
+    return f"`{exporter._generic_metric_name(metric_name)}`"
+
+
+def _exporter_metric(
+    values: list[Mapping[str, object]],
+    metric_name: str,
+) -> tuple[str, str]:
+    """Return rendered exporter metric names and units for matched rows."""
+    if not values:
+        return "not observed in fixture", "-"
+    samples = exporter.samples_from_metric_report_rows(values, IDENTITY)
+    metrics = sorted({sample.metric for sample in samples})
+    units = sorted({sample.unit for sample in samples if sample.unit})
+    if not metrics:
+        rendered_metrics = "not exported by exporter"
+    else:
+        rendered = []
+        if any(metric.startswith("hw.gb300.") for metric in metrics):
+            rendered.append(_generic_exporter_name(metric_name))
+        rendered.extend(f"`{metric}`" for metric in metrics if not metric.startswith("hw.gb300."))
+        rendered_metrics = ", ".join(rendered)
+    return rendered_metrics, (", ".join(units) if units else "-")
+
+
+def _catalog_rows(definition: ReportDefinition, report: ReportData | None) -> list[CatalogRow]:
+    """Build rendered catalog rows for one report."""
+    values = report.values if report is not None else ()
+    rows = []
+    for metric_property in definition.metric_properties:
+        matched = _matching_values(metric_property, values)
+        name = _metric_name(metric_property)
+        exporter_metric, exporter_unit = _exporter_metric(matched, name)
+        unit = exporter_unit if exporter_unit != "-" else _unit_hint(name)
+        rows.append(
+            CatalogRow(
+                metric_name=name,
+                context=_context(metric_property),
+                unit=unit,
+                observed_type=_value_type_summary(matched),
+                expanded_rows=len(matched),
+                exporter_metric=exporter_metric,
+            )
+        )
+    return rows
+
+
+def _inventory_row(definition: ReportDefinition, report: ReportData | None) -> str:
+    """Render one report inventory table row."""
+    values = report.values if report is not None else ()
+    return (
+        f"| `{definition.report}` | {definition.definition_type} | "
+        f"{len(definition.metric_properties)} | {len(values)} | "
+        f"{_value_type_summary(values)} |"
+    )
+
+
+def _md_escape(value: str) -> str:
+    """Escape Markdown table syntax in a cell."""
+    return value.replace("|", r"\|").replace("\n", " ")
+
+
+def render_document(
+    definitions: list[ReportDefinition],
+    reports: Mapping[str, ReportData],
+    *,
+    corpus: Path,
+) -> str:
+    """Render the full markdown catalog."""
+    lines = [
+        "# GB300 Telemetry Metrics",
+        "",
+        "Author: Mus <spyroot@gmail.com>",
+        "",
+        "This reference is generated from the Supermicro GB300 fixture files packed in",
+        f"`{corpus.relative_to(REPO_ROOT)}`, the captured Redfish JSON corpus used by",
+        "the offline tests, so this page does not require a live BMC or private endpoint.",
+        "",
+        "Regenerate it with `python tools/generate_telemetry_metrics_doc.py`; use",
+        "`python tools/generate_telemetry_metrics_doc.py --check` in gates to verify",
+        "that the checked-in copy matches the exporter mapper.",
+        "",
+        "## How To Read This",
+        "",
+        "`MetricReports`, the Redfish collection represented by the fixture files named",
+        "`_redfish_v1_TelemetryService_MetricReports*.json`, carries the observed rows.",
+        "`MetricReportDefinitions`, the Redfish collection represented by the fixture",
+        "files named `_redfish_v1_TelemetryService_MetricReportDefinitions*.json`,",
+        "carries the source metric templates.",
+        "",
+        "`MetricValue`, the value field in each Redfish `MetricReport` row, is a string",
+        "in this corpus. The observed type column below is inferred from those fixture",
+        "strings. Units are shown only when the exporter declares one, or as a name",
+        "hint when the Redfish report omits a unit. Treat `name hint` entries as",
+        "operator guidance, not schema-declared units.",
+        "",
+        "`Context` is the parent Redfish fragment or path segment that disambiguates",
+        "repeated source metric names without copying the full fixture path.",
+        "",
+        "`redfish_ctl exporter`, defined in `redfish_ctl/telemetry/cmd_exporter.py`,",
+        "emits the metrics shown in the `Exporter metric` column. Fabric properties use",
+        "curated `hw.fabric.*` names. GPU temperature, processor, throttle, clock, and",
+        "memory rows use curated `hw.gpu.*` names. Bounded categorical rows use",
+        "`hw.component.*`, `hw.fabric.link_down_reason`, or `hw.power.*` state gauges.",
+        "Remaining numeric rows become generated `hw.gb300.*` metric names derived from",
+        "the source metric name.",
+        "",
+        "## Safe Consumption",
+        "",
+        "Start with direct read-only Redfish GET paths before running a long-lived",
+        "exporter process:",
+        "",
+        "```bash",
+        "redfish_ctl metric-definitions",
+        "redfish_ctl metric-reports --report HGX_ProcessorPortMetrics_0",
+        "```",
+        "",
+        "Then run a one-shot Prometheus render from `redfish_ctl exporter`, which reads",
+        "the BMC and prints text instead of opening a listener:",
+        "",
+        "```bash",
+        "redfish_ctl exporter --vendor supermicro --once --output prometheus",
+        "```",
+        "",
+        "For SignalFx, `SPLUNK_ACCESS_TOKEN`, the ingest token read by the exporter",
+        "from the process environment, and `SPLUNK_INGEST_URL`, the full",
+        "`/v2/datapoint` URL read by the exporter, are required only when pushing.",
+        "Use `--once --output signalfx` first to inspect the datapoint envelope",
+        "without posting externally.",
+        "",
+        "## Checking Live Data In Splunk",
+        "",
+        "SignalFx is Splunk Observability Cloud, so the exporter's `signalfx` output pushes",
+        "these metrics straight into Splunk Observability; no extra bridge is required.",
+        "",
+        "1. Push to your org. `SPLUNK_INGEST_URL`, the SignalFx `/v2/datapoint` ingest",
+        "   URL read by the exporter, and `SPLUNK_ACCESS_TOKEN`, the org access token",
+        "   read by the exporter, must come from the environment:",
+        "",
+        "```bash",
+        "export SPLUNK_ACCESS_TOKEN='<org access token>'",
+        "export SPLUNK_INGEST_URL='https://ingest.<realm>.signalfx.com/v2/datapoint'",
+        "redfish_ctl exporter --vendor supermicro --output signalfx --push-signalfx",
+        "```",
+        "",
+        "2. Find the data in Splunk Observability. Under **Metrics -> Metric Finder**,",
+        "   search the metric names this exporter emits: `hw.fabric.*` (NVLink/port",
+        "   link state, BER, RX/TX throughput and errors), `hw.gpu.*` (GPU temperature,",
+        "   processor, clock, throttle, and memory gauges), `hw.component.*` and",
+        "   `hw.power.*` state gauges, `hw.gb300.*` (remaining GB300-specific numeric",
+        "   rows), plus `hw.temperature`, `hw.energy_kwh`, and `hw.leak.state` from",
+        "   the non-MetricReport samplers. Every datapoint carries these dimensions",
+        "   for filtering/grouping: `host.name`, `node`, `server.address`, `bmc.ip`,",
+        "   and `vendor`; report-derived datapoints also carry `report` and any",
+        "   applicable `gpu`, `port`, `sensor`, `memory`, or state label.",
+        "",
+        "3. Confirm points are arriving with a chart or SignalFlow query, for example",
+        "   fabric receive rate per port on one host:",
+        "",
+        "```",
+        "data('hw.fabric.raw_rx_gbps', filter=filter('host.name', '<bmc-host>')).publish()",
+        "```",
+        "",
+        "Datapoints land within a few seconds of the push; when the Metric Finder shows",
+        "the `hw.*` names carrying your `host.name` and `vendor` dimensions, live data",
+        "is flowing.",
+        "",
+        "For **Splunk Enterprise/Cloud (HEC)** rather than Observability: run the Prometheus",
+        "listener (`redfish_ctl exporter --output prometheus`, no `--once`) and point a",
+        "Splunk OpenTelemetry Collector (prometheus receiver -> `splunk_hec` exporter) at",
+        "it, which lands the same metrics in a HEC index.",
+        "",
+        "For a **native OTLP** pipeline, use `redfish_ctl exporter --output otlp` to push",
+        "these same `hw.*` series over OTLP. It honors the standard",
+        "`OTEL_EXPORTER_OTLP_*` environment variables and needs the `redfish_ctl[otlp]`",
+        "extra. See [Telemetry exporter](telemetry-exporter.md#otlp-opentelemetry).",
+        "",
+        "> Live verification of the push needs a real `SPLUNK_ACCESS_TOKEN` and your",
+        "> realm's `SPLUNK_INGEST_URL`; without them, use `--once --output signalfx`",
+        "> to validate the datapoint envelope offline.",
+        "",
+        "## Report Inventory",
+        "",
+        "| Report | Definition type | Definition metrics | Observed rows | Observed value types |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for definition in definitions:
+        lines.append(_inventory_row(definition, reports.get(definition.report)))
+    lines.extend([
+        "",
+        "## Metric Catalog",
+        "",
+        "Rows are grouped by Redfish report. `Expanded rows` is the count of concrete",
+        "fixture `MetricValue` rows matched by the definition template. `0` means the",
+        "definition exists but the current fixture did not include a matching sample.",
+        "",
+    ])
+    for definition in definitions:
+        lines.extend([
+            f"### `{definition.report}`",
+            "",
+            "| Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |",
+            "|---|---|---|---:|---:|---|",
+        ])
+        for row in _catalog_rows(definition, reports.get(definition.report)):
+            lines.append(
+                f"| `{_md_escape(row.metric_name)}` | {_md_escape(row.context)} | "
+                f"{_md_escape(row.unit)} | {_md_escape(row.observed_type)} | "
+                f"{row.expanded_rows} | {_md_escape(row.exporter_metric)} |"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate docs/telemetry-metrics.md from the committed GB300 corpus. "
+            "Audience: both humans and scripted callers."
+        )
+    )
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS,
+                        help="GB300 corpus tarball")
+    parser.add_argument("--leaf", default=DEFAULT_LEAF,
+                        help="top-level corpus directory inside the tarball")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT,
+                        help="markdown output path")
+    parser.add_argument("--check", action="store_true",
+                        help="fail if the output path is not already current")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    payloads = _load_json_members(args.corpus, args.leaf)
+    definitions = _load_definitions(payloads)
+    reports = _load_reports(payloads)
+    rendered = render_document(definitions, reports, corpus=args.corpus)
+
+    if args.check:
+        existing = args.output.read_text(encoding="utf-8") if args.output.exists() else ""
+        if existing != rendered:
+            diff = difflib.unified_diff(
+                existing.splitlines(),
+                rendered.splitlines(),
+                fromfile=str(args.output),
+                tofile="generated telemetry metrics",
+                lineterm="",
+            )
+            print("\n".join(diff), file=sys.stderr)
+            print("BLOCKER: docs/telemetry-metrics.md is stale; regenerate it",
+                  file=sys.stderr)
+            return 1
+        return 0
+
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"wrote {args.output.relative_to(REPO_ROOT)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a deterministic generator for the GB300 telemetry metrics catalog
- refresh docs/telemetry-metrics.md from the exporter mapper so curated hw.gpu.*, hw.fabric.*, hw.component.*, and hw.power.* outputs match current behavior
- tighten docs/observability.md to describe the traced request surfaces covered by the public telemetry contract

## Checks
- /Users/spyroot/miniconda3/envs/idrac_ctl/bin/python tools/generate_telemetry_metrics_doc.py --check
- git diff --check

Full pytest/Ruff validation is left to GitHub CI.