### PR TITLE
Add Dell hardware proof command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-card-hw-proof` | Verify Dell iDRAC card-service hardware proof of possession; lists targets by default and requires `--confirm` before POSTing. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_dell_card_hw_proof import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -42,6 +42,7 @@ ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DelliDRACCardService.VerifyHWProofOfPossession": Destructiveness.READ_ONLY,
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/oem/cmd_dell_card_hw_proof.py
+++ b/redfish_ctl/oem/cmd_dell_card_hw_proof.py
@@ -1,0 +1,319 @@
+"""Verify Dell iDRAC card-service hardware proof of possession.
+
+    redfish_ctl dell-card-hw-proof
+    redfish_ctl dell-card-hw-proof --dry_run
+    redfish_ctl dell-card-hw-proof --algorithm AES128CBC \\
+        --key-derivation-function DellSHA256 --confirm
+
+The command discovers ``DelliDRACCardService`` from Manager OEM links and
+resolves the advertised ``#DelliDRACCardService.VerifyHWProofOfPossession``
+target from that resource. It lists the target by default and previews the
+payload unless ``--confirm`` is supplied.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_ACTION_TYPE = "#DelliDRACCardService.VerifyHWProofOfPossession"
+_ACTION_NAME = "VerifyHWProofOfPossession"
+_SERVICE_NAME = "DelliDRACCardService"
+_DEFAULT_SERVICE_URI = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/{_SERVICE_NAME}"
+)
+
+
+class DellCardHwProof(RedfishManagerBase,
+                      scm_type=ApiRequestType.DellCardHwProof,
+                      name="dell-card-hw-proof",
+                      metaclass=Singleton):
+    """Discover and invoke Dell hardware proof-of-possession verification."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-card-hw-proof command."""
+        super(DellCardHwProof, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-card-hw-proof`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--algorithm",
+            dest="algorithm",
+            default=None,
+            help="Algorithm payload value; defaults to the advertised singleton",
+        )
+        cmd_parser.add_argument(
+            "--key-derivation-function",
+            dest="key_derivation_function",
+            default=None,
+            help=(
+                "KeyDerivationFunction payload value; defaults to the "
+                "advertised singleton"
+            ),
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DelliDRACCardService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the proof verification instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-card-hw-proof",
+            "command verify Dell iDRAC hardware proof of possession",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _oem_dell(data):
+        """Return the ``Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    @staticmethod
+    def _links_oem_dell(data):
+        """Return the ``Links.Oem.Dell`` block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = data.get("Links") if isinstance(data, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DelliDRACCardService resource URIs.
+
+        :param do_async: issue Manager queries on the async path when True.
+        :return: ordered list of candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(
+                self._links_oem_dell(manager),
+                _SERVICE_NAME,
+            )
+            if not service_uri:
+                service_uri = self._link(self._oem_dell(manager), _SERVICE_NAME)
+            if service_uri:
+                uris.append(service_uri)
+        if not uris:
+            uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uri.rstrip("/") for uri in uris))
+
+    @staticmethod
+    def _action_value(service, parameter):
+        """Return allowable values for one proof action parameter.
+
+        :param service: DelliDRACCardService resource body.
+        :param parameter: Redfish action parameter name.
+        :return: list of allowable strings advertised by the service.
+        """
+        actions = service.get("Actions") if isinstance(service, dict) else None
+        action = actions.get(_ACTION_TYPE) if isinstance(actions, dict) else None
+        if not isinstance(action, dict):
+            return []
+        values = action.get(f"{parameter}@Redfish.AllowableValues") or []
+        return list(values) if isinstance(values, list) else []
+
+    def _row_for(self, service_uri, do_async):
+        """Build a discovered hardware proof target row for one service URI.
+
+        :param service_uri: candidate DelliDRACCardService URI.
+        :param do_async: issue the service query on the async path when True.
+        :return: discovered row, or None when the action is absent.
+        """
+        service = self._get(service_uri, do_async)
+        if not service:
+            return None
+        target = self._flatten_action_targets(service).get(_ACTION_TYPE)
+        if not target:
+            return None
+        return {
+            "Resource": service_uri,
+            "Action": _ACTION_TYPE,
+            "Target": target,
+            "AllowedAlgorithms": self._action_value(service, "Algorithm"),
+            "AllowedKeyDerivationFunctions": self._action_value(
+                service,
+                "KeyDerivationFunction",
+            ),
+        }
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Discover Dell hardware proof verification targets.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DelliDRACCardService URI.
+        :return: list of discovered target rows.
+        """
+        uris = [resource_uri.rstrip("/")] if resource_uri else self._service_uris(
+            do_async
+        )
+        rows = []
+        for uri in dict.fromkeys(uris):
+            row = self._row_for(uri, do_async)
+            if row:
+                rows.append(row)
+        return rows
+
+    @staticmethod
+    def _default_value(value, allowed, field):
+        """Return a caller value or the resource's singleton default.
+
+        :param value: caller-provided value.
+        :param allowed: advertised allowable values.
+        :param field: payload field name for error messages.
+        :return: payload value.
+        :raises ValueError: when no value is available.
+        """
+        if value:
+            return value
+        if len(allowed) == 1:
+            return allowed[0]
+        raise ValueError(f"{field} is required")
+
+    def _payload_for(self, row, algorithm, key_derivation_function):
+        """Build the VerifyHWProofOfPossession payload.
+
+        :param row: discovered target row with allowable values.
+        :param algorithm: optional Algorithm value.
+        :param key_derivation_function: optional KeyDerivationFunction value.
+        :return: action payload.
+        """
+        return {
+            "Algorithm": self._default_value(
+                algorithm,
+                row["AllowedAlgorithms"],
+                "Algorithm",
+            ),
+            "KeyDerivationFunction": self._default_value(
+                key_derivation_function,
+                row["AllowedKeyDerivationFunctions"],
+                "KeyDerivationFunction",
+            ),
+        }
+
+    def execute(self,
+                algorithm: Optional[str] = None,
+                key_derivation_function: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or invoke Dell hardware proof verification.
+
+        :param algorithm: optional Algorithm payload value.
+        :param key_derivation_function: optional KeyDerivationFunction value.
+        :param resource_uri: optional service URI to disambiguate targets.
+        :param confirm: authorize a POST. Without this the action previews.
+        :param dry_run: force a preview even with ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish calls on the async path.
+        :return: CommandResult with discovered targets, preview, or POST result.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri=resource_uri)
+        should_preview = any((algorithm, key_derivation_function, dry_run, confirm))
+        if not should_preview:
+            return CommandResult({"hw_proof_targets": rows}, None, None, None)
+
+        if not rows:
+            return CommandResult(
+                {"action": _ACTION_TYPE, "available": []},
+                None,
+                None,
+                "Dell hardware proof action not found",
+            )
+        if len(rows) > 1:
+            return CommandResult(
+                {"matches": rows},
+                None,
+                None,
+                "multiple Dell hardware proof targets found; pass --resource-uri",
+            )
+
+        try:
+            payload = self._payload_for(rows[0], algorithm, key_derivation_function)
+        except ValueError as exc:
+            return CommandResult({"matches": rows}, None, None, str(exc))
+
+        result = self.invoke_action(
+            rows[0]["Resource"],
+            _ACTION_NAME,
+            payload=payload,
+            full_action_type=_ACTION_TYPE,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        if not confirm and isinstance(result.data, dict):
+            result.data["requires_confirm"] = True
+            result.data["blocked"] = (
+                "Dell hardware proof verification requires --confirm"
+            )
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -113,6 +113,7 @@ class ApiRequestType(Enum):
     EventSubmitTest = auto()
     HpeTestActions = auto()
     NvidiaDebugToken = auto()
+    DellCardHwProof = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()
     SubscriptionDelete = auto()

--- a/tests/test_dell_card_hw_proof_dualmode.py
+++ b/tests/test_dell_card_hw_proof_dualmode.py
@@ -1,0 +1,225 @@
+"""Dual-mode-style tests for Dell hardware proof verification."""
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import classify
+from redfish_ctl.oem.cmd_dell_card_hw_proof import DellCardHwProof
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+GENERIC_MANAGER_URI = "/redfish/v1/Managers/BMC"
+SERVICE_URI = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+TARGET_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/"
+    "Actions/DelliDRACCardService.VerifyHWProofOfPossession"
+)
+ACTION_TYPE = "#DelliDRACCardService.VerifyHWProofOfPossession"
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-xr8620t",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(redfish_service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [
+        request
+        for request in redfish_service.requests
+        if request.method == "POST"
+    ]
+
+
+def _seed_card_service(redfish_service, include_action=True):
+    """Overlay a Dell card service link and optional proof action."""
+    manager = deepcopy(redfish_service._state(GENERIC_MANAGER_URI))
+    manager.setdefault("Links", {}).setdefault("Oem", {}).setdefault("Dell", {})[
+        "DelliDRACCardService"
+    ] = {"@odata.id": SERVICE_URI}
+
+    service = {
+        "@odata.id": SERVICE_URI,
+        "@odata.type": "#DelliDRACCardService.v1_0_0.DelliDRACCardService",
+        "Id": "DelliDRACCardService",
+        "Name": "Dell iDRAC Card Service",
+        "Actions": {},
+    }
+    if include_action:
+        service["Actions"][ACTION_TYPE] = {
+            "target": TARGET_URI,
+            "Algorithm@Redfish.AllowableValues": ["AES128CBC"],
+            "KeyDerivationFunction@Redfish.AllowableValues": ["DellSHA256"],
+        }
+
+    for path, body in (
+        (GENERIC_MANAGER_URI, manager),
+        (SERVICE_URI, service),
+    ):
+        redfish_service._overlay[path] = body
+        redfish_service._overlay[path.lower()] = body
+
+
+def test_dell_card_hw_proof_lists_corpus_target(dell_corpus_mock):
+    """Listing discovers the Dell corpus hardware proof action."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardHwProof,
+        "dell-card-hw-proof",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["hw_proof_targets"] == [{
+        "Resource": SERVICE_URI,
+        "Action": ACTION_TYPE,
+        "Target": TARGET_URI,
+        "AllowedAlgorithms": ["AES128CBC"],
+        "AllowedKeyDerivationFunctions": ["DellSHA256"],
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_card_hw_proof_previews_default_payload(dell_corpus_mock):
+    """A selected proof verification previews unless --confirm is supplied."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardHwProof,
+        "dell-card-hw-proof",
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == ACTION_TYPE
+    assert result.data["level"] == "read_only"
+    assert result.data["target"] == TARGET_URI
+    assert result.data["payload"] == {
+        "Algorithm": "AES128CBC",
+        "KeyDerivationFunction": "DellSHA256",
+    }
+    assert result.data["requires_confirm"] is True
+    assert result.data["blocked"] == (
+        "Dell hardware proof verification requires --confirm"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_card_hw_proof_confirm_posts_payload(dell_corpus_mock):
+    """--confirm POSTs one Dell hardware proof verification request."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardHwProof,
+        "dell-card-hw-proof",
+        algorithm="AES128CBC",
+        key_derivation_function="DellSHA256",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == ACTION_TYPE
+    assert result.data["level"] == "read_only"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == TARGET_URI.lower()
+    assert posts[0].json() == {
+        "Algorithm": "AES128CBC",
+        "KeyDerivationFunction": "DellSHA256",
+    }
+
+
+def test_dell_card_hw_proof_rejects_invalid_algorithm(dell_corpus_mock):
+    """Inline Redfish metadata rejects unsupported Algorithm values."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardHwProof,
+        "dell-card-hw-proof",
+        algorithm="AES256CBC",
+        key_derivation_function="DellSHA256",
+        confirm=True,
+    )
+
+    assert result.error == (
+        "invalid value for DelliDRACCardService.VerifyHWProofOfPossession "
+        "Algorithm: AES256CBC; allowed: AES128CBC"
+    )
+    assert result.data["validation_errors"] == [{
+        "parameter": "Algorithm",
+        "value": "AES256CBC",
+        "allowed": ["AES128CBC"],
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_card_hw_proof_missing_action_reports_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """A card-service resource without the proof action returns a target error."""
+    _seed_card_service(redfish_service, include_action=False)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellCardHwProof,
+        "dell-card-hw-proof",
+        confirm=True,
+    )
+
+    assert result.error == "Dell hardware proof action not found"
+    assert result.data == {"action": ACTION_TYPE, "available": []}
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_card_hw_proof_exposes_policy_and_cli_entrypoint():
+    """The dell-card-hw-proof command is wired into policy and registry."""
+    assert classify(ACTION_TYPE).value == "read_only"
+
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellCardHwProof]["dell-card-hw-proof"] is (
+        DellCardHwProof
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellCardHwProof.register_subcommand(
+        DellCardHwProof
+    )
+    help_text = cmd_parser.format_help()
+
+    assert "--algorithm" in help_text
+    assert "--key-derivation-function" in help_text
+    assert "--resource-uri" in help_text
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text
+    assert cmd_name == "dell-card-hw-proof"
+    assert "hardware proof" in cmd_help


### PR DESCRIPTION
## Summary
- add a dell-card-hw-proof command for DelliDRACCardService.VerifyHWProofOfPossession
- list the Dell card-service target by default and preview the payload unless --confirm is supplied
- add Dell XR8620t corpus-backed coverage plus policy, registry, and command docs wiring

## Validation
- git diff --cached --check