### PR TITLE
Add Dell card key management command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-card-key-management` | Preview or run Dell iDRAC card-service key-management actions; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_dell_card_key_management import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -82,6 +82,12 @@ ACTION_POLICY = {
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,
     "#UpdateService.SimpleUpdate": Destructiveness.DESTRUCTIVE,
     "#UpdateService.StartUpdate": Destructiveness.DESTRUCTIVE,
+    "#DelliDRACCardService.DisableiLKM": Destructiveness.DESTRUCTIVE,
+    "#DelliDRACCardService.DisableSEKM": Destructiveness.DESTRUCTIVE,
+    "#DelliDRACCardService.EnableiLKM": Destructiveness.DESTRUCTIVE,
+    "#DelliDRACCardService.EnableSEKM": Destructiveness.DESTRUCTIVE,
+    "#DelliDRACCardService.Rekey": Destructiveness.DESTRUCTIVE,
+    "#DelliDRACCardService.iLKMToSEKMTransition": Destructiveness.DESTRUCTIVE,
 
     # irreversible: data loss or one-way security change — needs the extra token
     "#Drive.SecureErase": Destructiveness.IRREVERSIBLE,

--- a/redfish_ctl/oem/cmd_dell_card_key_management.py
+++ b/redfish_ctl/oem/cmd_dell_card_key_management.py
@@ -1,0 +1,351 @@
+"""Preview or run Dell card-service key-management actions.
+
+    redfish_ctl dell-card-key-management
+    redfish_ctl dell-card-key-management --action disable-sekm
+    redfish_ctl dell-card-key-management --action rekey --mode SEKM --confirm
+
+The command discovers ``DelliDRACCardService`` from Manager OEM links and
+resolves the advertised key-management action targets from that resource.
+Selected actions preview by default because they rewrite BMC security
+configuration. Use ``--confirm`` to POST one selected action.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SERVICE_NAME = "DelliDRACCardService"
+_DEFAULT_SERVICE_URI = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/{_SERVICE_NAME}"
+)
+
+
+@dataclass(frozen=True)
+class _CardKeyAction:
+    """Static selector metadata for one Dell card-service action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+    needs_mode: bool = False
+
+
+_ACTION_SPECS = {
+    "disable-ilkm": _CardKeyAction(
+        selector="disable-ilkm",
+        full_type="#DelliDRACCardService.DisableiLKM",
+        action_name="DisableiLKM",
+        description="disable local key management",
+    ),
+    "disable-sekm": _CardKeyAction(
+        selector="disable-sekm",
+        full_type="#DelliDRACCardService.DisableSEKM",
+        action_name="DisableSEKM",
+        description="disable secure enterprise key management",
+    ),
+    "enable-ilkm": _CardKeyAction(
+        selector="enable-ilkm",
+        full_type="#DelliDRACCardService.EnableiLKM",
+        action_name="EnableiLKM",
+        description="enable local key management",
+    ),
+    "enable-sekm": _CardKeyAction(
+        selector="enable-sekm",
+        full_type="#DelliDRACCardService.EnableSEKM",
+        action_name="EnableSEKM",
+        description="enable secure enterprise key management",
+    ),
+    "rekey": _CardKeyAction(
+        selector="rekey",
+        full_type="#DelliDRACCardService.Rekey",
+        action_name="Rekey",
+        description="rekey the selected Dell key-management mode",
+        needs_mode=True,
+    ),
+    "transition-ilkm-to-sekm": _CardKeyAction(
+        selector="transition-ilkm-to-sekm",
+        full_type="#DelliDRACCardService.iLKMToSEKMTransition",
+        action_name="iLKMToSEKMTransition",
+        description="transition from local to secure enterprise key management",
+    ),
+}
+
+
+class DellCardKeyManagement(RedfishManagerBase,
+                            scm_type=ApiRequestType.DellCardKeyManagement,
+                            name="dell-card-key-management",
+                            metaclass=Singleton):
+    """Discover and invoke Dell card-service key-management actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-card-key-management command."""
+        super(DellCardKeyManagement, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-card-key-management`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="key-management action to preview or run; omit to list targets",
+        )
+        cmd_parser.add_argument(
+            "--mode",
+            default=None,
+            help="Mode payload for --action rekey; usually SEKM or iLKM",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DelliDRACCardService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the selected key-management action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-card-key-management",
+            "command run Dell card-service key-management actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem(data):
+        """Return the ``Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM block, or an empty dict.
+        """
+        oem = data.get("Oem") if isinstance(data, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    @staticmethod
+    def _dell_oem_links(data):
+        """Return the ``Links.Oem.Dell`` extension block from a resource.
+
+        :param data: Redfish resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = data.get("Links") if isinstance(data, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating missing optional resources.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri.rstrip("/"), do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DelliDRACCardService resource URIs.
+
+        :param do_async: issue Manager queries on the async path when True.
+        :return: ordered list of candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(self._dell_oem_links(manager), _SERVICE_NAME)
+            if not service_uri:
+                service_uri = self._link(self._dell_oem(manager), _SERVICE_NAME)
+            if service_uri:
+                uris.append(service_uri)
+        if not uris:
+            uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uri.rstrip("/") for uri in uris))
+
+    @staticmethod
+    def _action_values(service, full_type, parameter):
+        """Return inline allowable values for one action parameter.
+
+        :param service: DelliDRACCardService resource body.
+        :param full_type: full ``#Type.Action`` action name.
+        :param parameter: Redfish action parameter name.
+        :return: list of allowable values advertised by the service.
+        """
+        actions = service.get("Actions") if isinstance(service, dict) else None
+        action = actions.get(full_type) if isinstance(actions, dict) else None
+        if not isinstance(action, dict):
+            return []
+        values = action.get(f"{parameter}@Redfish.AllowableValues") or []
+        return sorted(values) if isinstance(values, list) else []
+
+    def _rows_for(self, service_uri, do_async):
+        """Build discovered key-management rows for one service URI.
+
+        :param service_uri: candidate DelliDRACCardService URI.
+        :param do_async: issue the service query on the async path when True.
+        :return: list of discovered target rows.
+        """
+        service = self._get(service_uri, do_async)
+        if not service:
+            return []
+        targets = self._flatten_action_targets(service)
+        rows = []
+        for spec in _ACTION_SPECS.values():
+            target = targets.get(spec.full_type)
+            if not target:
+                continue
+            parameters = {}
+            mode_values = self._action_values(service, spec.full_type, "Mode")
+            if mode_values:
+                parameters["Mode"] = mode_values
+            rows.append({
+                "Resource": service_uri,
+                "Action": spec.selector,
+                "FullType": spec.full_type,
+                "Target": target,
+                "Description": spec.description,
+                "Parameters": parameters,
+            })
+        return rows
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Discover Dell card-service key-management targets.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DelliDRACCardService URI.
+        :return: list of discovered action rows.
+        """
+        uris = [resource_uri.rstrip("/")] if resource_uri else self._service_uris(
+            do_async
+        )
+        rows = []
+        for uri in dict.fromkeys(uris):
+            rows.extend(self._rows_for(uri, do_async))
+        return rows
+
+    @staticmethod
+    def _resolve_row(rows, action, resource_uri=None):
+        """Resolve one selected action row.
+
+        :param rows: discovered action rows.
+        :param action: selected action name.
+        :param resource_uri: optional DelliDRACCardService URI selector.
+        :return: matching row.
+        :raises InvalidArgument: when selection is absent or ambiguous.
+        """
+        matches = [row for row in rows if row["Action"] == action]
+        if resource_uri:
+            wanted = resource_uri.rstrip("/")
+            matches = [row for row in matches if row["Resource"].rstrip("/") == wanted]
+        if not matches:
+            raise InvalidArgument(f"Dell card key-management action not found: {action}")
+        if len(matches) > 1:
+            resources = [row["Resource"] for row in matches]
+            raise InvalidArgument(
+                "multiple Dell card key-management targets found; "
+                f"pass --resource-uri: {resources}"
+            )
+        return matches[0]
+
+    @staticmethod
+    def _payload_for(spec, mode):
+        """Build the selected key-management payload.
+
+        :param spec: selected action metadata.
+        :param mode: optional Mode argument for Rekey.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when arguments do not match the action.
+        """
+        clean_mode = (mode or "").strip()
+        if spec.needs_mode:
+            if not clean_mode:
+                raise InvalidArgument("--mode is required for --action rekey")
+            return {"Mode": clean_mode}
+        if clean_mode:
+            raise InvalidArgument("--mode is only valid with --action rekey")
+        return {}
+
+    def execute(self,
+                action: Optional[str] = None,
+                mode: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke Dell card-service key-management actions.
+
+        :param action: optional action selector; None lists discovered targets.
+        :param mode: ``Mode`` payload for ``--action rekey``.
+        :param resource_uri: optional DelliDRACCardService URI selector.
+        :param confirm: authorize a POST. Without this the action previews.
+        :param dry_run: force a preview even with ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish calls on the async path.
+        :return: CommandResult with discovered targets, preview, or POST result.
+        :raises InvalidArgument: when selection or payload arguments are invalid.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri=resource_uri)
+        if action is None:
+            if mode:
+                raise InvalidArgument("--mode is only valid with --action rekey")
+            return CommandResult({"key_management_targets": rows}, None, None, None)
+
+        spec = _ACTION_SPECS[action]
+        row = self._resolve_row(rows, action, resource_uri=resource_uri)
+        return self.invoke_action(
+            row["Resource"],
+            spec.action_name,
+            payload=self._payload_for(spec, mode),
+            full_action_type=spec.full_type,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -113,6 +113,7 @@ class ApiRequestType(Enum):
     EventSubmitTest = auto()
     HpeTestActions = auto()
     NvidiaDebugToken = auto()
+    DellCardKeyManagement = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()
     SubscriptionDelete = auto()

--- a/tests/test_dell_card_key_management_dualmode.py
+++ b/tests/test_dell_card_key_management_dualmode.py
@@ -1,0 +1,246 @@
+"""Dual-mode-style tests for Dell card-service key-management actions."""
+
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.oem.cmd_dell_card_key_management import DellCardKeyManagement
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+GENERIC_MANAGER_URI = "/redfish/v1/Managers/BMC"
+SERVICE_URI = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService"
+DISABLE_SEKM_TYPE = "#DelliDRACCardService.DisableSEKM"
+DISABLE_SEKM_TARGET = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/"
+    "Actions/DelliDRACCardService.DisableSEKM"
+)
+REKEY_TYPE = "#DelliDRACCardService.Rekey"
+REKEY_TARGET = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DelliDRACCardService/"
+    "Actions/DelliDRACCardService.Rekey"
+)
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-xr8620t",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(redfish_service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [
+        request
+        for request in redfish_service.requests
+        if request.method == "POST"
+    ]
+
+
+def _seed_card_service(redfish_service, include_action=True):
+    """Overlay a Dell card-service link and optional key-management action."""
+    manager = deepcopy(redfish_service._state(GENERIC_MANAGER_URI))
+    manager.setdefault("Links", {}).setdefault("Oem", {}).setdefault("Dell", {})[
+        "DelliDRACCardService"
+    ] = {"@odata.id": SERVICE_URI}
+
+    service = {
+        "@odata.id": SERVICE_URI,
+        "@odata.type": "#DelliDRACCardService.v1_0_0.DelliDRACCardService",
+        "Id": "DelliDRACCardService",
+        "Name": "Dell iDRAC Card Service",
+        "Actions": {},
+    }
+    if include_action:
+        service["Actions"][DISABLE_SEKM_TYPE] = {"target": DISABLE_SEKM_TARGET}
+
+    for path, body in (
+        (GENERIC_MANAGER_URI, manager),
+        (SERVICE_URI, service),
+    ):
+        redfish_service._overlay[path] = body
+        redfish_service._overlay[path.lower()] = body
+
+
+def test_dell_card_key_management_lists_corpus_targets(dell_corpus_mock):
+    """Listing discovers Dell corpus key-management action targets."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardKeyManagement,
+        "dell-card-key-management",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    targets = {row["Action"]: row for row in result.data["key_management_targets"]}
+    assert set(targets) == {
+        "disable-ilkm",
+        "disable-sekm",
+        "enable-ilkm",
+        "enable-sekm",
+        "rekey",
+        "transition-ilkm-to-sekm",
+    }
+    assert targets["disable-sekm"]["Target"] == DISABLE_SEKM_TARGET
+    assert targets["rekey"]["Target"] == REKEY_TARGET
+    assert targets["rekey"]["Parameters"] == {"Mode": ["SEKM", "iLKM"]}
+    assert _post_requests(service) == []
+
+
+def test_dell_card_key_management_previews_by_default(dell_corpus_mock):
+    """A selected key-management action resolves but does not POST by default."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardKeyManagement,
+        "dell-card-key-management",
+        action="disable-sekm",
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == DISABLE_SEKM_TYPE
+    assert result.data["target"] == DISABLE_SEKM_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(service) == []
+
+
+def test_dell_card_key_management_confirm_posts_rekey_payload(dell_corpus_mock):
+    """--confirm POSTs exactly one Dell card-service Rekey request."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardKeyManagement,
+        "dell-card-key-management",
+        action="rekey",
+        mode="SEKM",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == REKEY_TYPE
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == REKEY_TARGET.lower()
+    assert posts[0].json() == {"Mode": "SEKM"}
+
+
+def test_dell_card_key_management_rejects_invalid_rekey_mode(dell_corpus_mock):
+    """Inline Redfish metadata rejects unsupported Rekey Mode values."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellCardKeyManagement,
+        "dell-card-key-management",
+        action="rekey",
+        mode="BadMode",
+        confirm=True,
+    )
+
+    assert result.error == (
+        "invalid value for DelliDRACCardService.Rekey Mode: "
+        "BadMode; allowed: SEKM, iLKM"
+    )
+    assert result.data["validation_errors"] == [{
+        "parameter": "Mode",
+        "value": "BadMode",
+        "allowed": ["SEKM", "iLKM"],
+    }]
+    assert _post_requests(service) == []
+
+
+def test_dell_card_key_management_requires_mode_only_for_rekey(dell_corpus_mock):
+    """Mode is required for Rekey and rejected for other selectors."""
+    manager, service = dell_corpus_mock
+
+    with pytest.raises(InvalidArgument, match="--mode is required"):
+        manager.sync_invoke(
+            ApiRequestType.DellCardKeyManagement,
+            "dell-card-key-management",
+            action="rekey",
+            confirm=True,
+        )
+    with pytest.raises(InvalidArgument, match="only valid with --action rekey"):
+        manager.sync_invoke(
+            ApiRequestType.DellCardKeyManagement,
+            "dell-card-key-management",
+            action="enable-sekm",
+            mode="SEKM",
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_dell_card_key_management_missing_action_reports_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """A card-service resource without the selected action raises before POST."""
+    _seed_card_service(redfish_service, include_action=False)
+
+    with pytest.raises(InvalidArgument, match="action not found: disable-sekm"):
+        redfish_mock.sync_invoke(
+            ApiRequestType.DellCardKeyManagement,
+            "dell-card-key-management",
+            action="disable-sekm",
+            confirm=True,
+        )
+
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_card_key_management_exposes_policy_and_cli_entrypoint():
+    """The dell-card-key-management command is wired into policy and registry."""
+    assert classify(DISABLE_SEKM_TYPE).value == "destructive"
+    assert classify(REKEY_TYPE).value == "destructive"
+
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellCardKeyManagement][
+        "dell-card-key-management"
+    ] is DellCardKeyManagement
+
+    cmd_parser, cmd_name, cmd_help = DellCardKeyManagement.register_subcommand(
+        DellCardKeyManagement
+    )
+    help_text = cmd_parser.format_help()
+
+    assert "--action" in help_text
+    assert "--mode" in help_text
+    assert "--resource-uri" in help_text
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text
+    assert cmd_name == "dell-card-key-management"
+    assert "key-management" in cmd_help


### PR DESCRIPTION
## Summary
- add guarded `dell-card-key-management` support for Dell card-service key-management actions
- discover `DelliDRACCardService`, list available targets by default, and validate `Rekey` mode from Redfish metadata
- cover list, preview, confirm, validation, missing-action, registry, and policy paths with Dell XR8620t corpus tests

## Tests
- `git diff --check`
- Full test and lint suite pending in remote CI