### PR TITLE
Add Dell network attributes command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-network-attributes` | Read or stage Dell NetworkDeviceFunction `DellNetworkAttributes` Settings payloads; dry-run by default and `--confirm` applies. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -102,6 +102,7 @@ from .telemetry.cmd_exporter import *
 from .component_integrity.cmd_component_integrity import *
 from .component_integrity.cmd_spdm_measurements import *
 from .network.cmd_network_adapters import *
+from .network.cmd_dell_network_attributes import *
 from .network.cmd_nic_firmware import *
 from .ports.cmd_nvlink_ports import *
 from .actions.cmd_action_list import *

--- a/redfish_ctl/network/cmd_dell_network_attributes.py
+++ b/redfish_ctl/network/cmd_dell_network_attributes.py
@@ -1,0 +1,425 @@
+"""Read or stage Dell NetworkDeviceFunction network attributes.
+
+    redfish_ctl dell-network-attributes
+    redfish_ctl dell-network-attributes --target-id NIC.Slot.2-1-1 --from_spec nic.json
+    redfish_ctl dell-network-attributes --target-id NIC.Slot.2-1-1 --from_spec nic.json --confirm
+
+Dell exposes NIC partition attributes below each NetworkDeviceFunction as
+``Links.Oem.Dell.DellNetworkAttributes``. This command discovers those links,
+resolves their Redfish SettingsObject, and previews a PATCH by default.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..cmd_utils import from_json_spec
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import REDFISH_API, ApiRequestType, Singleton
+
+
+class DellNetworkAttributes(RedfishManagerBase,
+                            scm_type=ApiRequestType.DellNetworkAttributes,
+                            name="dell-network-attributes",
+                            metaclass=Singleton):
+    """Read or stage Dell NetworkDeviceFunction network attributes."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-network-attributes command."""
+        super(DellNetworkAttributes, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-network-attributes`` subcommand.
+
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--target-id",
+            required=False,
+            dest="target_id",
+            default=None,
+            help="NetworkDeviceFunction Id, DellNetworkAttributes URI, or Settings URI",
+        )
+        cmd_parser.add_argument(
+            "-s",
+            "--from_spec",
+            required=False,
+            dest="from_spec",
+            default=None,
+            metavar="file name",
+            help="JSON spec containing an Attributes object to PATCH",
+        )
+        cmd_parser.add_argument(
+            "--apply-time",
+            required=False,
+            dest="apply_time",
+            default=None,
+            help="optional @Redfish.SettingsApplyTime ApplyTime value",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="apply the PATCH; without it the command only previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without PATCHing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-network-attributes",
+            "read or stage Dell network device attributes",
+        )
+
+    @staticmethod
+    def _members(data):
+        """Return member ``@odata.id`` values from a Redfish collection.
+
+        :param data: parsed Redfish collection payload.
+        :return: list of member URI strings.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"]
+            for member in data.get("Members", [])
+            if isinstance(member, dict)
+            and isinstance(member.get("@odata.id"), str)
+        ]
+
+    @staticmethod
+    def _link(data, *path):
+        """Walk nested dict keys and return a linked ``@odata.id`` value.
+
+        :param data: parsed Redfish resource payload.
+        :param path: nested property names before the final link object.
+        :return: linked URI string, or None.
+        """
+        node = data
+        for key in path:
+            if not isinstance(node, dict):
+                return None
+            node = node.get(key)
+        if isinstance(node, dict) and isinstance(node.get("@odata.id"), str):
+            return node["@odata.id"]
+        return None
+
+    @staticmethod
+    def _id(uri, data):
+        """Return payload Id when available, otherwise the URI leaf.
+
+        :param uri: Redfish resource URI.
+        :param data: parsed Redfish resource payload.
+        :return: resource identifier string.
+        """
+        if isinstance(data, dict) and isinstance(data.get("Id"), str):
+            return data["Id"]
+        return uri.rstrip("/").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _controller_function_links(adapter):
+        """Return NetworkDeviceFunction links nested under adapter controllers.
+
+        :param adapter: parsed NetworkAdapter payload.
+        :return: list of NetworkDeviceFunction member URI strings.
+        """
+        uris = []
+        for controller in adapter.get("Controllers", []) if isinstance(adapter, dict) else []:
+            links = controller.get("Links") if isinstance(controller, dict) else {}
+            members = links.get("NetworkDeviceFunctions", []) if isinstance(links, dict) else []
+            for member in members:
+                if isinstance(member, dict) and isinstance(member.get("@odata.id"), str):
+                    uris.append(member["@odata.id"])
+        return uris
+
+    def _get(self, uri, do_async=False, do_expanded=False):
+        """Read a Redfish resource and return its parsed body.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :param do_expanded: request expanded output when supported by the caller.
+        :return: parsed resource payload.
+        :raises InvalidArgument: when the query fails.
+        """
+        result = self.base_query(uri, do_async=do_async, do_expanded=do_expanded)
+        if result.error:
+            raise InvalidArgument(f"failed to query {uri}: {result.error}")
+        return result.data or {}
+
+    def _function_uris(self, adapter_uri, adapter, do_async, do_expanded):
+        """Resolve NetworkDeviceFunction member URIs for one NetworkAdapter.
+
+        :param adapter_uri: NetworkAdapter URI.
+        :param adapter: parsed NetworkAdapter payload.
+        :param do_async: issue queries on the async path when True.
+        :param do_expanded: request expanded collection output when True.
+        :return: ordered unique function URI strings.
+        """
+        seen = set()
+        uris = []
+        collection_uri = self._link(adapter, "NetworkDeviceFunctions")
+        if collection_uri:
+            collection = self._get(collection_uri, do_async, do_expanded)
+            for uri in self._members(collection):
+                if uri not in seen:
+                    seen.add(uri)
+                    uris.append(uri)
+        for uri in self._controller_function_links(adapter):
+            if uri not in seen:
+                seen.add(uri)
+                uris.append(uri)
+        if not uris and adapter_uri:
+            fallback = f"{adapter_uri.rstrip('/')}/NetworkDeviceFunctions"
+            try:
+                collection = self._get(fallback, do_async, do_expanded)
+            except InvalidArgument:
+                return []
+            for uri in self._members(collection):
+                if uri not in seen:
+                    seen.add(uri)
+                    uris.append(uri)
+        return uris
+
+    def _discover(self, do_async=False, do_expanded=False):
+        """Discover DellNetworkAttributes targets from chassis adapter links.
+
+        :param do_async: issue queries on the async path when True.
+        :param do_expanded: request expanded collection output when True.
+        :return: list of target metadata rows.
+        """
+        rows = []
+        chassis = self._get(REDFISH_API.Chassis, do_async, do_expanded)
+        for chassis_uri in self._members(chassis):
+            try:
+                chassis_data = self._get(chassis_uri, do_async, do_expanded)
+            except InvalidArgument:
+                continue
+            adapters_uri = self._link(chassis_data, "NetworkAdapters")
+            if not adapters_uri:
+                continue
+            try:
+                adapters = self._get(adapters_uri, do_async, do_expanded)
+            except InvalidArgument:
+                continue
+            for adapter_uri in self._members(adapters):
+                try:
+                    adapter = self._get(adapter_uri, do_async, do_expanded)
+                except InvalidArgument:
+                    continue
+                adapter_id = self._id(adapter_uri, adapter)
+                for function_uri in self._function_uris(
+                        adapter_uri, adapter, do_async, do_expanded):
+                    try:
+                        function = self._get(function_uri, do_async, do_expanded)
+                    except InvalidArgument:
+                        continue
+                    attrs_uri = self._link(
+                        function, "Links", "Oem", "Dell", "DellNetworkAttributes"
+                    )
+                    if not attrs_uri:
+                        attrs_uri = self._link(
+                            function, "Oem", "Dell", "DellNetworkAttributes"
+                        )
+                    if not attrs_uri:
+                        continue
+                    try:
+                        attrs = self._get(attrs_uri, do_async, do_expanded)
+                    except InvalidArgument:
+                        continue
+                    settings_uri = self._link(
+                        attrs, "@Redfish.Settings", "SettingsObject"
+                    ) or f"{attrs_uri.rstrip('/')}/Settings"
+                    try:
+                        settings = self._get(settings_uri, do_async, do_expanded)
+                    except InvalidArgument:
+                        settings = {}
+                    current = attrs.get("Attributes", {})
+                    pending = settings.get("Attributes", {})
+                    redfish_settings = attrs.get("@Redfish.Settings", {})
+                    rows.append({
+                        "Chassis": chassis_uri.rsplit("/", 1)[-1],
+                        "Adapter": adapter_id,
+                        "Function": self._id(function_uri, function),
+                        "NetworkDeviceFunction": function_uri,
+                        "Attributes": attrs_uri,
+                        "Settings": settings_uri,
+                        "AttributeRegistry": attrs.get("AttributeRegistry"),
+                        "SupportedApplyTimes": redfish_settings.get(
+                            "SupportedApplyTimes", []
+                        ) if isinstance(redfish_settings, dict) else [],
+                        "AttributeCount": len(current) if isinstance(current, dict) else 0,
+                        "PendingAttributeCount": len(pending) if isinstance(pending, dict) else 0,
+                        "CurrentAttributes": current if isinstance(current, dict) else {},
+                        "PendingAttributes": pending if isinstance(pending, dict) else {},
+                    })
+        return rows
+
+    @staticmethod
+    def _matches(row, target_id):
+        """Return True when target_id identifies a discovered row.
+
+        :param row: discovered target metadata row.
+        :param target_id: function Id, NetworkDeviceFunction URI, attributes URI, or settings URI.
+        :return: whether the row matches.
+        """
+        if not target_id:
+            return False
+        wanted = str(target_id).lower()
+        candidates = (
+            row.get("Function"),
+            row.get("NetworkDeviceFunction"),
+            row.get("Attributes"),
+            row.get("Settings"),
+        )
+        return any(str(candidate).lower() == wanted for candidate in candidates if candidate)
+
+    def _target(self, target_id, do_async, do_expanded):
+        """Resolve a target row by id or URI.
+
+        :param target_id: function Id or relevant URI.
+        :param do_async: issue queries on the async path when True.
+        :param do_expanded: request expanded collection output when True.
+        :return: matching target row.
+        :raises InvalidArgument: when no matching row is found.
+        """
+        for row in self._discover(do_async, do_expanded):
+            if self._matches(row, target_id):
+                return row
+        raise InvalidArgument(f"No Dell network attributes target named {target_id}")
+
+    @staticmethod
+    def _payload(from_spec, target, apply_time=None):
+        """Load and validate an attribute PATCH payload.
+
+        :param from_spec: path to a JSON spec with an ``Attributes`` object.
+        :param target: resolved target row holding current attributes and apply times.
+        :param apply_time: optional SettingsApplyTime value to add.
+        :return: validated PATCH payload.
+        :raises InvalidArgument: when the payload is malformed or targets unknown attributes.
+        """
+        if not from_spec:
+            raise InvalidArgument("--from_spec is required when patching")
+        payload = from_json_spec(from_spec)
+        if not isinstance(payload, dict):
+            raise InvalidArgument("from_spec must contain a JSON object")
+        attrs = payload.get("Attributes")
+        if not isinstance(attrs, dict) or not attrs:
+            raise InvalidArgument("from_spec must contain a non-empty Attributes object")
+        current = target.get("CurrentAttributes", {})
+        unknown = sorted(set(attrs) - set(current)) if isinstance(current, dict) else []
+        if unknown:
+            raise InvalidArgument(
+                "unknown Dell network attribute(s) for "
+                f"{target['Function']}: {', '.join(unknown)}"
+            )
+        payload = dict(payload)
+        if apply_time:
+            supported = target.get("SupportedApplyTimes") or []
+            if supported and apply_time not in supported:
+                raise InvalidArgument(
+                    f"ApplyTime {apply_time!r} is not supported by {target['Function']}; "
+                    f"supported values: {', '.join(supported)}"
+                )
+            payload["@Redfish.SettingsApplyTime"] = {"ApplyTime": apply_time}
+        return payload
+
+    @staticmethod
+    def _public_target(row):
+        """Return target metadata without full attribute payloads.
+
+        :param row: discovered target row.
+        :return: compact target metadata for command output.
+        """
+        return {
+            key: value for key, value in row.items()
+            if key not in {"CurrentAttributes", "PendingAttributes"}
+        }
+
+    def execute(self,
+                target_id: Optional[str] = None,
+                from_spec: Optional[str] = None,
+                apply_time: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or apply Dell network attribute settings.
+
+        :param target_id: function Id or target URI. Omit to list targets.
+        :param from_spec: JSON spec with ``Attributes`` to PATCH.
+        :param apply_time: optional Redfish Settings ApplyTime value.
+        :param confirm: actually apply the PATCH when True.
+        :param dry_run: force preview mode even when confirm is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying Redfish calls on the async path.
+        :param do_expanded: request expanded collection output when supported.
+        :return: CommandResult with target list, preview, or PATCH outcome.
+        """
+        if not target_id:
+            rows = [self._public_target(row)
+                    for row in self._discover(do_async, do_expanded)]
+            return CommandResult(rows, None, None, None)
+
+        target = self._target(target_id, do_async, do_expanded)
+        public_target = self._public_target(target)
+        if not from_spec:
+            return CommandResult({
+                **public_target,
+                "CurrentAttributes": target.get("CurrentAttributes", {}),
+                "PendingAttributes": target.get("PendingAttributes", {}),
+                "read_only": True,
+            }, None, None, None)
+
+        payload = self._payload(from_spec, target, apply_time)
+        if dry_run or not confirm:
+            return CommandResult({
+                **public_target,
+                "dry_run": True,
+                "requires_confirm": True,
+                "blocked": "Dell network attribute PATCH requires --confirm",
+                "payload": payload,
+            }, None, None, None)
+
+        result, status = self.base_patch(
+            target["Settings"],
+            payload=payload,
+            do_async=do_async,
+        )
+        applied = {
+            "target": target["Settings"],
+            "status": str(status),
+            "error": result.error,
+        }
+        if result.error is not None:
+            return CommandResult({
+                **public_target,
+                "payload": payload,
+                "applied": applied,
+                "observed": None,
+            }, None, None, result.error)
+
+        updated = self._get(target["Settings"], do_async, do_expanded)
+        observed = {}
+        pending = updated.get("Attributes", {}) if isinstance(updated, dict) else {}
+        for attr_name in payload["Attributes"]:
+            observed[attr_name] = pending.get(attr_name)
+        return CommandResult({
+            **public_target,
+            "payload": payload,
+            "applied": applied,
+            "observed": observed,
+        }, None, None, None)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -106,6 +106,7 @@ class ApiRequestType(Enum):
     ComponentIntegrity = auto()
     SpdmMeasurements = auto()
     NetworkAdapters = auto()
+    DellNetworkAttributes = auto()
     NicFirmware = auto()
     NvLinkPorts = auto()
     Exporter = auto()

--- a/tests/test_dell_network_attributes_dualmode.py
+++ b/tests/test_dell_network_attributes_dualmode.py
@@ -1,0 +1,170 @@
+"""Dual-mode tests for Dell NetworkDeviceFunction attribute settings."""
+import json
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-xr8620t",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _patch_requests(service):
+    """Return PATCH requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded PATCH requests.
+    """
+    return [request for request in service.requests if request.method == "PATCH"]
+
+
+def test_dell_network_attributes_lists_corpus_targets_without_patch(dell_corpus_mock):
+    """Listing discovers DellNetworkAttributes settings targets from corpus links."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellNetworkAttributes,
+        "dell-network-attributes",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert len(result.data) == 8
+    row = {item["Function"]: item for item in result.data}["NIC.Slot.2-1-1"]
+    assert row["Adapter"] == "NIC.Slot.2"
+    assert row["Attributes"] == (
+        "/redfish/v1/Chassis/System.Embedded.1/NetworkAdapters/NIC.Slot.2/"
+        "NetworkDeviceFunctions/NIC.Slot.2-1-1/Oem/Dell/"
+        "DellNetworkAttributes/NIC.Slot.2-1-1"
+    )
+    assert row["Settings"] == f"{row['Attributes']}/Settings"
+    assert row["AttributeRegistry"] == "NetworkAttributeRegistry_NIC.Slot.2-1-1"
+    assert row["AttributeCount"] > 50
+    assert "Immediate" in row["SupportedApplyTimes"]
+    assert _patch_requests(service) == []
+
+
+def test_dell_network_attributes_reads_one_target_attributes(dell_corpus_mock):
+    """A target-id without a spec returns current and pending attributes."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellNetworkAttributes,
+        "dell-network-attributes",
+        target_id="NIC.Slot.2-1-1",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["read_only"] is True
+    assert result.data["CurrentAttributes"]["VLanId"] == 0
+    assert result.data["CurrentAttributes"]["LegacyBootProto"] == "PXE"
+    assert result.data["PendingAttributes"] == {}
+    assert _patch_requests(service) == []
+
+
+def test_dell_network_attributes_dry_run_previews_settings_patch(
+    dell_corpus_mock, tmp_path
+):
+    """A spec previews by default and does not PATCH the settings resource."""
+    manager, service = dell_corpus_mock
+    spec = tmp_path / "dell-network-attributes.json"
+    spec.write_text(json.dumps({"Attributes": {"VLanId": 101}}))
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellNetworkAttributes,
+        "dell-network-attributes",
+        target_id="NIC.Slot.2-1-1",
+        from_spec=str(spec),
+        apply_time="OnReset",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["requires_confirm"] is True
+    assert result.data["payload"] == {
+        "Attributes": {"VLanId": 101},
+        "@Redfish.SettingsApplyTime": {"ApplyTime": "OnReset"},
+    }
+    assert _patch_requests(service) == []
+
+
+def test_dell_network_attributes_confirm_patches_settings_target(
+    dell_corpus_mock, tmp_path
+):
+    """--confirm PATCHes only the discovered DellNetworkAttributes Settings URI."""
+    manager, service = dell_corpus_mock
+    spec = tmp_path / "dell-network-attributes.json"
+    spec.write_text(json.dumps({"Attributes": {"VLanId": 101}}))
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellNetworkAttributes,
+        "dell-network-attributes",
+        target_id="NIC.Slot.2-1-1",
+        from_spec=str(spec),
+        confirm=True,
+    )
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path.lower() == result.data["Settings"].lower()
+    assert patches[0].json() == {"Attributes": {"VLanId": 101}}
+    assert result.error is None
+    assert result.data["applied"]["target"] == result.data["Settings"]
+    assert result.data["applied"]["error"] is None
+    assert result.data["observed"] == {"VLanId": 101}
+
+
+def test_dell_network_attributes_rejects_unknown_attribute_before_patch(
+    dell_corpus_mock, tmp_path
+):
+    """Unknown attributes are rejected before any PATCH is sent."""
+    manager, service = dell_corpus_mock
+    spec = tmp_path / "bad-dell-network-attributes.json"
+    spec.write_text(json.dumps({"Attributes": {"NoSuchNetworkAttribute": "Enabled"}}))
+
+    with pytest.raises(InvalidArgument, match="unknown Dell network attribute"):
+        manager.sync_invoke(
+            ApiRequestType.DellNetworkAttributes,
+            "dell-network-attributes",
+            target_id="NIC.Slot.2-1-1",
+            from_spec=str(spec),
+            confirm=True,
+        )
+
+    assert _patch_requests(service) == []


### PR DESCRIPTION
## Summary

- Add `dell-network-attributes` to discover Dell NetworkDeviceFunction `DellNetworkAttributes` Settings targets from chassis network adapters.
- Support target listing, read-only attribute inspection, dry-run PATCH previews, and guarded `--confirm` PATCHes with pending-setting readback.
- Add Dell XR8620t corpus-backed coverage for listing, reading, dry-run preview, confirmed PATCH, and unknown-attribute rejection.

## Validation

- `conda run -n idrac_ctl python -m pytest -q tests/test_dell_network_attributes_dualmode.py`
  - `5 passed in 1.68s`
- `conda run -n idrac_ctl ruff check redfish_ctl/network/cmd_dell_network_attributes.py redfish_ctl/redfish_manager_shared.py redfish_ctl/__init__.py tests/test_dell_network_attributes_dualmode.py`
  - `All checks passed!`
- `conda run -n idrac_ctl python -m pytest -q`
  - Fails in `tests/test_mock_bmc_get_hammer.py::test_get_hammer_200_threads_keeps_bodies_correct` with a timeout connecting to `127.0.0.1`; an isolated rerun of that existing test fails the same way.
