### PR TITLE
Clarify live write safety wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ redfish_ctl --help             # every subcommand
 ```
 
 Reads are safe. Commands that change hardware are labeled **Guarded** or **Write** in the
-[command reference](docs/commands.md#registered-commands): Guarded commands require an explicit
-intent flag such as `--confirm`; Write commands can mutate immediately and require explicit target
-approval before live use. Preview with `--show` or `--dry_run` when the command supports it, then
+[command reference](docs/commands.md#registered-commands). Both labels mean live use requires an
+approved target and an explicit intent step, such as `--confirm`, `--commit`, or another
+command-specific apply flag. Preview with `--show` or `--dry_run` when the command supports it, then
 see [Mutating Commands](#mutating-commands) below before applying anything.
 
 > **Upgrading from `idrac_ctl`?** Install `redfish_ctl` — the `idrac_ctl` command, `import idrac_ctl`,

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -241,9 +241,9 @@ covered by the Dell, Supermicro, HPE, or generic fixture corpora listed in [Vend
 
 ## Mutating Workflow Pattern
 
-Commands labeled **Guarded** block or preview writes by default and require an explicit intent flag,
-usually `--confirm`. Commands labeled **Write** can mutate as soon as they are invoked; do not run
-them live without explicit target approval, and use `--show` or `--dry_run` first when available.
+Commands labeled **Guarded** or **Write** are hardware-changing paths. Run them live only on an
+approved target and only with the command's explicit intent step, such as `--confirm`, `--commit`, or
+another action-specific apply flag. Use `--show` or `--dry_run` first when available.
 
 Before running either kind of write, use the same four phases:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,7 +32,8 @@ Platform/vendor labels:
 
 Run **Read** examples from the repository root with `bash examples/<script>`. For **Guarded** and
 **Write** examples, inspect the script first, confirm each live step, and run only on an approved
-target.
+target. Hardware-changing steps must use the script's explicit intent flag, such as `--confirm`,
+`--commit`, `--dry_run`/apply, or the action-specific flag documented for that command.
 
 | Example | Platform/vendor | Safety | Purpose |
 |---|---|---|---|


### PR DESCRIPTION
Summary:
- remove wording that implied Write commands could run live without an explicit intent step
- align the README, command reference, and examples index around approved targets and command-specific apply flags
- keep preview guidance for --show and --dry_run where supported

Validation:
- git diff --check -- README.md docs/commands.md examples/README.md
- not run: docs-only wording change; repository gates run in CI