### PR TITLE
Reject encoded traversal in raw GET paths

### DIFF
--- a/redfish_ctl/cmd_get.py
+++ b/redfish_ctl/cmd_get.py
@@ -5,12 +5,23 @@
 """
 from abc import abstractmethod
 from typing import Optional
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import unquote, urlsplit, urlunsplit
 
 from .cmd_exceptions import InvalidArgument
 from .redfish_manager_base import RedfishManagerBase
 from .redfish_manager_shared import ApiRequestType, Singleton
 from .redfish_manager import CommandResult
+
+
+def _decode_path_for_validation(path: str) -> str:
+    """Decode path escapes enough to catch encoded traversal controls."""
+    decoded = path
+    for _ in range(3):
+        next_decoded = unquote(decoded)
+        if next_decoded == decoded:
+            return decoded
+        decoded = next_decoded
+    return decoded
 
 
 def _normalize_redfish_uri(uri: str) -> str:
@@ -37,7 +48,11 @@ def _normalize_redfish_uri(uri: str) -> str:
     if path != "/redfish/v1" and not path.startswith("/redfish/v1/"):
         raise InvalidArgument("get URI must start with /redfish/v1")
 
-    for segment in path.split("/"):
+    decoded_path = _decode_path_for_validation(path)
+    if "\\" in decoded_path:
+        raise InvalidArgument("get URI must use forward slashes")
+
+    for segment in decoded_path.split("/"):
         if segment in {".", ".."}:
             raise InvalidArgument("get URI must not contain path traversal segments")
 

--- a/redfish_ctl/cmd_get.py
+++ b/redfish_ctl/cmd_get.py
@@ -14,7 +14,11 @@ from .redfish_manager import CommandResult
 
 
 def _decode_path_for_validation(path: str) -> str:
-    """Decode path escapes enough to catch encoded traversal controls."""
+    """Decode path escapes enough to catch encoded traversal controls.
+
+    :param path: parsed Redfish resource path.
+    :return: decoded path used only for validation.
+    """
     decoded = path
     for _ in range(3):
         next_decoded = unquote(decoded)

--- a/tests/test_query_idrac_dualmode.py
+++ b/tests/test_query_idrac_dualmode.py
@@ -101,10 +101,14 @@ def test_raw_get_preserves_safe_query_string(redfish_mock, redfish_service):
         ("https://example.invalid/redfish/v1/Managers", "not absolute URLs"),
         ("//example.invalid/redfish/v1/Managers", "not absolute URLs"),
         ("/redfish/v1/../Managers", "path traversal"),
+        ("/redfish/v1/%2e%2e/Managers", "path traversal"),
+        ("/redfish/v1/%252e%252e/Managers", "path traversal"),
+        ("/redfish/v1/Managers%2f..%2fSystems", "path traversal"),
         ("/redfish/v1/Managers#top", "must not include a fragment"),
         ("/api/v1/Managers", "must start with /redfish/v1"),
         ("redfish/v1/Managers", "must start with /redfish/v1"),
         (r"/redfish/v1\\Managers", "forward slashes"),
+        ("/redfish/v1/Managers%5cSystem", "forward slashes"),
     ],
 )
 def test_raw_get_rejects_non_resource_paths(redfish_api, uri, message):


### PR DESCRIPTION
## Summary
- Decode escaped raw GET path components before traversal validation.
- Reject encoded and double-encoded dot segments, encoded slash traversal, and encoded backslashes.

## Validation
- git diff --check
- git diff --cached --check
- GitHub Actions matrix pending after PR creation.