### PR TITLE
Add Dell RAID patrol-read command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-raid-patrol-read` | Start or stop Dell RAID patrol read; previews unless `--confirm` is given. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -18,6 +18,7 @@ from .compute.cmd_compute_setting import *
 
 from .redfish_manager_shared import *
 from .raid.cmd_raid_service import *
+from .raid.cmd_raid_patrol_read import *
 #
 # bios commands
 from .bios.cmd_bios import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -8,8 +8,8 @@ dry-run unless ``--confirm`` is given, or additionally needs an explicit
 
 Fail-safe by construction: an action not in the table is treated as DESTRUCTIVE,
 so a newly exposed (unclassified) action can never POST without an explicit
-confirm. This module is product-neutral — it names standard DMTF + NVIDIA OEM
-action types only and imports nothing from the Redfish manager layer.
+confirm. This module is product-neutral — it names standard DMTF and vendor OEM
+action types and imports nothing from the Redfish manager layer.
 
 Author Mus spyroot@gmail.com
 """
@@ -60,6 +60,8 @@ ACTION_POLICY = {
     "#NvidiaWorkloadPower.DisableProfiles": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.GenerateToken": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.DisableToken": Destructiveness.REVERSIBLE,
+    "#DellRaidService.StartPatrolRead": Destructiveness.REVERSIBLE,
+    "#DellRaidService.StopPatrolRead": Destructiveness.REVERSIBLE,
 
     # destructive: service disruption / config rewrite — dry-run unless --confirm
     "#ComputerSystem.Reset": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/raid/cmd_raid_patrol_read.py
+++ b/redfish_ctl/raid/cmd_raid_patrol_read.py
@@ -1,0 +1,151 @@
+"""Preview or run Dell RAID patrol-read actions.
+
+    redfish_ctl dell-raid-patrol-read
+    redfish_ctl dell-raid-patrol-read --action start --confirm
+    redfish_ctl dell-raid-patrol-read --action stop --confirm
+
+The command resolves the advertised ``#DellRaidService.StartPatrolRead`` and
+``#DellRaidService.StopPatrolRead`` targets from DellRaidService. It previews by
+default and only POSTs when ``--confirm`` is supplied.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_PATROL_ACTIONS = {
+    "start": "#DellRaidService.StartPatrolRead",
+    "stop": "#DellRaidService.StopPatrolRead",
+}
+
+
+class DellRaidPatrolRead(RedfishManagerBase,
+                         scm_type=ApiRequestType.DellRaidPatrolRead,
+                         name="dell-raid-patrol-read",
+                         metaclass=Singleton):
+    """Preview or run Dell RAID patrol-read start/stop actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-raid-patrol-read command."""
+        super(DellRaidPatrolRead, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-raid-patrol-read`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=tuple(_PATROL_ACTIONS),
+            default=None,
+            help="patrol-read action to preview or run",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the selected patrol-read POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-raid-patrol-read",
+            "command start or stop Dell RAID patrol read",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    def _dell_raid_service_uri(self, do_async):
+        """Resolve DellRaidService from the system OEM link or standard Dell path.
+
+        :param do_async: issue the system query over the async Redfish path.
+        :return: the DellRaidService URI to inspect for advertised actions.
+        """
+        try:
+            system_uri = self.idrac_manage_servers
+        except Exception:
+            system_uri = ""
+        system_uri = system_uri or "/redfish/v1/Systems/System.Embedded.1"
+        try:
+            system = self.base_query(system_uri, do_async=do_async).data or {}
+        except Exception:
+            system = {}
+        dell = ((system.get("Oem") or {}).get("Dell") or {})
+        return self._link(dell, "DellRaidService") or (
+            f"{system_uri.rstrip('/')}/Oem/Dell/DellRaidService"
+        )
+
+    def execute(self,
+                action: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Resolve and optionally invoke Dell RAID patrol-read actions.
+
+        :param action: ``start`` or ``stop``; when omitted, list advertised targets.
+        :param confirm: authorize the selected patrol-read POST to actually fire.
+        :param dry_run: resolve the target and show it without POSTing;
+            overrides ``confirm``.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with advertised targets, preview, or execution result.
+        """
+        service_uri = self._dell_raid_service_uri(do_async)
+        if not action:
+            service = self.base_query(service_uri, do_async=do_async).data or {}
+            actions = service.get("Actions") or {}
+            targets = {
+                name: (actions.get(full_type) or {}).get("target")
+                for name, full_type in _PATROL_ACTIONS.items()
+                if (actions.get(full_type) or {}).get("target")
+            }
+            return CommandResult(
+                {
+                    "service": service_uri,
+                    "actions": targets,
+                    "available": sorted(actions),
+                },
+                None,
+                None,
+                None,
+            )
+
+        full_type = _PATROL_ACTIONS[action]
+        return self.invoke_action(
+            service_uri,
+            full_type.rsplit(".", 1)[-1],
+            payload={},
+            full_action_type=full_type,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -63,6 +63,7 @@ class ApiRequestType(Enum):
     SystemQuery = auto()
     VirtualDiskQuery = auto()
     RaidServiceQuery = auto()
+    DellRaidPatrolRead = auto()
     StorageQuery = auto()
     Tasks = auto()
     GetTask = auto()

--- a/tests/test_dell_raid_patrol_read_dualmode.py
+++ b/tests/test_dell_raid_patrol_read_dualmode.py
@@ -237,7 +237,7 @@ def test_dell_raid_patrol_read_missing_action_reports_available(
     assert "#DellRaidService.StopPatrolRead" not in result.data["available"]
     assert result.error == (
         "action '#DellRaidService.StopPatrolRead' not found on "
-        RAID_SERVICE
+        + RAID_SERVICE
     )
     assert _post_requests(requests) == []
 

--- a/tests/test_dell_raid_patrol_read_dualmode.py
+++ b/tests/test_dell_raid_patrol_read_dualmode.py
@@ -1,0 +1,264 @@
+"""Dual-mode-style coverage for DellRaidService patrol-read actions."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.raid.cmd_raid_patrol_read import DellRaidPatrolRead
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+RAID_SERVICE = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+START_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.StartPatrolRead"
+STOP_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.StopPatrolRead"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+def _corpus_body(path):
+    """Return one Dell corpus fixture body as JSON.
+
+    :param path: Redfish resource path to read from the extracted corpus.
+    :return: parsed fixture payload.
+    """
+    fixture = _fixture_for_path(path)
+    if fixture is None:
+        raise AssertionError(f"missing Dell fixture for {path}")
+    return json.loads(fixture.read_text())
+
+
+@pytest.fixture
+def dell_raid_manager_factory():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: factory producing a manager and recorded requests list.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    started = []
+
+    def factory(service_body=None):
+        requests = []
+
+        def get_cb(request, context):
+            requests.append(request)
+            if request.path.lower() == RAID_SERVICE.lower() and service_body is not None:
+                context.status_code = 200
+                return json.dumps(service_body)
+            fixture = _fixture_for_path(request.path)
+            if fixture is None:
+                context.status_code = 404
+                return json.dumps({"error": f"no fixture for {request.path}"})
+            context.status_code = 200
+            return fixture.read_text()
+
+        def post_cb(request, context):
+            requests.append(request)
+            context.status_code = 202
+            context.headers["Location"] = "/redfish/v1/TaskService/Tasks/raid-patrol-1"
+            return json.dumps({
+                "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/raid-patrol-1"}
+            })
+
+        mocker = requests_mock.Mocker()
+        mocker.start()
+        started.append(mocker)
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-raid",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        return manager, requests
+
+    yield factory
+
+    for mocker in reversed(started):
+        mocker.stop()
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_raid_patrol_read_lists_targets_without_posting(dell_raid_manager_factory):
+    """With no action, the command lists patrol-read targets and never POSTs."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidPatrolRead,
+        "dell-raid-patrol-read",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["service"] == RAID_SERVICE
+    assert result.data["actions"] == {
+        "start": START_TARGET,
+        "stop": STOP_TARGET,
+    }
+    assert "#DellRaidService.StartPatrolRead" in result.data["available"]
+    assert "#DellRaidService.StopPatrolRead" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_patrol_read_previews_start_by_default(dell_raid_manager_factory):
+    """A selected patrol-read action previews by default and does not POST."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidPatrolRead,
+        "dell-raid-patrol-read",
+        action="start",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.StartPatrolRead",
+        "target": START_TARGET,
+        "payload": {},
+        "level": "reversible",
+        "blocked": None,
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_patrol_read_confirm_posts_start(dell_raid_manager_factory):
+    """--confirm POSTs StartPatrolRead to the corpus-advertised target."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidPatrolRead,
+        "dell-raid-patrol-read",
+        action="start",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.StartPatrolRead"
+    assert result.data["target"] == START_TARGET
+    assert result.data["level"] == "reversible"
+    assert result.data["task_id"] == "raid-patrol-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == START_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_raid_patrol_read_confirm_posts_stop(dell_raid_manager_factory):
+    """--confirm POSTs StopPatrolRead to the corpus-advertised target."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidPatrolRead,
+        "dell-raid-patrol-read",
+        action="stop",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.StopPatrolRead"
+    assert result.data["target"] == STOP_TARGET
+    assert result.data["level"] == "reversible"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == STOP_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_raid_patrol_read_dry_run_overrides_confirm(dell_raid_manager_factory):
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidPatrolRead,
+        "dell-raid-patrol-read",
+        action="stop",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == STOP_TARGET
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_patrol_read_missing_action_reports_available(
+    dell_raid_manager_factory,
+):
+    """A DellRaidService without StopPatrolRead reports the missing action."""
+    service_body = _corpus_body(RAID_SERVICE)
+    service_body["Actions"] = dict(service_body["Actions"])
+    service_body["Actions"].pop("#DellRaidService.StopPatrolRead")
+    manager, requests = dell_raid_manager_factory(service_body=service_body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidPatrolRead,
+        "dell-raid-patrol-read",
+        action="stop",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["action"] == "#DellRaidService.StopPatrolRead"
+    assert "#DellRaidService.StartPatrolRead" in result.data["available"]
+    assert "#DellRaidService.StopPatrolRead" not in result.data["available"]
+    assert result.error == (
+        "action '#DellRaidService.StopPatrolRead' not found on "
+        RAID_SERVICE
+    )
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_patrol_read_policy_and_registry():
+    """Patrol-read actions are classified and the command is registered."""
+    assert classify("#DellRaidService.StartPatrolRead") is Destructiveness.REVERSIBLE
+    assert classify("#DellRaidService.StopPatrolRead") is Destructiveness.REVERSIBLE
+
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellRaidPatrolRead]["dell-raid-patrol-read"] is (
+        DellRaidPatrolRead
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellRaidPatrolRead.register_subcommand(
+        DellRaidPatrolRead
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-raid-patrol-read"
+    assert "patrol" in cmd_help
+    assert "--action" in help_text
+    assert "--confirm" in help_text
+    assert "--dry_run" in help_text


### PR DESCRIPTION
## Summary
- Add `dell-raid-patrol-read` for the DellRaidService StartPatrolRead and StopPatrolRead actions.
- Resolve the advertised DellRaidService target and preview by default unless `--confirm` is supplied.
- Add Dell XR8620t corpus-backed coverage plus command registration, policy, and docs.

## Validation
- `git diff --check`
- GitHub Actions pending