### PR TITLE
Add Dell RAID config action command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-raid-config-actions` | Set selected DellRaidService virtual-disk boot and RAID asset-name values; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -18,6 +18,7 @@ from .compute.cmd_compute_setting import *
 
 from .redfish_manager_shared import *
 from .raid.cmd_raid_service import *
+from .raid.cmd_dell_raid_config_actions import *
 #
 # bios commands
 from .bios.cmd_bios import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -76,6 +76,8 @@ ACTION_POLICY = {
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
+    "#DellRaidService.SetAssetName": Destructiveness.DESTRUCTIVE,
+    "#DellRaidService.SetBootVD": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/raid/cmd_dell_raid_config_actions.py
+++ b/redfish_ctl/raid/cmd_dell_raid_config_actions.py
@@ -107,20 +107,34 @@ class DellRaidConfigActions(RedfishManagerBase,
 
     @staticmethod
     def _link(data, key):
-        """Return a Redfish link target from a ``{key: {@odata.id}}`` property."""
+        """Return a Redfish link target from a linked property.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
     @staticmethod
     def _dell_links(resource):
-        """Return ``Links.Oem.Dell`` from a Redfish resource."""
+        """Return ``Links.Oem.Dell`` from a Redfish resource.
+
+        :param resource: Redfish resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
         links = resource.get("Links") if isinstance(resource, dict) else None
         oem = links.get("Oem") if isinstance(links, dict) else None
         dell = oem.get("Dell") if isinstance(oem, dict) else None
         return dell if isinstance(dell, dict) else {}
 
     def _get(self, uri, do_async):
-        """GET a Redfish resource body, returning an empty dict on read failure."""
+        """GET a Redfish resource body, tolerating optional resource gaps.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict on read failure.
+        """
         try:
             data = self.base_query(uri, do_async=do_async).data or {}
         except Exception:
@@ -128,7 +142,11 @@ class DellRaidConfigActions(RedfishManagerBase,
         return data if isinstance(data, dict) else {}
 
     def _raid_service_uri(self, do_async):
-        """Resolve DellRaidService from the selected ComputerSystem OEM links."""
+        """Resolve DellRaidService from the selected ComputerSystem OEM links.
+
+        :param do_async: issue the query on the async path when True.
+        :return: DellRaidService URI.
+        """
         system_uri = self.idrac_manage_servers
         system = self._get(system_uri, do_async)
         linked = self._link(self._dell_links(system), "DellRaidService")
@@ -138,7 +156,11 @@ class DellRaidConfigActions(RedfishManagerBase,
         return f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellRaidService"
 
     def _discover_rows(self, do_async):
-        """Discover the configured DellRaidService actions."""
+        """Discover the configured DellRaidService actions.
+
+        :param do_async: issue underlying Redfish queries on the async path when True.
+        :return: tuple of (DellRaidService URI, action metadata, action rows).
+        """
         service_uri = self._raid_service_uri(do_async)
         service = self._get(service_uri, do_async)
         actions = self.discover_redfish_actions(self, service)
@@ -160,7 +182,13 @@ class DellRaidConfigActions(RedfishManagerBase,
 
     @staticmethod
     def _payload(spec, target_fqdd, asset_name):
-        """Build and validate the payload for one selected action."""
+        """Build and validate the payload for one selected action.
+
+        :param spec: DellRaidService action selector metadata.
+        :param target_fqdd: TargetFQDD payload value for virtual disk actions.
+        :param asset_name: AssetName payload value for enclosure metadata actions.
+        :return: payload dict accepted by the selected action.
+        """
         values = {
             "AssetName": asset_name,
             "TargetFQDD": target_fqdd,
@@ -188,7 +216,19 @@ class DellRaidConfigActions(RedfishManagerBase,
                 verbose: Optional[bool] = False,
                 do_async: Optional[bool] = False,
                 **kwargs) -> CommandResult:
-        """List, preview, or run selected DellRaidService configuration actions."""
+        """List, preview, or run selected DellRaidService configuration actions.
+
+        :param action: selector from ``_ACTION_SPECS``; omit to list targets.
+        :param target_fqdd: TargetFQDD payload value for ``set-boot-vd``.
+        :param asset_name: AssetName payload value for ``set-asset-name``.
+        :param confirm: send the selected POST when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
         service_uri, actions, rows = self._discover_rows(bool(do_async))
         if action is None:
             return CommandResult(rows, actions, None, None)

--- a/redfish_ctl/raid/cmd_dell_raid_config_actions.py
+++ b/redfish_ctl/raid/cmd_dell_raid_config_actions.py
@@ -1,0 +1,220 @@
+"""Preview or run selected DellRaidService configuration actions.
+
+    redfish_ctl dell-raid-config-actions
+    redfish_ctl dell-raid-config-actions \
+        --action set-boot-vd --target-fqdd Disk.Virtual.0 --confirm
+    redfish_ctl dell-raid-config-actions \
+        --action set-asset-name --asset-name RackA-Drawer2 --confirm
+
+The command resolves action targets from the DellRaidService ``Actions`` block
+and previews by default. Selected actions change storage configuration metadata
+and only POST when ``--confirm`` is supplied.
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+
+@dataclass(frozen=True)
+class _DellRaidConfigActionSpec:
+    selector: str
+    full_type: str
+    action_name: str
+    description: str
+    required: tuple[str, ...]
+
+
+_ACTION_SPECS = {
+    "set-asset-name": _DellRaidConfigActionSpec(
+        selector="set-asset-name",
+        full_type="#DellRaidService.SetAssetName",
+        action_name="SetAssetName",
+        description="set the Dell RAID enclosure asset name",
+        required=("AssetName",),
+    ),
+    "set-boot-vd": _DellRaidConfigActionSpec(
+        selector="set-boot-vd",
+        full_type="#DellRaidService.SetBootVD",
+        action_name="SetBootVD",
+        description="set a virtual disk as the boot virtual disk",
+        required=("TargetFQDD",),
+    ),
+}
+
+
+class DellRaidConfigActions(RedfishManagerBase,
+                            scm_type=ApiRequestType.DellRaidConfigActions,
+                            name="dell-raid-config-actions",
+                            metaclass=Singleton):
+    """Preview or run selected DellRaidService configuration actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-raid-config-actions command."""
+        super(DellRaidConfigActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-raid-config-actions`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="Dell RAID configuration action to preview or run",
+        )
+        cmd_parser.add_argument(
+            "--target-fqdd",
+            dest="target_fqdd",
+            default=None,
+            help="TargetFQDD payload value for virtual-disk actions",
+        )
+        cmd_parser.add_argument(
+            "--asset-name",
+            dest="asset_name",
+            default=None,
+            help="AssetName payload value for set-asset-name",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the selected POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-raid-config-actions",
+            "command selected Dell RAID configuration actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property."""
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_links(resource):
+        """Return ``Links.Oem.Dell`` from a Redfish resource."""
+        links = resource.get("Links") if isinstance(resource, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, returning an empty dict on read failure."""
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _raid_service_uri(self, do_async):
+        """Resolve DellRaidService from the selected ComputerSystem OEM links."""
+        system_uri = self.idrac_manage_servers
+        system = self._get(system_uri, do_async)
+        linked = self._link(self._dell_links(system), "DellRaidService")
+        if linked:
+            return linked
+        system_id = system_uri.rstrip("/").rsplit("/", 1)[-1]
+        return f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellRaidService"
+
+    def _discover_rows(self, do_async):
+        """Discover the configured DellRaidService actions."""
+        service_uri = self._raid_service_uri(do_async)
+        service = self._get(service_uri, do_async)
+        actions = self.discover_redfish_actions(self, service)
+        targets = self._flatten_action_targets(service)
+        rows = []
+        for spec in _ACTION_SPECS.values():
+            target = targets.get(spec.full_type)
+            if not target:
+                continue
+            rows.append({
+                "Action": spec.selector,
+                "FullType": spec.full_type,
+                "Resource": service_uri,
+                "Target": target,
+                "Description": spec.description,
+                "RequiredPayload": list(spec.required),
+            })
+        return service_uri, actions, rows
+
+    @staticmethod
+    def _payload(spec, target_fqdd, asset_name):
+        """Build and validate the payload for one selected action."""
+        values = {
+            "AssetName": asset_name,
+            "TargetFQDD": target_fqdd,
+        }
+        payload = {
+            key: values[key]
+            for key in spec.required
+            if values.get(key) is not None
+        }
+        missing = [key for key in spec.required if key not in payload]
+        if missing:
+            raise InvalidArgument(
+                f"{spec.selector} requires: {', '.join(missing)}"
+            )
+        return payload
+
+    def execute(self,
+                action: Optional[str] = None,
+                target_fqdd: Optional[str] = None,
+                asset_name: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or run selected DellRaidService configuration actions."""
+        service_uri, actions, rows = self._discover_rows(bool(do_async))
+        if action is None:
+            return CommandResult(rows, actions, None, None)
+
+        spec = _ACTION_SPECS[action]
+        row = next((item for item in rows if item["Action"] == action), None)
+        if row is None:
+            return CommandResult(
+                {
+                    "raid_service": service_uri,
+                    "action": spec.full_type,
+                    "available": rows,
+                },
+                actions,
+                None,
+                f"Dell RAID configuration action not found: {action}",
+            )
+
+        payload = self._payload(spec, target_fqdd, asset_name)
+        return self.invoke_action(
+            row["Resource"],
+            spec.action_name,
+            payload=payload,
+            full_action_type=spec.full_type,
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -63,6 +63,7 @@ class ApiRequestType(Enum):
     SystemQuery = auto()
     VirtualDiskQuery = auto()
     RaidServiceQuery = auto()
+    DellRaidConfigActions = auto()
     StorageQuery = auto()
     Tasks = auto()
     GetTask = auto()

--- a/tests/test_dell_raid_config_actions_dualmode.py
+++ b/tests/test_dell_raid_config_actions_dualmode.py
@@ -1,0 +1,245 @@
+"""Dual-mode-style coverage for DellRaidService configuration actions."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.raid.cmd_dell_raid_config_actions import DellRaidConfigActions
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+RAID_SERVICE = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+BOOT_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.SetBootVD"
+ASSET_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.SetAssetName"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path."""
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+def _corpus_body(path):
+    """Return one Dell corpus fixture body as JSON."""
+    fixture = _fixture_for_path(path)
+    if fixture is None:
+        raise AssertionError(f"missing Dell fixture for {path}")
+    return json.loads(fixture.read_text())
+
+
+@pytest.fixture
+def dell_raid_manager_factory():
+    """Serve the committed Dell corpus over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    started = []
+
+    def factory(service_body=None):
+        requests = []
+
+        def get_cb(request, context):
+            requests.append(request)
+            if request.path.lower() == RAID_SERVICE.lower() and service_body is not None:
+                context.status_code = 200
+                return json.dumps(service_body)
+            fixture = _fixture_for_path(request.path)
+            if fixture is None:
+                context.status_code = 404
+                return json.dumps({"error": f"no fixture for {request.path}"})
+            context.status_code = 200
+            return fixture.read_text()
+
+        def post_cb(request, context):
+            requests.append(request)
+            context.status_code = 202
+            context.headers["Location"] = "/redfish/v1/TaskService/Tasks/raid-config-1"
+            return json.dumps({
+                "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/raid-config-1"}
+            })
+
+        mocker = requests_mock.Mocker()
+        mocker.start()
+        started.append(mocker)
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-raid",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        return manager, requests
+
+    yield factory
+
+    for mocker in reversed(started):
+        mocker.stop()
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_raid_config_actions_list_targets_without_posting(
+    dell_raid_manager_factory,
+):
+    """With no action, the command lists supported targets and never POSTs."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidConfigActions,
+        "dell-raid-config-actions",
+    )
+
+    rows = {row["Action"]: row for row in result.data}
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert rows["set-boot-vd"]["Target"] == BOOT_TARGET
+    assert rows["set-boot-vd"]["RequiredPayload"] == ["TargetFQDD"]
+    assert rows["set-asset-name"]["Target"] == ASSET_TARGET
+    assert rows["set-asset-name"]["RequiredPayload"] == ["AssetName"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_config_actions_previews_boot_vd_by_default(
+    dell_raid_manager_factory,
+):
+    """SetBootVD previews by default and does not POST."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidConfigActions,
+        "dell-raid-config-actions",
+        action="set-boot-vd",
+        target_fqdd="Disk.Virtual.0",
+    )
+
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.SetBootVD",
+        "target": BOOT_TARGET,
+        "payload": {"TargetFQDD": "Disk.Virtual.0"},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_config_actions_confirm_posts_asset_name(
+    dell_raid_manager_factory,
+):
+    """--confirm POSTs SetAssetName to the corpus-advertised target."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidConfigActions,
+        "dell-raid-config-actions",
+        action="set-asset-name",
+        asset_name="rack-a-drawer-2",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.SetAssetName"
+    assert result.data["target"] == ASSET_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "raid-config-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == ASSET_TARGET.lower()
+    assert posts[0].json() == {"AssetName": "rack-a-drawer-2"}
+
+
+def test_dell_raid_config_actions_dry_run_overrides_confirm(
+    dell_raid_manager_factory,
+):
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidConfigActions,
+        "dell-raid-config-actions",
+        action="set-boot-vd",
+        target_fqdd="Disk.Virtual.0",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == BOOT_TARGET
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_config_actions_missing_payload_is_rejected(
+    dell_raid_manager_factory,
+):
+    """The command rejects a selected action before POST when required payload is missing."""
+    manager, requests = dell_raid_manager_factory()
+
+    with pytest.raises(InvalidArgument, match="set-boot-vd requires: TargetFQDD"):
+        manager.sync_invoke(
+            ApiRequestType.DellRaidConfigActions,
+            "dell-raid-config-actions",
+            action="set-boot-vd",
+            confirm=True,
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_config_actions_missing_action_reports_available(
+    dell_raid_manager_factory,
+):
+    """A DellRaidService without SetBootVD reports the missing action."""
+    service_body = _corpus_body(RAID_SERVICE)
+    service_body["Actions"] = dict(service_body["Actions"])
+    service_body["Actions"].pop("#DellRaidService.SetBootVD")
+    manager, requests = dell_raid_manager_factory(service_body=service_body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidConfigActions,
+        "dell-raid-config-actions",
+        action="set-boot-vd",
+        target_fqdd="Disk.Virtual.0",
+        confirm=True,
+    )
+
+    assert result.error == "Dell RAID configuration action not found: set-boot-vd"
+    assert result.data["action"] == "#DellRaidService.SetBootVD"
+    assert result.data["available"][0]["Action"] == "set-asset-name"
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_config_actions_policy_and_registry():
+    """Configuration actions are classified and the command is registered."""
+    assert classify("#DellRaidService.SetAssetName") is Destructiveness.DESTRUCTIVE
+    assert classify("#DellRaidService.SetBootVD") is Destructiveness.DESTRUCTIVE
+
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellRaidConfigActions][
+        "dell-raid-config-actions"
+    ] is DellRaidConfigActions
+
+    cmd_parser, cmd_name, cmd_help = DellRaidConfigActions.register_subcommand(
+        DellRaidConfigActions
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-raid-config-actions"
+    assert "Dell RAID configuration" in cmd_help
+    assert "--target-fqdd" in help_text
+    assert "--asset-name" in help_text


### PR DESCRIPTION
## Summary
- add a guarded dell-raid-config-actions command for DellRaidService SetBootVD and SetAssetName
- classify both actions so they preview by default and require --confirm before POSTing
- add Dell corpus-backed coverage and the command-table row

## Testing
- git diff --check
- GitHub Actions pending