### PR TITLE
Add Dell RAID value check command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-raid-check-values` | Validate proposed DellRaidService virtual-disk properties with `CheckVDValues` and return the BMC validation body. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -17,6 +17,7 @@ from .compute.cmd_power_state import *
 from .compute.cmd_compute_setting import *
 
 from .redfish_manager_shared import *
+from .raid.cmd_dell_raid_check_values import *
 from .raid.cmd_raid_service import *
 #
 # bios commands

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -42,6 +42,7 @@ ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
     "#ComponentIntegrity.TPMGetSignedMeasurements": Destructiveness.READ_ONLY,
+    "#DellRaidService.CheckVDValues": Destructiveness.READ_ONLY,
 
     # reversible: state changes that can be undone
     "#EventService.SubmitTestEvent": Destructiveness.REVERSIBLE,

--- a/redfish_ctl/raid/cmd_dell_raid_check_values.py
+++ b/redfish_ctl/raid/cmd_dell_raid_check_values.py
@@ -1,0 +1,290 @@
+"""Validate proposed DellRaidService virtual-disk property values.
+
+    redfish_ctl dell-raid-check-values
+    redfish_ctl dell-raid-check-values --property RAIDLevel --value RAID1
+    redfish_ctl dell-raid-check-values --property Size --value 1024 --dry_run
+
+Dell exposes ``#DellRaidService.CheckVDValues`` as a POST-backed validation
+action on ``DellRaidService``. The action checks proposed virtual-disk values
+and returns validation data; it does not change storage state.
+"""
+import json
+from abc import abstractmethod
+from typing import Iterable, Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, RedfishApiRespond, Singleton
+from ..redfish_shared import RedfishApi
+
+_CHECK_ACTION = "#DellRaidService.CheckVDValues"
+_CHECK_NAME = "CheckVDValues"
+
+
+def _as_list(values: Optional[Iterable[str]]) -> list[str]:
+    """Normalize argparse and direct-call values to a list of strings.
+
+    :param values: None, one string, or an iterable of strings.
+    :return: normalized list, empty when no values were supplied.
+    """
+    if values is None:
+        return []
+    if isinstance(values, str):
+        return [values]
+    return [str(value) for value in values]
+
+
+class DellRaidCheckValues(RedfishManagerBase,
+                          scm_type=ApiRequestType.DellRaidCheckValues,
+                          name="dell-raid-check-values",
+                          metaclass=Singleton):
+    """Run DellRaidService.CheckVDValues as a read-only validation query."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-raid-check-values command."""
+        super(DellRaidCheckValues, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-raid-check-values`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--property",
+            action="append",
+            dest="property_names",
+            default=None,
+            help="virtual-disk property name to validate; repeat with --value",
+        )
+        cmd_parser.add_argument(
+            "--value",
+            action="append",
+            dest="property_values",
+            default=None,
+            help="virtual-disk property value paired with --property",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-raid-check-values",
+            "command validate Dell RAID virtual-disk values",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_links(resource):
+        """Return the ``Links.Oem.Dell`` block from a ComputerSystem.
+
+        :param resource: Redfish ComputerSystem resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = resource.get("Links") if isinstance(resource, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource, returning an empty dict on optional gaps.
+
+        :param uri: Redfish URI to read.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed JSON dict, or an empty dict.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _raid_service_uri(self, do_async):
+        """Resolve DellRaidService from the selected ComputerSystem.
+
+        :param do_async: issue the system read on the async path when True.
+        :return: DellRaidService URI, falling back to the legacy Dell path.
+        """
+        system_uri = self.idrac_manage_servers
+        system = self._get(system_uri, do_async)
+        linked = self._link(self._dell_links(system), "DellRaidService")
+        if linked:
+            return linked
+        system_id = system_uri.rstrip("/").rsplit("/", 1)[-1]
+        return f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellRaidService"
+
+    @staticmethod
+    def _allowable(action):
+        """Return the advertised virtual-disk property names for CheckVDValues.
+
+        :param action: discovered RedfishAction for ``CheckVDValues``.
+        :return: sorted allowed ``VDPropNameArrayIn`` entries.
+        """
+        args = getattr(action, "args", {}) or {}
+        return sorted(args.get("VDPropNameArrayIn", []) or [])
+
+    def _discover_row(self, do_async):
+        """Discover the CheckVDValues target and advertised property names.
+
+        :param do_async: issue underlying Redfish reads on the async path when True.
+        :return: tuple of (service URI, action map, row dict or None).
+        """
+        service_uri = self._raid_service_uri(do_async)
+        service = self._get(service_uri, do_async)
+        actions = self.discover_redfish_actions(self, service)
+        targets = self._flatten_action_targets(service)
+        target = targets.get(_CHECK_ACTION)
+        if not target:
+            return service_uri, actions, None
+        action = actions.get(_CHECK_NAME)
+        return service_uri, actions, {
+            "Action": "check-vd-values",
+            "FullType": _CHECK_ACTION,
+            "Resource": service_uri,
+            "Target": target,
+            "Description": "validate proposed Dell RAID virtual-disk values",
+            "Parameters": {
+                "VDPropNameArrayIn": self._allowable(action),
+                "VDPropValueArrayIn": [],
+            },
+        }
+
+    @staticmethod
+    def _payload(property_names, property_values):
+        """Build and validate a CheckVDValues payload.
+
+        :param property_names: selected virtual-disk property names.
+        :param property_values: selected virtual-disk property values.
+        :return: CheckVDValues payload, or None when the caller requested a list.
+        :raises InvalidArgument: if names and values are missing or mismatched.
+        """
+        names = _as_list(property_names)
+        values = _as_list(property_values)
+        if not names and not values:
+            return None
+        if not names or not values:
+            raise InvalidArgument("provide both --property and --value")
+        if len(names) != len(values):
+            raise InvalidArgument("--property and --value must be supplied in pairs")
+        return {
+            "VDPropNameArrayIn": names,
+            "VDPropValueArrayIn": values,
+        }
+
+    def _invoke_sync(self, preview, payload):
+        """POST the read-only validation action and preserve the JSON response.
+
+        :param preview: dry-run CommandResult from ``invoke_action``.
+        :param payload: CheckVDValues payload to send.
+        :return: CommandResult with execution metadata and response body.
+        """
+        if not isinstance(preview.data, dict):
+            return preview
+        if preview.data.get("level") != "read_only":
+            return CommandResult(
+                preview.data,
+                preview.discovered,
+                None,
+                f"{_CHECK_ACTION} is not classified as read-only",
+            )
+
+        target = preview.data["target"]
+        response = self.api_post_call(
+            f"{self._default_method}{self.redfish_ip}{target}",
+            json.dumps(payload),
+            self.json_content_type,
+        )
+        api_resp = self.default_post_success(response, expected=200)
+        data = {
+            "executed": True,
+            "action": _CHECK_ACTION,
+            "target": target,
+            "payload": payload,
+            "level": "read_only",
+        }
+        data.update(self.api_success_msg(api_resp))
+        if api_resp == RedfishApiRespond.AcceptedTaskGenerated:
+            data["task_id"] = self.job_id_from_header(response)
+        else:
+            try:
+                data["response"] = response.json()
+            except ValueError:
+                pass
+        return CommandResult(data, preview.discovered, None, None)
+
+    def execute(self,
+                property_names: Optional[Iterable[str]] = None,
+                property_values: Optional[Iterable[str]] = None,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or run the DellRaidService.CheckVDValues action.
+
+        :param property_names: repeated virtual-disk property names.
+        :param property_values: repeated virtual-disk property values.
+        :param dry_run: resolve and validate without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying reads/POST on the async path when True.
+        :return: CommandResult with a listing, dry-run preview, execution result,
+            or missing-action error.
+        """
+        service_uri, actions, row = self._discover_row(bool(do_async))
+        payload = self._payload(property_names, property_values)
+        if payload is None:
+            return CommandResult([row] if row else [], actions, None, None)
+        if row is None:
+            return CommandResult(
+                {
+                    "raid_service": service_uri,
+                    "action": _CHECK_ACTION,
+                    "available": sorted(actions),
+                },
+                actions,
+                None,
+                "Dell RAID CheckVDValues action not found",
+            )
+
+        preview = self.invoke_action(
+            row["Resource"],
+            _CHECK_NAME,
+            payload=payload,
+            full_action_type=_CHECK_ACTION,
+            do_async=bool(do_async),
+            expected_status=200,
+            dry_run=True,
+        )
+        if preview.error or dry_run:
+            return preview
+        if do_async:
+            return self.invoke_action(
+                row["Resource"],
+                _CHECK_NAME,
+                payload=payload,
+                full_action_type=_CHECK_ACTION,
+                do_async=True,
+                expected_status=200,
+            )
+        return self._invoke_sync(preview, payload)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -63,6 +63,7 @@ class ApiRequestType(Enum):
     SystemQuery = auto()
     VirtualDiskQuery = auto()
     RaidServiceQuery = auto()
+    DellRaidCheckValues = auto()
     StorageQuery = auto()
     Tasks = auto()
     GetTask = auto()

--- a/tests/test_dell_raid_check_values_dualmode.py
+++ b/tests/test_dell_raid_check_values_dualmode.py
@@ -1,0 +1,262 @@
+"""Dual-mode-style coverage for DellRaidService.CheckVDValues."""
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.raid.cmd_dell_raid_check_values import DellRaidCheckValues
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+RAID_SERVICE = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+CHECK_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.CheckVDValues"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path."""
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+def _corpus_body(path):
+    """Return one Dell corpus fixture body as JSON."""
+    fixture = _fixture_for_path(path)
+    if fixture is None:
+        raise AssertionError(f"missing Dell fixture for {path}")
+    return json.loads(fixture.read_text())
+
+
+@pytest.fixture
+def dell_raid_manager_factory():
+    """Serve the committed Dell corpus over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    started = []
+
+    def factory(service_body=None, post_body=None):
+        requests = []
+
+        def get_cb(request, context):
+            requests.append(request)
+            if request.path.lower() == RAID_SERVICE.lower() and service_body is not None:
+                context.status_code = 200
+                return json.dumps(service_body)
+            fixture = _fixture_for_path(request.path)
+            if fixture is None:
+                context.status_code = 404
+                return json.dumps({"error": f"no fixture for {request.path}"})
+            context.status_code = 200
+            return fixture.read_text()
+
+        def post_cb(request, context):
+            requests.append(request)
+            context.status_code = 200
+            return json.dumps(post_body or {"Status": "Valid"})
+
+        mocker = requests_mock.Mocker()
+        mocker.start()
+        started.append(mocker)
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-raid",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        return manager, requests
+
+    yield factory
+
+    for mocker in reversed(started):
+        mocker.stop()
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_raid_check_values_lists_corpus_target_without_posting(
+    dell_raid_manager_factory,
+):
+    """With no values, the command lists the advertised CheckVDValues target."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidCheckValues,
+        "dell-raid-check-values",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == [{
+        "Action": "check-vd-values",
+        "FullType": "#DellRaidService.CheckVDValues",
+        "Resource": RAID_SERVICE,
+        "Target": CHECK_TARGET,
+        "Description": "validate proposed Dell RAID virtual-disk values",
+        "Parameters": {
+            "VDPropNameArrayIn": [
+                "RAIDLevel",
+                "Size",
+                "SpanDepth",
+                "SpanLength",
+                "StartingLBA",
+                "T10PIStatus",
+            ],
+            "VDPropValueArrayIn": [],
+        },
+    }]
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_check_values_dry_run_validates_payload_without_posting(
+    dell_raid_manager_factory,
+):
+    """--dry_run resolves the target and validates property names."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidCheckValues,
+        "dell-raid-check-values",
+        property_names=["RAIDLevel", "Size"],
+        property_values=["RAID1", "1024"],
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.CheckVDValues",
+        "target": CHECK_TARGET,
+        "payload": {
+            "VDPropNameArrayIn": ["RAIDLevel", "Size"],
+            "VDPropValueArrayIn": ["RAID1", "1024"],
+        },
+        "level": "read_only",
+        "blocked": None,
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_check_values_posts_read_only_action_by_default(
+    dell_raid_manager_factory,
+):
+    """CheckVDValues is read-only, so the selected validation POSTs by default."""
+    manager, requests = dell_raid_manager_factory(
+        post_body={"Status": "Valid", "Checked": ["RAIDLevel"]}
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidCheckValues,
+        "dell-raid-check-values",
+        property_names=["RAIDLevel"],
+        property_values=["RAID1"],
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.CheckVDValues"
+    assert result.data["level"] == "read_only"
+    assert result.data["target"] == CHECK_TARGET
+    assert result.data["response"] == {"Status": "Valid", "Checked": ["RAIDLevel"]}
+    assert len(posts) == 1
+    assert posts[0].path.lower() == CHECK_TARGET.lower()
+    assert posts[0].json() == {
+        "VDPropNameArrayIn": ["RAIDLevel"],
+        "VDPropValueArrayIn": ["RAID1"],
+    }
+
+
+def test_dell_raid_check_values_rejects_invalid_property_without_posting(
+    dell_raid_manager_factory,
+):
+    """Advertised VDPropNameArrayIn allowable values are enforced."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidCheckValues,
+        "dell-raid-check-values",
+        property_names=["Bogus"],
+        property_values=["x"],
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellRaidService.CheckVDValues VDPropNameArrayIn: "
+        "Bogus; allowed: RAIDLevel, Size, SpanDepth, SpanLength, StartingLBA, "
+        "T10PIStatus"
+    )
+    assert result.data["validation_errors"][0]["parameter"] == "VDPropNameArrayIn"
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_check_values_rejects_mismatched_pairs(
+    dell_raid_manager_factory,
+):
+    """Each virtual-disk property name must have a paired value."""
+    manager, requests = dell_raid_manager_factory()
+
+    with pytest.raises(InvalidArgument, match="must be supplied in pairs"):
+        manager.sync_invoke(
+            ApiRequestType.DellRaidCheckValues,
+            "dell-raid-check-values",
+            property_names=["RAIDLevel", "Size"],
+            property_values=["RAID1"],
+        )
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_check_values_missing_action_reports_available(
+    dell_raid_manager_factory,
+):
+    """A DellRaidService without CheckVDValues reports the missing action."""
+    service_body = _corpus_body(RAID_SERVICE)
+    service_body["Actions"] = dict(service_body["Actions"])
+    service_body["Actions"].pop("#DellRaidService.CheckVDValues")
+    manager, requests = dell_raid_manager_factory(service_body=service_body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidCheckValues,
+        "dell-raid-check-values",
+        property_names=["RAIDLevel"],
+        property_values=["RAID1"],
+    )
+
+    assert result.error == "Dell RAID CheckVDValues action not found"
+    assert result.data["action"] == "#DellRaidService.CheckVDValues"
+    assert "AssignSpare" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_check_values_policy_and_registry():
+    """CheckVDValues is classified read-only and the command is registered."""
+    assert classify("#DellRaidService.CheckVDValues") is Destructiveness.READ_ONLY
+
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellRaidCheckValues][
+        "dell-raid-check-values"
+    ] is DellRaidCheckValues
+
+    cmd_parser, cmd_name, cmd_help = DellRaidCheckValues.register_subcommand(
+        DellRaidCheckValues
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-raid-check-values"
+    assert "Dell RAID" in cmd_help
+    assert "--property" in help_text
+    assert "--value" in help_text


### PR DESCRIPTION
## Summary
- add a DellRaidService CheckVDValues command that lists the corpus-advertised target or validates property/value pairs through the read-only action
- wire command registration, action policy, command docs, and Dell corpus-backed coverage
- preserve the synchronous validation response body for callers

## Validation
- git diff --check
- git diff --cached --check
- conda run -n idrac_ctl python -m py_compile redfish_ctl/raid/cmd_dell_raid_check_values.py tests/test_dell_raid_check_values_dualmode.py redfish_ctl/redfish_manager_shared.py redfish_ctl/actions/action_policy.py redfish_ctl/__init__.py

Not run locally: pytest/Ruff, because project gates run in CI/Kubernetes.