### PR TITLE
Remove credential upload helpers from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ TWINE ?= $(CONDA_RUN) twine
 DOCKER ?= docker
 IMAGE ?= redfish-ctl
 
-.PHONY: help test lint typecheck build bench-concurrency docker-test docker-image docs-voice-check docstring-gate docstring-gate-all k8s-sandbox k8s-consumer k8s-explorer clean gb300-check gb300-image gb300-agent-image gb300-provision gb300-test gb300-lint gb300-gate gb300-shell gb300-clean gb300-push-key
+.PHONY: help test lint typecheck build bench-concurrency docker-test docker-image docs-voice-check docstring-gate docstring-gate-all k8s-sandbox k8s-consumer k8s-explorer clean gb300-check gb300-image gb300-test gb300-lint gb300-gate gb300-shell gb300-clean
 
 DOCSTRING_BASE ?= origin/main
 
@@ -99,32 +99,31 @@ clean: ## Remove local build, test, and type-check artifacts.
 # GB300 remote docker test fleet — ALL gates run there, never on a laptop.
 # Slot/host resolution comes from scripts/gb300.sh + .internal/gb300-fleet.env
 # (gitignored; see TEAM_GUIDE.md "GB300 Docker test environment"). The env
-# file is also included here so a locally defined image name (for example an
-# internal agent image layered on the public base) wins over the default.
+# file is also included here so a locally defined image name wins over the
+# default.
 #   SLOT  = fleet slot number (required for the per-slot targets)
-#   AGENT = your agent name; isolates your /work volume and container
+#   RUN_LABEL = workspace label; isolates your /work volume and container
 #   REF   = git ref to test (default main); any pushed branch works
 # ---------------------------------------------------------------------------
 -include .internal/gb300-fleet.env
 GB300_SH    := ./scripts/gb300.sh
 GB300_HOSTC  = $$($(GB300_SH) host $(SLOT))
-AGENT      ?= $(shell whoami)
+RUN_LABEL  ?= $(shell whoami)
 REF        ?= main
 PYTEST_ARGS ?= -q
-# Image choice lives in scripts/gb300.sh: the credentialed agent image when a
+# Image choice lives in scripts/gb300.sh: a credentialed private image when a
 # node has it, the public base otherwise; pass GB300_IMAGE=<name> to pin one.
 
-gb300-check: ## Live-check every fleet slot: ssh, docker, base + agent images, disk.
-	@printf '%-5s %-22s %-8s %-8s %-8s %-6s\n' SLOT HOST DOCKER BASE AGENT DISK; \
+gb300-check: ## Live-check every fleet slot: ssh, docker, base image, disk.
+	@printf '%-5s %-22s %-8s %-8s %-6s\n' SLOT HOST DOCKER BASE DISK; \
 	for s in $$($(GB300_SH) list); do \
 		h=$$($(GB300_SH) host $$s); \
 		out=$$(ssh -o BatchMode=yes -o ConnectTimeout=5 $$h ' \
 			d=no; docker info >/dev/null 2>&1 && d=ok; \
 			b=absent; docker image inspect redfish-ctl-dev >/dev/null 2>&1 && b=present; \
-			a=absent; docker image inspect redfish-ctl-agent >/dev/null 2>&1 && a=present; \
 			df=$$(df -h / | awk "NR==2 {print \$$5}"); \
-			echo "$$d $$b $$a $$df"' 2>/dev/null) || out="UNREACHABLE - - -"; \
-		printf '%-5s %-22s %-8s %-8s %-8s %-6s\n' "$$s" "$$h" $$out; \
+			echo "$$d $$b $$df"' 2>/dev/null) || out="UNREACHABLE - -"; \
+		printf '%-5s %-22s %-8s %-8s %-6s\n' "$$s" "$$h" $$out; \
 	done
 
 # Both build targets stage the context in a temp file instead of piping it
@@ -138,25 +137,9 @@ gb300-image: ## Build the public base image on a slot from this checkout's HEAD.
 		'docker build -t redfish-ctl-dev -f docker/Dockerfile.gb300-dev -' < "$$ctx"; \
 	rc=$$?; rm -f "$$ctx"; exit $$rc
 
-gb300-agent-image: ## Build the internal agent image (base + staged credentials) on a slot. SLOT=<n>
-	@test -n "$(SLOT)" || { echo "usage: make gb300-agent-image SLOT=<n>"; exit 2; }
-	@test -f .internal/docker/secrets/git_key || { \
-		echo "stage credentials first — see .internal/docker/README.md"; exit 2; }
-	@ctx=$$(mktemp) && \
-	tar -C .internal/docker -cf "$$ctx" . && \
-	ssh $(GB300_HOSTC) \
-		'docker build -t redfish-ctl-agent -f Dockerfile.gb300-agent -' < "$$ctx"; \
-	rc=$$?; rm -f "$$ctx"; exit $$rc
-
-gb300-provision: ## Build base + agent images on every slot (operator bootstrap).
-	@for s in $$($(GB300_SH) list); do \
-		echo "=== slot $$s ==="; \
-		$(MAKE) gb300-image SLOT=$$s && $(MAKE) gb300-agent-image SLOT=$$s || exit 1; \
-	done
-
-gb300-test: ## Run the offline pytest suite on a slot. SLOT=<n> [REF=main] [AGENT=me]
+gb300-test: ## Run the offline pytest suite on a slot. SLOT=<n> [REF=main] [RUN_LABEL=me]
 	@test -n "$(SLOT)" || { echo "usage: make gb300-test SLOT=<n> [REF=<branch>]"; exit 2; }
-	$(GB300_SH) run $(SLOT) $(AGENT) $(REF) pytest $(PYTEST_ARGS)
+	$(GB300_SH) run $(SLOT) $(RUN_LABEL) $(REF) pytest $(PYTEST_ARGS)
 
 # Ruff scope matches the project convention: the tree carries pre-existing
 # lint debt, so only files changed vs origin/main are checked (a whole-tree
@@ -166,16 +149,16 @@ GB300_RUFF_CHANGED = git fetch -q origin main && \
 
 gb300-lint: ## Ruff over files changed vs origin/main, on a slot. SLOT=<n> REF=<branch>
 	@test -n "$(SLOT)" || { echo "usage: make gb300-lint SLOT=<n> REF=<branch>"; exit 2; }
-	$(GB300_SH) run $(SLOT) $(AGENT) $(REF) sh -c '$(GB300_RUFF_CHANGED)'
+	$(GB300_SH) run $(SLOT) $(RUN_LABEL) $(REF) sh -c '$(GB300_RUFF_CHANGED)'
 
 gb300-gate: ## Full PR gate on a slot: pytest + changed-files ruff + whole-tree docstring gate.
 	@test -n "$(SLOT)" || { echo "usage: make gb300-gate SLOT=<n> [REF=<branch>]"; exit 2; }
-	$(GB300_SH) run $(SLOT) $(AGENT) $(REF) sh -c \
+	$(GB300_SH) run $(SLOT) $(RUN_LABEL) $(REF) sh -c \
 		'pytest -q && $(GB300_RUFF_CHANGED) && python tools/docstring_gate.py --all'
 
-gb300-shell: ## Interactive dev shell on a slot (conda env active). SLOT=<n> [AGENT=me]
+gb300-shell: ## Interactive dev shell on a slot (conda env active). SLOT=<n> [RUN_LABEL=me]
 	@test -n "$(SLOT)" || { echo "usage: make gb300-shell SLOT=<n>"; exit 2; }
-	$(GB300_SH) shell $(SLOT) $(AGENT)
+	$(GB300_SH) shell $(SLOT) $(RUN_LABEL)
 
 gb300-clean: ## Remove exited rfctl containers + dangling layers on a slot. SLOT=<n>
 	@test -n "$(SLOT)" || { echo "usage: make gb300-clean SLOT=<n>"; exit 2; }
@@ -183,13 +166,3 @@ gb300-clean: ## Remove exited rfctl containers + dangling layers on a slot. SLOT
 		ids=$$(docker ps -aq --filter status=exited --filter name=rfctl); \
 		if [ -n "$$ids" ]; then docker rm $$ids >/dev/null; fi; \
 		docker image prune -f'
-
-gb300-push-key: ## Operator only: install the git key + gh token on every slot.
-	@test -f "$(HOME)/.ssh/id_rsa" || { echo "no ~/.ssh/id_rsa"; exit 2; }
-	@for s in $$($(GB300_SH) list); do \
-		h=$$($(GB300_SH) host $$s); \
-		scp -o BatchMode=yes -o ConnectTimeout=5 -q ~/.ssh/id_rsa $$h:.ssh/redfish_ctl_git \
-			&& gh auth token | ssh $$h 'cat > .ssh/redfish_ctl_gh_token; chmod 600 .ssh/redfish_ctl_git .ssh/redfish_ctl_gh_token' \
-			&& echo "slot $$s ($$h): key + token installed" \
-			|| echo "slot $$s ($$h): FAILED"; \
-	done


### PR DESCRIPTION
## Summary
- Remove Makefile targets that staged local credential material or piped SSH/GitHub credentials into remote slots.
- Keep the read/test remote gate targets and switch their visible run label to `RUN_LABEL`.
- Drop the obsolete private-image check from `gb300-check` now that the related build target is gone.

## Validation
- `git diff --check`
- Static grep confirmed no key/token upload helper patterns remain in `Makefile`.
- GitHub Actions passed `test (3.10)`, `test (3.11)`, `test (3.12)`, `test (3.13)`, and `test (3.14)` on the PR head.

Not run: pytest, Ruff, Docker, or make gates locally; project validation runs on the remote CI/fleet surfaces.