### PR TITLE
Add Dell LC clear provisioning command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-clear-provisioning` | Clear Dell Lifecycle Controller provisioning server configuration; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_clear_provisioning import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -69,6 +69,7 @@ ACTION_POLICY = {
     "#Control.ResetToDefaults": Destructiveness.DESTRUCTIVE,
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ClearProvisioningServer": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE

--- a/redfish_ctl/dell_lc/cmd_dell_lc_clear_provisioning.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_clear_provisioning.py
@@ -1,0 +1,207 @@
+"""Preview or clear the Dell Lifecycle Controller provisioning server config.
+
+    redfish_ctl dell-lc-clear-provisioning
+    redfish_ctl dell-lc-clear-provisioning --confirm
+
+The command resolves ``#DellLCService.ClearProvisioningServer`` from the Dell
+Lifecycle Controller service. Clearing the provisioning server changes BMC
+configuration, so the command previews by default and only POSTs when
+``--confirm`` is provided.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_CLEAR_PROVISIONING_ACTION = "#DellLCService.ClearProvisioningServer"
+_SERVICE_NAME = "DellLCService"
+_DEFAULT_SERVICE_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+_LEGACY_SERVICE_URI = (
+    "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService"
+)
+
+
+class DellLcClearProvisioningServer(
+        RedfishManagerBase,
+        scm_type=ApiRequestType.DellLcClearProvisioningServer,
+        name="dell-lc-clear-provisioning",
+        metaclass=Singleton):
+    """Discover and invoke DellLCService.ClearProvisioningServer."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-clear-provisioning command."""
+        super(DellLcClearProvisioningServer, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-clear-provisioning`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the clear-provisioning action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-clear-provisioning",
+            "command clear Dell Lifecycle Controller provisioning server config",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the Dell block under ``Manager.Links.Oem``.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM links dict, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional-resource misses.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: issue Manager queries on the async path when True.
+        :return: de-duplicated candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(
+                self._dell_oem_links(manager),
+                _SERVICE_NAME,
+            )
+            if service_uri:
+                uris.append(service_uri)
+            uris.append(manager_uri.rstrip("/") + f"/Oem/Dell/{_SERVICE_NAME}")
+        uris.extend([_DEFAULT_SERVICE_URI, _LEGACY_SERVICE_URI])
+        return list(dict.fromkeys(uri for uri in uris if uri))
+
+    def _metadata(self, do_async, resource_uri=None):
+        """Return the discovered clear-provisioning target metadata.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DellLCService URI.
+        :return: CommandResult containing target metadata or an error.
+        """
+        checked = []
+        uris = [resource_uri] if resource_uri else self._service_uris(do_async)
+        for uri in dict.fromkeys(uri for uri in uris if uri):
+            service = self._get(uri, do_async)
+            if not service:
+                checked.append(uri)
+                continue
+            target = self._flatten_action_targets(service).get(
+                _CLEAR_PROVISIONING_ACTION
+            )
+            actions = self.discover_redfish_actions(self, service)
+            if target:
+                return CommandResult(
+                    {
+                        "lc_service": uri,
+                        "action": _CLEAR_PROVISIONING_ACTION,
+                        "target": target,
+                    },
+                    actions,
+                    None,
+                    None,
+                )
+            checked.append(uri)
+        return CommandResult(
+            {
+                "action": _CLEAR_PROVISIONING_ACTION,
+                "checked": checked,
+            },
+            None,
+            None,
+            f"action '{_CLEAR_PROVISIONING_ACTION}' not found",
+        )
+
+    def execute(self,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or invoke DellLCService.ClearProvisioningServer.
+
+        :param resource_uri: optional DellLCService URI to inspect directly.
+        :param confirm: POST the action when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue Redfish reads/POST on the async path when True.
+        :return: CommandResult with a preview, execution result, or error.
+        """
+        metadata = self._metadata(bool(do_async), resource_uri)
+        if metadata.error is not None:
+            return metadata
+
+        result = self.invoke_action(
+            metadata.data["lc_service"],
+            "ClearProvisioningServer",
+            payload={},
+            full_action_type=_CLEAR_PROVISIONING_ACTION,
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        if result.error is None and isinstance(result.data, dict):
+            result.data.setdefault("lc_service", metadata.data["lc_service"])
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -38,6 +38,7 @@ class ApiRequestType(Enum):
     DellOemTask = auto()
     DellLcQuery = auto()
     DellOemDisconnect = auto()
+    DellLcClearProvisioningServer = auto()
 
     RemoteServicesRssAPIStatus = auto()
     RemoteServicesAPIStatus = auto()

--- a/tests/test_dell_lc_clear_provisioning_dualmode.py
+++ b/tests/test_dell_lc_clear_provisioning_dualmode.py
@@ -1,0 +1,159 @@
+"""Dual-mode tests for clearing Dell LC provisioning-server settings."""
+import copy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_clear_provisioning import (
+    DellLcClearProvisioningServer,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+CLEAR_TARGET = (
+    f"{LC_SERVICE}/Actions/"
+    "DellLCService.ClearProvisioningServer"
+)
+
+
+@pytest.fixture
+def dell_lc_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-lc",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _overlay_lc_service(service, body):
+    """Overlay DellLCService under both common request casings."""
+    service._overlay[LC_SERVICE] = body
+    service._overlay[LC_SERVICE.lower()] = body
+
+
+def test_clear_provisioning_dry_runs_by_default(dell_lc_mock):
+    """The corpus-backed action target is resolved without POSTing."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClearProvisioningServer,
+        "dell-lc-clear-provisioning",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["action"] == "#DellLCService.ClearProvisioningServer"
+    assert result.data["target"] == CLEAR_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "destructive"
+    assert result.data["lc_service"] == LC_SERVICE
+    assert _post_requests(service) == []
+
+
+def test_clear_provisioning_confirm_posts_empty_payload(dell_lc_mock):
+    """--confirm POSTs exactly one empty-body clear action."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClearProvisioningServer,
+        "dell-lc-clear-provisioning",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "destructive"
+    assert result.data["lc_service"] == LC_SERVICE
+    assert len(posts) == 1
+    assert posts[0].path.lower() == CLEAR_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_clear_provisioning_dry_run_overrides_confirm(dell_lc_mock):
+    """Explicit dry-run wins over --confirm and avoids the POST."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClearProvisioningServer,
+        "dell-lc-clear-provisioning",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["target"] == CLEAR_TARGET
+    assert _post_requests(service) == []
+
+
+def test_clear_provisioning_reports_missing_action_without_post(dell_lc_mock):
+    """A service missing ClearProvisioningServer reports the miss."""
+    manager, service = dell_lc_mock
+    body = copy.deepcopy(service._state(LC_SERVICE))
+    body["Actions"].pop("#DellLCService.ClearProvisioningServer")
+    _overlay_lc_service(service, body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClearProvisioningServer,
+        "dell-lc-clear-provisioning",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#DellLCService.ClearProvisioningServer' not found"
+    )
+    assert result.data["action"] == "#DellLCService.ClearProvisioningServer"
+    assert LC_SERVICE in result.data["checked"]
+    assert _post_requests(service) == []
+
+
+def test_clear_provisioning_is_registered_and_classified():
+    """The command is registered and classified as guarded."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellLcClearProvisioningServer][
+        "dell-lc-clear-provisioning"
+    ] is DellLcClearProvisioningServer
+
+    assert classify("#DellLCService.ClearProvisioningServer") is (
+        Destructiveness.DESTRUCTIVE
+    )


### PR DESCRIPTION
## Summary
- add `dell-lc-clear-provisioning` for `DellLCService.ClearProvisioningServer` with discovery-first target resolution
- keep the action dry-run by default and require `--confirm` before POSTing
- cover dry-run, confirmed POST, dry-run override, missing-action, registration, and policy classification cases against the Dell XR8620t corpus

## Validation
- `git diff --check`
- `git diff --cached --check`