### PR TITLE
Add Dell LC autodiscovery command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-autodiscovery` | List or re-initiate Dell LC auto-discovery requests; `--perform` previews by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -9,6 +9,7 @@ from .system.cmd_system_import import *
 #
 from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
+from .dell_lc.cmd_dell_lc_autodiscovery import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
 #

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -76,6 +76,8 @@ ACTION_POLICY = {
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ReInitiateAutoDiscovery": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ReInitiateDHS": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/dell_lc/cmd_dell_lc_autodiscovery.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_autodiscovery.py
@@ -1,0 +1,266 @@
+"""Preview or re-initiate Dell Lifecycle Controller auto-discovery.
+
+    redfish_ctl dell-lc-autodiscovery
+    redfish_ctl dell-lc-autodiscovery --perform NextBoot
+    redfish_ctl dell-lc-autodiscovery --mode dhs --perform Off --confirm
+
+The command resolves ``#DellLCService.ReInitiateAutoDiscovery`` or
+``#DellLCService.ReInitiateDHS`` from the Dell Lifecycle Controller service.
+Re-initiating discovery changes BMC provisioning behavior, so the command lists
+targets with no ``--perform`` value and otherwise previews by default.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_SERVICE_NAME = "DellLCService"
+_DEFAULT_SERVICE_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+_LEGACY_SERVICE_URI = (
+    "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService"
+)
+
+_ACTION_SPECS = {
+    "auto-discovery": {
+        "short": "ReInitiateAutoDiscovery",
+        "full": "#DellLCService.ReInitiateAutoDiscovery",
+    },
+    "dhs": {
+        "short": "ReInitiateDHS",
+        "full": "#DellLCService.ReInitiateDHS",
+    },
+}
+
+
+class DellLcAutoDiscovery(RedfishManagerBase,
+                          scm_type=ApiRequestType.DellLcAutoDiscovery,
+                          name="dell-lc-autodiscovery",
+                          metaclass=Singleton):
+    """List or invoke Dell LC auto-discovery actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-autodiscovery command."""
+        super(DellLcAutoDiscovery, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-lc-autodiscovery`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--mode",
+            choices=tuple(_ACTION_SPECS),
+            default="auto-discovery",
+            help="Dell LC action family to run",
+        )
+        cmd_parser.add_argument(
+            "--perform",
+            dest="perform_auto_discovery",
+            default=None,
+            help="PerformAutoDiscovery value such as NextBoot, Now, or Off; "
+                 "omit to list discovered action targets",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the selected action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-autodiscovery",
+            "command manage Dell LC auto-discovery action requests",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the Dell block under ``Manager.Links.Oem``.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM links dict, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional-resource misses.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: issue Manager queries on the async path when True.
+        :return: de-duplicated candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(
+                self._dell_oem_links(manager),
+                _SERVICE_NAME,
+            )
+            if service_uri:
+                uris.append(service_uri)
+            uris.append(manager_uri.rstrip("/") + f"/Oem/Dell/{_SERVICE_NAME}")
+        uris.extend([_DEFAULT_SERVICE_URI, _LEGACY_SERVICE_URI])
+        return list(dict.fromkeys(uri for uri in uris if uri))
+
+    @staticmethod
+    def _action_summary(actions, action_name):
+        """Return target and inline allowed values for one discovered action.
+
+        :param actions: mapping returned by ``discover_redfish_actions``.
+        :param action_name: short Redfish action name.
+        :return: dict with target and allowed ``PerformAutoDiscovery`` values.
+        """
+        action = actions.get(action_name)
+        args = getattr(action, "args", {}) or {}
+        allowed = sorted(args.get("PerformAutoDiscovery") or [])
+        return {
+            "target": getattr(action, "target", None),
+            "allowed_perform_auto_discovery": allowed,
+        }
+
+    def _metadata(self, do_async, resource_uri=None):
+        """Return discovered auto-discovery action metadata.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DellLCService URI.
+        :return: CommandResult containing target metadata or an error.
+        """
+        checked = []
+        uris = [resource_uri] if resource_uri else self._service_uris(do_async)
+        for uri in dict.fromkeys(uri for uri in uris if uri):
+            service = self._get(uri, do_async)
+            if not service:
+                checked.append(uri)
+                continue
+            actions = self.discover_redfish_actions(self, service)
+            full_targets = self._flatten_action_targets(service)
+            discovered = {}
+            for mode, spec in _ACTION_SPECS.items():
+                if spec["full"] in full_targets:
+                    discovered[mode] = self._action_summary(
+                        actions,
+                        spec["short"],
+                    )
+                    discovered[mode]["action"] = spec["full"]
+            if discovered:
+                return CommandResult(
+                    {
+                        "lc_service": uri,
+                        "actions": discovered,
+                    },
+                    actions,
+                    None,
+                    None,
+                )
+            checked.append(uri)
+        wanted = ", ".join(spec["full"] for spec in _ACTION_SPECS.values())
+        return CommandResult(
+            {"actions": sorted(_ACTION_SPECS), "checked": checked},
+            None,
+            None,
+            f"actions not found: {wanted}",
+        )
+
+    def execute(self,
+                mode: Optional[str] = "auto-discovery",
+                perform_auto_discovery: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke DellLCService auto-discovery actions.
+
+        :param mode: ``auto-discovery`` or ``dhs``.
+        :param perform_auto_discovery: desired ``PerformAutoDiscovery`` value.
+        :param resource_uri: optional DellLCService URI to inspect directly.
+        :param confirm: POST the action when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue Redfish reads/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        metadata = self._metadata(bool(do_async), resource_uri)
+        if metadata.error is not None or perform_auto_discovery is None:
+            return metadata
+
+        action_mode = mode or "auto-discovery"
+        spec = _ACTION_SPECS.get(action_mode)
+        if spec is None:
+            valid = ", ".join(sorted(_ACTION_SPECS))
+            return CommandResult(
+                {"mode": action_mode, "valid_modes": sorted(_ACTION_SPECS)},
+                None,
+                None,
+                f"invalid mode '{action_mode}'; expected one of: {valid}",
+            )
+
+        result = self.invoke_action(
+            metadata.data["lc_service"],
+            spec["short"],
+            payload={"PerformAutoDiscovery": perform_auto_discovery},
+            full_action_type=spec["full"],
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        if result.error is None and isinstance(result.data, dict):
+            result.data.setdefault("lc_service", metadata.data["lc_service"])
+            result.data.setdefault("mode", action_mode)
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcAutoDiscovery = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/tests/test_dell_lc_autodiscovery_dualmode.py
+++ b/tests/test_dell_lc_autodiscovery_dualmode.py
@@ -1,0 +1,243 @@
+"""Dual-mode tests for Dell LC auto-discovery actions."""
+import copy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_autodiscovery import DellLcAutoDiscovery
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+AUTO_TARGET = (
+    f"{LC_SERVICE}/Actions/DellLCService.ReInitiateAutoDiscovery"
+)
+DHS_TARGET = f"{LC_SERVICE}/Actions/DellLCService.ReInitiateDHS"
+
+
+@pytest.fixture
+def dell_lc_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-lc",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _overlay_lc_service(service, body):
+    """Overlay DellLCService under both common request casings."""
+    service._overlay[LC_SERVICE] = body
+    service._overlay[LC_SERVICE.lower()] = body
+
+
+def test_autodiscovery_lists_targets_without_post(dell_lc_mock):
+    """With no --perform value, the command reports both action targets."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcAutoDiscovery,
+        "dell-lc-autodiscovery",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["lc_service"] == LC_SERVICE
+    assert result.data["actions"]["auto-discovery"] == {
+        "target": AUTO_TARGET,
+        "allowed_perform_auto_discovery": ["NextBoot", "Now", "Off"],
+        "action": "#DellLCService.ReInitiateAutoDiscovery",
+    }
+    assert result.data["actions"]["dhs"] == {
+        "target": DHS_TARGET,
+        "allowed_perform_auto_discovery": ["NextBoot", "Now", "Off"],
+        "action": "#DellLCService.ReInitiateDHS",
+    }
+    assert _post_requests(service) == []
+
+
+def test_autodiscovery_perform_defaults_to_dry_run(dell_lc_mock):
+    """A PerformAutoDiscovery value previews by default and does not POST."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcAutoDiscovery,
+        "dell-lc-autodiscovery",
+        perform_auto_discovery="NextBoot",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["action"] == "#DellLCService.ReInitiateAutoDiscovery"
+    assert result.data["target"] == AUTO_TARGET
+    assert result.data["payload"] == {"PerformAutoDiscovery": "NextBoot"}
+    assert result.data["level"] == "destructive"
+    assert result.data["lc_service"] == LC_SERVICE
+    assert result.data["mode"] == "auto-discovery"
+    assert _post_requests(service) == []
+
+
+def test_autodiscovery_confirm_posts_selected_action(dell_lc_mock):
+    """--confirm POSTs one ReInitiateAutoDiscovery payload."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcAutoDiscovery,
+        "dell-lc-autodiscovery",
+        perform_auto_discovery="Now",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellLCService.ReInitiateAutoDiscovery"
+    assert result.data["target"] == AUTO_TARGET
+    assert result.data["task_id"] == service.JOB_ID
+    assert result.data["level"] == "destructive"
+    assert result.data["lc_service"] == LC_SERVICE
+    assert len(posts) == 1
+    assert posts[0].path.lower() == AUTO_TARGET.lower()
+    assert posts[0].json() == {"PerformAutoDiscovery": "Now"}
+
+
+def test_autodiscovery_dhs_mode_posts_dhs_target(dell_lc_mock):
+    """The DHS mode selects DellLCService.ReInitiateDHS."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcAutoDiscovery,
+        "dell-lc-autodiscovery",
+        mode="dhs",
+        perform_auto_discovery="Off",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["action"] == "#DellLCService.ReInitiateDHS"
+    assert result.data["target"] == DHS_TARGET
+    assert result.data["mode"] == "dhs"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == DHS_TARGET.lower()
+    assert posts[0].json() == {"PerformAutoDiscovery": "Off"}
+
+
+def test_autodiscovery_dry_run_overrides_confirm(dell_lc_mock):
+    """Explicit dry-run wins over --confirm and avoids the POST."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcAutoDiscovery,
+        "dell-lc-autodiscovery",
+        perform_auto_discovery="Now",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == AUTO_TARGET
+    assert _post_requests(service) == []
+
+
+def test_autodiscovery_rejects_invalid_perform_value(dell_lc_mock):
+    """Inline allowable values reject unsupported PerformAutoDiscovery values."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcAutoDiscovery,
+        "dell-lc-autodiscovery",
+        perform_auto_discovery="Immediate",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.ReInitiateAutoDiscovery "
+        "PerformAutoDiscovery: Immediate; allowed: NextBoot, Now, Off"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "PerformAutoDiscovery",
+            "value": "Immediate",
+            "allowed": ["NextBoot", "Now", "Off"],
+        }
+    ]
+    assert _post_requests(service) == []
+
+
+def test_autodiscovery_reports_missing_actions_without_post(dell_lc_mock):
+    """A service missing both re-initiate actions reports the miss."""
+    manager, service = dell_lc_mock
+    body = copy.deepcopy(service._state(LC_SERVICE))
+    body["Actions"].pop("#DellLCService.ReInitiateAutoDiscovery")
+    body["Actions"].pop("#DellLCService.ReInitiateDHS")
+    _overlay_lc_service(service, body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcAutoDiscovery,
+        "dell-lc-autodiscovery",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "actions not found: #DellLCService.ReInitiateAutoDiscovery, "
+        "#DellLCService.ReInitiateDHS"
+    )
+    assert LC_SERVICE in result.data["checked"]
+    assert _post_requests(service) == []
+
+
+def test_autodiscovery_is_registered_and_classified():
+    """The command is registered and both actions are guarded."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellLcAutoDiscovery][
+        "dell-lc-autodiscovery"
+    ] is DellLcAutoDiscovery
+
+    assert classify("#DellLCService.ReInitiateAutoDiscovery") is (
+        Destructiveness.DESTRUCTIVE
+    )
+    assert classify("#DellLCService.ReInitiateDHS") is (
+        Destructiveness.DESTRUCTIVE
+    )


### PR DESCRIPTION
## Summary
- add dell-lc-autodiscovery for ReInitiateAutoDiscovery and ReInitiateDHS
- list targets with no perform value; preview by default and require --confirm before POST
- validate PerformAutoDiscovery values from action metadata and cover the Dell XR8620t corpus path

## Validation
- git diff --check
- not run: pytest/ruff locally; this repository gates in CI