### PR TITLE
Add Dell LC iSM installer command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-ism-installer` | Expose Dell iSM installer media through `DellLCService.ExposeiSMInstallerToHostOS`; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_ism_installer import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -77,6 +77,7 @@ ACTION_POLICY = {
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.ExposeiSMInstallerToHostOS": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/dell_lc/cmd_dell_lc_ism_installer.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_ism_installer.py
@@ -1,0 +1,205 @@
+"""Preview or expose Dell iSM installer media through DellLCService.
+
+    redfish_ctl dell-lc-ism-installer
+    redfish_ctl dell-lc-ism-installer --dry_run
+    redfish_ctl dell-lc-ism-installer --confirm
+
+``DellLCService.ExposeiSMInstallerToHostOS``, advertised by Dell's Lifecycle
+Controller service, can expose installer media to the host operating system.
+The command discovers the service through Manager OEM links and previews by
+default; it POSTs only when ``--confirm`` is supplied.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_ACTION = "#DellLCService.ExposeiSMInstallerToHostOS"
+_ACTION_NAME = "ExposeiSMInstallerToHostOS"
+_SERVICE_FALLBACKS = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService",
+    "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService",
+)
+
+
+class DellLcIsmInstaller(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellLcIsmInstaller,
+    name="dell-lc-ism-installer",
+    metaclass=Singleton,
+):
+    """Discover and invoke DellLCService.ExposeiSMInstallerToHostOS."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ``dell-lc-ism-installer`` command."""
+        super(DellLcIsmInstaller, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-ism-installer`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when more than one target is found",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the iSM installer expose action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-ism-installer",
+            "command expose Dell iSM installer media through DellLCService",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the ``Links.Oem.Dell`` block from a Manager resource.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional-resource misses.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _dell_lc_service_uris(self, do_async, resource_uri=None):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: run underlying Manager reads asynchronously when True.
+        :param resource_uri: optional exact DellLCService URI supplied by the caller.
+        :return: de-duplicated service URI list.
+        """
+        if resource_uri:
+            return [resource_uri.rstrip("/")]
+
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(self._dell_oem_links(manager), "DellLCService")
+            if not service_uri:
+                service_uri = f"{manager_uri.rstrip('/')}/Oem/Dell/DellLCService"
+            if service_uri not in uris:
+                uris.append(service_uri)
+        if uris:
+            return uris
+        for fallback in _SERVICE_FALLBACKS:
+            if fallback not in uris:
+                uris.append(fallback)
+        return uris
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Return discovered iSM installer action rows.
+
+        :param do_async: run Redfish queries asynchronously when True.
+        :param resource_uri: optional exact DellLCService URI supplied by the caller.
+        :return: list of action target rows.
+        """
+        rows = []
+        for service_uri in self._dell_lc_service_uris(do_async, resource_uri):
+            resource = self._get(service_uri, do_async)
+            target = self._flatten_action_targets(resource).get(_ACTION)
+            if target:
+                rows.append({
+                    "Action": _ACTION,
+                    "Resource": service_uri,
+                    "Target": target,
+                    "Payload": {},
+                })
+        return rows
+
+    def execute(
+            self,
+            resource_uri: Optional[str] = None,
+            confirm: Optional[bool] = False,
+            dry_run: Optional[bool] = False,
+            filename: Optional[str] = None,
+            data_type: Optional[str] = "json",
+            verbose: Optional[bool] = False,
+            do_async: Optional[bool] = False,
+            **kwargs) -> CommandResult:
+        """Preview or invoke DellLCService.ExposeiSMInstallerToHostOS.
+
+        :param resource_uri: optional exact DellLCService URI to inspect.
+        :param confirm: POST the action when True; otherwise return a dry-run preview.
+        :param dry_run: force a no-POST preview even when confirmation is supplied.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying GET/POST on the async path when True.
+        :return: CommandResult with preview, execution result, or missing-action error.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri)
+        if not rows:
+            return CommandResult(
+                {"action": _ACTION, "available": []},
+                None,
+                None,
+                f"action '{_ACTION}' not found on DellLCService",
+            )
+        if len(rows) > 1:
+            return CommandResult(
+                {"matches": rows},
+                None,
+                None,
+                "multiple DellLCService iSM installer targets found; pass --resource-uri",
+            )
+
+        row = rows[0]
+        return self.invoke_action(
+            row["Resource"],
+            _ACTION_NAME,
+            payload={},
+            full_action_type=_ACTION,
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcIsmInstaller = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -32,6 +32,9 @@ def test_policy_classifies_known_and_unknown():
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
+    assert classify("#DellLCService.ExposeiSMInstallerToHostOS") is (
+        Destructiveness.DESTRUCTIVE
+    )
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE
     assert classify(None) is Destructiveness.DESTRUCTIVE

--- a/tests/test_dell_lc_ism_installer_dualmode.py
+++ b/tests/test_dell_lc_ism_installer_dualmode.py
@@ -1,0 +1,168 @@
+"""Dual-mode-style coverage for DellLCService.ExposeiSMInstallerToHostOS."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+LC_SERVICE = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+ISM_ACTION = "#DellLCService.ExposeiSMInstallerToHostOS"
+ISM_TARGET = f"{LC_SERVICE}/Actions/DellLCService.ExposeiSMInstallerToHostOS"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path."""
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_lc_manager():
+    """Serve the committed Dell corpus over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+    remove_action = {"enabled": False}
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        data = json.loads(fixture.read_text(encoding="utf-8"))
+        if remove_action["enabled"] and request.path.lower() == LC_SERVICE.lower():
+            data = dict(data)
+            actions = dict(data.get("Actions") or {})
+            actions.pop(ISM_ACTION, None)
+            data["Actions"] = actions
+        return json.dumps(data)
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/ism-1"
+        return json.dumps({"Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/ism-1"}})
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-ism",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests, remove_action
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_ism_installer_without_confirm_is_preview_only(dell_lc_manager):
+    """The iSM installer action previews by default and does not POST."""
+    manager, requests, _remove_action = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcIsmInstaller,
+        "dell-lc-ism-installer",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": ISM_ACTION,
+        "target": ISM_TARGET,
+        "payload": {},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_ism_installer_confirm_posts_to_discovered_target(dell_lc_manager):
+    """With --confirm the command POSTs to the target from DellLCService."""
+    manager, requests, _remove_action = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcIsmInstaller,
+        "dell-lc-ism-installer",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == ISM_ACTION
+    assert result.data["target"] == ISM_TARGET
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == ISM_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_ism_installer_confirm_with_dry_run_still_does_not_post(dell_lc_manager):
+    """--dry_run keeps the command in preview mode even with --confirm."""
+    manager, requests, _remove_action = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcIsmInstaller,
+        "dell-lc-ism-installer",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == ISM_TARGET
+    assert _post_requests(requests) == []
+
+
+def test_ism_installer_resource_uri_override_skips_manager_discovery(dell_lc_manager):
+    """A direct DellLCService URI can be used when Manager discovery is ambiguous."""
+    manager, requests, _remove_action = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcIsmInstaller,
+        "dell-lc-ism-installer",
+        resource_uri=LC_SERVICE,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["target"] == ISM_TARGET
+    assert not any(request.path == "/redfish/v1/Managers" for request in requests)
+    assert _post_requests(requests) == []
+
+
+def test_ism_installer_missing_action_reports_no_post(dell_lc_manager):
+    """A BMC without the action returns a structured error and never POSTs."""
+    manager, requests, remove_action = dell_lc_manager
+    remove_action["enabled"] = True
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcIsmInstaller,
+        "dell-lc-ism-installer",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == f"action '{ISM_ACTION}' not found on DellLCService"
+    assert result.data == {"action": ISM_ACTION, "available": []}
+    assert _post_requests(requests) == []


### PR DESCRIPTION
## Summary

Adds a guarded `dell-lc-ism-installer` command for Dell Lifecycle Controller `DellLCService.ExposeiSMInstallerToHostOS`.

The command discovers `DellLCService` through Manager OEM links, resolves the advertised action target from the resource body, previews by default, and only POSTs when `--confirm` is supplied.

## Validation

- `git diff --check`
- `git diff --cached --check`
- GitHub Actions will run the full test matrix

No live BMC was used.