### PR TITLE
Add Dell RAID virtual disk rename command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-raid-rename-vd` | Rename a Dell RAID virtual disk; previews unless `--confirm` is given. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -18,6 +18,7 @@ from .compute.cmd_compute_setting import *
 
 from .redfish_manager_shared import *
 from .raid.cmd_raid_service import *
+from .raid.cmd_dell_raid_rename_vd import *
 #
 # bios commands
 from .bios.cmd_bios import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,7 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellRaidService.RenameVD": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/raid/cmd_dell_raid_rename_vd.py
+++ b/redfish_ctl/raid/cmd_dell_raid_rename_vd.py
@@ -1,0 +1,217 @@
+"""Preview or run DellRaidService RenameVD.
+
+    redfish_ctl dell-raid-rename-vd
+    redfish_ctl dell-raid-rename-vd \
+        --target-fqdd Disk.Virtual.0 --name data-vd
+    redfish_ctl dell-raid-rename-vd \
+        --target-fqdd Disk.Virtual.0 --name data-vd --confirm
+
+The command resolves the action target from the DellRaidService ``Actions``
+block and previews by default. ``RenameVD`` changes virtual-disk metadata and
+only POSTs when ``--confirm`` is supplied.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_RENAME_VD_ACTION = "#DellRaidService.RenameVD"
+
+
+class DellRaidRenameVD(RedfishManagerBase,
+                       scm_type=ApiRequestType.DellRaidRenameVD,
+                       name="dell-raid-rename-vd",
+                       metaclass=Singleton):
+    """Preview or run the DellRaidService RenameVD action."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-raid-rename-vd command."""
+        super(DellRaidRenameVD, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-raid-rename-vd`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--target-fqdd",
+            dest="target_fqdd",
+            default=None,
+            help="virtual disk FQDD to rename",
+        )
+        cmd_parser.add_argument(
+            "--name",
+            dest="vd_name",
+            default=None,
+            help="new virtual disk name",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the RenameVD POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-raid-rename-vd",
+            "rename a Dell RAID virtual disk",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a linked property.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_links(resource):
+        """Return ``Links.Oem.Dell`` from a Redfish resource.
+
+        :param resource: Redfish resource body.
+        :return: Dell OEM links block, or an empty dict.
+        """
+        links = resource.get("Links") if isinstance(resource, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional resource gaps.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict on read failure.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _raid_service_uri(self, do_async):
+        """Resolve DellRaidService from the selected ComputerSystem OEM links.
+
+        :param do_async: issue the query on the async path when True.
+        :return: DellRaidService URI.
+        """
+        system_uri = self.idrac_manage_servers
+        system = self._get(system_uri, do_async)
+        linked = self._link(self._dell_links(system), "DellRaidService")
+        if linked:
+            return linked
+        system_id = system_uri.rstrip("/").rsplit("/", 1)[-1]
+        return f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellRaidService"
+
+    def _discover(self, do_async):
+        """Discover the DellRaidService RenameVD target.
+
+        :param do_async: issue underlying Redfish queries on the async path when True.
+        :return: tuple of (DellRaidService URI, action metadata, RenameVD target).
+        """
+        service_uri = self._raid_service_uri(do_async)
+        service = self._get(service_uri, do_async)
+        actions = self.discover_redfish_actions(self, service)
+        target = self._flatten_action_targets(service).get(_RENAME_VD_ACTION)
+        return service_uri, actions, target
+
+    @staticmethod
+    def _payload(target_fqdd, vd_name):
+        """Build and validate the RenameVD payload.
+
+        :param target_fqdd: virtual disk FQDD to rename.
+        :param vd_name: new virtual disk name.
+        :return: payload dict accepted by DellRaidService.RenameVD.
+        """
+        missing = []
+        if not target_fqdd:
+            missing.append("TargetFQDD")
+        if not vd_name:
+            missing.append("Name")
+        if missing:
+            raise InvalidArgument(
+                f"dell-raid-rename-vd requires: {', '.join(missing)}"
+            )
+        return {"TargetFQDD": target_fqdd, "Name": vd_name}
+
+    def execute(self,
+                target_fqdd: Optional[str] = None,
+                vd_name: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or run DellRaidService RenameVD.
+
+        :param target_fqdd: virtual disk FQDD to rename.
+        :param vd_name: new virtual disk name.
+        :param confirm: send the RenameVD POST when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        service_uri, actions, target = self._discover(bool(do_async))
+        if not target_fqdd and not vd_name:
+            rows = []
+            if target:
+                rows.append({
+                    "Action": "rename-vd",
+                    "FullType": _RENAME_VD_ACTION,
+                    "Resource": service_uri,
+                    "Target": target,
+                    "RequiredPayload": ["TargetFQDD", "Name"],
+                })
+            return CommandResult(rows, actions, None, None)
+
+        if target is None:
+            available = sorted(self._flatten_action_targets(
+                self._get(service_uri, bool(do_async))
+            ))
+            return CommandResult(
+                {
+                    "raid_service": service_uri,
+                    "action": _RENAME_VD_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                "Dell RAID RenameVD action not found",
+            )
+
+        payload = self._payload(target_fqdd, vd_name)
+        return self.invoke_action(
+            service_uri,
+            "RenameVD",
+            payload=payload,
+            full_action_type=_RENAME_VD_ACTION,
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -63,6 +63,7 @@ class ApiRequestType(Enum):
     SystemQuery = auto()
     VirtualDiskQuery = auto()
     RaidServiceQuery = auto()
+    DellRaidRenameVD = auto()
     StorageQuery = auto()
     Tasks = auto()
     GetTask = auto()

--- a/tests/test_dell_raid_rename_vd_dualmode.py
+++ b/tests/test_dell_raid_rename_vd_dualmode.py
@@ -1,0 +1,245 @@
+"""Dual-mode-style coverage for DellRaidService RenameVD."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.raid.cmd_dell_raid_rename_vd import DellRaidRenameVD
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+RAID_SERVICE = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+RENAME_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.RenameVD"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path."""
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+def _corpus_body(path):
+    """Return one Dell corpus fixture body as JSON."""
+    fixture = _fixture_for_path(path)
+    if fixture is None:
+        raise AssertionError(f"missing Dell fixture for {path}")
+    return json.loads(fixture.read_text())
+
+
+@pytest.fixture
+def dell_raid_manager_factory():
+    """Serve the committed Dell corpus over requests-mock."""
+    requests_mock = pytest.importorskip("requests_mock")
+    started = []
+
+    def factory(service_body=None):
+        requests = []
+
+        def get_cb(request, context):
+            requests.append(request)
+            is_override = (
+                request.path.lower() == RAID_SERVICE.lower()
+                and service_body is not None
+            )
+            if is_override:
+                context.status_code = 200
+                return json.dumps(service_body)
+            fixture = _fixture_for_path(request.path)
+            if fixture is None:
+                context.status_code = 404
+                return json.dumps({"error": f"no fixture for {request.path}"})
+            context.status_code = 200
+            return fixture.read_text()
+
+        def post_cb(request, context):
+            requests.append(request)
+            context.status_code = 202
+            context.headers["Location"] = "/redfish/v1/TaskService/Tasks/rename-vd-1"
+            return json.dumps({
+                "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/rename-vd-1"}
+            })
+
+        mocker = requests_mock.Mocker()
+        mocker.start()
+        started.append(mocker)
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-raid",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        return manager, requests
+
+    yield factory
+
+    for mocker in reversed(started):
+        mocker.stop()
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_raid_rename_vd_lists_target_without_posting(
+    dell_raid_manager_factory,
+):
+    """With no payload, the command lists RenameVD and never POSTs."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidRenameVD,
+        "dell-raid-rename-vd",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == [{
+        "Action": "rename-vd",
+        "FullType": "#DellRaidService.RenameVD",
+        "Resource": RAID_SERVICE,
+        "Target": RENAME_TARGET,
+        "RequiredPayload": ["TargetFQDD", "Name"],
+    }]
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_rename_vd_previews_by_default(dell_raid_manager_factory):
+    """RenameVD previews by default and does not POST."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidRenameVD,
+        "dell-raid-rename-vd",
+        target_fqdd="Disk.Virtual.0",
+        vd_name="data-vd",
+    )
+
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.RenameVD",
+        "target": RENAME_TARGET,
+        "payload": {"TargetFQDD": "Disk.Virtual.0", "Name": "data-vd"},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_rename_vd_confirm_posts(dell_raid_manager_factory):
+    """--confirm POSTs RenameVD to the corpus-advertised target."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidRenameVD,
+        "dell-raid-rename-vd",
+        target_fqdd="Disk.Virtual.0",
+        vd_name="data-vd",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.RenameVD"
+    assert result.data["target"] == RENAME_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "rename-vd-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == RENAME_TARGET.lower()
+    assert posts[0].json() == {"TargetFQDD": "Disk.Virtual.0", "Name": "data-vd"}
+
+
+def test_dell_raid_rename_vd_dry_run_overrides_confirm(
+    dell_raid_manager_factory,
+):
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    manager, requests = dell_raid_manager_factory()
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidRenameVD,
+        "dell-raid-rename-vd",
+        target_fqdd="Disk.Virtual.0",
+        vd_name="data-vd",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == RENAME_TARGET
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_rename_vd_missing_payload_is_rejected(
+    dell_raid_manager_factory,
+):
+    """The command rejects missing required payload before POST."""
+    manager, requests = dell_raid_manager_factory()
+
+    with pytest.raises(InvalidArgument, match="requires: Name"):
+        manager.sync_invoke(
+            ApiRequestType.DellRaidRenameVD,
+            "dell-raid-rename-vd",
+            target_fqdd="Disk.Virtual.0",
+            confirm=True,
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_rename_vd_missing_action_reports_available(
+    dell_raid_manager_factory,
+):
+    """A DellRaidService without RenameVD reports the missing action."""
+    service_body = _corpus_body(RAID_SERVICE)
+    service_body["Actions"] = dict(service_body["Actions"])
+    service_body["Actions"].pop("#DellRaidService.RenameVD")
+    manager, requests = dell_raid_manager_factory(service_body=service_body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidRenameVD,
+        "dell-raid-rename-vd",
+        target_fqdd="Disk.Virtual.0",
+        vd_name="data-vd",
+        confirm=True,
+    )
+
+    assert result.error == "Dell RAID RenameVD action not found"
+    assert result.data["action"] == "#DellRaidService.RenameVD"
+    assert "#DellRaidService.SetBootVD" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_raid_rename_vd_policy_and_registry():
+    """RenameVD is classified and the command is registered."""
+    assert classify("#DellRaidService.RenameVD") is Destructiveness.DESTRUCTIVE
+
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellRaidRenameVD][
+        "dell-raid-rename-vd"
+    ] is DellRaidRenameVD
+
+    cmd_parser, cmd_name, cmd_help = DellRaidRenameVD.register_subcommand(
+        DellRaidRenameVD
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-raid-rename-vd"
+    assert "virtual disk" in cmd_help
+    assert "--target-fqdd" in help_text
+    assert "--name" in help_text


### PR DESCRIPTION
## Summary

- add a guarded `dell-raid-rename-vd` command that discovers `DellRaidService.RenameVD` from the Dell OEM service link
- require a virtual disk FQDD and new name for the RenameVD payload
- add corpus-backed tests for listing, preview, confirmed POST, dry-run override, missing action handling, policy classification, and registry wiring

## Validation

- `git diff --cached --check`
- GitHub Actions will run the repository gates for the PR