### PR TITLE
Add Dell RAID clear action command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-raid-clear-actions` | Preview Dell RAID clear actions. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -18,6 +18,7 @@ from .compute.cmd_compute_setting import *
 
 from .redfish_manager_shared import *
 from .raid.cmd_raid_service import *
+from .raid.cmd_dell_raid_clear_actions import *
 #
 # bios commands
 from .bios.cmd_bios import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -77,6 +77,8 @@ ACTION_POLICY = {
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
+    "#DellRaidService.ClearControllerPreservedCache": Destructiveness.IRREVERSIBLE,
+    "#DellRaidService.ClearForeignConfig": Destructiveness.IRREVERSIBLE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/raid/cmd_dell_raid_clear_actions.py
+++ b/redfish_ctl/raid/cmd_dell_raid_clear_actions.py
@@ -1,0 +1,291 @@
+"""Preview or run DellRaidService clear actions.
+
+    redfish_ctl dell-raid-clear-actions
+    redfish_ctl dell-raid-clear-actions --action foreign-config
+    redfish_ctl dell-raid-clear-actions --action preserved-cache --confirm \
+        --i-understand-irreversible
+
+The command resolves DellRaidService from the selected ComputerSystem and lists
+advertised clear actions without mutating by default. These actions can discard
+controller state, so both ``--confirm`` and ``--i-understand-irreversible`` are
+required before a POST is sent.
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_CLEAR_PRESERVED_CACHE_ACTION = "#DellRaidService.ClearControllerPreservedCache"
+_CLEAR_FOREIGN_CONFIG_ACTION = "#DellRaidService.ClearForeignConfig"
+_SYSTEM_FALLBACK = f"{RedfishApi.Version}/Systems/System.Embedded.1"
+_SERVICE_SUFFIX = "Oem/Dell/DellRaidService"
+
+
+@dataclass(frozen=True)
+class _ClearAction:
+    """Static selector metadata for one DellRaidService clear action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+
+
+_ACTION_SPECS = {
+    "foreign-config": _ClearAction(
+        selector="foreign-config",
+        full_type=_CLEAR_FOREIGN_CONFIG_ACTION,
+        action_name="ClearForeignConfig",
+    ),
+    "preserved-cache": _ClearAction(
+        selector="preserved-cache",
+        full_type=_CLEAR_PRESERVED_CACHE_ACTION,
+        action_name="ClearControllerPreservedCache",
+    ),
+}
+
+
+class DellRaidClearActions(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellRaidClearActions,
+    name="dell-raid-clear-actions",
+    metaclass=Singleton,
+):
+    """Preview or run DellRaidService clear actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-raid-clear-actions command."""
+        super(DellRaidClearActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-raid-clear-actions`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="clear action to preview or invoke",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="authorize the selected DellRaidService POST",
+        )
+        cmd_parser.add_argument(
+            "--i-understand-irreversible",
+            action="store_true",
+            dest="confirm_irreversible",
+            default=False,
+            help="required with --confirm because the clear action discards state",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides confirmation",
+        )
+        return (
+            cmd_parser,
+            "dell-raid-clear-actions",
+            "preview or run Dell RAID clear actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _oem_dell_link(cls, resource, key):
+        """Return a Dell OEM link from ``Links.Oem.Dell`` or ``Oem.Dell``.
+
+        :param resource: Redfish resource body to inspect.
+        :param key: Dell OEM link name.
+        :return: the linked URI, or None when absent.
+        """
+        links = (resource or {}).get("Links") or {}
+        linked = cls._link(((links.get("Oem") or {}).get("Dell") or {}), key)
+        if linked:
+            return linked
+        return cls._link((((resource or {}).get("Oem") or {}).get("Dell") or {}), key)
+
+    @staticmethod
+    def _clean_required(value, label):
+        """Normalize a required string option.
+
+        :param value: option value to normalize.
+        :param label: user-facing field label for errors.
+        :return: stripped string.
+        :raises InvalidArgument: when the value is missing or empty.
+        """
+        stripped = (value or "").strip()
+        if not stripped:
+            raise InvalidArgument(f"{label} cannot be empty")
+        return stripped
+
+    def _system_uri(self):
+        """Return the selected ComputerSystem URI.
+
+        :return: manager-selected system URI, or Dell default fallback.
+        """
+        try:
+            system_uri = self.idrac_manage_servers
+        except Exception:
+            system_uri = ""
+        return system_uri or _SYSTEM_FALLBACK
+
+    def _read_optional(self, uri, do_async):
+        """Read a Redfish resource, returning ``None`` on lookup failure.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query over the async Redfish path.
+        :return: resource body when readable, otherwise None.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _raid_service(self, do_async):
+        """Resolve and read the DellRaidService resource.
+
+        :param do_async: issue the query over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or ``(uri, CommandResult)`` on failure.
+        """
+        system_uri = self._system_uri()
+        system = self._read_optional(system_uri, do_async) or {}
+        system_id = system_uri.rstrip("/").rsplit("/", 1)[-1]
+        candidates = [
+            self._oem_dell_link(system, "DellRaidService"),
+            f"{system_uri}/{_SERVICE_SUFFIX}",
+            f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellRaidService",
+        ]
+        seen = set()
+        for uri in candidates:
+            if not uri or uri in seen:
+                continue
+            seen.add(uri)
+            data = self._read_optional(uri, do_async)
+            if data is not None:
+                return uri, data
+        fallback = next(
+            (uri for uri in candidates if uri),
+            f"{system_uri}/{_SERVICE_SUFFIX}",
+        )
+        return (
+            fallback,
+            CommandResult(
+                None,
+                None,
+                None,
+                "DellRaidService is not available on this host",
+            ),
+        )
+
+    def _discover_rows(self, do_async):
+        """Discover available clear action targets and metadata.
+
+        :param do_async: issue underlying queries over the async path.
+        :return: tuple of service URI, discovered action map, and rows.
+        """
+        raid_uri, service = self._raid_service(do_async)
+        if isinstance(service, CommandResult):
+            return raid_uri, {}, service
+        actions = self.discover_redfish_actions(self, service)
+        targets = self._flatten_action_targets(service)
+        rows = []
+        for spec in _ACTION_SPECS.values():
+            target = targets.get(spec.full_type)
+            if not target:
+                continue
+            rows.append({
+                "Action": spec.selector,
+                "FullType": spec.full_type,
+                "Resource": raid_uri,
+                "Target": target,
+                "RequiredPayload": [],
+                "Level": "irreversible",
+            })
+        return raid_uri, actions, rows
+
+    def execute(self,
+                action: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                confirm_irreversible: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or run DellRaidService clear actions.
+
+        :param action: selected action: ``foreign-config`` or ``preserved-cache``.
+        :param confirm: authorize the DellRaidService POST.
+        :param confirm_irreversible: extra irreversible confirmation token.
+        :param dry_run: resolve the target without POSTing; overrides confirmation.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        raid_uri, actions, rows = self._discover_rows(bool(do_async))
+        if isinstance(rows, CommandResult):
+            return rows
+        if action is None:
+            return CommandResult(
+                {"raid_service": raid_uri, "actions": rows},
+                actions,
+                None,
+                None,
+            )
+
+        selected = self._clean_required(action, "action")
+        if selected not in _ACTION_SPECS:
+            raise InvalidArgument(
+                "action must be one of: foreign-config, preserved-cache"
+            )
+        spec = _ACTION_SPECS[selected]
+        if not any(row["Action"] == selected for row in rows):
+            return CommandResult(
+                {
+                    "raid_service": raid_uri,
+                    "action": spec.full_type,
+                    "available": rows,
+                },
+                actions,
+                None,
+                f"action '{spec.full_type}' not found on {raid_uri}",
+            )
+        return self.invoke_action(
+            raid_uri,
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+            confirm_irreversible=bool(confirm_irreversible),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -32,6 +32,7 @@ class ApiRequestType(Enum):
     VolumeCreate = auto()
     VolumeDelete = auto()
     VolumeCheckConsistency = auto()
+    DellRaidClearActions = auto()
     ImportOneTimeBoot = auto()
 
     # dell oem

--- a/tests/test_dell_raid_clear_actions_dualmode.py
+++ b/tests/test_dell_raid_clear_actions_dualmode.py
@@ -1,0 +1,231 @@
+"""Dual-mode-style coverage for DellRaidService clear actions."""
+import json
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.raid.cmd_dell_raid_clear_actions import DellRaidClearActions
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+RAID_SERVICE = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+FOREIGN_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.ClearForeignConfig"
+PRESERVED_TARGET = (
+    f"{RAID_SERVICE}/Actions/DellRaidService.ClearControllerPreservedCache"
+)
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-raid-clear-actions",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _without_action(action_name):
+    """Return the DellRaidService fixture body with one action removed."""
+    fixture = (
+        DELL_CORPUS
+        / "_redfish_v1_Systems_System.Embedded.1_Oem_Dell_DellRaidService.json"
+    )
+    body = json.loads(fixture.read_text())
+    body["Actions"] = dict(body["Actions"])
+    body["Actions"].pop(action_name, None)
+    return body
+
+
+def test_dell_raid_clear_actions_list_targets_without_post(dell_corpus_mock):
+    """Calling without an action lists advertised clear actions."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidClearActions,
+        "dell-raid-clear-actions",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["raid_service"] == RAID_SERVICE
+    actions = {row["Action"]: row for row in result.data["actions"]}
+    assert set(actions) == {"foreign-config", "preserved-cache"}
+    assert actions["foreign-config"]["Target"] == FOREIGN_TARGET
+    assert actions["foreign-config"]["RequiredPayload"] == []
+    assert actions["foreign-config"]["Level"] == "irreversible"
+    assert actions["preserved-cache"]["Target"] == PRESERVED_TARGET
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_clear_foreign_config_previews_by_default(dell_corpus_mock):
+    """ClearForeignConfig stays a no-POST preview by default."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidClearActions,
+        "dell-raid-clear-actions",
+        action="foreign-config",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.ClearForeignConfig",
+        "target": FOREIGN_TARGET,
+        "payload": {},
+        "level": "irreversible",
+        "blocked": (
+            "irreversible action requires --confirm and "
+            "--i-understand-irreversible"
+        ),
+    }
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_clear_confirm_alone_does_not_post(dell_corpus_mock):
+    """Irreversible clear actions require the extra confirmation token."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidClearActions,
+        "dell-raid-clear-actions",
+        action="preserved-cache",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["level"] == "irreversible"
+    assert result.data["blocked"] == (
+        "irreversible action requires --confirm and --i-understand-irreversible"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_clear_posts_with_both_confirmations(dell_corpus_mock):
+    """Both confirmation flags POST to the corpus-advertised action target."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidClearActions,
+        "dell-raid-clear-actions",
+        action="foreign-config",
+        confirm=True,
+        confirm_irreversible=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.ClearForeignConfig"
+    assert result.data["target"] == FOREIGN_TARGET
+    assert result.data["task_id"] == MockRedfishService.JOB_ID
+    assert len(posts) == 1
+    assert posts[0].path.lower() == FOREIGN_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_raid_clear_dry_run_overrides_confirmation(dell_corpus_mock):
+    """--dry_run keeps a fully confirmed clear action from POSTing."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidClearActions,
+        "dell-raid-clear-actions",
+        action="preserved-cache",
+        confirm=True,
+        confirm_irreversible=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.ClearControllerPreservedCache",
+        "target": PRESERVED_TARGET,
+        "payload": {},
+        "level": "irreversible",
+        "blocked": None,
+    }
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_clear_missing_action_reports_available(dell_corpus_mock):
+    """A service without the selected action returns an actionable no-POST error."""
+    manager, service = dell_corpus_mock
+    service._overlay[RAID_SERVICE.lower()] = _without_action(
+        "#DellRaidService.ClearForeignConfig"
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidClearActions,
+        "dell-raid-clear-actions",
+        action="foreign-config",
+        confirm=True,
+        confirm_irreversible=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["action"] == "#DellRaidService.ClearForeignConfig"
+    assert result.error == (
+        "action '#DellRaidService.ClearForeignConfig' not found on "
+        f"{RAID_SERVICE}"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_clear_policy_and_registry_are_wired():
+    """The command is registered and its clear actions use the strongest guard."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellRaidClearActions][
+        "dell-raid-clear-actions"
+    ] is DellRaidClearActions
+
+    for action in (
+        "#DellRaidService.ClearControllerPreservedCache",
+        "#DellRaidService.ClearForeignConfig",
+    ):
+        assert classify(action) is Destructiveness.IRREVERSIBLE
+
+    cmd_parser, cmd_name, cmd_help = DellRaidClearActions.register_subcommand(
+        DellRaidClearActions
+    )
+    help_text = cmd_parser.format_help()
+    assert cmd_name == "dell-raid-clear-actions"
+    assert "clear actions" in cmd_help
+    assert "--action" in help_text
+    assert "--confirm" in help_text
+    assert "--i-understand-irreversible" in help_text
+    assert "--dry_run" in help_text


### PR DESCRIPTION
## Summary
- add `dell-raid-clear-actions` for `DellRaidService.ClearForeignConfig` and `DellRaidService.ClearControllerPreservedCache`
- resolve DellRaidService from the selected system before using the corpus-advertised action targets
- require irreversible confirmation before either clear action can POST

## Tests
- `git diff --check`
- `git diff --cached --check`