### PR TITLE
Add Dell RAID foreign config command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-raid-foreign-config` | Preview Dell RAID foreign import/unlock actions. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -18,6 +18,7 @@ from .compute.cmd_compute_setting import *
 
 from .redfish_manager_shared import *
 from .raid.cmd_raid_service import *
+from .raid.cmd_dell_raid_foreign_config import *
 #
 # bios commands
 from .bios.cmd_bios import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -85,6 +85,8 @@ ACTION_POLICY = {
 
     # irreversible: data loss or one-way security change — needs the extra token
     "#Drive.SecureErase": Destructiveness.IRREVERSIBLE,
+    "#DellRaidService.ImportForeignConfig": Destructiveness.IRREVERSIBLE,
+    "#DellRaidService.UnLockSecureForeignConfig": Destructiveness.IRREVERSIBLE,
     "#Manager.ResetToDefaults": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.RevokeKeys": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.UpdateMinimumSecurityVersion": Destructiveness.IRREVERSIBLE,

--- a/redfish_ctl/raid/cmd_dell_raid_foreign_config.py
+++ b/redfish_ctl/raid/cmd_dell_raid_foreign_config.py
@@ -1,0 +1,291 @@
+"""Preview or run DellRaidService foreign-configuration actions.
+
+    redfish_ctl dell-raid-foreign-config
+    redfish_ctl dell-raid-foreign-config --action import
+    redfish_ctl dell-raid-foreign-config --action unlock-secure --confirm \
+        --i-understand-irreversible
+
+The command resolves DellRaidService from the selected ComputerSystem and lists
+advertised foreign-configuration actions without mutating by default. Importing
+or unlocking secure foreign RAID configuration can alter storage state, so both
+``--confirm`` and ``--i-understand-irreversible`` are required before POST.
+"""
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_IMPORT_FOREIGN_CONFIG_ACTION = "#DellRaidService.ImportForeignConfig"
+_UNLOCK_SECURE_FOREIGN_CONFIG_ACTION = (
+    "#DellRaidService.UnLockSecureForeignConfig"
+)
+_SYSTEM_FALLBACK = f"{RedfishApi.Version}/Systems/System.Embedded.1"
+_SERVICE_SUFFIX = "Oem/Dell/DellRaidService"
+
+
+@dataclass(frozen=True)
+class _ForeignConfigAction:
+    """Static selector metadata for one DellRaidService foreign action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+
+
+_ACTION_SPECS = {
+    "import": _ForeignConfigAction(
+        selector="import",
+        full_type=_IMPORT_FOREIGN_CONFIG_ACTION,
+        action_name="ImportForeignConfig",
+    ),
+    "unlock-secure": _ForeignConfigAction(
+        selector="unlock-secure",
+        full_type=_UNLOCK_SECURE_FOREIGN_CONFIG_ACTION,
+        action_name="UnLockSecureForeignConfig",
+    ),
+}
+
+
+class DellRaidForeignConfigActions(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellRaidForeignConfigActions,
+    name="dell-raid-foreign-config",
+    metaclass=Singleton,
+):
+    """Preview or run DellRaidService foreign-configuration actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-raid-foreign-config command."""
+        super(DellRaidForeignConfigActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-raid-foreign-config`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="foreign-configuration action to preview or invoke",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="authorize the selected DellRaidService POST",
+        )
+        cmd_parser.add_argument(
+            "--i-understand-irreversible",
+            action="store_true",
+            dest="confirm_irreversible",
+            default=False,
+            help="required with --confirm because the action changes RAID state",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides confirmation",
+        )
+        return (
+            cmd_parser,
+            "dell-raid-foreign-config",
+            "preview or run Dell RAID foreign-configuration actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _oem_dell_link(cls, resource, key):
+        """Return a Dell OEM link from ``Links.Oem.Dell`` or ``Oem.Dell``.
+
+        :param resource: Redfish resource body to inspect.
+        :param key: Dell OEM link name.
+        :return: the linked URI, or None when absent.
+        """
+        links = (resource or {}).get("Links") or {}
+        linked = cls._link(((links.get("Oem") or {}).get("Dell") or {}), key)
+        if linked:
+            return linked
+        return cls._link((((resource or {}).get("Oem") or {}).get("Dell") or {}), key)
+
+    @staticmethod
+    def _clean_required(value, label):
+        """Normalize a required string option.
+
+        :param value: option value to normalize.
+        :param label: user-facing field label for errors.
+        :return: stripped string.
+        :raises InvalidArgument: when the value is missing or empty.
+        """
+        stripped = (value or "").strip()
+        if not stripped:
+            raise InvalidArgument(f"{label} cannot be empty")
+        return stripped
+
+    def _system_uri(self):
+        """Return the selected ComputerSystem URI.
+
+        :return: manager-selected system URI, or Dell default fallback.
+        """
+        try:
+            system_uri = self.idrac_manage_servers
+        except Exception:
+            system_uri = ""
+        return system_uri or _SYSTEM_FALLBACK
+
+    def _read_optional(self, uri, do_async):
+        """Read a Redfish resource, returning ``None`` on lookup failure.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query over the async Redfish path.
+        :return: resource body when readable, otherwise None.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+
+    def _raid_service(self, do_async):
+        """Resolve and read the DellRaidService resource.
+
+        :param do_async: issue the query over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or ``(uri, CommandResult)`` on failure.
+        """
+        system_uri = self._system_uri()
+        system = self._read_optional(system_uri, do_async) or {}
+        system_id = system_uri.rstrip("/").rsplit("/", 1)[-1]
+        candidates = [
+            self._oem_dell_link(system, "DellRaidService"),
+            f"{system_uri}/{_SERVICE_SUFFIX}",
+            f"{RedfishApi.Version}/Dell/Systems/{system_id}/DellRaidService",
+        ]
+        seen = set()
+        for uri in candidates:
+            if not uri or uri in seen:
+                continue
+            seen.add(uri)
+            data = self._read_optional(uri, do_async)
+            if data is not None:
+                return uri, data
+        fallback = next(
+            (uri for uri in candidates if uri),
+            f"{system_uri}/{_SERVICE_SUFFIX}",
+        )
+        return (
+            fallback,
+            CommandResult(
+                None,
+                None,
+                None,
+                "DellRaidService is not available on this host",
+            ),
+        )
+
+    def _discover_rows(self, do_async):
+        """Discover available foreign-configuration action targets.
+
+        :param do_async: issue underlying queries over the async path.
+        :return: tuple of service URI, discovered action map, and rows.
+        """
+        raid_uri, service = self._raid_service(do_async)
+        if isinstance(service, CommandResult):
+            return raid_uri, {}, service
+        actions = self.discover_redfish_actions(self, service)
+        targets = self._flatten_action_targets(service)
+        rows = []
+        for spec in _ACTION_SPECS.values():
+            target = targets.get(spec.full_type)
+            if not target:
+                continue
+            rows.append({
+                "Action": spec.selector,
+                "FullType": spec.full_type,
+                "Resource": raid_uri,
+                "Target": target,
+                "RequiredPayload": [],
+                "Level": "irreversible",
+            })
+        return raid_uri, actions, rows
+
+    def execute(self,
+                action: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                confirm_irreversible: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or run DellRaidService foreign actions.
+
+        :param action: selected action: ``import`` or ``unlock-secure``.
+        :param confirm: authorize the DellRaidService POST.
+        :param confirm_irreversible: extra irreversible confirmation token.
+        :param dry_run: resolve the target without POSTing; overrides confirmation.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying queries/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        raid_uri, actions, rows = self._discover_rows(bool(do_async))
+        if isinstance(rows, CommandResult):
+            return rows
+        if action is None:
+            return CommandResult(
+                {"raid_service": raid_uri, "actions": rows},
+                actions,
+                None,
+                None,
+            )
+
+        selected = self._clean_required(action, "action")
+        if selected not in _ACTION_SPECS:
+            raise InvalidArgument("action must be one of: import, unlock-secure")
+        spec = _ACTION_SPECS[selected]
+        if not any(row["Action"] == selected for row in rows):
+            return CommandResult(
+                {
+                    "raid_service": raid_uri,
+                    "action": spec.full_type,
+                    "available": rows,
+                },
+                actions,
+                None,
+                f"action '{spec.full_type}' not found on {raid_uri}",
+            )
+        return self.invoke_action(
+            raid_uri,
+            spec.action_name,
+            payload={},
+            full_action_type=spec.full_type,
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+            confirm_irreversible=bool(confirm_irreversible),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -63,6 +63,7 @@ class ApiRequestType(Enum):
     SystemQuery = auto()
     VirtualDiskQuery = auto()
     RaidServiceQuery = auto()
+    DellRaidForeignConfigActions = auto()
     StorageQuery = auto()
     Tasks = auto()
     GetTask = auto()

--- a/tests/test_dell_raid_foreign_config_dualmode.py
+++ b/tests/test_dell_raid_foreign_config_dualmode.py
@@ -1,0 +1,231 @@
+"""Dual-mode-style coverage for DellRaidService foreign-config actions."""
+import json
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.raid.cmd_dell_raid_foreign_config import DellRaidForeignConfigActions
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+RAID_SERVICE = "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/DellRaidService"
+IMPORT_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.ImportForeignConfig"
+UNLOCK_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.UnLockSecureForeignConfig"
+
+
+@pytest.fixture
+def dell_corpus_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-raid-foreign-config",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _without_action(action_name):
+    """Return the DellRaidService fixture body with one action removed."""
+    fixture = (
+        DELL_CORPUS
+        / "_redfish_v1_Systems_System.Embedded.1_Oem_Dell_DellRaidService.json"
+    )
+    body = json.loads(fixture.read_text())
+    body["Actions"] = dict(body["Actions"])
+    body["Actions"].pop(action_name, None)
+    return body
+
+
+def test_dell_raid_foreign_config_lists_targets_without_post(dell_corpus_mock):
+    """Calling without an action lists advertised foreign-config actions."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidForeignConfigActions,
+        "dell-raid-foreign-config",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["raid_service"] == RAID_SERVICE
+    actions = {row["Action"]: row for row in result.data["actions"]}
+    assert set(actions) == {"import", "unlock-secure"}
+    assert actions["import"]["Target"] == IMPORT_TARGET
+    assert actions["import"]["RequiredPayload"] == []
+    assert actions["import"]["Level"] == "irreversible"
+    assert actions["unlock-secure"]["Target"] == UNLOCK_TARGET
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_import_foreign_config_previews_by_default(dell_corpus_mock):
+    """ImportForeignConfig stays a no-POST preview by default."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidForeignConfigActions,
+        "dell-raid-foreign-config",
+        action="import",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.ImportForeignConfig",
+        "target": IMPORT_TARGET,
+        "payload": {},
+        "level": "irreversible",
+        "blocked": (
+            "irreversible action requires --confirm and "
+            "--i-understand-irreversible"
+        ),
+    }
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_foreign_config_confirm_alone_does_not_post(dell_corpus_mock):
+    """Irreversible foreign-config actions require the extra confirmation token."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidForeignConfigActions,
+        "dell-raid-foreign-config",
+        action="unlock-secure",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["level"] == "irreversible"
+    assert result.data["blocked"] == (
+        "irreversible action requires --confirm and --i-understand-irreversible"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_foreign_config_posts_with_both_confirmations(dell_corpus_mock):
+    """Both confirmation flags POST to the corpus-advertised action target."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidForeignConfigActions,
+        "dell-raid-foreign-config",
+        action="unlock-secure",
+        confirm=True,
+        confirm_irreversible=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellRaidService.UnLockSecureForeignConfig"
+    assert result.data["target"] == UNLOCK_TARGET
+    assert result.data["task_id"] == MockRedfishService.JOB_ID
+    assert len(posts) == 1
+    assert posts[0].path.lower() == UNLOCK_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_raid_foreign_config_dry_run_overrides_confirmation(dell_corpus_mock):
+    """--dry_run keeps a fully confirmed foreign-config action from POSTing."""
+    manager, service = dell_corpus_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidForeignConfigActions,
+        "dell-raid-foreign-config",
+        action="import",
+        confirm=True,
+        confirm_irreversible=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": "#DellRaidService.ImportForeignConfig",
+        "target": IMPORT_TARGET,
+        "payload": {},
+        "level": "irreversible",
+        "blocked": None,
+    }
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_foreign_config_missing_action_reports_available(dell_corpus_mock):
+    """A service without the selected action returns an actionable no-POST error."""
+    manager, service = dell_corpus_mock
+    service._overlay[RAID_SERVICE.lower()] = _without_action(
+        "#DellRaidService.ImportForeignConfig"
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellRaidForeignConfigActions,
+        "dell-raid-foreign-config",
+        action="import",
+        confirm=True,
+        confirm_irreversible=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.data["action"] == "#DellRaidService.ImportForeignConfig"
+    assert result.error == (
+        "action '#DellRaidService.ImportForeignConfig' not found on "
+        f"{RAID_SERVICE}"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_raid_foreign_config_policy_and_registry_are_wired():
+    """The command is registered and its foreign actions use the strongest guard."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellRaidForeignConfigActions][
+        "dell-raid-foreign-config"
+    ] is DellRaidForeignConfigActions
+
+    for action in (
+        "#DellRaidService.ImportForeignConfig",
+        "#DellRaidService.UnLockSecureForeignConfig",
+    ):
+        assert classify(action) is Destructiveness.IRREVERSIBLE
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellRaidForeignConfigActions.register_subcommand(
+            DellRaidForeignConfigActions
+        )
+    )
+    help_text = cmd_parser.format_help()
+    assert cmd_name == "dell-raid-foreign-config"
+    assert "foreign" in cmd_help
+    assert "--action" in help_text
+    assert "--confirm" in help_text
+    assert "--i-understand-irreversible" in help_text
+    assert "--dry_run" in help_text


### PR DESCRIPTION
## Summary
- add `dell-raid-foreign-config` for DellRaidService ImportForeignConfig and UnLockSecureForeignConfig
- resolve DellRaidService from the selected ComputerSystem and preview by default
- classify both actions as irreversible and cover list, dry-run, confirm, and missing-action paths with Dell corpus tests

## Tests
- `git diff --check`
- `git diff --cached --check`
- GitHub CI pending