### PR TITLE
Add Dell LC client certificate action command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-client-cert-actions` | List, preview, or confirm Dell LC auto-discovery certificate maintenance actions. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_client_cert_actions import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -80,6 +80,9 @@ ACTION_POLICY = {
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,
     "#NvidiaDebugToken.InstallToken": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.DeleteAutoDiscoveryClientCerts": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.DeleteAutoDiscoveryServerPublicKey": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.DownloadClientCerts": Destructiveness.DESTRUCTIVE,
     "#UpdateService.SimpleUpdate": Destructiveness.DESTRUCTIVE,
     "#UpdateService.StartUpdate": Destructiveness.DESTRUCTIVE,
 

--- a/redfish_ctl/dell_lc/cmd_dell_lc_client_cert_actions.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_client_cert_actions.py
@@ -1,0 +1,279 @@
+"""Preview or run Dell LC client-certificate maintenance actions.
+
+    redfish_ctl dell-lc-client-cert-actions
+    redfish_ctl dell-lc-client-cert-actions --mode download-client-certs
+    redfish_ctl dell-lc-client-cert-actions --mode delete-client-certs --confirm
+
+The command resolves client-certificate actions advertised by DellLCService.
+These actions change provisioning trust material, so the command lists targets
+when ``--mode`` is omitted and otherwise dry-runs unless ``--confirm`` is
+provided.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_SERVICE_NAME = "DellLCService"
+_SERVICE_FALLBACKS = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService",
+    "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService",
+)
+
+_ACTION_SPECS = {
+    "delete-client-certs": {
+        "short": "DeleteAutoDiscoveryClientCerts",
+        "full": "#DellLCService.DeleteAutoDiscoveryClientCerts",
+    },
+    "delete-server-key": {
+        "short": "DeleteAutoDiscoveryServerPublicKey",
+        "full": "#DellLCService.DeleteAutoDiscoveryServerPublicKey",
+    },
+    "download-client-certs": {
+        "short": "DownloadClientCerts",
+        "full": "#DellLCService.DownloadClientCerts",
+    },
+}
+
+
+class DellLcClientCertActions(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellLcClientCertActions,
+    name="dell-lc-client-cert-actions",
+    metaclass=Singleton,
+):
+    """List or invoke DellLCService client-certificate actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the ``dell-lc-client-cert-actions`` command."""
+        super(DellLcClientCertActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-client-cert-actions`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--mode",
+            choices=tuple(_ACTION_SPECS),
+            default=None,
+            help="Dell LC certificate action to run; omit to list targets",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the selected action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-client-cert-actions",
+            "command manage Dell LC auto-discovery certificate actions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the Dell block under ``Manager.Links.Oem``.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM links dict, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional-resource misses.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async, resource_uri=None):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: issue Manager queries on the async path when True.
+        :param resource_uri: optional direct DellLCService URI.
+        :return: de-duplicated candidate service URIs.
+        """
+        if resource_uri:
+            return [resource_uri.rstrip("/")]
+
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(
+                self._dell_oem_links(manager),
+                _SERVICE_NAME,
+            )
+            if service_uri:
+                uris.append(service_uri)
+            uris.append(manager_uri.rstrip("/") + f"/Oem/Dell/{_SERVICE_NAME}")
+        uris.extend(_SERVICE_FALLBACKS)
+        return list(dict.fromkeys(uri for uri in uris if uri))
+
+    @staticmethod
+    def _action_row(actions, action_name, full_action):
+        """Return a normalized row for one discovered action.
+
+        :param actions: mapping returned by ``discover_redfish_actions``.
+        :param action_name: short Redfish action name.
+        :param full_action: full Redfish action name.
+        :return: target/action summary dict, or None when absent.
+        """
+        action = actions.get(action_name)
+        target = getattr(action, "target", None)
+        if not target:
+            return None
+        return {
+            "action": full_action,
+            "target": target,
+            "payload": {},
+        }
+
+    def _metadata(self, do_async, resource_uri=None):
+        """Return discovered Dell LC certificate action metadata.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DellLCService URI.
+        :return: CommandResult containing target metadata or an error.
+        """
+        checked = []
+        for uri in self._service_uris(do_async, resource_uri):
+            service = self._get(uri, do_async)
+            if not service:
+                checked.append(uri)
+                continue
+
+            actions = self.discover_redfish_actions(self, service)
+            discovered = {}
+            for mode, spec in _ACTION_SPECS.items():
+                row = self._action_row(
+                    actions,
+                    spec["short"],
+                    spec["full"],
+                )
+                if row is not None:
+                    discovered[mode] = row
+            if discovered:
+                return CommandResult(
+                    {
+                        "lc_service": uri,
+                        "actions": discovered,
+                    },
+                    actions,
+                    None,
+                    None,
+                )
+            checked.append(uri)
+
+        wanted = ", ".join(spec["full"] for spec in _ACTION_SPECS.values())
+        return CommandResult(
+            {"actions": sorted(_ACTION_SPECS), "checked": checked},
+            None,
+            None,
+            f"actions not found: {wanted}",
+        )
+
+    def execute(
+            self,
+            mode: Optional[str] = None,
+            resource_uri: Optional[str] = None,
+            confirm: Optional[bool] = False,
+            dry_run: Optional[bool] = False,
+            filename: Optional[str] = None,
+            data_type: Optional[str] = "json",
+            verbose: Optional[bool] = False,
+            do_async: Optional[bool] = False,
+            **kwargs) -> CommandResult:
+        """List, preview, or invoke DellLCService certificate actions.
+
+        :param mode: selected action mode, or None to list discovered actions.
+        :param resource_uri: optional DellLCService URI to inspect directly.
+        :param confirm: POST the action when True.
+        :param dry_run: force preview mode even when ``confirm`` is True.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue Redfish reads/POST on the async path when True.
+        :return: CommandResult with a listing, preview, execution result, or error.
+        """
+        metadata = self._metadata(bool(do_async), resource_uri)
+        if metadata.error is not None or mode is None:
+            return metadata
+
+        spec = _ACTION_SPECS.get(mode)
+        if spec is None:
+            valid = ", ".join(sorted(_ACTION_SPECS))
+            return CommandResult(
+                {"mode": mode, "valid_modes": sorted(_ACTION_SPECS)},
+                None,
+                None,
+                f"invalid mode '{mode}'; expected one of: {valid}",
+            )
+        if mode not in metadata.data["actions"]:
+            return CommandResult(
+                {
+                    "mode": mode,
+                    "available_modes": sorted(metadata.data["actions"]),
+                },
+                None,
+                None,
+                f"action '{spec['full']}' not found on DellLCService",
+            )
+
+        result = self.invoke_action(
+            metadata.data["lc_service"],
+            spec["short"],
+            payload={},
+            full_action_type=spec["full"],
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        if result.error is None and isinstance(result.data, dict):
+            result.data.setdefault("lc_service", metadata.data["lc_service"])
+            result.data.setdefault("mode", mode)
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -39,6 +39,7 @@ class ApiRequestType(Enum):
     DellLcQuery = auto()
     DellOemDisconnect = auto()
 
+    DellLcClientCertActions = auto()
     RemoteServicesRssAPIStatus = auto()
     RemoteServicesAPIStatus = auto()
     TasksList = auto()

--- a/tests/test_dell_lc_client_cert_actions_dualmode.py
+++ b/tests/test_dell_lc_client_cert_actions_dualmode.py
@@ -1,0 +1,212 @@
+"""Dual-mode tests for Dell LC client-certificate actions."""
+import copy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_client_cert_actions import (
+    DellLcClientCertActions,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+DELETE_CERTS_TARGET = (
+    f"{LC_SERVICE}/Actions/DellLCService.DeleteAutoDiscoveryClientCerts"
+)
+DELETE_KEY_TARGET = (
+    f"{LC_SERVICE}/Actions/DellLCService.DeleteAutoDiscoveryServerPublicKey"
+)
+DOWNLOAD_TARGET = f"{LC_SERVICE}/Actions/DellLCService.DownloadClientCerts"
+
+
+@pytest.fixture
+def dell_lc_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus."""
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-lc",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _overlay_lc_service(service, body):
+    """Overlay DellLCService under both common request casings."""
+    service._overlay[LC_SERVICE] = body
+    service._overlay[LC_SERVICE.lower()] = body
+
+
+def test_client_cert_actions_list_targets_without_post(dell_lc_mock):
+    """With no selected mode, the command reports all certificate targets."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClientCertActions,
+        "dell-lc-client-cert-actions",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["lc_service"] == LC_SERVICE
+    assert result.data["actions"]["delete-client-certs"] == {
+        "action": "#DellLCService.DeleteAutoDiscoveryClientCerts",
+        "target": DELETE_CERTS_TARGET,
+        "payload": {},
+    }
+    assert result.data["actions"]["delete-server-key"] == {
+        "action": "#DellLCService.DeleteAutoDiscoveryServerPublicKey",
+        "target": DELETE_KEY_TARGET,
+        "payload": {},
+    }
+    assert result.data["actions"]["download-client-certs"] == {
+        "action": "#DellLCService.DownloadClientCerts",
+        "target": DOWNLOAD_TARGET,
+        "payload": {},
+    }
+    assert _post_requests(service) == []
+
+
+def test_client_cert_action_defaults_to_dry_run(dell_lc_mock):
+    """Selecting a mode previews the action and does not POST by default."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClientCertActions,
+        "dell-lc-client-cert-actions",
+        mode="delete-client-certs",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["action"] == (
+        "#DellLCService.DeleteAutoDiscoveryClientCerts"
+    )
+    assert result.data["target"] == DELETE_CERTS_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "destructive"
+    assert result.data["lc_service"] == LC_SERVICE
+    assert result.data["mode"] == "delete-client-certs"
+    assert _post_requests(service) == []
+
+
+def test_client_cert_action_confirm_posts_selected_target(dell_lc_mock):
+    """--confirm POSTs the selected action with an empty payload."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClientCertActions,
+        "dell-lc-client-cert-actions",
+        mode="delete-server-key",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == (
+        "#DellLCService.DeleteAutoDiscoveryServerPublicKey"
+    )
+    assert result.data["target"] == DELETE_KEY_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["lc_service"] == LC_SERVICE
+    assert result.data["mode"] == "delete-server-key"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == DELETE_KEY_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_client_cert_action_dry_run_overrides_confirm(dell_lc_mock):
+    """Explicit dry-run wins over --confirm and avoids the POST."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClientCertActions,
+        "dell-lc-client-cert-actions",
+        mode="download-client-certs",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["target"] == DOWNLOAD_TARGET
+    assert result.data["blocked"] is None
+    assert _post_requests(service) == []
+
+
+def test_client_cert_actions_report_missing_actions_without_post(dell_lc_mock):
+    """A service missing the certificate actions reports the miss."""
+    manager, service = dell_lc_mock
+    body = copy.deepcopy(service._state(LC_SERVICE))
+    for action in (
+        "#DellLCService.DeleteAutoDiscoveryClientCerts",
+        "#DellLCService.DeleteAutoDiscoveryServerPublicKey",
+        "#DellLCService.DownloadClientCerts",
+    ):
+        body["Actions"].pop(action)
+    _overlay_lc_service(service, body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcClientCertActions,
+        "dell-lc-client-cert-actions",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "actions not found: #DellLCService.DeleteAutoDiscoveryClientCerts, "
+        "#DellLCService.DeleteAutoDiscoveryServerPublicKey, "
+        "#DellLCService.DownloadClientCerts"
+    )
+    assert LC_SERVICE in result.data["checked"]
+    assert _post_requests(service) == []
+
+
+def test_client_cert_actions_are_registered_and_classified():
+    """The command is registered and its actions are guarded."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellLcClientCertActions][
+        "dell-lc-client-cert-actions"
+    ] is DellLcClientCertActions
+
+    for action in (
+        "#DellLCService.DeleteAutoDiscoveryClientCerts",
+        "#DellLCService.DeleteAutoDiscoveryServerPublicKey",
+        "#DellLCService.DownloadClientCerts",
+    ):
+        assert classify(action) is Destructiveness.DESTRUCTIVE


### PR DESCRIPTION
## Summary
- add a guarded dell-lc-client-cert-actions command for DellLCService auto-discovery certificate maintenance
- list advertised targets without mutation and require --confirm for POST execution
- add Dell XR8620t corpus-backed dual-mode coverage and command documentation

## Validation
- git diff --check
- git diff --cached --check
- local pytest/Ruff not run; validation is handled by CI for this repository