### PR TITLE
Add Dell persistent media initialization command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-persistent-initialize-media` | Initialize Dell vFlash media through `DellPersistentStorageService.InitializeMedia`; previews by default and requires `--confirm --i-understand-irreversible` to write. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_dell_persistent_initialize_media import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -88,6 +88,7 @@ ACTION_POLICY = {
     "#Manager.ResetToDefaults": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.RevokeKeys": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.UpdateMinimumSecurityVersion": Destructiveness.IRREVERSIBLE,
+    "#DellPersistentStorageService.InitializeMedia": Destructiveness.IRREVERSIBLE,
 }
 
 # An unclassified action is treated as DESTRUCTIVE: it can never POST without an

--- a/redfish_ctl/oem/cmd_dell_persistent_initialize_media.py
+++ b/redfish_ctl/oem/cmd_dell_persistent_initialize_media.py
@@ -1,0 +1,222 @@
+"""Preview or initialize Dell vFlash media.
+
+    redfish_ctl dell-persistent-initialize-media
+    redfish_ctl dell-persistent-initialize-media --confirm \
+        --i-understand-irreversible
+
+The command discovers ``#DellPersistentStorageService.InitializeMedia`` from the
+Manager OEM Dell persistent-storage service. Initializing vFlash media can erase
+stored partition data, so the command previews by default and only POSTs when
+both confirmation flags are supplied.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..actions.action_policy import classify
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_INITIALIZE_MEDIA_ACTION = "#DellPersistentStorageService.InitializeMedia"
+_SERVICE_NAME = "DellPersistentStorageService"
+_DEFAULT_SERVICE_URI = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/{_SERVICE_NAME}"
+)
+
+
+class DellPersistentInitializeMedia(
+    RedfishManagerBase,
+    scm_type=ApiRequestType.DellPersistentInitializeMedia,
+    name="dell-persistent-initialize-media",
+    metaclass=Singleton,
+):
+    """Discover and invoke DellPersistentStorageService.InitializeMedia."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-persistent-initialize-media command."""
+        super(DellPersistentInitializeMedia, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-persistent-initialize-media`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellPersistentStorageService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="authorize the InitializeMedia POST",
+        )
+        cmd_parser.add_argument(
+            "--i-understand-irreversible",
+            action="store_true",
+            dest="confirm_irreversible",
+            default=False,
+            help="required with --confirm because media initialization can erase data",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target without POSTing; overrides confirmation",
+        )
+        return (
+            cmd_parser,
+            "dell-persistent-initialize-media",
+            "preview or initialize Dell vFlash media",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _dell_oem_link(cls, manager):
+        """Return the persistent-storage service link from Manager OEM data.
+
+        :param manager: Manager resource body.
+        :return: linked DellPersistentStorageService URI, or None.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem_links = links.get("Oem") if isinstance(links, dict) else None
+        dell_links = oem_links.get("Dell") if isinstance(oem_links, dict) else None
+        linked = cls._link(dell_links or {}, _SERVICE_NAME)
+        if linked:
+            return linked
+        oem = manager.get("Oem") if isinstance(manager, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return cls._link(dell or {}, _SERVICE_NAME)
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, returning an empty object on failure.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when absent.
+        """
+        try:
+            data = self.base_query(uri.rstrip("/"), do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DellPersistentStorageService URIs.
+
+        :param do_async: issue Manager queries on the async path when True.
+        :return: ordered, de-duplicated candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            clean_manager = manager_uri.rstrip("/")
+            manager = self._get(clean_manager, do_async)
+            linked = self._dell_oem_link(manager)
+            if linked:
+                uris.append(linked.rstrip("/"))
+            uris.append(f"{clean_manager}/Oem/Dell/{_SERVICE_NAME}")
+        uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uri for uri in uris if uri))
+
+    def _metadata(self, do_async, resource_uri=None):
+        """Return InitializeMedia target metadata.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DellPersistentStorageService URI.
+        :return: CommandResult with target metadata, or an action-not-found error.
+        """
+        checked = []
+        uris = [resource_uri.rstrip("/")] if resource_uri else self._service_uris(do_async)
+        for uri in dict.fromkeys(uris):
+            service = self._get(uri, do_async)
+            if not service:
+                checked.append(uri)
+                continue
+            actions = self.discover_redfish_actions(self, service)
+            target = self._flatten_action_targets(service).get(
+                _INITIALIZE_MEDIA_ACTION
+            )
+            if target:
+                return CommandResult(
+                    {
+                        "persistent_storage_service": uri,
+                        "action": _INITIALIZE_MEDIA_ACTION,
+                        "target": target,
+                        "level": classify(_INITIALIZE_MEDIA_ACTION).value,
+                    },
+                    actions,
+                    None,
+                    None,
+                )
+            checked.append(uri)
+        return CommandResult(
+            {
+                "action": _INITIALIZE_MEDIA_ACTION,
+                "checked": checked,
+            },
+            None,
+            None,
+            f"action '{_INITIALIZE_MEDIA_ACTION}' not found",
+        )
+
+    def execute(self,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                confirm_irreversible: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or invoke DellPersistentStorageService.InitializeMedia.
+
+        :param resource_uri: optional DellPersistentStorageService URI selector.
+        :param confirm: authorize the POST when paired with irreversible consent.
+        :param confirm_irreversible: acknowledge that initialization can erase data.
+        :param dry_run: force preview mode even when confirmation is supplied.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue Redfish reads/POST on the async path when True.
+        :return: CommandResult with target metadata, preview, or POST result.
+        """
+        metadata = self._metadata(bool(do_async), resource_uri)
+        if metadata.error is not None:
+            return metadata
+        return self.invoke_action(
+            metadata.data["persistent_storage_service"],
+            "InitializeMedia",
+            payload={},
+            full_action_type=_INITIALIZE_MEDIA_ACTION,
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+            confirm_irreversible=bool(confirm_irreversible),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -113,6 +113,7 @@ class ApiRequestType(Enum):
     EventSubmitTest = auto()
     HpeTestActions = auto()
     NvidiaDebugToken = auto()
+    DellPersistentInitializeMedia = auto()
     EventServiceQuery = auto()
     SubscriptionCreate = auto()
     SubscriptionDelete = auto()

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1.json
@@ -42,7 +42,14 @@
       {
         "@odata.id": "/redfish/v1/Chassis/System.Embedded.1"
       }
-    ]
+    ],
+    "Oem": {
+      "Dell": {
+        "DellPersistentStorageService": {
+          "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellPersistentStorageService"
+        }
+      }
+    }
   },
   "Oem": {
     "Dell": {

--- a/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DellPersistentStorageService.json
+++ b/tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DellPersistentStorageService.json
@@ -1,0 +1,13 @@
+{
+  "@odata.context": "/redfish/v1/$metadata#DellPersistentStorageService.DellPersistentStorageService",
+  "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellPersistentStorageService",
+  "@odata.type": "#DellPersistentStorageService.v1_1_0.DellPersistentStorageService",
+  "Actions": {
+    "#DellPersistentStorageService.InitializeMedia": {
+      "target": "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellPersistentStorageService/Actions/DellPersistentStorageService.InitializeMedia"
+    }
+  },
+  "Description": "The DellPersistentStorageService resource provides vFlash actions.",
+  "Id": "DellPersistentStorageService",
+  "Name": "DellPersistentStorageService"
+}

--- a/tests/test_dell_persistent_initialize_media_dualmode.py
+++ b/tests/test_dell_persistent_initialize_media_dualmode.py
@@ -1,0 +1,93 @@
+"""Dual-mode tests for Dell persistent-storage media initialization."""
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+PERSISTENT_STORAGE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellPersistentStorageService"
+)
+INITIALIZE_TARGET = (
+    f"{PERSISTENT_STORAGE}/Actions/"
+    "DellPersistentStorageService.InitializeMedia"
+)
+
+
+def _post_requests(redfish_service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param redfish_service: the mock service fixture.
+    :return: list of recorded POST requests.
+    """
+    return [
+        request for request in redfish_service.requests
+        if request.method == "POST"
+    ]
+
+
+def test_dell_persistent_initialize_media_previews_by_default(
+    redfish_mock,
+    redfish_service,
+):
+    """The media initialization command resolves the target without POSTing."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellPersistentInitializeMedia,
+        "dell-persistent-initialize-media",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellPersistentStorageService.InitializeMedia"
+    assert result.data["target"] == INITIALIZE_TARGET
+    assert result.data["payload"] == {}
+    assert result.data["level"] == "irreversible"
+    assert result.data["blocked"] == (
+        "irreversible action requires --confirm and --i-understand-irreversible"
+    )
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_persistent_initialize_media_confirm_only_stays_blocked(
+    redfish_mock,
+    redfish_service,
+):
+    """The irreversible guard blocks confirm-only initialization attempts."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellPersistentInitializeMedia,
+        "dell-persistent-initialize-media",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["level"] == "irreversible"
+    assert result.data["blocked"] == (
+        "irreversible action requires --confirm and --i-understand-irreversible"
+    )
+    assert _post_requests(redfish_service) == []
+
+
+def test_dell_persistent_initialize_media_posts_with_irreversible_consent(
+    redfish_mock,
+    redfish_service,
+):
+    """The command POSTs an empty body only with the irreversible confirmation."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellPersistentInitializeMedia,
+        "dell-persistent-initialize-media",
+        confirm=True,
+        confirm_irreversible=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["task_id"] == redfish_service.JOB_ID
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellPersistentStorageService.InitializeMedia"
+    assert result.data["target"] == INITIALIZE_TARGET
+    assert result.data["level"] == "irreversible"
+    posts = _post_requests(redfish_service)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == INITIALIZE_TARGET.lower()
+    assert posts[0].json() == {}


### PR DESCRIPTION
## Summary
- add guarded `dell-persistent-initialize-media` for `DellPersistentStorageService.InitializeMedia`
- classify media initialization as irreversible so it requires `--confirm --i-understand-irreversible` before POST
- add Dell fixture coverage for default preview, confirm-only blocking, and confirmed POST behavior

## Validation
- `git diff --cached --check`
- `jq empty tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1.json`
- `jq empty tests/idrac_fixtures/_redfish_v1_Managers_iDRAC.Embedded.1_Oem_Dell_DellPersistentStorageService.json`

Not run locally: pytest, Ruff, and Docker gates run in CI for this repository.