### PR TITLE
Add Dell BIOS device recovery command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-bios-device-recovery` | Recover a Dell BIOS device through `DellBIOSService.DeviceRecovery`; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -29,6 +29,7 @@ from .bios.cmd_bios_profile import *
 from .bios.cmd_change_bios import *
 from .bios.cmd_bios_snapshot import *
 from .bios.cmd_bios_reset_default import *
+from .bios.cmd_dell_bios_device_recovery import *
 #
 from .attribute.cmd_attribute import *
 from .attribute.cmd_attribute_clear_pending import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -69,6 +69,7 @@ ACTION_POLICY = {
     "#Control.ResetToDefaults": Destructiveness.DESTRUCTIVE,
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
+    "#DellBIOSService.DeviceRecovery": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE

--- a/redfish_ctl/bios/cmd_dell_bios_device_recovery.py
+++ b/redfish_ctl/bios/cmd_dell_bios_device_recovery.py
@@ -1,0 +1,344 @@
+"""Preview or invoke Dell BIOS device recovery.
+
+    redfish_ctl dell-bios-device-recovery
+    redfish_ctl dell-bios-device-recovery --system-uri /redfish/v1/Systems/System.Embedded.1
+    redfish_ctl dell-bios-device-recovery --device BIOS --confirm
+
+The command resolves ``#DellBIOSService.DeviceRecovery`` from a Dell
+ComputerSystem's OEM DellBIOSService link. The action is classified as
+destructive, so the default invocation only previews the target and payload.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_DEVICE_RECOVERY_ACTION = "#DellBIOSService.DeviceRecovery"
+_DELL_BIOS_SERVICE = "Oem/Dell/DellBIOSService"
+
+
+class DellBiosDeviceRecovery(RedfishManagerBase,
+                             scm_type=ApiRequestType.DellBiosDeviceRecovery,
+                             name="dell-bios-device-recovery",
+                             metaclass=Singleton):
+    """Preview or invoke DellBIOSService.DeviceRecovery."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-bios-device-recovery command."""
+        super(DellBiosDeviceRecovery, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-bios-device-recovery`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--system-uri",
+            required=False,
+            dest="system_uri",
+            type=str,
+            default=None,
+            help="ComputerSystem URI that owns DellBIOSService; omitted value "
+                 "probes discovered systems",
+        )
+        cmd_parser.add_argument(
+            "--device",
+            required=False,
+            dest="device",
+            type=str,
+            default="BIOS",
+            help="DeviceRecovery Device payload value advertised by the service",
+        )
+        cmd_parser.add_argument(
+            "--list",
+            action="store_true",
+            dest="list_only",
+            default=False,
+            help="list discovered DellBIOSService targets without POSTing",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the DeviceRecovery POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-bios-device-recovery",
+            "command recover a Dell BIOS device through DellBIOSService",
+        )
+
+    @staticmethod
+    def _normalize_uri(uri):
+        """Return a Redfish URI without a trailing slash.
+
+        :param uri: Redfish resource URI.
+        :return: normalized URI, or None for blank input.
+        """
+        if uri is None:
+            return None
+        normalized = str(uri).strip().rstrip("/")
+        return normalized or None
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish ``@odata.id`` link from ``data[key]``.
+
+        :param data: resource object containing a link field.
+        :param key: link key to read.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _oem_dell(cls, system):
+        """Return a ComputerSystem ``Links.Oem.Dell`` block.
+
+        :param system: ComputerSystem resource body.
+        :return: Dell OEM links object, or an empty dict.
+        """
+        links = system.get("Links") if isinstance(system, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get_object(self, uri, do_async, optional=False):
+        """Read a Redfish object resource.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the GET over the async path when True.
+        :param optional: return an empty object instead of surfacing read errors.
+        :return: parsed object body or an empty dict.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            if optional:
+                return {}
+            raise
+        return data if isinstance(data, dict) else {}
+
+    def _candidate_systems(self, system_uri=None):
+        """Return ComputerSystem URIs that may own DellBIOSService.
+
+        :param system_uri: optional explicit ComputerSystem URI.
+        :return: de-duplicated list of normalized ComputerSystem URIs.
+        """
+        explicit = self._normalize_uri(system_uri)
+        if explicit is not None:
+            return [explicit]
+
+        candidates = []
+        try:
+            candidates.extend(self.discover_computer_system_ids() or [])
+        except Exception:
+            pass
+        try:
+            candidates.append(self.idrac_manage_servers)
+        except Exception:
+            pass
+
+        seen = set()
+        normalized = []
+        for candidate in candidates:
+            value = self._normalize_uri(candidate)
+            if value is not None and value not in seen:
+                normalized.append(value)
+                seen.add(value)
+        return normalized
+
+    @classmethod
+    def _fallback_service_uri(cls, system_uri):
+        """Return the conventional DellBIOSService child URI.
+
+        :param system_uri: ComputerSystem URI.
+        :return: DellBIOSService URI under the system.
+        """
+        return f"{system_uri.rstrip('/')}/{_DELL_BIOS_SERVICE}"
+
+    def _service_uri_for_system(self, system_uri, do_async):
+        """Resolve DellBIOSService from a ComputerSystem OEM Dell link.
+
+        :param system_uri: ComputerSystem URI.
+        :param do_async: issue the ComputerSystem GET over the async path.
+        :return: advertised or conventional DellBIOSService URI.
+        """
+        system = self._get_object(system_uri, do_async, optional=True)
+        linked = self._link(self._oem_dell(system), "DellBIOSService")
+        return linked or self._fallback_service_uri(system_uri)
+
+    @staticmethod
+    def _allowable_devices(service):
+        """Return Device allowable values advertised by DellBIOSService.
+
+        :param service: DellBIOSService resource body.
+        :return: list of allowed Device values.
+        """
+        actions = service.get("Actions") if isinstance(service, dict) else None
+        action = actions.get(_DEVICE_RECOVERY_ACTION) if isinstance(actions, dict) else None
+        values = (
+            action.get("Device@Redfish.AllowableValues")
+            if isinstance(action, dict)
+            else None
+        )
+        return list(values) if isinstance(values, list) else []
+
+    def _recovery_targets(self, do_async, system_uri=None):
+        """Discover DellBIOSService DeviceRecovery action targets.
+
+        :param do_async: issue Redfish queries on the async path.
+        :param system_uri: optional explicit ComputerSystem URI.
+        :return: CommandResult containing discovered target rows or an error.
+        """
+        candidates = self._candidate_systems(system_uri)
+        if not candidates:
+            return CommandResult(
+                {"action": _DEVICE_RECOVERY_ACTION, "targets": []},
+                None,
+                None,
+                "no ComputerSystem URI available for DellBIOSService",
+            )
+
+        rows = []
+        attempted = []
+        last_actions = None
+        last_targets = {}
+        for candidate in candidates:
+            service_uri = self._service_uri_for_system(candidate, do_async)
+            attempted.append(service_uri)
+            service = self._get_object(service_uri, do_async, optional=True)
+            actions = self.discover_redfish_actions(self, service)
+            targets = self._flatten_action_targets(service)
+            last_actions = actions
+            last_targets = targets
+            target = targets.get(_DEVICE_RECOVERY_ACTION)
+            if target is None:
+                continue
+            rows.append({
+                "system": candidate,
+                "bios_service": service_uri,
+                "target": target,
+                "devices": self._allowable_devices(service),
+            })
+
+        if rows:
+            return CommandResult(
+                {"action": _DEVICE_RECOVERY_ACTION, "targets": rows},
+                last_actions,
+                None,
+                None,
+            )
+
+        available = sorted(
+            set(list((last_actions or {}).keys()) + list(last_targets.keys()))
+        )
+        return CommandResult(
+            {
+                "action": _DEVICE_RECOVERY_ACTION,
+                "attempted": attempted,
+                "available": available,
+            },
+            last_actions,
+            None,
+            (
+                f"action '{_DEVICE_RECOVERY_ACTION}' not found on "
+                "DellBIOSService"
+            ),
+        )
+
+    @staticmethod
+    def _payload(device):
+        """Build the DeviceRecovery payload.
+
+        :param device: advertised Device value to recover.
+        :return: DeviceRecovery payload.
+        """
+        return {"Device": str(device or "").strip()}
+
+    def execute(self,
+                system_uri: Optional[str] = None,
+                device: Optional[str] = "BIOS",
+                list_only: Optional[bool] = False,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or run DellBIOSService.DeviceRecovery.
+
+        :param system_uri: optional ComputerSystem URI owning DellBIOSService.
+        :param device: Device payload value; usually ``BIOS``.
+        :param list_only: list discovered targets without POSTing.
+        :param confirm: authorize the DeviceRecovery POST to actually fire.
+        :param dry_run: resolve the target and show it without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying queries and POST on the async path.
+        :return: CommandResult with target metadata, preview, or POST result.
+        """
+        metadata = self._recovery_targets(do_async, system_uri=system_uri)
+        if metadata.error is not None:
+            return metadata
+
+        rows = metadata.data["targets"]
+        payload = self._payload(device)
+        if list_only:
+            return CommandResult(
+                {
+                    "action": _DEVICE_RECOVERY_ACTION,
+                    "targets": rows,
+                    "payload": payload,
+                },
+                metadata.discovered,
+                None,
+                None,
+            )
+
+        if len(rows) > 1 and system_uri is None:
+            return CommandResult(
+                {
+                    "dry_run": True,
+                    "action": _DEVICE_RECOVERY_ACTION,
+                    "targets": rows,
+                    "payload": payload,
+                    "blocked": "select --system-uri before invoking DeviceRecovery",
+                },
+                metadata.discovered,
+                None,
+                None,
+            )
+
+        row = rows[0]
+        result = self.invoke_action(
+            row["bios_service"],
+            "DeviceRecovery",
+            payload=payload,
+            full_action_type=_DEVICE_RECOVERY_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        if isinstance(result.data, dict):
+            result.data.setdefault("system", row["system"])
+            result.data.setdefault("bios_service", row["bios_service"])
+            result.data.setdefault("device", payload["Device"])
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -36,6 +36,7 @@ class ApiRequestType(Enum):
 
     # dell oem
     DellOemTask = auto()
+    DellBiosDeviceRecovery = auto()
     DellLcQuery = auto()
     DellOemDisconnect = auto()
 

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -31,6 +31,7 @@ def test_policy_classifies_known_and_unknown():
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
+    assert classify("#DellBIOSService.DeviceRecovery") is Destructiveness.DESTRUCTIVE
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE

--- a/tests/test_dell_bios_device_recovery_dualmode.py
+++ b/tests/test_dell_bios_device_recovery_dualmode.py
@@ -1,0 +1,175 @@
+"""Dual-mode-style coverage for DellBIOSService.DeviceRecovery."""
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+
+SYSTEM = "/redfish/v1/Systems/System.Embedded.1"
+BIOS_SERVICE = f"{SYSTEM}/Oem/Dell/DellBIOSService"
+ACTION = "#DellBIOSService.DeviceRecovery"
+TARGET = f"{BIOS_SERVICE}/Actions/DellBIOSService.DeviceRecovery"
+TASK_ID = "JID_000000000001"
+
+
+def _fixture_for_path(path):
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+def _post_requests(requests):
+    return [request for request in requests if request.method == "POST"]
+
+
+@contextmanager
+def _mock_dell_corpus(remove_action=False):
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        body = json.loads(fixture.read_text())
+        if remove_action and request.path.lower() == BIOS_SERVICE.lower():
+            body["Actions"].pop(ACTION, None)
+        context.status_code = 200
+        return json.dumps(body)
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = f"/redfish/v1/TaskService/Tasks/{TASK_ID}"
+        return ""
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def test_dell_bios_device_recovery_lists_corpus_target():
+    """The command lists the DellBIOSService target advertised by the corpus."""
+    with _mock_dell_corpus() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellBiosDeviceRecovery,
+            "dell-bios-device-recovery",
+            list_only=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["action"] == ACTION
+    assert result.data["targets"] == [
+        {
+            "system": SYSTEM,
+            "bios_service": BIOS_SERVICE,
+            "target": TARGET,
+            "devices": ["BIOS"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_bios_device_recovery_previews_by_default():
+    """DeviceRecovery defaults to a destructive-action dry-run."""
+    with _mock_dell_corpus() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellBiosDeviceRecovery,
+            "dell-bios-device-recovery",
+        )
+
+    assert result.error is None
+    assert result.data == {
+        "dry_run": True,
+        "action": ACTION,
+        "target": TARGET,
+        "payload": {"Device": "BIOS"},
+        "level": "destructive",
+        "blocked": "destructive action requires --confirm",
+        "system": SYSTEM,
+        "bios_service": BIOS_SERVICE,
+        "device": "BIOS",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_bios_device_recovery_confirm_posts_device_payload():
+    """With --confirm the command POSTs the advertised DeviceRecovery payload."""
+    with _mock_dell_corpus() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellBiosDeviceRecovery,
+            "dell-bios-device-recovery",
+            confirm=True,
+        )
+
+    posts = _post_requests(requests)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["task_id"] == TASK_ID
+    assert result.data["action"] == ACTION
+    assert result.data["target"] == TARGET
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path == TARGET.lower()
+    assert posts[0].json() == {"Device": "BIOS"}
+
+
+def test_dell_bios_device_recovery_rejects_unadvertised_device():
+    """Payload validation rejects Device values outside the service metadata."""
+    with _mock_dell_corpus() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellBiosDeviceRecovery,
+            "dell-bios-device-recovery",
+            device="BMC",
+            confirm=True,
+        )
+
+    assert result.error == (
+        "invalid value for DellBIOSService.DeviceRecovery Device: BMC; "
+        "allowed: BIOS"
+    )
+    assert result.data["action"] == ACTION
+    assert result.data["target"] == TARGET
+    assert result.data["payload"] == {"Device": "BMC"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_bios_device_recovery_missing_action_reports_available():
+    """A service without DeviceRecovery reports the missing action and never POSTs."""
+    with _mock_dell_corpus(remove_action=True) as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellBiosDeviceRecovery,
+            "dell-bios-device-recovery",
+            confirm=True,
+        )
+
+    assert result.error == (
+        f"action '{ACTION}' not found on DellBIOSService"
+    )
+    assert result.data["action"] == ACTION
+    assert result.data["available"] == []
+    assert result.data["attempted"] == [BIOS_SERVICE]
+    assert _post_requests(requests) == []


### PR DESCRIPTION
## Summary
- add guarded dell-bios-device-recovery for DellBIOSService.DeviceRecovery
- discover DellBIOSService from the owning ComputerSystem OEM Dell link
- add Dell XR8620t corpus-backed coverage for list, preview, confirm, invalid Device, and missing action paths

## Validation
- git diff --check
- git diff --cached --check
- GitHub CI pending