### PR TITLE
Add Dell LC ePSA diagnostics command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-epsa-diagnostics` | Preview or run Dell Lifecycle Controller ePSA diagnostics through `DellLCService.RunePSADiagnostics`; requires `--confirm --i-understand-reboot` to execute. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -9,6 +9,7 @@ from .system.cmd_system_import import *
 #
 from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
+from .dell_lc.cmd_dell_lc_epsa_diagnostics import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
 #

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,7 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.RunePSADiagnostics": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/dell_lc/cmd_dell_lc_epsa_diagnostics.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_epsa_diagnostics.py
@@ -1,0 +1,257 @@
+"""Run Dell Lifecycle Controller ePSA diagnostics through DellLCService.
+
+    redfish_ctl dell-lc-epsa-diagnostics
+    redfish_ctl dell-lc-epsa-diagnostics --run-mode Express --reboot-job-type PowerCycle
+    redfish_ctl dell-lc-epsa-diagnostics --confirm --i-understand-reboot
+
+``#DellLCService.RunePSADiagnostics`` can schedule host reboot or power-cycle
+behavior. The command therefore previews by default, validates the advertised
+payload values, and only POSTs when both ``--confirm`` and
+``--i-understand-reboot`` are supplied.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_EPSA_ACTION = "#DellLCService.RunePSADiagnostics"
+
+
+class DellLcEpsaDiagnostics(RedfishManagerBase,
+                            scm_type=ApiRequestType.DellLcEpsaDiagnostics,
+                            name="dell-lc-epsa-diagnostics",
+                            metaclass=Singleton):
+    """Run Dell LC ePSA diagnostics through the discovered DellLCService."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-epsa-diagnostics command."""
+        super(DellLcEpsaDiagnostics, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-lc-epsa-diagnostics`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--run-mode",
+            "--run_mode",
+            required=False,
+            dest="run_mode",
+            type=str,
+            default="Express",
+            help="RunMode value to send, default: Express",
+        )
+        cmd_parser.add_argument(
+            "--reboot-job-type",
+            "--reboot_job_type",
+            required=False,
+            dest="reboot_job_type",
+            type=str,
+            default="GracefulRebootWithoutForcedShutdown",
+            help="RebootJobType value to send, default: GracefulRebootWithoutForcedShutdown",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the RunePSADiagnostics POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--i-understand-reboot",
+            action="store_true",
+            dest="confirm_reboot",
+            default=False,
+            help="acknowledge that the diagnostics action can reboot or power-cycle the host",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-epsa-diagnostics",
+            "command run Dell LC ePSA diagnostics",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _oem_dell_link(data, key):
+        """Return a link from ``Oem.Dell.<key>`` when it is present.
+
+        :param data: resource body containing an optional Dell OEM link block.
+        :param key: Dell OEM link key to resolve.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        oem = (data or {}).get("Oem")
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return DellLcEpsaDiagnostics._link(dell, key) if isinstance(dell, dict) else None
+
+    @staticmethod
+    def _members(data):
+        """Return collection member ``@odata.id`` strings from a Redfish body.
+
+        :param data: a Redfish collection body.
+        :return: list of member URIs.
+        """
+        if not isinstance(data, dict):
+            return []
+        return [
+            member["@odata.id"] for member in data.get("Members", [])
+            if isinstance(member, dict) and isinstance(member.get("@odata.id"), str)
+        ]
+
+    def _get(self, uri, do_async):
+        """GET a resource body, returning ``{}`` when discovery cannot read it.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed response body, or {} on read failure.
+        """
+        try:
+            return self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+
+    def _discover_lc_services(self, do_async):
+        """Find DellLCService resources exposing the ePSA diagnostics action.
+
+        The modern Dell corpus links the service from ``Manager.Oem.Dell``.
+        Older fixtures expose the legacy ``/redfish/v1/Dell/Managers/...``
+        layout, so both shapes are probed.
+
+        :param do_async: issue the underlying reads on the async path when True.
+        :return: list of ``{"Id": <id>, "uri": <service uri>}`` dictionaries.
+        """
+        candidates = []
+        for manager_uri in self._members(self._get(f"{RedfishApi.Version}/Managers", do_async)):
+            manager = self._get(manager_uri, do_async)
+            linked = self._oem_dell_link(manager, "DellLCService")
+            if linked:
+                candidates.append(linked)
+            manager_id = manager.get("Id") if isinstance(manager, dict) else None
+            if manager_id:
+                candidates.append(f"{RedfishApi.Version}/Dell/Managers/{manager_id}/DellLCService")
+
+        if not candidates:
+            candidates.append(
+                f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+            )
+
+        services = []
+        seen = set()
+        for service_uri in candidates:
+            if service_uri in seen:
+                continue
+            service = self._get(service_uri, do_async)
+            actions = service.get("Actions") if isinstance(service, dict) else None
+            if not isinstance(actions, dict) or _EPSA_ACTION not in actions:
+                continue
+            seen.add(service_uri)
+            services.append({
+                "Id": service.get("Id") or service_uri.rsplit("/", 1)[-1],
+                "uri": service_uri,
+            })
+        return services
+
+    @staticmethod
+    def _payload(run_mode, reboot_job_type):
+        """Build the RunePSADiagnostics action payload.
+
+        :param run_mode: ePSA ``RunMode`` value.
+        :param reboot_job_type: ePSA ``RebootJobType`` value.
+        :return: JSON payload for the action.
+        :raises InvalidArgument: when a required value is blank.
+        """
+        run_mode = (run_mode or "").strip()
+        reboot_job_type = (reboot_job_type or "").strip()
+        if not run_mode:
+            raise InvalidArgument("run mode cannot be empty")
+        if not reboot_job_type:
+            raise InvalidArgument("reboot job type cannot be empty")
+        return {
+            "RunMode": run_mode,
+            "RebootJobType": reboot_job_type,
+        }
+
+    def execute(self,
+                run_mode: Optional[str] = "Express",
+                reboot_job_type: Optional[str] = "GracefulRebootWithoutForcedShutdown",
+                confirm: Optional[bool] = False,
+                confirm_reboot: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List/preview or run Dell LC ePSA diagnostics.
+
+        The command resolves a DellLCService that advertises
+        ``#DellLCService.RunePSADiagnostics``. It never POSTs by default; actual
+        execution requires ``--confirm`` plus ``--i-understand-reboot`` because
+        the advertised ``RebootJobType`` values include host-disrupting modes.
+
+        :param run_mode: Dell ePSA ``RunMode`` payload value.
+        :param reboot_job_type: Dell ePSA ``RebootJobType`` payload value.
+        :param confirm: authorize the diagnostic action POST.
+        :param confirm_reboot: extra acknowledgement for reboot/power-cycle risk.
+        :param dry_run: force a preview even when confirmation flags are set.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue reads/POST on the async path when True.
+        :return: CommandResult with discovered services, dry-run preview, or
+            execution result.
+        :raises InvalidArgument: when no capable service is discovered or a
+            required payload value is blank.
+        """
+        services = self._discover_lc_services(bool(do_async))
+        if not services:
+            raise InvalidArgument(
+                "no DellLCService exposing #DellLCService.RunePSADiagnostics found"
+            )
+
+        result = self.invoke_action(
+            services[0]["uri"],
+            "RunePSADiagnostics",
+            payload=self._payload(run_mode, reboot_job_type),
+            full_action_type=_EPSA_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not (bool(confirm) and bool(confirm_reboot)),
+            confirm=bool(confirm),
+        )
+        if (
+                confirm
+                and not confirm_reboot
+                and not dry_run
+                and result.error is None
+                and isinstance(result.data, dict)):
+            result.data["blocked"] = (
+                "ePSA diagnostics requires --confirm and --i-understand-reboot"
+            )
+        return result

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -41,6 +41,7 @@ class ApiRequestType(Enum):
 
     RemoteServicesRssAPIStatus = auto()
     RemoteServicesAPIStatus = auto()
+    DellLcEpsaDiagnostics = auto()
     TasksList = auto()
 
     ChangeBootOrder = auto()

--- a/tests/test_dell_lc_epsa_diagnostics_dualmode.py
+++ b/tests/test_dell_lc_epsa_diagnostics_dualmode.py
@@ -1,0 +1,223 @@
+"""Dual-mode-style tests for Dell LC ePSA diagnostics."""
+
+import copy
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.dell_lc.cmd_dell_lc_epsa_diagnostics import DellLcEpsaDiagnostics
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+LC_SERVICE_PATH = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+EPSA_TARGET = f"{LC_SERVICE_PATH}/Actions/DellLCService.RunePSADiagnostics"
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock service."""
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _install_lc_service(redfish_service, body=None):
+    """Overlay a DellLCService fixture that advertises RunePSADiagnostics."""
+    service = body or {
+        "@odata.id": LC_SERVICE_PATH,
+        "@odata.type": "#DellLCService.v1_5_0.DellLCService",
+        "Id": "DellLCService",
+        "Name": "Dell Lifecycle Controller Service",
+        "Actions": {
+            "#DellLCService.RunePSADiagnostics": {
+                "RunMode@Redfish.AllowableValues": [
+                    "Express",
+                    "ExpressAndExtended",
+                    "Extended",
+                ],
+                "RebootJobType@Redfish.AllowableValues": [
+                    "GracefulRebootWithForcedShutdown",
+                    "GracefulRebootWithoutForcedShutdown",
+                    "PowerCycle",
+                ],
+                "target": EPSA_TARGET,
+            }
+        },
+    }
+    manager = {
+        "@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1",
+        "Id": "iDRAC.Embedded.1",
+        "Oem": {
+            "Dell": {
+                "DellLCService": {"@odata.id": LC_SERVICE_PATH},
+            }
+        },
+    }
+    redfish_service._overlay[LC_SERVICE_PATH] = service
+    redfish_service._overlay[LC_SERVICE_PATH.lower()] = service
+    redfish_service._overlay["/redfish/v1/Managers/iDRAC.Embedded.1"] = manager
+    redfish_service._overlay["/redfish/v1/managers/idrac.embedded.1"] = manager
+    return service
+
+
+def test_epsa_diagnostics_defaults_to_dry_run(redfish_mock, redfish_service):
+    """dell-lc-epsa-diagnostics previews by default and never POSTs."""
+    _install_lc_service(redfish_service)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcEpsaDiagnostics,
+        "dell-lc-epsa-diagnostics",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.RunePSADiagnostics"
+    assert result.data["target"] == EPSA_TARGET
+    assert result.data["payload"] == {
+        "RunMode": "Express",
+        "RebootJobType": "GracefulRebootWithoutForcedShutdown",
+    }
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert _post_requests(redfish_service) == []
+
+
+def test_epsa_confirm_without_reboot_ack_still_does_not_post(
+    redfish_mock,
+    redfish_service,
+):
+    """--confirm alone is not enough for a diagnostic action that can reboot."""
+    _install_lc_service(redfish_service)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcEpsaDiagnostics,
+        "dell-lc-epsa-diagnostics",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] == (
+        "ePSA diagnostics requires --confirm and --i-understand-reboot"
+    )
+    assert _post_requests(redfish_service) == []
+
+
+def test_epsa_confirm_with_reboot_ack_posts_payload(redfish_mock, redfish_service):
+    """Both explicit flags allow one POST to the discovered Dell LC target."""
+    _install_lc_service(redfish_service)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcEpsaDiagnostics,
+        "dell-lc-epsa-diagnostics",
+        run_mode="Extended",
+        reboot_job_type="PowerCycle",
+        confirm=True,
+        confirm_reboot=True,
+    )
+
+    posts = [
+        request
+        for request in _post_requests(redfish_service)
+        if request.path.lower() == EPSA_TARGET.lower()
+    ]
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["target"] == EPSA_TARGET
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].json() == {
+        "RunMode": "Extended",
+        "RebootJobType": "PowerCycle",
+    }
+
+
+def test_epsa_dry_run_overrides_both_confirmation_flags(
+    redfish_mock,
+    redfish_service,
+):
+    """--dry_run remains a no-POST preview even with both confirmation flags."""
+    _install_lc_service(redfish_service)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcEpsaDiagnostics,
+        "dell-lc-epsa-diagnostics",
+        confirm=True,
+        confirm_reboot=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert _post_requests(redfish_service) == []
+
+
+def test_epsa_invalid_allowable_value_reports_without_post(
+    redfish_mock,
+    redfish_service,
+):
+    """Advertised RunMode values are enforced before any POST occurs."""
+    _install_lc_service(redfish_service)
+
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcEpsaDiagnostics,
+        "dell-lc-epsa-diagnostics",
+        run_mode="Full",
+        confirm=True,
+        confirm_reboot=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.RunePSADiagnostics RunMode: "
+        "Full; allowed: Express, ExpressAndExtended, Extended"
+    )
+    assert _post_requests(redfish_service) == []
+
+
+def test_epsa_missing_action_reports_blocker(redfish_mock, redfish_service):
+    """A DellLCService without the action fails closed before POST."""
+    service = _install_lc_service(redfish_service)
+    missing = copy.deepcopy(service)
+    missing["Actions"].pop("#DellLCService.RunePSADiagnostics")
+    redfish_service._overlay[LC_SERVICE_PATH] = missing
+    redfish_service._overlay[LC_SERVICE_PATH.lower()] = missing
+
+    with pytest.raises(InvalidArgument, match="no DellLCService exposing"):
+        redfish_mock.sync_invoke(
+            ApiRequestType.DellLcEpsaDiagnostics,
+            "dell-lc-epsa-diagnostics",
+            confirm=True,
+            confirm_reboot=True,
+        )
+    assert _post_requests(redfish_service) == []
+
+
+def test_epsa_rejects_blank_payload_values() -> None:
+    """Required payload values must not be blank."""
+    with pytest.raises(InvalidArgument, match="run mode cannot be empty"):
+        DellLcEpsaDiagnostics._payload(" ", "PowerCycle")
+    with pytest.raises(InvalidArgument, match="reboot job type cannot be empty"):
+        DellLcEpsaDiagnostics._payload("Express", "")
+
+
+def test_epsa_command_is_registered() -> None:
+    """The command is wired into the registry and parser."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellLcEpsaDiagnostics]["dell-lc-epsa-diagnostics"]
+        is DellLcEpsaDiagnostics
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellLcEpsaDiagnostics.register_subcommand(
+        DellLcEpsaDiagnostics
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-lc-epsa-diagnostics"
+    assert "ePSA" in cmd_help
+    assert "--confirm" in help_text
+    assert "--i-understand-reboot" in help_text


### PR DESCRIPTION
## Summary
- Add a guarded `dell-lc-epsa-diagnostics` command for `DellLCService.RunePSADiagnostics`.
- Discover Dell Lifecycle Controller service links from Manager OEM data with a legacy fallback path.
- Require `--confirm --i-understand-reboot` before POSTing and cover dry-run, validation, and registration behavior with offline tests.

## Checks
- Not run locally; GitHub CI runs the offline test matrix for the PR.