### PR TITLE
Bind the project to the shared standards manifest

### DIFF
--- a/standards-binding.yaml
+++ b/standards-binding.yaml
@@ -1,0 +1,20 @@
+apiVersion: standards.spyroot.dev/v1alpha1
+kind: ProjectStandardsBinding
+metadata:
+  name: redfish_ctl
+spec:
+  source:
+    localPath: /Users/spyroot/dev/standards
+    repository: https://gitlab.rnd.embedings.ai/spyroot/standards.git
+    revision: edc1120073be0dc5e54917462f48f9f1ea37b335
+  requiredContracts:
+    - ci
+    - unit-testing
+    - smoke-testing
+    - blockers
+    - agent-workspace
+    - automation
+    - project-consumer
+  projectAdditions:
+    - TEAM_GUIDE.md
+  exceptions: []


### PR DESCRIPTION
Adds `standards-binding.yaml`, pinning the shared standards repo at
`edc1120073be0dc5e54917462f48f9f1ea37b335` and declaring the seven contracts
this project consumes: `ci`, `unit-testing`, `smoke-testing`, `blockers`,
`agent-workspace`, `automation`, `project-consumer`.

The agent read order now starts with this file, so it has to be on `main` — a
pointer that exists only on a branch resolves for nobody.

Verified before committing: the pinned revision resolves in the standards clone
(`edc1120 Initial shared standards`) and all seven required contracts are present
at that revision.