### PR TITLE
Bump the shared standards pin to 033518d

### DIFF
--- a/standards-binding.yaml
+++ b/standards-binding.yaml
@@ -6,7 +6,7 @@ spec:
   source:
     localPath: /Users/spyroot/dev/standards
     repository: https://gitlab.rnd.embedings.ai/spyroot/standards.git
-    revision: edc1120073be0dc5e54917462f48f9f1ea37b335
+    revision: 033518d3f5aeda30e1d1a315382e0cedf2ca84cb
   requiredContracts:
     - ci
     - unit-testing


### PR DESCRIPTION
Moves `standards-binding.yaml` from `edc1120` to `033518d`, one commit forward.

## Evidence

**Full diff between pins** (`git diff --stat edc1120 033518d`):
```
 README.md                            |  11 +-
 manifest.yaml                        |   9 +-
 schemas/go-no-go-profile.schema.json | 301 +++++++++++++++++++++++++++++++++++
 templates/PROJECT_STANDARDS.md       |   8 +-
 templates/standards-binding.yaml     |   1 +
 5 files changed, 324 insertions(+), 6 deletions(-)
```

**Required contracts untouched:** `git diff --name-only edc1120 033518d -- docs/agents/contracts/ docs/agents/protocols/project-consumer.md` returns empty — none of the seven contracts this project binds changed.

**Direct descent, no history rewrite:** `git merge-base edc1120 033518d` == `edc1120` (fast-forward), exactly 1 commit between pins.

**Schema-consumption check:** the new revision adds a `schemas:` section to `manifest.yaml` declaring `go-no-go-profile` (`required: true`). Nothing executable in this repository reads `standards-binding.yaml` or the standards manifest (verified: no reference in `scripts/`, `gates/`, `.github/`, `.gitlab-ci.yml`); the only schema this repo's tooling consumes is its own `schemas/gates.schema.json`. The binding is read by agents, so there is no CI regression surface for a pin change.

**Template drift note:** the new template adds `agent-workspace` to `requiredContracts`; this project's binding already lists it.