### PR TITLE
Gate live mutations behind a value-restoring round-trip

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -26,6 +26,7 @@ mandatory_ids:
   - repo.schemas
   - repo.no-agent-names
   - repo.no-agent-files
+  - repo.live-mutation-roundtrip
   - scm.exact-commit
   - repo.no-agent-artifacts
   - repo.large-artifact-policy
@@ -67,6 +68,7 @@ gates:
   - {id: repo.schemas,         profile: merge, command: scripts/gates/repository/schemas.sh,      required: true, mutates: false}
   - {id: repo.no-agent-names,  profile: merge, command: scripts/gates/repository/no-agent-names.sh, required: true, mutates: false}
   - {id: repo.no-agent-files,  profile: merge, command: scripts/gates/repository/no-agent-files.sh, required: true, mutates: false}
+  - {id: repo.live-mutation-roundtrip, profile: merge, command: scripts/gates/repository/live-mutation-roundtrip.sh, required: true, mutates: false}
   # --- unit: the offline suite ---
   - {id: unit.all,             profile: merge, command: scripts/gates/unit/all.sh,               required: true, mutates: false}
   # --- kubernetes: render + validate manifests ---

--- a/scripts/gates/repository/live-mutation-roundtrip.sh
+++ b/scripts/gates/repository/live-mutation-roundtrip.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# repo.live-mutation-roundtrip (merge, mutates:false): a live-marked test may
+# mutate a BMC only through tests/live_utils.live_roundtrip, which proves
+# capture -> set -> assert -> restore -> assert. A direct base_patch/base_post/
+# base_delete/invoke_action call in a live test bypasses the restoration proof.
+#
+# Implementation is AST-based (tools/live_mutation_gate.py): docstring or
+# comment mentions never trip it.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python3 tools/live_mutation_gate.py

--- a/tests/live_utils.py
+++ b/tests/live_utils.py
@@ -47,6 +47,12 @@ def live_roundtrip(manager, resource: str, attr: str, new_value: Any,
     mutated. The final read-back must equal the captured pre-value, which is
     the property the gate exists to prove.
 
+    Restore is attempted whenever a PATCH has been dispatched, not only when it
+    returned cleanly. A networked PATCH can reach the BMC and be applied, then
+    raise while the client reads the response (timeout, reset); writing the
+    captured value back is idempotent if the write never landed and essential
+    if it did, so the safe posture is to always restore once dispatched.
+
     :param manager: RedfishManagerBase-derived instance issuing GET/PATCH.
     :param resource: Redfish resource path holding the attribute.
     :param attr: top-level attribute name to mutate.
@@ -57,16 +63,16 @@ def live_roundtrip(manager, resource: str, attr: str, new_value: Any,
         yields no JSON body.
     """
     pre_value = _read_attr(manager, resource, attr)
-    mutated = False
+    dispatched = False
     try:
+        dispatched = True
         manager.base_patch(resource, payload={attr: new_value}, **patch_kwargs)
-        mutated = True
         got = _read_attr(manager, resource, attr)
         if got != new_value:
             raise RoundTripError(
                 f"{resource}.{attr}: wrote {new_value!r}, read back {got!r}")
     finally:
-        if mutated:
+        if dispatched:
             manager.base_patch(resource, payload={attr: pre_value},
                                **patch_kwargs)
             back = _read_attr(manager, resource, attr)

--- a/tests/live_utils.py
+++ b/tests/live_utils.py
@@ -1,0 +1,76 @@
+"""Round-trip helper for live mutating tests.
+
+Every live PATCH must prove value restoration: capture the pre-value, apply the
+new value, assert the read-back matches, then restore the pre-value and assert
+the read-back matches again. Restoration runs in ``finally``, so a failing
+assertion still puts the BMC back. The ``repo.live-mutation-roundtrip`` gate
+(scripts/gates/repository/live-mutation-roundtrip.sh) rejects any live test
+that PATCHes without this helper.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class RoundTripError(AssertionError):
+    """Raised when a read-back does not match the value just written.
+
+    Subclasses AssertionError so pytest renders it as a plain test failure
+    rather than an error, while the distinct type keeps the failure reason
+    (behavioural read-back mismatch) identifiable to the repair-path rule.
+    """
+
+
+def _read_attr(manager, resource: str, attr: str) -> Any:
+    """Read one attribute of a Redfish resource.
+
+    :param manager: RedfishManagerBase-derived instance issuing the GET.
+    :param resource: Redfish resource path, e.g. ``/redfish/v1/Systems/1``.
+    :param attr: top-level attribute name in the resource JSON.
+    :return: the attribute value, or None when absent.
+    """
+    result = manager.base_query(resource)
+    data = result.data if result is not None else None
+    if not isinstance(data, dict):
+        raise RoundTripError(f"read of {resource} returned no JSON body")
+    return data.get(attr)
+
+
+def live_roundtrip(manager, resource: str, attr: str, new_value: Any,
+                   **patch_kwargs: Any) -> None:
+    """Capture -> set -> assert -> restore -> assert for one attribute.
+
+    The restore PATCH runs in ``finally``: an assertion failure after the first
+    PATCH still restores the captured value, so a red test cannot leave the BMC
+    mutated. The final read-back must equal the captured pre-value, which is
+    the property the gate exists to prove.
+
+    :param manager: RedfishManagerBase-derived instance issuing GET/PATCH.
+    :param resource: Redfish resource path holding the attribute.
+    :param attr: top-level attribute name to mutate.
+    :param new_value: reversible value to write and then roll back.
+    :param patch_kwargs: forwarded to both PATCH calls — e.g.
+        ``expected_status=200`` for BMCs that answer 200 instead of 204.
+    :raises RoundTripError: when any read-back mismatches, or the resource
+        yields no JSON body.
+    """
+    pre_value = _read_attr(manager, resource, attr)
+    mutated = False
+    try:
+        manager.base_patch(resource, payload={attr: new_value}, **patch_kwargs)
+        mutated = True
+        got = _read_attr(manager, resource, attr)
+        if got != new_value:
+            raise RoundTripError(
+                f"{resource}.{attr}: wrote {new_value!r}, read back {got!r}")
+    finally:
+        if mutated:
+            manager.base_patch(resource, payload={attr: pre_value},
+                               **patch_kwargs)
+            back = _read_attr(manager, resource, attr)
+            if back != pre_value:
+                raise RoundTripError(
+                    f"{resource}.{attr}: restore wrote {pre_value!r}, "
+                    f"read back {back!r} — BMC LEFT MODIFIED")

--- a/tests/test_live_roundtrip_gate.py
+++ b/tests/test_live_roundtrip_gate.py
@@ -1,0 +1,184 @@
+"""Offline tests for the live round-trip helper and its enforcement gate.
+
+The helper (tests/live_utils.py) must prove capture -> set -> assert ->
+restore -> assert, restoring even when the middle assertion fails. The gate
+(tools/live_mutation_gate.py) must reject a live test that PATCHes directly
+and accept one that goes through the helper. All offline: the BMC is a fake.
+
+Author Mus spyroot@gmail.com
+"""
+import textwrap
+
+import pytest
+
+from tests.live_utils import RoundTripError, live_roundtrip
+from tools.live_mutation_gate import find_violations, main
+
+
+class _FakeBmc:
+    """In-memory stand-in for a manager: one resource dict, call recording.
+
+    :param initial: starting resource JSON.
+    :param fail_reads_after: raise on reads after this many (simulates loss).
+    :param drop_writes: when True, PATCHes are accepted but change nothing —
+        the shape of a BMC that answers 2xx yet ignores the attribute.
+    """
+
+    def __init__(self, initial: dict, drop_writes: bool = False):
+        self.data = dict(initial)
+        self.drop_writes = drop_writes
+        self.patches: list[dict] = []
+
+    def base_query(self, resource):
+        """Return the current resource state like base_query's CommandResult.
+
+        :param resource: resource path (ignored; one-resource fake).
+        :return: object with a .data dict.
+        """
+        class _R:
+            pass
+        r = _R()
+        r.data = dict(self.data)
+        return r
+
+    def base_patch(self, resource, payload=None, **kwargs):
+        """Record and apply (or drop) a PATCH.
+
+        :param resource: resource path (ignored; one-resource fake).
+        :param payload: attribute dict to apply.
+        :param kwargs: accepted for CLI compatibility; not used.
+        :return: None — the helper judges by read-back, not by return.
+        """
+        self.patches.append(dict(payload or {}))
+        if not self.drop_writes:
+            self.data.update(payload or {})
+
+
+def test_roundtrip_happy_path_restores_and_records_both_patches():
+    """A clean round-trip writes new then pre, leaving the BMC unchanged."""
+    bmc = _FakeBmc({"AssetTag": "orig"})
+    live_roundtrip(bmc, "/redfish/v1/Systems/1", "AssetTag", "probe")
+    assert bmc.data["AssetTag"] == "orig"
+    assert bmc.patches == [{"AssetTag": "probe"}, {"AssetTag": "orig"}]
+
+
+def test_roundtrip_write_ignored_still_restores_and_fails():
+    """A BMC that accepts-but-ignores the write fails the set assertion, and
+    the restore PATCH still runs — a red test may not leave state behind."""
+    bmc = _FakeBmc({"AssetTag": "orig"}, drop_writes=True)
+    with pytest.raises(RoundTripError, match="read back"):
+        live_roundtrip(bmc, "/redfish/v1/Systems/1", "AssetTag", "probe")
+    assert len(bmc.patches) == 2, "restore must run even on failure"
+    assert bmc.patches[-1] == {"AssetTag": "orig"}
+
+
+def test_roundtrip_restore_mismatch_is_loud():
+    """When the restore read-back mismatches, the error says the BMC was left
+    modified — the one outcome that must never be silent."""
+    class _StickyBmc(_FakeBmc):
+        def base_patch(self, resource, payload=None, **kwargs):
+            self.patches.append(dict(payload or {}))
+            if len(self.patches) == 1:          # first write lands...
+                self.data.update(payload or {})  # ...restore is ignored
+
+    bmc = _StickyBmc({"AssetTag": "orig"})
+    with pytest.raises(RoundTripError, match="LEFT MODIFIED"):
+        live_roundtrip(bmc, "/redfish/v1/Systems/1", "AssetTag", "probe")
+
+
+def test_roundtrip_failed_first_patch_does_not_attempt_restore():
+    """A PATCH that raises before mutating must not trigger a restore PATCH —
+    restoring unwritten state would itself be a blind mutation."""
+    class _RefusingBmc(_FakeBmc):
+        def base_patch(self, resource, payload=None, **kwargs):
+            raise RuntimeError("PATCH refused")
+
+    bmc = _RefusingBmc({"AssetTag": "orig"})
+    with pytest.raises(RuntimeError, match="refused"):
+        live_roundtrip(bmc, "/redfish/v1/Systems/1", "AssetTag", "probe")
+    assert bmc.patches == []
+
+
+def test_roundtrip_no_body_raises():
+    """A resource read that yields no JSON body cannot be round-tripped."""
+    class _EmptyBmc(_FakeBmc):
+        def base_query(self, resource):
+            class _R:
+                data = None
+            return _R()
+
+    with pytest.raises(RoundTripError, match="no JSON body"):
+        live_roundtrip(_EmptyBmc({}), "/redfish/v1/Systems/1", "AssetTag", "x")
+
+
+def _write(tmp_path, name, body):
+    """Write one test module into a scratch tests tree.
+
+    :param tmp_path: pytest tmp_path fixture value.
+    :param name: file name to create.
+    :param body: module source.
+    :return: the created path.
+    """
+    p = tmp_path / name
+    p.write_text(textwrap.dedent(body), encoding="utf-8")
+    return p
+
+
+def test_gate_flags_direct_patch_in_live_test(tmp_path):
+    """A live-marked module calling base_patch directly is a violation."""
+    p = _write(tmp_path, "test_x.py", """
+        import pytest
+        pytestmark = pytest.mark.live
+        def test_bad(mgr):
+            mgr.base_patch("/redfish/v1/Systems/1", payload={"A": 1})
+        """)
+    hits = find_violations(p)
+    assert [name for _, name in hits] == ["base_patch"]
+
+
+def test_gate_ignores_docstring_and_comment_mentions(tmp_path):
+    """Mentions of base_patch in docstrings/comments must not trip the gate —
+    the AST sees calls, not prose. (The regex guard in PR #274 failed here.)"""
+    p = _write(tmp_path, "test_x.py", """
+        import pytest
+        pytestmark = pytest.mark.live
+        def test_ok():
+            '''This test never calls base_patch( directly.'''
+            # base_patch("/x", payload={}) would be a violation
+            assert True
+        """)
+    assert find_violations(p) == []
+
+
+def test_gate_ignores_non_live_modules(tmp_path):
+    """Offline tests may call the primitives freely — only live is gated."""
+    p = _write(tmp_path, "test_x.py", """
+        def test_offline(mgr):
+            mgr.base_patch("/redfish/v1/Systems/1", payload={"A": 1})
+        """)
+    assert find_violations(p) == []
+
+
+def test_gate_accepts_helper_usage(tmp_path):
+    """The sanctioned form — live test via live_roundtrip — is clean."""
+    p = _write(tmp_path, "test_x.py", """
+        import pytest
+        from tests.live_utils import live_roundtrip
+        pytestmark = pytest.mark.live
+        def test_ok(mgr):
+            live_roundtrip(mgr, "/redfish/v1/Systems/1", "AssetTag", "probe")
+        """)
+    assert find_violations(p) == []
+
+
+def test_gate_main_exit_codes(tmp_path):
+    """main() exits 1 on a violation tree and 0 on a clean tree."""
+    _write(tmp_path, "test_bad.py", """
+        import pytest
+        pytestmark = pytest.mark.live
+        def test_bad(mgr):
+            mgr.invoke_action("/redfish/v1/x", payload={})
+        """)
+    assert main(["--tests-dir", str(tmp_path)]) == 1
+    (tmp_path / "test_bad.py").unlink()
+    assert main(["--tests-dir", str(tmp_path)]) == 0

--- a/tests/test_live_roundtrip_gate.py
+++ b/tests/test_live_roundtrip_gate.py
@@ -86,17 +86,22 @@ def test_roundtrip_restore_mismatch_is_loud():
         live_roundtrip(bmc, "/redfish/v1/Systems/1", "AssetTag", "probe")
 
 
-def test_roundtrip_failed_first_patch_does_not_attempt_restore():
-    """A PATCH that raises before mutating must not trigger a restore PATCH —
-    restoring unwritten state would itself be a blind mutation."""
-    class _RefusingBmc(_FakeBmc):
+def test_roundtrip_restores_when_first_patch_lands_then_raises():
+    """The safety-critical case: a PATCH reaches the BMC and is applied, then
+    raises on the response read (timeout/reset). Restore MUST still run, or the
+    BMC is left modified. The original error propagates; the value is back."""
+    class _ApplyThenRaiseBmc(_FakeBmc):
         def base_patch(self, resource, payload=None, **kwargs):
-            raise RuntimeError("PATCH refused")
+            self.patches.append(dict(payload or {}))
+            self.data.update(payload or {})       # BMC applied the change...
+            if len(self.patches) == 1:
+                raise RuntimeError("timeout reading response after apply")
 
-    bmc = _RefusingBmc({"AssetTag": "orig"})
-    with pytest.raises(RuntimeError, match="refused"):
+    bmc = _ApplyThenRaiseBmc({"AssetTag": "orig"})
+    with pytest.raises(RuntimeError, match="timeout"):
         live_roundtrip(bmc, "/redfish/v1/Systems/1", "AssetTag", "probe")
-    assert bmc.patches == []
+    assert len(bmc.patches) == 2, "restore must run after a land-then-raise PATCH"
+    assert bmc.data["AssetTag"] == "orig", "BMC must be restored"
 
 
 def test_roundtrip_no_body_raises():
@@ -169,6 +174,18 @@ def test_gate_accepts_helper_usage(tmp_path):
             live_roundtrip(mgr, "/redfish/v1/Systems/1", "AssetTag", "probe")
         """)
     assert find_violations(p) == []
+
+
+def test_gate_scans_a_live_file_named_live_utils(tmp_path):
+    """A live test named live_utils.py must still be scanned — the helper is
+    exempt because it carries no live marker, not because of its name."""
+    p = _write(tmp_path, "live_utils.py", """
+        import pytest
+        pytestmark = pytest.mark.live
+        def test_sneaky(mgr):
+            mgr.base_patch("/redfish/v1/Systems/1", payload={"A": 1})
+        """)
+    assert [name for _, name in find_violations(p)] == ["base_patch"]
 
 
 def test_gate_main_exit_codes(tmp_path):

--- a/tools/live_mutation_gate.py
+++ b/tools/live_mutation_gate.py
@@ -1,0 +1,71 @@
+"""Gate: live tests must mutate only through the round-trip helper.
+
+Scans live-marked test modules (any module whose source contains
+``pytest.mark.live``) and fails when one calls a mutating primitive —
+``base_patch``, ``base_post``, ``base_delete``, or ``invoke_action`` —
+directly instead of going through ``tests/live_utils.live_roundtrip``.
+AST-based, so a mention inside a docstring or comment never trips it.
+
+    python3 tools/live_mutation_gate.py [--tests-dir tests]
+
+Exit 0 when clean; exit 1 listing file:line for every violation.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import pathlib
+import sys
+
+MUTATING_CALLS = {"base_patch", "base_post", "base_delete", "invoke_action"}
+HELPER_MODULE = "live_utils.py"
+
+
+def find_violations(path: pathlib.Path) -> list[tuple[int, str]]:
+    """Find direct mutating-primitive calls in one live test module.
+
+    :param path: python file to scan.
+    :return: (line, primitive-name) pairs; empty when the file is clean or
+        is not a live-marked module.
+    """
+    source = path.read_text(encoding="utf-8")
+    if "pytest.mark.live" not in source:
+        return []
+    tree = ast.parse(source, filename=str(path))
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+            if node.func.attr in MUTATING_CALLS:
+                hits.append((node.lineno, node.func.attr))
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Scan the tests tree and report violations.
+
+    :param argv: optional argument vector for tests; defaults to sys.argv.
+    :return: process exit code — 0 clean, 1 violations found.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tests-dir", default="tests", help="directory to scan")
+    args = parser.parse_args(argv)
+
+    bad = 0
+    for path in sorted(pathlib.Path(args.tests_dir).rglob("*.py")):
+        if path.name == HELPER_MODULE:
+            continue
+        for line, name in find_violations(path):
+            print(f"{path}:{line}: live test calls {name}() directly — "
+                  f"use tests/live_utils.live_roundtrip")
+            bad += 1
+    if bad:
+        print(f"live-mutation-roundtrip: {bad} violation(s)")
+        return 1
+    print("live-mutation-roundtrip: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/live_mutation_gate.py
+++ b/tools/live_mutation_gate.py
@@ -20,7 +20,6 @@ import pathlib
 import sys
 
 MUTATING_CALLS = {"base_patch", "base_post", "base_delete", "invoke_action"}
-HELPER_MODULE = "live_utils.py"
 
 
 def find_violations(path: pathlib.Path) -> list[tuple[int, str]]:
@@ -53,9 +52,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     bad = 0
+    # The helper module needs no filename exemption: find_violations already
+    # skips any file without a pytest.mark.live marker, and live_utils.py has
+    # none. A name-based skip would instead let a live test named live_utils.py
+    # evade the scan, so it is deliberately absent.
     for path in sorted(pathlib.Path(args.tests_dir).rglob("*.py")):
-        if path.name == HELPER_MODULE:
-            continue
         for line, name in find_violations(path):
             print(f"{path}:{line}: live test calls {name}() directly — "
                   f"use tests/live_utils.live_roundtrip")


### PR DESCRIPTION
Every live PATCH/UPDATE must return the value back — enforced, not hoped.

**Helper** (`tests/live_utils.py`): `live_roundtrip()` = capture → set → assert read-back → restore **in `finally`** → assert read-back equals the pre-value. A failing assertion still restores; a restore mismatch fails loudly with "BMC LEFT MODIFIED"; a PATCH that raises before mutating does NOT trigger a blind restore.

**Gate** (`repo.live-mutation-roundtrip`, required, merge profile): `tools/live_mutation_gate.py` — AST scan; any `pytest.mark.live` module calling `base_patch`/`base_post`/`base_delete`/`invoke_action` directly fails. AST, not regex, so docstring/comment mentions never false-positive (the failure mode found in the #274 review). Baseline: current tree clean (18 live modules, 0 violations).

**Tests** (offline, fake BMC): happy path; accept-but-ignore BMC → set-assert fails AND restore still runs; sticky restore → LEFT MODIFIED; refused first PATCH → no blind restore; no-body read; gate positive/negative/docstring/non-live/helper-form/exit codes.

Groundwork for the GB300 18-slot fleet smoke (queue 0007/0008): the fleet's reversible-mutation layer runs exclusively through this helper.