### PR TITLE
Add gitleaks allowlist for public corpora and synthetic key fixtures

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,25 @@
+# gitleaks config for the repo.no-secrets gate (scripts/gates/repository/no-secrets.sh).
+# Keeps every default rule active and adds path-scoped allowlists ONLY for the
+# two known-public, non-credential locations that the generic-api-key rule
+# false-positives on. Secrets anywhere outside these paths are still caught.
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = """Captured Redfish corpora. Per docs/internal/corpus/CORPA_POLICE.md the
+captures come from decommissioned, sandboxed, privately-addressed lab gear and are public by
+decided policy. Redfish never returns account passwords (every Password field is null), so the
+SNMPv3 localized-key hex the generic-api-key rule matches here is config material from dead
+hardware, not a live secret. Scoped to the corpus paths only."""
+paths = [
+    '''tests/.*_corpus/.*''',
+    '''tests/.*_corpus\.tar\.gz''',
+    '''tests/corpus/.*''',
+]
+
+[[allowlists]]
+description = """Synthetic SNMPv3-key fixtures in the corpus contract test — literal placeholder
+hex (0123456789abcdef..., deadbeef*8, cafebabe...) used to exercise redaction, never real keys."""
+paths = [
+    '''tests/test_full_corpus_contract\.py''',
+]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,25 +1,36 @@
 # gitleaks config for the repo.no-secrets gate (scripts/gates/repository/no-secrets.sh).
-# Keeps every default rule active and adds path-scoped allowlists ONLY for the
-# two known-public, non-credential locations that the generic-api-key rule
-# false-positives on. Secrets anywhere outside these paths are still caught.
+# Keeps every default rule active and narrowly suppresses ONLY the known
+# false-positive class: Dell iDRAC credential-derived attribute values
+# (SNMPv3 v3 keys, IPMI keys, SHA256 password hashes + salts) in the public
+# corpora and the synthetic-hex contract test.
+#
+# Each allowlist requires BOTH an anchored corpus/test path AND a line matching
+# one of the specific Dell attribute names (condition = "AND", regexTarget =
+# "line"). A real secret placed under these paths later — an AWS key, a JWT, a
+# PEM private key on a normal line — does NOT match the attribute-name regex and
+# is still caught. Path-only allowlisting was rejected in review as too broad.
 [extend]
 useDefault = true
 
 [[allowlists]]
-description = """Captured Redfish corpora. Per docs/internal/corpus/CORPA_POLICE.md the
-captures come from decommissioned, sandboxed, privately-addressed lab gear and are public by
-decided policy. Redfish never returns account passwords (every Password field is null), so the
-SNMPv3 localized-key hex the generic-api-key rule matches here is config material from dead
-hardware, not a live secret. Scoped to the corpus paths only."""
+description = """Dell iDRAC credential-derived DellAttributes values in captured Redfish corpora.
+Per docs/internal/corpus/CORPA_POLICE.md the captures come from decommissioned, sandboxed,
+privately-addressed lab gear with throwaway credentials and are public by decided policy.
+Suppresses ONLY the specific Dell attribute lines (v3 keys, IPMI keys, SHA256 password hashes and
+salts), never an arbitrary secret elsewhere in the same file."""
+condition = "AND"
+regexTarget = "line"
 paths = [
-    '''tests/.*_corpus/.*''',
-    '''tests/.*_corpus\.tar\.gz''',
-    '''tests/corpus/.*''',
+    '''^tests/[^/]*_corpus/.*''',
+    '''^tests/corpus/.*''',
 ]
+regexes = ['''"Users\.\d+\.(SHA\d*v3Key|MD5v3Key|IPMIKey|SHA256Password|SHA256PasswordSalt)"''']
 
 [[allowlists]]
-description = """Synthetic SNMPv3-key fixtures in the corpus contract test — literal placeholder
-hex (0123456789abcdef..., deadbeef*8, cafebabe...) used to exercise redaction, never real keys."""
-paths = [
-    '''tests/test_full_corpus_contract\.py''',
-]
+description = """Synthetic Dell key fixtures in the corpus contract test — literal placeholder hex
+(0123456789abcdef..., deadbeef*8, cafebabe...) on the same Users.N.<attr> attribute lines, used to
+exercise redaction; never real keys."""
+condition = "AND"
+regexTarget = "line"
+paths = ['''^tests/test_full_corpus_contract\.py$''']
+regexes = ['''"Users\.\d+\.(SHA\d*v3Key|MD5v3Key|IPMIKey|SHA256Password|SHA256PasswordSalt)"''']


### PR DESCRIPTION
**This unblocks the private (internal GitLab) CI.** Internal `main` reconciled to GitHub main and the first real pipeline (44) failed on ONE gate — `repo.no-secrets` — because `gitleaks` ran with no config. Everything else (toolbox smoke, meta-gate) passed.

**What the 16 findings actually are** (verified against the corpus): Dell iDRAC **credential-derived** `DellAttributes` values — SHA256 password **hashes** + salts, IPMI keys, and SNMPv3 v3 keys — in `tests/dell_xr8620t_corpus/`, plus synthetic placeholder hex in `tests/test_full_corpus_contract.py`. Per `docs/internal/corpus/CORPA_POLICE.md` the captures are from decommissioned, sandboxed, throwaway-credential lab gear and are public by decided policy. Operator confirmed: allowlist (keep corpus byte-identical) over redaction.

**The fix** (`.gitleaks.toml`): keeps every default rule active (`useDefault = true`) and suppresses a finding ONLY when BOTH hold (`condition = "AND"`, `regexTarget = "line"`): an anchored corpus/test path AND a line naming a specific Dell credential attribute (`Users.N.{SHA*v3Key,MD5v3Key,IPMIKey,SHA256Password,SHA256PasswordSalt}`).

**Proven narrow (not a blanket bypass):**
- all 16 cleared; history scan (713 commits) clean; gate prints `repo.no-secrets: OK`.
- a real (non-example) GitHub PAT + generic key on **normal lines** inside a corpus path → **still caught**.
- even a token placed as a `SHA256Password` **value** → still caught.
- secret detection everywhere outside these paths is unchanged.

Security-sensitive by nature; the allowlist breadth is the thing to scrutinize, and the scoping above is why it is safe.