### PR TITLE
Route all event-loop resolution through the 3.14-safe helper

### DIFF
--- a/redfish_ctl/bios/cmd_bios.py
+++ b/redfish_ctl/bios/cmd_bios.py
@@ -161,7 +161,7 @@ class BiosQuery(RedfishManagerBase,
             response = self.api_get_call(r, headers)
             self.default_error_handler(response)
         else:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
             response = loop.run_until_complete(
                 self.api_async_get_until_complete(r, headers)
             )
@@ -203,7 +203,7 @@ class BiosQuery(RedfishManagerBase,
                     response = self.api_get_call(r, headers)
                     self.default_error_handler(response)
                 else:
-                    loop = asyncio.get_event_loop()
+                    loop = self._event_loop()
                     response = loop.run_until_complete(
                         self.api_async_get_until_complete(r, headers)
                     )

--- a/redfish_ctl/boot_source/cmd_boot_settings.py
+++ b/redfish_ctl/boot_source/cmd_boot_settings.py
@@ -81,7 +81,7 @@ class BootSettings(RedfishManagerBase,
                 response = self.api_get_call(r, headers)
                 self.default_error_handler(response)
             else:
-                loop = asyncio.get_event_loop()
+                loop = self._event_loop()
                 response = loop.run_until_complete(
                     self.api_async_get_until_complete(r, headers)
                 )

--- a/redfish_ctl/boot_source/cmd_boot_source_get.py
+++ b/redfish_ctl/boot_source/cmd_boot_source_get.py
@@ -91,7 +91,7 @@ class BootSource(RedfishManagerBase,
                 response = self.api_get_call(r, headers)
                 self.default_error_handler(response)
             else:
-                loop = asyncio.get_event_loop()
+                loop = self._event_loop()
                 response = loop.run_until_complete(
                     self.api_async_get_until_complete(r, headers)
                 )

--- a/redfish_ctl/cmd_boot.py
+++ b/redfish_ctl/cmd_boot.py
@@ -87,7 +87,7 @@ class BootQuery(RedfishManagerBase,
                 response = self.api_get_call(r, headers)
                 self.default_error_handler(response)
             else:
-                loop = asyncio.get_event_loop()
+                loop = self._event_loop()
                 response = loop.run_until_complete(
                     self.api_async_get_until_complete(r, headers)
                 )

--- a/redfish_ctl/events/cmd_subscription_lifecycle.py
+++ b/redfish_ctl/events/cmd_subscription_lifecycle.py
@@ -53,18 +53,6 @@ class _SubscriptionBase(RedfishManagerBase):
         link = (data or {}).get(key)
         return link.get("@odata.id") if isinstance(link, dict) else None
 
-    @staticmethod
-    def _ensure_event_loop():
-        """Return the current asyncio event loop, creating one if none is set.
-
-        :return: an asyncio event loop usable for the async Redfish calls.
-        """
-        try:
-            return asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            return loop
 
     def _subscription_collection_uri(self, do_async):
         """Resolve the EventService Subscriptions collection URI.
@@ -74,7 +62,7 @@ class _SubscriptionBase(RedfishManagerBase):
         :raises InvalidArgument: when the EventService Subscriptions link is absent.
         """
         if do_async:
-            self._ensure_event_loop()
+            self._event_loop()
         service = self.base_query(
             REDFISH_API.EventServiceQuery,
             do_async=do_async,
@@ -92,7 +80,7 @@ class _SubscriptionBase(RedfishManagerBase):
         :return: the ``@odata.id`` of each subscription member (possibly empty).
         """
         if do_async:
-            self._ensure_event_loop()
+            self._event_loop()
         collection = self.base_query(subscriptions_uri, do_async=do_async).data or {}
         members = collection.get("Members")
         if not isinstance(members, list):
@@ -197,7 +185,7 @@ class _SubscriptionBase(RedfishManagerBase):
                 return self.api_post_call(request, json.dumps(body), headers)
             if method == HTTPMethod.DELETE:
                 return self.api_delete_call(request, headers)
-        loop = self._ensure_event_loop()
+        loop = self._event_loop()
         if method == HTTPMethod.POST:
             return loop.run_until_complete(
                 self._await_async_response(

--- a/redfish_ctl/firmware/cmd_firmware.py
+++ b/redfish_ctl/firmware/cmd_firmware.py
@@ -91,7 +91,7 @@ class FirmwareQuery(RedfishManagerBase,
             response = self.api_get_call(r, headers)
             self.default_error_handler(response)
         else:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
             response = loop.run_until_complete(self.api_async_get_until_complete(r, headers))
 
         self.default_error_handler(response)

--- a/redfish_ctl/pci/cmd_pci.py
+++ b/redfish_ctl/pci/cmd_pci.py
@@ -82,7 +82,7 @@ class PciDeviceQuery(RedfishManagerBase,
                 response = self.api_get_call(r, headers)
                 self.default_error_handler(response)
             else:
-                loop = asyncio.get_event_loop()
+                loop = self._event_loop()
                 response = loop.run_until_complete(
                     self.api_async_get_until_complete(r, headers))
             data = response.json()

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -47,6 +47,25 @@ CommandResult = collections.namedtuple("cmd_result",
 
 class RedfishManager:
 
+    @staticmethod
+    def _event_loop() -> asyncio.AbstractEventLoop:
+        """Return a usable event loop for a synchronous caller.
+
+        ``asyncio.get_event_loop()`` used to create a loop implicitly when none existed. Python 3.12
+        deprecated that and 3.14 removed it, so on 3.14 it raises RuntimeError and every async path in
+        this client dies before sending anything. Creating the loop explicitly when there is none keeps
+        one behaviour across 3.10 through 3.14.
+
+        :return: the running loop when one exists, otherwise a new loop installed for this thread.
+        :raises RuntimeError: never — the no-loop case is handled by creating one.
+        """
+        try:
+            return asyncio.get_event_loop_policy().get_event_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            return loop
+
     def __init__(self,
                  redfish_ip: Optional[str] = "",
                  redfish_username: Optional[str] = "root",
@@ -349,7 +368,7 @@ class RedfishManager:
         :return: http response object
         """
         if loop is None:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
         response = await self.api_async_get_call(loop, req, hdr)
         await self.async_default_error_handler(await response)
         return await response
@@ -488,7 +507,7 @@ class RedfishManager:
             self.query_counter += 1
             self.default_error_handler(response)
         else:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
             response = loop.run_until_complete(
                 self.api_async_get_until_complete(
                     r, headers

--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -390,7 +390,7 @@ class RedfishManagerBase(RedfishManager):
         :return:
         """
         if loop is None:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
         response = await self.api_async_get_call(loop, req, hdr)
         await self.async_default_error_handler(await response)
         return await response
@@ -1061,7 +1061,7 @@ class RedfishManagerBase(RedfishManager):
         :return:
         """
         if loop is None:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
         response = await self.api_async_patch_call(loop, r, payload, hdr)
         api_respond_status = await self.async_default_patch_success(
             await response, expected=expected, ignore_error_code=ignore_error_code)
@@ -1087,7 +1087,7 @@ class RedfishManagerBase(RedfishManager):
         :return:
         """
         if loop is None:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
         response = await self.api_async_delete_call(loop, r, payload, hdr)
         api_respond_status = await self.async_default_delete_success(
             await response, expected=expected, ignore_error_code=ignore_error_code)
@@ -1113,7 +1113,7 @@ class RedfishManagerBase(RedfishManager):
         :return:
         """
         if loop is None:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
         response = await self.api_async_post_call(loop, r, payload, hdr)
         api_respond_status = await self.async_default_post_success(
             await response, ignore_error_code=ignore_error_code, expected=expected
@@ -1419,24 +1419,6 @@ class RedfishManagerBase(RedfishManager):
             ]
         return payload
 
-    @staticmethod
-    def _event_loop() -> asyncio.AbstractEventLoop:
-        """Return a usable event loop for a synchronous caller.
-
-        ``asyncio.get_event_loop()`` used to create a loop implicitly when none existed. Python 3.12
-        deprecated that and 3.14 removed it, so on 3.14 it raises RuntimeError and every async path in
-        this client dies before sending anything. Creating the loop explicitly when there is none keeps
-        one behaviour across 3.10 through 3.14.
-
-        :return: the running loop when one exists, otherwise a new loop installed for this thread.
-        :raises RuntimeError: never — the no-loop case is handled by creating one.
-        """
-        try:
-            return asyncio.get_event_loop_policy().get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            return loop
 
     def base_request_respond(
             self,

--- a/redfish_ctl/storage/cmd_storage_controllers.py
+++ b/redfish_ctl/storage/cmd_storage_controllers.py
@@ -121,7 +121,7 @@ class StorageQuery(RedfishManagerBase, scm_type=ApiRequestType.StorageQuery,
             response = self.api_get_call(r, headers)
             self.default_error_handler(response)
         else:
-            loop = asyncio.get_event_loop()
+            loop = self._event_loop()
             response = loop.run_until_complete(self.api_async_get_until_complete(r, headers))
 
         data = response.json()

--- a/tests/test_no_raw_get_event_loop.py
+++ b/tests/test_no_raw_get_event_loop.py
@@ -1,0 +1,63 @@
+"""Audit: no module calls asyncio.get_event_loop() directly.
+
+get_event_loop() raises RuntimeError on Python 3.14 (in the CI matrix) when no
+loop is running, killing every async Redfish path before it sends anything. The
+package routes loop resolution through RedfishManager._event_loop(), which is
+3.14-safe. This test AST-scans the package and fails if a raw call reappears —
+the one sanctioned exception is the helper's own policy-form call.
+
+Author Mus spyroot@gmail.com
+"""
+import ast
+import pathlib
+
+import pytest
+
+_PKG = pathlib.Path(__file__).resolve().parent.parent / "redfish_ctl"
+# The single sanctioned raw call lives inside _event_loop() itself, and it is the
+# policy form asyncio.get_event_loop_policy().get_event_loop(), which the audit
+# below ignores because its receiver is the policy object, not the asyncio module.
+
+
+def _raw_module_get_event_loop_calls(path: pathlib.Path) -> list[int]:
+    """Return line numbers of ``asyncio.get_event_loop()`` calls in one module.
+
+    Only flags calls whose receiver is the ``asyncio`` module directly; the
+    helper's ``get_event_loop_policy().get_event_loop()`` has a Call receiver and
+    is not flagged.
+
+    :param path: python source file to scan.
+    :return: 1-indexed line numbers of raw module-level get_event_loop() calls.
+    """
+    hits: list[int] = []
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get_event_loop"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "asyncio"):
+            hits.append(node.lineno)
+    return hits
+
+
+def test_no_module_uses_raw_get_event_loop():
+    """No redfish_ctl module may call asyncio.get_event_loop() directly."""
+    offenders = {
+        str(p.relative_to(_PKG.parent)): lines
+        for p in sorted(_PKG.rglob("*.py"))
+        if (lines := _raw_module_get_event_loop_calls(p))
+    }
+    assert not offenders, (
+        "raw asyncio.get_event_loop() found (raises on 3.14); use "
+        f"self._event_loop() instead: {offenders}")
+
+
+@pytest.mark.parametrize("layer", [
+    "redfish_ctl/redfish_manager.py",
+    "redfish_ctl/redfish_manager_base.py",
+])
+def test_helper_available_across_layers(layer):
+    """_event_loop must be resolvable from the generic layer and the base — it
+    lives on RedfishManager (parent), so both inherit it."""
+    src = (_PKG.parent / layer).read_text(encoding="utf-8")
+    assert "self._event_loop()" in src or "def _event_loop(" in src


### PR DESCRIPTION
**Root fix for the async-path Python 3.14 breakage** the triage found across the base layer and #283/#285/#287.

`asyncio.get_event_loop()` raises `RuntimeError` on Python 3.14 (in the CI matrix, `ci.yml`) when no loop is running — killing every async Redfish path before it sends anything. The `_event_loop()` helper (added in #340) already handles this, but it lived on `RedfishManagerBase`, so the generic `RedfishManager` parent and 8 command modules each re-rolled the raw call.

**Change:**
- Moved `_event_loop()` up to `RedfishManager` (the product-neutral generic layer) — both layers and every command module now inherit `self._event_loop()`.
- Replaced all **15** raw `asyncio.get_event_loop()` sites.
- Deleted a duplicate `_ensure_event_loop` in the subscription command; its 3 callers now use the inherited helper.
- **AST audit test** (`tests/test_no_raw_get_event_loop.py`) fails if a raw call reappears — the one sanctioned exception is the helper's own policy-form call.

**Verified:** audit test green; package imports; `RedfishManager._event_loop` present, `RedfishManagerBase` inherits, dup gone, helper returns a real loop. The only raw call remaining is the helper's own `get_event_loop_policy().get_event_loop()`, which is the 3.14-safe form.

Once merged, #283/#285/#287's async-path 3.14 findings are resolved at the root (their command modules inherit the fix).