### PR TITLE
Gate the destructive-action policy against silent downgrade

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -27,6 +27,7 @@ mandatory_ids:
   - repo.no-agent-names
   - repo.no-agent-files
   - repo.live-mutation-roundtrip
+  - repo.mutation-policy
   - scm.exact-commit
   - repo.no-agent-artifacts
   - repo.large-artifact-policy
@@ -69,6 +70,7 @@ gates:
   - {id: repo.no-agent-names,  profile: merge, command: scripts/gates/repository/no-agent-names.sh, required: true, mutates: false}
   - {id: repo.no-agent-files,  profile: merge, command: scripts/gates/repository/no-agent-files.sh, required: true, mutates: false}
   - {id: repo.live-mutation-roundtrip, profile: merge, command: scripts/gates/repository/live-mutation-roundtrip.sh, required: true, mutates: false}
+  - {id: repo.mutation-policy, profile: merge, command: scripts/gates/repository/mutation-policy.sh, required: true, mutates: false}
   # --- unit: the offline suite ---
   - {id: unit.all,             profile: merge, command: scripts/gates/unit/all.sh,               required: true, mutates: false}
   # --- kubernetes: render + validate manifests ---

--- a/scripts/gates/repository/mutation-policy.sh
+++ b/scripts/gates/repository/mutation-policy.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# repo.mutation-policy (merge, mutates:false): destructive Redfish actions must
+# stay classified DESTRUCTIVE or IRREVERSIBLE in action_policy. A power-off,
+# password change, certificate replace, manager reset, or data erase can never
+# be downgraded to REVERSIBLE/READ_ONLY, and the fail-safe default must hold.
+# Implementation: tools/mutation_policy_gate.py.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python3 tools/mutation_policy_gate.py

--- a/tests/test_mutation_policy_gate.py
+++ b/tests/test_mutation_policy_gate.py
@@ -1,0 +1,69 @@
+"""Offline tests for the destructive-action policy gate.
+
+The gate (tools/mutation_policy_gate.py) locks the invariant that no
+service-disrupting or credential/security-rewriting action can be classified
+below DESTRUCTIVE. These tests prove the real policy satisfies it and that the
+gate actually catches a downgrade — a gate that always passes is worthless.
+
+Author Mus spyroot@gmail.com
+"""
+import pytest
+
+from redfish_ctl.actions.action_policy import Destructiveness
+from tools import mutation_policy_gate as gate
+
+
+def test_real_policy_is_clean():
+    """The shipped ACTION_POLICY must satisfy every invariant."""
+    assert gate.check() == []
+
+
+def test_main_exit_zero_on_clean_policy():
+    """main() returns 0 against the real policy."""
+    assert gate.main() == 0
+
+
+@pytest.mark.parametrize("name", [
+    "#ComputerSystem.Reset",
+    "#Manager.Reset",
+    "#Manager.ResetToDefaults",
+    "#CertificateService.ReplaceCertificate",
+    "#Bios.ChangePassword",
+])
+def test_hard_no_family_downgrade_is_caught(monkeypatch, name):
+    """Downgrading any hard-no anchor (power/reset/manager/cert/password) to
+    REVERSIBLE must be reported — this is the regression the gate exists for."""
+    from redfish_ctl.actions import action_policy
+    patched = dict(action_policy.ACTION_POLICY)
+    patched[name] = Destructiveness.REVERSIBLE
+    monkeypatch.setattr(gate, "ACTION_POLICY", patched)
+    bad = gate.check()
+    assert any(name in line for line in bad), f"downgrade of {name} not caught"
+
+
+def test_missing_hard_no_family_is_caught(monkeypatch):
+    """Deleting a hard-no family from the policy is a violation — absence must
+    not silently drop it to the (safe) default and pass."""
+    from redfish_ctl.actions import action_policy
+    patched = dict(action_policy.ACTION_POLICY)
+    del patched["#CertificateService.ReplaceCertificate"]
+    monkeypatch.setattr(gate, "ACTION_POLICY", patched)
+    assert any("ReplaceCertificate" in line and "missing" in line
+               for line in gate.check())
+
+
+def test_default_level_downgrade_is_caught(monkeypatch):
+    """If the fail-safe default is loosened from DESTRUCTIVE, the gate fails —
+    an unclassified action must never fall through to a runnable level."""
+    monkeypatch.setattr(gate, "DEFAULT_LEVEL", Destructiveness.REVERSIBLE)
+    assert any("DEFAULT_LEVEL" in line for line in gate.check())
+
+
+def test_new_keyworded_action_must_be_destructive(monkeypatch):
+    """A newly added action whose name carries a destructive keyword (here a
+    firmware SimpleUpdate) may not be introduced at REVERSIBLE."""
+    from redfish_ctl.actions import action_policy
+    patched = dict(action_policy.ACTION_POLICY)
+    patched["#UpdateService.SimpleUpdate"] = Destructiveness.REVERSIBLE
+    monkeypatch.setattr(gate, "ACTION_POLICY", patched)
+    assert any("SimpleUpdate" in line for line in gate.check())

--- a/tools/mutation_policy_gate.py
+++ b/tools/mutation_policy_gate.py
@@ -1,0 +1,124 @@
+"""Gate: destructive Redfish actions can never be classified below DESTRUCTIVE.
+
+The round-trip gate (repo.live-mutation-roundtrip) proves reversible mutations
+restore their value. This gate guards the other side: an action that powers a
+host off, changes a password, replaces a certificate, resets a manager, or
+erases data must stay at DESTRUCTIVE or IRREVERSIBLE in
+``redfish_ctl.actions.action_policy.ACTION_POLICY``. A future edit that
+downgrades one to REVERSIBLE or READ_ONLY would let it run through the
+reversible path (or freely), defeating the confirm requirement — this gate
+fails that edit at CI.
+
+    python3 tools/mutation_policy_gate.py
+
+Exit 0 when every invariant holds; exit 1 listing each violation.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import sys
+
+from redfish_ctl.actions.action_policy import (
+    ACTION_POLICY,
+    DEFAULT_LEVEL,
+    Destructiveness,
+)
+
+# Ordered least→most disruptive, so "at least DESTRUCTIVE" is an index compare.
+_ORDER = [
+    Destructiveness.READ_ONLY,
+    Destructiveness.REVERSIBLE,
+    Destructiveness.DESTRUCTIVE,
+    Destructiveness.IRREVERSIBLE,
+]
+
+# Any action whose type name contains one of these substrings MUST classify at
+# DESTRUCTIVE or above. The names describe service-disrupting or config/security
+# rewriting operations; none is ever safely reversible-or-below.
+_DANGER_SUBSTRINGS = (
+    "Reset",            # ComputerSystem/Manager/Chassis/NetworkAdapter/Control/Bios/SecureBoot
+    "ChangePassword",   # credential change
+    "ReplaceCertificate",  # BMC/service certificate replacement
+    "SecureErase",      # drive data loss
+    "RevokeKeys",       # RoT key revocation
+    "ResetKeys",        # SecureBoot key reset
+    "ClearLog",         # log erasure
+    "ClearMetricReports",
+    "SimpleUpdate",     # firmware
+    "StartUpdate",
+    "Install",          # license/firmware/debug-token install
+    "CheckConsistency",
+    "MinimumSecurityVersion",  # one-way security-version bump
+)
+
+# Named anchors that MUST be present and at least DESTRUCTIVE. These map to the
+# operator's absolute hard-no families (power/reset, manager reset, cert change,
+# password change); their absence is itself a regression, so presence is checked
+# as well as level.
+_REQUIRED_MIN = {
+    "#ComputerSystem.Reset": Destructiveness.DESTRUCTIVE,      # power off / reboot / cycle
+    "#Manager.Reset": Destructiveness.DESTRUCTIVE,             # BMC reset
+    "#Manager.ResetToDefaults": Destructiveness.DESTRUCTIVE,   # BMC factory reset
+    "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,  # cert change
+    "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,       # password change
+}
+
+
+def _at_least(level: Destructiveness, minimum: Destructiveness) -> bool:
+    """Return True when ``level`` is as disruptive as ``minimum`` or more.
+
+    :param level: the classification under test.
+    :param minimum: the floor it must reach.
+    :return: True when level ranks at or above minimum.
+    """
+    return _ORDER.index(level) >= _ORDER.index(minimum)
+
+
+def check() -> list[str]:
+    """Return every policy-invariant violation; empty list when clean.
+
+    :return: human-readable violation strings, one per broken invariant.
+    """
+    bad: list[str] = []
+
+    if DEFAULT_LEVEL is not Destructiveness.DESTRUCTIVE:
+        bad.append(
+            f"DEFAULT_LEVEL is {DEFAULT_LEVEL.value}, must be destructive "
+            "(an unclassified action has to fail safe)")
+
+    for name, level in ACTION_POLICY.items():
+        if any(s in name for s in _DANGER_SUBSTRINGS):
+            if not _at_least(level, Destructiveness.DESTRUCTIVE):
+                bad.append(
+                    f"{name} is {level.value}; a destructive-keyword action "
+                    "must be destructive or irreversible")
+
+    for name, minimum in _REQUIRED_MIN.items():
+        if name not in ACTION_POLICY:
+            bad.append(f"{name} missing from ACTION_POLICY (hard-no family)")
+        elif not _at_least(ACTION_POLICY[name], minimum):
+            bad.append(
+                f"{name} is {ACTION_POLICY[name].value}, must be at least "
+                f"{minimum.value}")
+
+    return bad
+
+
+def main() -> int:
+    """Run the invariant check and report.
+
+    :return: 0 when every invariant holds, 1 otherwise.
+    """
+    bad = check()
+    for line in bad:
+        print(f"mutation-policy: {line}")
+    if bad:
+        print(f"mutation-policy: {len(bad)} violation(s)")
+        return 1
+    print("mutation-policy: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Replaces #345, which auto-closed when its base branch (#344) was deleted on merge. Same content rebased onto main (now has #344's round-trip gate).

Locks the invariant that power-off, password change, certificate replace, manager reset, and data-erase actions stay classified DESTRUCTIVE or IRREVERSIBLE in `action_policy`; the fail-safe default holds. A PR downgrading one to REVERSIBLE fails `repo.mutation-policy` at CI. Complements #344. Brain-reviewed at think_max on #345; 10 offline tests.