### PR TITLE
Converge command backlog round 2 (7 PRs)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-supportassist-schedule` | Manage Dell LC SupportAssist auto-collection schedules; previews by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-supportassist-export` | Export the last Dell SupportAssist collection; previews unless `--confirm` is given. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-vflash-state` | Enable or disable Dell vFlash through `DellPersistentStorageService.VFlashStateChange`; dry-run by default and `--confirm` posts. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -118,6 +118,7 @@ Safety labels:
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
+| `dell-system-lcd-errors` | Show Dell system errors on the chassis LCD through `DellSystemManagementService.ShowErrorsOnLCD`; dry-run by default and `--confirm` posts. | Guarded |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |
 | `environment-metrics` | Read linked EnvironmentMetrics resources for power, energy, temperature, and power-limit rollups. | Read |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-lc-log-comment` | Insert a Dell Lifecycle Controller log comment; dry-run by default and `--confirm` posts. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -117,6 +117,7 @@ Safety labels:
 | `compute-query` | Read ComputerSystem settings. | Read |
 | `console-info` | Report serial, graphical, and shell console links per manager. | Read |
 | `current_boot` | Read current boot source details. | Read |
+| `dell-vflash-partition` | List or invoke Dell VFlash partition actions exposed by `DellPersistentStorageService`; previews by default and erase-class actions require both confirmation flags. | Guarded |
 | `dell-lc-svc` | Read Dell Lifecycle Controller service data. | Read |
 | `discovery` | Recursively walk Redfish resources and record allowed methods. | Read |
 | `eject_vm` | Eject virtual media. | Write |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,8 +4,8 @@ Author: Mus <spyroot@gmail.com>
 
 `redfish_ctl` emits OpenTelemetry **metrics** and **traces** over OTLP, so a fleet of server BMCs —
 and the operations run against them — become visible in Splunk Observability APM (or any OTLP
-backend: Grafana Tempo/Mimir, an OpenTelemetry Collector, etc.). No agent on the host, no code in the
-firmware; everything is read out-of-band over the Redfish API and shipped as standard telemetry.
+backend: Grafana Tempo/Mimir, an OpenTelemetry Collector, etc.). No host-side daemon and no code in
+the firmware; everything is read out-of-band over the Redfish API and shipped as standard telemetry.
 
 ## What problem this addresses
 
@@ -13,8 +13,9 @@ At fleet scale (hundreds to thousands of servers, each with a different tuning p
 team mutates BMCs constantly — tuning BIOS, upgrading firmware, setting boot order, remediating
 drift — usually through a k8s operator. Without telemetry, that activity is invisible: which node's
 BIOS apply failed, which vendor's firmware flash is slow, which reconcile is stuck waiting on a
-reboot. `redfish_ctl` turns every read and every mutation into a span, so that activity shows up as a
-normal APM service map + trace waterfall + per-operation error/latency breakdown.
+reboot. `redfish_ctl` wraps command executions in operation spans and traced Redfish request helpers
+in client spans, so covered activity shows up as a normal APM service map, trace waterfall, and
+per-operation error/latency breakdown.
 
 ## Who it is for
 
@@ -44,13 +45,14 @@ flowchart LR
 Two signals, one pipeline:
 
 - **Traces.** Each command run through the engine opens an **operation span** named by the command
-  (`firmware-update`, `bios-change`, `reboot`). Every BMC HTTP call inside it opens a `SpanKind.CLIENT`
-  span (`redfish.bmc.request`) carrying `peer.service="bmc"`. Because the BMC is uninstrumented, Splunk
+  (`firmware-update`, `bios-change`, `reboot`). BMC calls routed through the manager HTTP verbs, the
+  Redfish action primitive, and the firmware upload helper open `SpanKind.CLIENT` spans
+  (`redfish.bmc.request`) carrying `peer.service="bmc"`. Because the BMC is uninstrumented, Splunk
   infers it as a single downstream service node — so a whole fleet renders as `redfish-ctl → bmc`, not
   one node per address. Failures set the span to ERROR (from the HTTP status or `CommandResult.error`),
-  which drives the red edges, error rate, and Root Cause in APM. See the span model in
-  [`.internal/design-notes/splunk-apm-traces/`] (design notes) and the code in
-  `redfish_ctl/telemetry/tracing.py`.
+  which drives the red edges, error rate, and Root Cause in APM. The public span contract lives in
+  `specs/telemetry/span_contract.yaml`; the merge-gate coverage requirements live in
+  `specs/telemetry/gates.md`, and the implementation is in `redfish_ctl/telemetry/tracing.py`.
 - **Metrics.** The exporter samples hardware state (power, thermal, fans, GPU, leak detection, fabric)
   into the stable `hw.*` metric family. Traces say *what operation ran and whether it failed*; metrics
   say *what the hardware did* — a firmware-update span sits next to the `hw.power` spike it caused,
@@ -63,7 +65,7 @@ within the Troubleshooting MetricSet cardinality budget.
 
 ## Quick start — stream to Splunk in three commands
 
-Install with the OTLP extra, point at your collector (or Splunk OTLP endpoint), and run any command
+Install with the OTLP extra, point at your collector (or Splunk OTLP endpoint), and run a command
 with tracing on:
 
 ```bash
@@ -93,6 +95,6 @@ to an in-cluster Collector), see the [Kubernetes guide](../k8s/README.md) and th
 
 ## Try it with zero hardware
 
-The mock BMC serves the committed GB300 corpus over HTTP and can replay mutations, so the full
-read-and-mutate path — and the traces it produces — can be exercised with no real BMC. See
+The mock BMC serves the committed GB300 corpus over HTTP and can replay captured mutations, so
+supported read paths and replay-backed mutation paths can be exercised with no real BMC. See
 [Simulation and replay](simulation-and-replay.md).

--- a/docs/telemetry-metrics.md
+++ b/docs/telemetry-metrics.md
@@ -6,6 +6,10 @@ This reference is generated from the Supermicro GB300 fixture files packed in
 `tests/supermicro_gb300_corpus.tar.gz`, the captured Redfish JSON corpus used by
 the offline tests, so this page does not require a live BMC or private endpoint.
 
+Regenerate it with `python tools/generate_telemetry_metrics_doc.py`; use
+`python tools/generate_telemetry_metrics_doc.py --check` in gates to verify
+that the checked-in copy matches the exporter mapper.
+
 ## How To Read This
 
 `MetricReports`, the Redfish collection represented by the fixture files named
@@ -23,11 +27,13 @@ operator guidance, not schema-declared units.
 `Context` is the parent Redfish fragment or path segment that disambiguates
 repeated source metric names without copying the full fixture path.
 
-`redfish_ctl exporter`, defined in `redfish_ctl/telemetry/cmd_exporter.py`, emits
-numeric `MetricValue` rows only. Known fabric counters use curated
-`hw.fabric.*` names. GPU temperature, processor, throttle, clock, and memory
-rows use curated `hw.gpu.*` names. Remaining numeric rows become generated
-`hw.gb300.*` metric names derived from the source metric name.
+`redfish_ctl exporter`, defined in `redfish_ctl/telemetry/cmd_exporter.py`,
+emits the metrics shown in the `Exporter metric` column. Fabric properties use
+curated `hw.fabric.*` names. GPU temperature, processor, throttle, clock, and
+memory rows use curated `hw.gpu.*` names. Bounded categorical rows use
+`hw.component.*`, `hw.fabric.link_down_reason`, or `hw.power.*` state gauges.
+Remaining numeric rows become generated `hw.gb300.*` metric names derived from
+the source metric name.
 
 ## Safe Consumption
 
@@ -55,10 +61,11 @@ without posting externally.
 ## Checking Live Data In Splunk
 
 SignalFx is Splunk Observability Cloud, so the exporter's `signalfx` output pushes
-these metrics straight into Splunk Observability — no extra bridge.
+these metrics straight into Splunk Observability; no extra bridge is required.
 
-1. Push to your org (realm ingest URL + an access token). `SPLUNK_INGEST_URL` and
-   `SPLUNK_ACCESS_TOKEN` are read from the environment by `redfish_ctl exporter`:
+1. Push to your org. `SPLUNK_INGEST_URL`, the SignalFx `/v2/datapoint` ingest
+   URL read by the exporter, and `SPLUNK_ACCESS_TOKEN`, the org access token
+   read by the exporter, must come from the environment:
 
 ```bash
 export SPLUNK_ACCESS_TOKEN='<org access token>'
@@ -66,39 +73,41 @@ export SPLUNK_INGEST_URL='https://ingest.<realm>.signalfx.com/v2/datapoint'
 redfish_ctl exporter --vendor supermicro --output signalfx --push-signalfx
 ```
 
-2. Find the data in Splunk Observability. Under **Metrics -> Metric Finder**, search the
-   metric names this exporter emits: `hw.fabric.*` (NVLink/port link state, BER, RX/TX
-   throughput and errors), `hw.gpu.*` (GPU temperature, processor, clock, throttle,
-   and memory gauges), `hw.gb300.*` (remaining GB300-specific numeric rows), and
-   `hw.temperature`, `hw.energy_kwh`, `hw.component_integrity.enabled`. Every datapoint
-   carries these **dimensions** for filtering/grouping: `host.name`, `chassis`, `gpu`,
-   `port`, `sensor`, `vendor`, `report`.
+2. Find the data in Splunk Observability. Under **Metrics -> Metric Finder**,
+   search the metric names this exporter emits: `hw.fabric.*` (NVLink/port
+   link state, BER, RX/TX throughput and errors), `hw.gpu.*` (GPU temperature,
+   processor, clock, throttle, and memory gauges), `hw.component.*` and
+   `hw.power.*` state gauges, `hw.gb300.*` (remaining GB300-specific numeric
+   rows), plus `hw.temperature`, `hw.energy_kwh`, and `hw.leak.state` from
+   the non-MetricReport samplers. Every datapoint carries these dimensions
+   for filtering/grouping: `host.name`, `node`, `server.address`, `bmc.ip`,
+   and `vendor`; report-derived datapoints also carry `report` and any
+   applicable `gpu`, `port`, `sensor`, `memory`, or state label.
 
-3. Confirm points are arriving with a chart or SignalFlow query, e.g. fabric receive rate
-   per port on one host:
+3. Confirm points are arriving with a chart or SignalFlow query, for example
+   fabric receive rate per port on one host:
 
 ```
-data('hw.fabric.raw_rx_gbps', filter=filter('host', '<bmc-host>')).publish()
+data('hw.fabric.raw_rx_gbps', filter=filter('host.name', '<bmc-host>')).publish()
 ```
 
-Datapoints land within a few seconds of the push; when the Metric Finder shows the `hw.*`
-names carrying your `host`/`vendor` dimensions, live data is flowing.
+Datapoints land within a few seconds of the push; when the Metric Finder shows
+the `hw.*` names carrying your `host.name` and `vendor` dimensions, live data
+is flowing.
 
 For **Splunk Enterprise/Cloud (HEC)** rather than Observability: run the Prometheus
-listener (`redfish_ctl exporter --output prometheus`, no `--once`) and point a Splunk
-OpenTelemetry Collector (prometheus receiver -> `splunk_hec` exporter) at it, which lands
-the same metrics in a HEC index.
+listener (`redfish_ctl exporter --output prometheus`, no `--once`) and point a
+Splunk OpenTelemetry Collector (prometheus receiver -> `splunk_hec` exporter) at
+it, which lands the same metrics in a HEC index.
 
-For a **native OTLP** pipeline (no Collector hop for the BMC data), use
-`redfish_ctl exporter --output otlp` — it pushes these same `hw.*` series over OTLP and honors the
-standard `OTEL_EXPORTER_OTLP_*` environment so it behaves like any other OTLP producer. The identity
-dimensions become OTel resource attributes and the per-metric dimensions become datapoint attributes;
-monotonic counters are emitted as OTLP Sum and instantaneous readings as Gauge. Needs the
-`redfish_ctl[otlp]` extra. See [Telemetry exporter](telemetry-exporter.md#otlp-opentelemetry).
+For a **native OTLP** pipeline, use `redfish_ctl exporter --output otlp` to push
+these same `hw.*` series over OTLP. It honors the standard
+`OTEL_EXPORTER_OTLP_*` environment variables and needs the `redfish_ctl[otlp]`
+extra. See [Telemetry exporter](telemetry-exporter.md#otlp-opentelemetry).
 
-> Live verification of the push needs a real `SPLUNK_ACCESS_TOKEN` and your realm's
-> `SPLUNK_INGEST_URL`; without them, use `--once --output signalfx` to validate the
-> datapoint envelope offline.
+> Live verification of the push needs a real `SPLUNK_ACCESS_TOKEN` and your
+> realm's `SPLUNK_INGEST_URL`; without them, use `--once --output signalfx`
+> to validate the datapoint envelope offline.
 
 ## Report Inventory
 
@@ -126,52 +135,52 @@ definition exists but the current fixture did not include a matching sample.
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
 | `ProcessorModule_{ProcessorId}_CPU_{CpuId}_CoreUtil_{CoreId}` | Chassis/HGX_CPU_{CpuId}/Sensors | not declared | number:144 | 144 | `hw.gb300.processor_module_processor_id_cpu_cpu_id_core_util_core_id` |
-| `ProcessorModule_{ProcessorId}_MemCntl_0_Freq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_processor_id_mem_cntl_0_freq_0` |
-| `ProcessorModule_{ProcessorId}_CPU_0_CpuFreq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_processor_id_cpu_0_cpu_freq_0` |
+| `ProcessorModule_{ProcessorId}_MemCntl_0_Freq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: MHz | number:2 | 2 | `hw.gb300.processor_module_processor_id_mem_cntl_0_freq_0` |
+| `ProcessorModule_{ProcessorId}_CPU_0_CpuFreq_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: MHz | number:2 | 2 | `hw.gb300.processor_module_processor_id_cpu_0_cpu_freq_0` |
 | `ProcessorModule_{ProcessorId}_Vreg_0_CpuVoltage_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: voltage | number:2 | 2 | `hw.gb300.processor_module_processor_id_vreg_0_cpu_voltage_0` |
 | `ProcessorModule_{ProcessorId}_Vreg_0_SocVoltage_0` | Chassis/HGX_CPU_{CpuId}/Sensors | name hint: voltage | number:2 | 2 | `hw.gb300.processor_module_processor_id_vreg_0_soc_voltage_0` |
 | `MemoryPageRetirementCount` | Oem/Nvidia | name hint: count | number:2 | 2 | `hw.gb300.memory_page_retirement_count` |
-| `EDPViolationState` | Oem/Nvidia | not declared | string:2 | 2 | `not exported by exporter` |
-| `PowerBreakPerformanceState` | Oem/Nvidia | name hint: power | string:2 | 2 | `not exported by exporter` |
-| `MemorySpareChannelPresence` | Oem/Nvidia | not declared | boolean:2 | 2 | `not exported by exporter` |
-| `State` | Status | not declared | string:20 | 20 | `not exported by exporter` |
-| `State` | Status | not declared | string:4 | 4 | `not exported by exporter` |
+| `EDPViolationState` | Oem/Nvidia | not declared | string:2 | 2 | `hw.power.edp_violation_state` |
+| `PowerBreakPerformanceState` | Oem/Nvidia | name hint: power | string:2 | 2 | `hw.power.break_performance_state` |
+| `MemorySpareChannelPresence` | Oem/Nvidia | not declared | boolean:2 | 2 | `hw.gb300.memory_spare_channel_presence` |
+| `State` | Status | not declared | string:20 | 20 | `hw.component.state` |
+| `State` | Status | not declared | string:4 | 4 | `hw.component.state` |
 
 ### `HGX_HealthMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `Health` | Status | not declared | string:2 | 2 | `not exported by exporter` |
-| `HealthRollup` | Status | not declared | string:2 | 2 | `not exported by exporter` |
-| `Health` | Status | not declared | string:4 | 4 | `not exported by exporter` |
-| `HealthRollup` | Status | not declared | string:4 | 4 | `not exported by exporter` |
-| `Health` | Status | not declared | string:1 | 1 | `not exported by exporter` |
-| `HealthRollup` | Status | not declared | string:1 | 1 | `not exported by exporter` |
+| `Health` | Status | not declared | string:2 | 2 | `hw.component.health` |
+| `HealthRollup` | Status | not declared | string:2 | 2 | `hw.component.health_rollup` |
+| `Health` | Status | not declared | string:4 | 4 | `hw.component.health` |
+| `HealthRollup` | Status | not declared | string:4 | 4 | `hw.component.health_rollup` |
+| `Health` | Status | not declared | string:1 | 1 | `hw.component.health` |
+| `HealthRollup` | Status | not declared | string:1 | 1 | `hw.component.health_rollup` |
 
 ### `HGX_MemoryMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `RowRemappingFailed` | Oem/Nvidia | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `OperatingSpeedMHz` | OperatingSpeedMHz | name hint: MHz | number:4 | 4 | `hw.gb300.operating_speed_mhz` |
-| `BandwidthPercent` | BandwidthPercent | name hint: percent | number:4 | 4 | `hw.gb300.bandwidth_percent` |
-| `CapacityUtilizationPercent` | CapacityUtilizationPercent | name hint: percent | number:4 | 4 | `hw.gb300.capacity_utilization_percent` |
-| `CorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gb300.correctable_eccerror_count` |
-| `UncorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gb300.uncorrectable_eccerror_count` |
-| `CorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.correctable_row_remapping_count` |
-| `UncorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.uncorrectable_row_remapping_count` |
-| `MaxAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.max_availability_bank_count` |
-| `HighAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.high_availability_bank_count` |
-| `PartialAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.partial_availability_bank_count` |
-| `LowAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.low_availability_bank_count` |
-| `NoAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gb300.no_availability_bank_count` |
+| `RowRemappingFailed` | Oem/Nvidia | not declared | boolean:4 | 4 | `hw.gpu.memory.row_remapping_failed` |
+| `OperatingSpeedMHz` | Systems/HGX_Baseboard_0/Memory/GPU_{GpuId}_DRAM_0 | MHz | number:4 | 4 | `hw.gpu.memory.clock_mhz` |
+| `BandwidthPercent` | Systems/HGX_Baseboard_0/Memory/GPU_{GpuId}_DRAM_0 | % | number:4 | 4 | `hw.gpu.memory.bandwidth_utilization` |
+| `CapacityUtilizationPercent` | Systems/HGX_Baseboard_0/Memory/GPU_{GpuId}_DRAM_0 | % | number:4 | 4 | `hw.gpu.memory.capacity_utilization` |
+| `CorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gpu.memory.ecc_errors` |
+| `UncorrectableECCErrorCount` | LifeTime | name hint: count | number:4 | 4 | `hw.gpu.memory.ecc_errors` |
+| `CorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `UncorrectableRowRemappingCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `MaxAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `HighAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `PartialAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `LowAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
+| `NoAvailabilityBankCount` | Oem/Nvidia/RowRemapping | name hint: count | number:4 | 4 | `hw.gpu.memory.row_remap_count` |
 
 ### `HGX_PlatformEnvironmentMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
 | `HGX_BMC_0_Temp_0` | Chassis/HGX_BMC_0/Sensors | name hint: temperature | number:1 | 1 | `hw.gb300.hgx_bmc_0_temp_0` |
-| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | varies by resolved sensor | number:1 | 1 | `hw.gb300.<resolved_metric_property>` |
+| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | not declared | number:1 | 1 | `hw.gb300.<resolved_metric_property>` |
 | `ProcessorModule_{PMWild}_CPU_0_Energy_0` | Chassis/HGX_CPU_{PMWild}/Sensors | name hint: energy | number:2 | 2 | `hw.gb300.processor_module_pmwild_cpu_0_energy_0` |
 | `ProcessorModule_{PMWild}_CPU_0_EnforcedEDPc_0` | Chassis/HGX_CPU_{PMWild}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_pmwild_cpu_0_enforced_edpc_0` |
 | `ProcessorModule_{PMWild}_CPU_0_EnforcedEDPp_0` | Chassis/HGX_CPU_{PMWild}/Sensors | not declared | number:2 | 2 | `hw.gb300.processor_module_pmwild_cpu_0_enforced_edpp_0` |
@@ -181,11 +190,11 @@ definition exists but the current fixture did not include a matching sample.
 | `ProcessorModule_{PMWild}_Vreg_0_CpuPower_0` | Chassis/HGX_CPU_{PMWild}/Sensors | name hint: power | number:2 | 2 | `hw.gb300.processor_module_pmwild_vreg_0_cpu_power_0` |
 | `ProcessorModule_{PMWild}_Vreg_0_SocPower_0` | Chassis/HGX_CPU_{PMWild}/Sensors | name hint: power | number:2 | 2 | `hw.gb300.processor_module_pmwild_vreg_0_soc_power_0` |
 | `HGX_GPU_{GWild}_DRAM_0_Power_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: power | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_dram_0_power_0` |
-| `HGX_GPU_{GWild}_DRAM_0_Temp_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: temperature | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_dram_0_temp_0` |
+| `HGX_GPU_{GWild}_DRAM_0_Temp_0` | Chassis/HGX_GPU_{GWild}/Sensors | Cel | number:4 | 4 | `hw.gpu.temperature` |
 | `HGX_GPU_{GWild}_Energy_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: energy | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_energy_0` |
 | `HGX_GPU_{GWild}_Power_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: power | number:8 | 8 | `hw.gb300.hgx_gpu_gwild_power_0` |
-| `HGX_GPU_{GWild}_TEMP_0` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: temperature | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_temp_0` |
-| `HGX_GPU_{GWild}_TEMP_1` | Chassis/HGX_GPU_{GWild}/Sensors | name hint: temperature | number:4 | 4 | `hw.gb300.hgx_gpu_gwild_temp_1` |
+| `HGX_GPU_{GWild}_TEMP_0` | Chassis/HGX_GPU_{GWild}/Sensors | Cel | number:4 | 4 | `hw.gpu.temperature` |
+| `HGX_GPU_{GWild}_TEMP_1` | Chassis/HGX_GPU_{GWild}/Sensors | Cel | number:4 | 4 | `hw.gpu.temperature` |
 | `HGX_ProcessorModule_{PMWild}_Exhaust_Temp_0` | Chassis/HGX_ProcessorModule_{PMWild}/Sensors | name hint: temperature | number:2 | 2 | `hw.gb300.hgx_processor_module_pmwild_exhaust_temp_0` |
 | `HGX_ProcessorModule_{PMWild}_Inlet_Temp_0` | Chassis/HGX_ProcessorModule_{PMWild}/Sensors | name hint: temperature | number:2 | 2 | `hw.gb300.hgx_processor_module_pmwild_inlet_temp_0` |
 | `HGX_ProcessorModule_{PMWild}_Inlet_Temp_1` | Chassis/HGX_ProcessorModule_{PMWild}/Sensors | name hint: temperature | number:2 | 2 | `hw.gb300.hgx_processor_module_pmwild_inlet_temp_1` |
@@ -194,40 +203,40 @@ definition exists but the current fixture did not include a matching sample.
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `TensorCoreActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.tensor_core_activity_percent` |
-| `SMOccupancyPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.smoccupancy_percent` |
-| `SMActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.smactivity_percent` |
+| `TensorCoreActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `SMOccupancyPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `SMActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 | `PCIeRawTxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.gb300.pcie_raw_tx_bandwidth_gbps` |
 | `PCIeRawRxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.gb300.pcie_raw_rx_bandwidth_gbps` |
-| `NVOfaUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.nvofa_utilization_percent` |
+| `NVOfaUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 | `NVLinkRawTxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.raw_tx_gbps` |
 | `NVLinkRawRxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.raw_rx_gbps` |
 | `NVLinkDataTxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.tx_gbps` |
 | `NVLinkDataRxBandwidthGbps` | Oem/Nvidia | Gbps | number:4 | 4 | `hw.fabric.rx_gbps` |
-| `NVJpgUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.nvjpg_utilization_percent` |
-| `{InstanceId}` | Oem/Nvidia/NVJpgInstanceUtilizationPercent | varies by resolved sensor | number:32 | 32 | `hw.gb300.<resolved_metric_property>` |
-| `{InstanceId}` | Oem/Nvidia/NVDecInstanceUtilizationPercent | varies by resolved sensor | number:32 | 32 | `hw.gb300.<resolved_metric_property>` |
-| `NVDecUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.nvdec_utilization_percent` |
-| `IntegerActivityUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.integer_activity_utilization_percent` |
-| `IMMAUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.immautilization_percent` |
-| `HMMAUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.hmmautilization_percent` |
-| `GraphicsEngineActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.graphics_engine_activity_percent` |
-| `FP64ActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.fp64_activity_percent` |
-| `FP32ActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.fp32_activity_percent` |
-| `FP16ActivityPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.fp16_activity_percent` |
-| `DMMAUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.dmmautilization_percent` |
+| `NVJpgUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `{InstanceId}` | Oem/Nvidia/NVJpgInstanceUtilizationPercent | % | number:32 | 32 | `hw.gpu.compute.utilization` |
+| `{InstanceId}` | Oem/Nvidia/NVDecInstanceUtilizationPercent | % | number:32 | 32 | `hw.gpu.compute.utilization` |
+| `NVDecUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `IntegerActivityUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `IMMAUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `HMMAUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `GraphicsEngineActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `FP64ActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `FP32ActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `FP16ActivityPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
+| `DMMAUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 
 ### `HGX_ProcessorMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `State` | Status | not declared | not observed | 0 | `not exported by exporter` |
-| `PCIeType` | PCIeInterface | not declared | string:4 | 4 | `not exported by exporter` |
+| `State` | Status | not declared | - | 0 | not observed in fixture |
+| `PCIeType` | PCIeInterface | not declared | string:4 | 4 | not exported by exporter |
 | `MaxLanes` | PCIeInterface | not declared | number:4 | 4 | `hw.gb300.max_lanes` |
 | `LanesInUse` | PCIeInterface | not declared | number:4 | 4 | `hw.gb300.lanes_in_use` |
-| `OperatingSpeedMHz` | OperatingSpeedMHz | name hint: MHz | number:4 | 4 | `hw.gb300.operating_speed_mhz` |
-| `BandwidthPercent` | BandwidthPercent | name hint: percent | number:4 | 4 | `hw.gb300.bandwidth_percent` |
-| `SMUtilizationPercent` | Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.smutilization_percent` |
+| `OperatingSpeedMHz` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | MHz | number:4 | 4 | `hw.gpu.clock_mhz` |
+| `BandwidthPercent` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | name hint: percent | number:4 | 4 | `hw.gb300.bandwidth_percent` |
+| `SMUtilizationPercent` | Oem/Nvidia | % | number:4 | 4 | `hw.gpu.compute.utilization` |
 | `CorrectableECCErrorCount` | CacheMetricsTotal/LifeTime | name hint: count | number:4 | 4 | `hw.gb300.correctable_eccerror_count` |
 | `UncorrectableECCErrorCount` | CacheMetricsTotal/LifeTime | name hint: count | number:4 | 4 | `hw.gb300.uncorrectable_eccerror_count` |
 | `CorrectableErrorCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.correctable_error_count` |
@@ -238,166 +247,166 @@ definition exists but the current fixture did not include a matching sample.
 | `ReplayRolloverCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.replay_rollover_count` |
 | `NAKSentCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.naksent_count` |
 | `NAKReceivedCount` | PCIeErrors | name hint: count | number:4 | 4 | `hw.gb300.nakreceived_count` |
-| `ThrottleReasons` | Oem/Nvidia | not declared | not observed | 0 | `not exported by exporter` |
-| `PCIeTXBytes` | Oem/Nvidia | name hint: bytes | number:4 | 4 | `hw.gb300.pcie_txbytes` |
-| `PCIeRXBytes` | Oem/Nvidia | name hint: bytes | number:4 | 4 | `hw.gb300.pcie_rxbytes` |
-| `PowerLimitThrottleDuration` | PowerLimitThrottleDuration | name hint: power | string:4 | 4 | `not exported by exporter` |
-| `ThermalLimitThrottleDuration` | ThermalLimitThrottleDuration | not declared | string:4 | 4 | `not exported by exporter` |
-| `HardwareViolationThrottleDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `GlobalSoftwareViolationThrottleDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `AccumulatedGPUContextUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `AccumulatedSMUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | `not exported by exporter` |
-| `RampDownWattsPerSecond` | RampDownWattsPerSecond | not declared | number:4 | 4 | `hw.gb300.ramp_down_watts_per_second` |
-| `RampDownHysteresisSeconds` | RampDownHysteresisSeconds | not declared | number:4 | 4 | `hw.gb300.ramp_down_hysteresis_seconds` |
-| `RampUpWattsPerSecond` | RampUpWattsPerSecond | not declared | number:4 | 4 | `hw.gb300.ramp_up_watts_per_second` |
-| `TMPFloorPercent` | TMPFloorPercent | name hint: percent | number:4 | 4 | `hw.gb300.tmpfloor_percent` |
-| `ImmediateRampDown` | ImmediateRampDown | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `RemainingLifetimeCircuitryPercent` | RemainingLifetimeCircuitryPercent | name hint: percent | number:4 | 4 | `hw.gb300.remaining_lifetime_circuitry_percent` |
-| `Enabled` | Enabled | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowFLRPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowOneShotConfig` | Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
-| `AllowPersistentConfig` | Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `not exported by exporter` |
+| `ThrottleReasons` | Oem/Nvidia | not declared | - | 0 | not observed in fixture |
+| `PCIeTXBytes` | Oem/Nvidia | By | number:4 | 4 | `hw.gb300.pcie_txbytes` |
+| `PCIeRXBytes` | Oem/Nvidia | By | number:4 | 4 | `hw.gb300.pcie_rxbytes` |
+| `PowerLimitThrottleDuration` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `ThermalLimitThrottleDuration` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId} | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `HardwareViolationThrottleDuration` | Oem/Nvidia | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `GlobalSoftwareViolationThrottleDuration` | Oem/Nvidia | s | string:4 | 4 | `hw.gpu.throttle.duration_seconds` |
+| `AccumulatedGPUContextUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | not exported by exporter |
+| `AccumulatedSMUtilizationDuration` | Oem/Nvidia | not declared | string:4 | 4 | not exported by exporter |
+| `RampDownWattsPerSecond` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | number:4 | 4 | `hw.gb300.ramp_down_watts_per_second` |
+| `RampDownHysteresisSeconds` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | number:4 | 4 | `hw.gb300.ramp_down_hysteresis_seconds` |
+| `RampUpWattsPerSecond` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | number:4 | 4 | `hw.gb300.ramp_up_watts_per_second` |
+| `TMPFloorPercent` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.tmpfloor_percent` |
+| `ImmediateRampDown` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | boolean:4 | 4 | `hw.gb300.immediate_ramp_down` |
+| `RemainingLifetimeCircuitryPercent` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: percent | number:4 | 4 | `hw.gb300.remaining_lifetime_circuitry_percent` |
+| `Enabled` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | boolean:4 | 4 | `hw.gb300.enabled` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/InbandReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0Firewall | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EGMMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/BAR0TypeConfig | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCDevMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/CCMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ClockLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ECCEnable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/EDPpScalingFactor | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/ForceTestCoupling | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/FusingMode | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HBMFrequencyChange | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/HULKLicenseUpdate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InSystemTest | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/InfoROMFileSystemRecreate | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/NVLinkDisable | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PCIeVFConfiguration | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel1 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/PowerSmoothingPrivilegeLevel2 | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingAllowed | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/RowRemappingFeature | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPCurrentLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMaxLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPMinLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
+| `AllowFLRPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_flrpersistent_config` |
+| `AllowOneShotConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_one_shot_config` |
+| `AllowPersistentConfig` | Oem/Nvidia/DOEReconfigPermissions/TGPRatedLimit | not declared | boolean:4 | 4 | `hw.gb300.allow_persistent_config` |
 
 ### `HGX_ProcessorPortGPMMetrics_0`
 
@@ -412,30 +421,30 @@ definition exists but the current fixture did not include a matching sample.
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `CurrentSpeedGbps` | CurrentSpeedGbps | Gbps | number:72 | 72 | `hw.fabric.port_speed` |
-| `TXBytes` | TXBytes | By | number:72 | 72 | `hw.fabric.tx_bytes` |
-| `RXBytes` | RXBytes | By | number:72 | 72 | `hw.fabric.rx_bytes` |
-| `RXErrors` | RXErrors | name hint: count | number:72 | 72 | `hw.fabric.rx_errors` |
-| `RXFrames` | Networking | name hint: count | number:72 | 72 | `hw.fabric.rx_frames` |
-| `TXFrames` | Networking | name hint: count | number:72 | 72 | `hw.fabric.tx_frames` |
+| `CurrentSpeedGbps` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports | Gbps | number:72 | 72 | `hw.fabric.port_speed` |
+| `TXBytes` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports/NVLink_{NvlinkId} | By | number:72 | 72 | `hw.fabric.tx_bytes` |
+| `RXBytes` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports/NVLink_{NvlinkId} | By | number:72 | 72 | `hw.fabric.rx_bytes` |
+| `RXErrors` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports/NVLink_{NvlinkId} | name hint: count | number:72 | 72 | `hw.fabric.rx_errors` |
+| `RXFrames` | Networking | not declared | number:72 | 72 | `hw.fabric.rx_frames` |
+| `TXFrames` | Networking | not declared | number:72 | 72 | `hw.fabric.tx_frames` |
 | `TXDiscards` | Networking | not declared | number:72 | 72 | `hw.fabric.tx_discards` |
-| `MalformedPackets` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.malformed_packets` |
-| `VL15Dropped` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.vl15_dropped` |
-| `VL15TXPackets` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.vl15_tx_packets` |
+| `MalformedPackets` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.malformed_packets` |
+| `VL15Dropped` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.vl15_dropped` |
+| `VL15TXPackets` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.vl15_tx_packets` |
 | `VL15TXBytes` | Oem/Nvidia | By | number:72 | 72 | `hw.fabric.vl15_tx_bytes` |
 | `NeighborMTUDiscards` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.neighbor_mtudiscards` |
 | `LinkErrorRecoveryCount` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.link_error_recovery_count` |
 | `LinkDownedCount` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.link_down_count` |
 | `RXRemotePhysicalErrors` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.rx_remote_physical_errors` |
 | `RXSwitchRelayErrors` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.rx_switch_relay_errors` |
-| `QP1Dropped` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.gb300.qp1_dropped` |
+| `QP1Dropped` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.qp1_dropped` |
 | `TXWait` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.tx_wait` |
 | `BitErrorRate` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.bit_error_rate` |
 | `TXNoProtocolBytes` | Oem/Nvidia | By | number:72 | 72 | `hw.fabric.tx_no_protocol_bytes` |
 | `RXNoProtocolBytes` | Oem/Nvidia | By | number:72 | 72 | `hw.fabric.rx_no_protocol_bytes` |
-| `RuntimeError` | Oem/Nvidia/NVLinkErrors | name hint: count | number:72 | 72 | `hw.gb300.runtime_error` |
-| `TrainingError` | Oem/Nvidia/NVLinkErrors | name hint: count | number:72 | 72 | `hw.gb300.training_error` |
-| `LinkDownReasonCode` | Oem/Nvidia | not declared | string:72 | 72 | `not exported by exporter` |
+| `RuntimeError` | Oem/Nvidia/NVLinkErrors | not declared | number:72 | 72 | `hw.gb300.runtime_error` |
+| `TrainingError` | Oem/Nvidia/NVLinkErrors | not declared | number:72 | 72 | `hw.gb300.training_error` |
+| `LinkDownReasonCode` | Oem/Nvidia | not declared | string:72 | 72 | `hw.fabric.link_down_reason` |
 | `EffectiveBER` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.effective_ber` |
 | `SymbolErrors` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.symbol_errors` |
 | `TotalRawBER` | Oem/Nvidia | not declared | number:72 | 72 | `hw.fabric.raw_ber` |
@@ -443,30 +452,30 @@ definition exists but the current fixture did not include a matching sample.
 | `UnintentionalLinkDownCount` | Oem/Nvidia | name hint: count | number:72 | 72 | `hw.fabric.unintentional_link_down_count` |
 | `RXWidth` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.rxwidth` |
 | `TXWidth` | Oem/Nvidia | not declared | number:72 | 72 | `hw.gb300.txwidth` |
-| `CurrentSpeedGbps` | CurrentSpeedGbps | Gbps | number:4 | 4 | `hw.fabric.port_speed` |
+| `CurrentSpeedGbps` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Ports | Gbps | number:4 | 4 | `hw.fabric.port_speed` |
 
 ### `HGX_ProcessorResetMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
-| `PF_FLR_ResetEntryCount` | PF_FLR_ResetEntryCount | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_entry_count` |
-| `PF_FLR_ResetExitCount` | PF_FLR_ResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_exit_count` |
-| `ConventionalResetEntryCount` | ConventionalResetEntryCount | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_entry_count` |
-| `ConventionalResetExitCount` | ConventionalResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_exit_count` |
-| `FundamentalResetEntryCount` | FundamentalResetEntryCount | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_entry_count` |
-| `FundamentalResetExitCount` | FundamentalResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_exit_count` |
-| `IRoTResetExitCount` | IRoTResetExitCount | name hint: count | number:4 | 4 | `hw.gb300.iro_treset_exit_count` |
-| `LastResetType` | LastResetType | not declared | string:4 | 4 | `not exported by exporter` |
+| `PF_FLR_ResetEntryCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_entry_count` |
+| `PF_FLR_ResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.pf_flr_reset_exit_count` |
+| `ConventionalResetEntryCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_entry_count` |
+| `ConventionalResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.conventional_reset_exit_count` |
+| `FundamentalResetEntryCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_entry_count` |
+| `FundamentalResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.fundamental_reset_exit_count` |
+| `IRoTResetExitCount` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | name hint: count | number:4 | 4 | `hw.gb300.iro_treset_exit_count` |
+| `LastResetType` | Systems/HGX_Baseboard_0/Processors/GPU_{GpuId}/Oem/Nvidia | not declared | string:4 | 4 | `hw.component.last_reset_type` |
 
 ### `PlatformEnvironmentMetrics_0`
 
 | Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |
 |---|---|---|---:|---:|---|
 | `BMC_0_DCSCM_Temp_0` | Chassis/BMC_0/Sensors | name hint: temperature | number:1 | 1 | `hw.gb300.bmc_0_dcscm_temp_0` |
-| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | varies by resolved sensor | not observed | 0 | `not exported by exporter` |
-| `IO_Board_{IWild}_CX7_0_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | not observed | 0 | `not exported by exporter` |
-| `IO_Board_{IWild}_CX7_1_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | not observed | 0 | `not exported by exporter` |
+| `{BSWild}` | Chassis/HGX_Chassis_0/Sensors | not declared | - | 0 | not observed in fixture |
+| `IO_Board_{IWild}_CX7_0_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | - | 0 | not observed in fixture |
+| `IO_Board_{IWild}_CX7_1_Temp_0` | Chassis/IO_Board_{IWild}/Sensors | name hint: temperature | - | 0 | not observed in fixture |
 | `NVME_M2_0_Temp_0` | Chassis/NVME_M2_0/Sensors | name hint: temperature | number:1 | 1 | `hw.gb300.nvme_m2_0_temp_0` |
-| `{PDBWild}` | Chassis/PDB_0/Sensors | varies by resolved sensor | number:13 | 13 | `hw.gb300.<resolved_metric_property>` |
-| `{BFSWild}` | Chassis/Riser_Slot{BFWild}_BlueField_3_SmartNIC_Main_Card/Sensors | varies by resolved sensor | not observed | 0 | `not exported by exporter` |
-| `StorageBackplane_{SBWild}_SSD_{SBDWild}_Temp_0` | Chassis/StorageBackplane_{SBWild}/Sensors | name hint: temperature | number:8 | 8 | `hw.gb300.storage_backplane_sbwild_ssd_sbdwild_temp_0` |
+| `{PDBWild}` | Chassis/PDB_0/Sensors | not declared | number:13 | 13 | `hw.gb300.<resolved_metric_property>` |
+| `{BFSWild}` | Chassis/Riser_Slot{BFWild}_BlueField_3_SmartNIC_Main_Card/Sensors | not declared | - | 0 | not observed in fixture |
+| `StorageBackplane_{SBWild}_SSD_{SBDWild}_Temp_0` | Chassis/StorageBackplane_{SBWild}/Sensors | name hint: temperature | number:8 | 8 | not exported by exporter |

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -6,6 +6,7 @@ from .redfish_shared import *
 from .system.cmd_system import *
 from .system.cmd_system_config import *
 from .system.cmd_system_import import *
+from .system.cmd_dell_system_lcd_errors import *
 #
 from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -123,6 +123,7 @@ from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
+from .oem.cmd_dell_persistent_partition import *
 from .manager.cmd_console_info import *
 from .serial_console.cmd_serial_console import *
 from .manager.cmd_manager_time import *

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -9,6 +9,7 @@ from .system.cmd_system_import import *
 #
 from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
+from .dell_lc.cmd_dell_lc_log_comment import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
 #

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_supportassist_export import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -11,6 +11,7 @@ from .cmd_boot import *
 from .dell_lc.cmd_dell_lc_api import *
 from .dell_lc.cmd_dell_lc_rs import *
 from .dell_lc.cmd_dell_lc_services import *
+from .dell_lc.cmd_dell_lc_supportassist_schedule import *
 #
 # compute
 from .compute.cmd_power_state import *

--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -121,6 +121,7 @@ from .firmware.cmd_firmware_update import *
 from .telemetry.cmd_telemetry_triggers import *
 from .network.cmd_network_ports import *
 from .oem.cmd_oem_info import *
+from .oem.cmd_dell_vflash_state import *
 from .oem.cmd_hpe_test_actions import *
 from .oem.cmd_nvidia_debug_token import *
 from .manager.cmd_console_info import *

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -70,6 +70,7 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellLCService.SupportAssistExportLastCollection": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -76,6 +76,7 @@ ACTION_POLICY = {
     # secure-erase / RoT-key / factory-reset class actions).
     "#LogService.ClearLog": Destructiveness.DESTRUCTIVE,
     "#TelemetryService.ClearMetricReports": Destructiveness.DESTRUCTIVE,
+    "#DellSystemManagementService.ShowErrorsOnLCD": Destructiveness.DESTRUCTIVE,
     "#Volume.CheckConsistency": Destructiveness.DESTRUCTIVE,
     "#CertificateService.ReplaceCertificate": Destructiveness.DESTRUCTIVE,
     "#SecureBootDatabase.ResetKeys": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -8,8 +8,8 @@ dry-run unless ``--confirm`` is given, or additionally needs an explicit
 
 Fail-safe by construction: an action not in the table is treated as DESTRUCTIVE,
 so a newly exposed (unclassified) action can never POST without an explicit
-confirm. This module is product-neutral — it names standard DMTF + NVIDIA OEM
-action types only and imports nothing from the Redfish manager layer.
+confirm. This module is product-neutral — it names standard DMTF and vendor OEM
+action types and imports nothing from the Redfish manager layer.
 
 Author Mus spyroot@gmail.com
 """
@@ -36,8 +36,7 @@ class Destructiveness(Enum):
 
 
 # Keyed by the full Redfish action type "#Type.Action" (as discover_redfish_actions
-# reports it in RedfishAction.full_redfish_name). Covers the 25 action types the
-# GB300 NVL exposes plus a couple of standard siblings.
+# reports it in RedfishAction.full_redfish_name).
 ACTION_POLICY = {
     # read-only: a signed-measurement fetch carried over POST
     "#ComponentIntegrity.SPDMGetSignedMeasurements": Destructiveness.READ_ONLY,
@@ -70,6 +69,12 @@ ACTION_POLICY = {
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.AttachPartition": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.CreatePartition": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.CreatePartitionUsingImage": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.DetachPartition": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.ExportDataFromPartition": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.ModifyPartition": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE
     # (--confirm) rather than IRREVERSIBLE (the extra token is reserved for
@@ -88,6 +93,9 @@ ACTION_POLICY = {
     "#Manager.ResetToDefaults": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.RevokeKeys": Destructiveness.IRREVERSIBLE,
     "#NvidiaRoTProtectedComponent.UpdateMinimumSecurityVersion": Destructiveness.IRREVERSIBLE,
+    "#DellPersistentStorageService.DeletePartition": Destructiveness.IRREVERSIBLE,
+    "#DellPersistentStorageService.FormatPartition": Destructiveness.IRREVERSIBLE,
+    "#DellPersistentStorageService.InitializeMedia": Destructiveness.IRREVERSIBLE,
 }
 
 # An unclassified action is treated as DESTRUCTIVE: it can never POST without an

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -60,6 +60,8 @@ ACTION_POLICY = {
     "#NvidiaWorkloadPower.DisableProfiles": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.GenerateToken": Destructiveness.REVERSIBLE,
     "#NvidiaDebugToken.DisableToken": Destructiveness.REVERSIBLE,
+    "#DellLCService.SupportAssistClearAutoCollectSchedule": Destructiveness.REVERSIBLE,
+    "#DellLCService.SupportAssistSetAutoCollectSchedule": Destructiveness.REVERSIBLE,
 
     # destructive: service disruption / config rewrite — dry-run unless --confirm
     "#ComputerSystem.Reset": Destructiveness.DESTRUCTIVE,

--- a/redfish_ctl/actions/action_policy.py
+++ b/redfish_ctl/actions/action_policy.py
@@ -8,8 +8,8 @@ dry-run unless ``--confirm`` is given, or additionally needs an explicit
 
 Fail-safe by construction: an action not in the table is treated as DESTRUCTIVE,
 so a newly exposed (unclassified) action can never POST without an explicit
-confirm. This module is product-neutral — it names standard DMTF + NVIDIA OEM
-action types only and imports nothing from the Redfish manager layer.
+confirm. This module is product-neutral — it names standard DMTF actions and
+selected vendor OEM action types without importing the Redfish manager layer.
 
 Author Mus spyroot@gmail.com
 """
@@ -69,6 +69,7 @@ ACTION_POLICY = {
     "#Control.ResetToDefaults": Destructiveness.DESTRUCTIVE,
     "#Bios.ResetBios": Destructiveness.DESTRUCTIVE,
     "#Bios.ChangePassword": Destructiveness.DESTRUCTIVE,
+    "#DellPersistentStorageService.VFlashStateChange": Destructiveness.DESTRUCTIVE,
     "#LicenseService.Install": Destructiveness.DESTRUCTIVE,
     # ClearLog erases log entries (unrecoverable), but it neither disrupts the
     # host/BMC nor makes a one-way security change, so it sits at DESTRUCTIVE

--- a/redfish_ctl/dell_lc/cmd_dell_lc_log_comment.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_log_comment.py
@@ -1,0 +1,257 @@
+"""Insert a comment or worknote into the Dell Lifecycle Controller log.
+
+    redfish_ctl dell-lc-log-comment
+    redfish_ctl dell-lc-log-comment --comment "maintenance note"
+    redfish_ctl dell-lc-log-comment --comment "follow-up" --log-sequence-number 123 --confirm
+
+The command resolves ``#DellLCService.InsertCommentInLCLog`` from the Dell LC
+service. With no comment it lists the discovered action target. With a comment it
+previews by default; ``--confirm`` is required before the POST is sent.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_LC_LOG_COMMENT_ACTION = "#DellLCService.InsertCommentInLCLog"
+_STANDARD_LC_SERVICE = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+_LEGACY_LC_SERVICE = f"{RedfishApi.Version}/Dell/Managers/iDRAC.Embedded.1/DellLCService"
+
+
+class DellLcLogComment(RedfishManagerBase,
+                       scm_type=ApiRequestType.DellLcLogComment,
+                       name="dell-lc-log-comment",
+                       metaclass=Singleton):
+    """Preview or insert a Dell Lifecycle Controller log comment."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-log-comment command."""
+        super(DellLcLogComment, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-lc-log-comment`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--comment",
+            required=False,
+            dest="comment",
+            type=str,
+            default=None,
+            help="comment/worknote text to insert into the Lifecycle Controller log",
+        )
+        cmd_parser.add_argument(
+            "--log-sequence-number",
+            required=False,
+            dest="log_sequence_number",
+            type=str,
+            default=None,
+            help="optional LC log sequence number to attach the comment to",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the InsertCommentInLCLog POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-log-comment",
+            "command insert a Dell Lifecycle Controller log comment",
+        )
+
+    @staticmethod
+    def _nested_link(data, *keys):
+        """Return an ``@odata.id`` nested under ``keys``.
+
+        :param data: resource body to inspect.
+        :param keys: dictionary path ending at a Redfish link object.
+        :return: link target URI, or None when absent or malformed.
+        """
+        node = data or {}
+        for key in keys:
+            if not isinstance(node, dict):
+                return None
+            node = node.get(key)
+        return node.get("@odata.id") if isinstance(node, dict) else None
+
+    def _linked_lc_service_uri(self, do_async):
+        """Resolve DellLCService from Manager Links/Oem/Dell when available.
+
+        :param do_async: issue manager reads over the async Redfish path.
+        :return: linked DellLCService URI, or None when no manager exposes it.
+        """
+        try:
+            manager_ids = self.discover_manager_ids()
+        except Exception:
+            manager_ids = []
+        for manager_uri in manager_ids:
+            try:
+                manager = self.base_query(manager_uri, do_async=do_async).data or {}
+            except Exception:
+                continue
+            linked = self._nested_link(
+                manager, "Links", "Oem", "Dell", "DellLCService"
+            )
+            if linked:
+                return linked
+        return None
+
+    def _service_candidates(self, do_async):
+        """Return candidate DellLCService URIs in preferred order.
+
+        :param do_async: issue discovery reads over the async Redfish path.
+        :return: tuple of unique candidate service URIs.
+        """
+        candidates = [
+            self._linked_lc_service_uri(do_async),
+            _STANDARD_LC_SERVICE,
+            _LEGACY_LC_SERVICE,
+        ]
+        result = []
+        for uri in candidates:
+            if uri and uri not in result:
+                result.append(uri)
+        return tuple(result)
+
+    def _read_lc_service(self, do_async):
+        """Read DellLCService using linked and legacy path candidates.
+
+        :param do_async: issue queries over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or a CommandResult error.
+        """
+        errors = []
+        for uri in self._service_candidates(do_async):
+            try:
+                result = self.base_query(uri, do_async=do_async)
+            except Exception as exc:
+                errors.append(f"{uri}: {exc}")
+                continue
+            if result.error is not None:
+                errors.append(f"{uri}: {result.error}")
+                continue
+            data = result.data or {}
+            if isinstance(data, dict) and data:
+                return uri, data
+        error = "; ".join(errors) if errors else "no DellLCService candidate URI"
+        return CommandResult(None, None, None, f"failed to read DellLCService: {error}")
+
+    def _comment_metadata(self, do_async):
+        """Return discovered InsertCommentInLCLog target metadata.
+
+        :param do_async: issue the DellLCService query over the async path.
+        :return: CommandResult with target metadata, or an error if absent.
+        """
+        service_info = self._read_lc_service(do_async)
+        if isinstance(service_info, CommandResult):
+            return service_info
+        uri, service = service_info
+        actions = self.discover_redfish_actions(self, service)
+        target = self._flatten_action_targets(service).get(_LC_LOG_COMMENT_ACTION)
+        if target is None:
+            available = sorted(set(list(actions.keys())
+                                   + list(self._flatten_action_targets(service).keys())))
+            return CommandResult(
+                {
+                    "lc_service": uri,
+                    "action": _LC_LOG_COMMENT_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_LC_LOG_COMMENT_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "lc_service": uri,
+                "action": _LC_LOG_COMMENT_ACTION,
+                "target": target,
+            },
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _payload(comment, log_sequence_number=None):
+        """Build the InsertCommentInLCLog payload.
+
+        :param comment: worknote/comment text.
+        :param log_sequence_number: optional LC log sequence number.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when ``comment`` is empty after trimming.
+        """
+        text = (comment or "").strip()
+        if not text:
+            raise InvalidArgument("Lifecycle Controller log comment cannot be empty")
+        payload = {"Comment": text}
+        sequence = (log_sequence_number or "").strip()
+        if sequence:
+            payload["LogSequenceNumber"] = sequence
+        return payload
+
+    def execute(self,
+                comment: Optional[str] = None,
+                log_sequence_number: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke the Dell LC log-comment action.
+
+        With no ``--comment`` this command only reports the discovered
+        InsertCommentInLCLog target. With a comment it resolves the target and
+        previews the POST unless ``--confirm`` is passed. ``--dry_run`` remains a
+        no-POST override even with ``--confirm``.
+
+        :param comment: worknote/comment text to insert; None lists target metadata.
+        :param log_sequence_number: optional LC log sequence number to annotate.
+        :param confirm: authorize the action POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: a CommandResult with target metadata, the action outcome, or a
+            blocked/dry-run preview.
+        :raises InvalidArgument: when ``comment`` is empty after trimming.
+        """
+        metadata = self._comment_metadata(do_async)
+        if comment is None or metadata.error is not None:
+            return metadata
+
+        service_uri = metadata.data["lc_service"]
+        return self.invoke_action(
+            service_uri,
+            "InsertCommentInLCLog",
+            payload=self._payload(comment, log_sequence_number),
+            full_action_type=_LC_LOG_COMMENT_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_export.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_export.py
@@ -1,0 +1,482 @@
+"""Export the last Dell SupportAssist collection through DellLCService.
+
+    redfish_ctl dell-lc-supportassist-export
+    redfish_ctl dell-lc-supportassist-export --share-type NFS --share-name /exports --dry_run
+    redfish_ctl dell-lc-supportassist-export --share-type HTTPS --ip-address repo.example --confirm
+
+The command resolves ``#DellLCService.SupportAssistExportLastCollection`` from
+the Dell Lifecycle Controller service. Exporting a collection can send support
+data to a local or network share, so the action previews by default and only
+POSTs when ``--confirm`` is provided.
+"""
+import os
+from abc import abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_SUPPORTASSIST_EXPORT_ACTION = "#DellLCService.SupportAssistExportLastCollection"
+
+
+class DellLcSupportAssistExport(RedfishManagerBase,
+                                scm_type=ApiRequestType.DellLcSupportAssistExport,
+                                name="dell-lc-supportassist-export",
+                                metaclass=Singleton):
+    """Preview or invoke DellLCService.SupportAssistExportLastCollection."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-supportassist-export command."""
+        super(DellLcSupportAssistExport, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-supportassist-export`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--share-type",
+            required=False,
+            dest="share_type",
+            type=str,
+            default=None,
+            help="ShareType value for the export action",
+        )
+        cmd_parser.add_argument(
+            "--ip-address",
+            required=False,
+            dest="ip_address",
+            type=str,
+            default=None,
+            help="network share host or address",
+        )
+        cmd_parser.add_argument(
+            "--share-name",
+            required=False,
+            dest="share_name",
+            type=str,
+            default=None,
+            help="network share name or local export destination",
+        )
+        cmd_parser.add_argument(
+            "--file-name",
+            required=False,
+            dest="file_name",
+            type=str,
+            default=None,
+            help="optional output file name for the export",
+        )
+        cmd_parser.add_argument(
+            "--username",
+            required=False,
+            dest="share_username",
+            type=str,
+            default=None,
+            help="optional network share username",
+        )
+        password_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        password_group.add_argument(
+            "--password-env",
+            required=False,
+            dest="share_password_env",
+            type=str,
+            default=None,
+            help="environment variable containing the share password",
+        )
+        password_group.add_argument(
+            "--password-file",
+            required=False,
+            dest="share_password_file",
+            type=str,
+            default=None,
+            help="file containing the share password",
+        )
+        cmd_parser.add_argument(
+            "--workgroup",
+            required=False,
+            dest="workgroup",
+            type=str,
+            default=None,
+            help="optional CIFS workgroup",
+        )
+        cmd_parser.add_argument(
+            "--ignore-cert-warning",
+            required=False,
+            dest="ignore_cert_warning",
+            type=str,
+            default=None,
+            help="IgnoreCertWarning value when HTTPS is used",
+        )
+        cmd_parser.add_argument(
+            "--proxy-support",
+            required=False,
+            dest="proxy_support",
+            type=str,
+            default=None,
+            help="ProxySupport value for the export action",
+        )
+        cmd_parser.add_argument(
+            "--proxy-type",
+            required=False,
+            dest="proxy_type",
+            type=str,
+            default=None,
+            help="ProxyType value for the export action",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the SupportAssist export POST",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-supportassist-export",
+            "command export the last Dell SupportAssist collection",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body holding the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: link target URI, or None when absent.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _manager_id(manager_uri):
+        """Return the Manager id from a Manager URI.
+
+        :param manager_uri: Manager resource URI.
+        :return: last path segment, or None when malformed.
+        """
+        value = (manager_uri or "").rstrip("/")
+        return value.rsplit("/", 1)[-1] if value else None
+
+    def _get(self, uri, do_async):
+        """Read a Redfish resource, returning None when the GET is not usable.
+
+        :param uri: Redfish resource URI to fetch.
+        :param do_async: issue the read through the async path when True.
+        :return: parsed JSON object or None.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data
+        except Exception:
+            return None
+        return data if isinstance(data, dict) else None
+
+    @staticmethod
+    def _append_unique(items, value):
+        """Append a non-empty candidate URI once.
+
+        :param items: list being built.
+        :param value: candidate URI.
+        """
+        if value and value not in items:
+            items.append(value)
+
+    def _candidate_lc_uris(self, do_async):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: issue discovery reads through the async path when True.
+        :return: ordered list of candidate DellLCService URIs.
+        """
+        candidates = []
+        try:
+            managers = self.discover_manager_ids() or []
+        except Exception:
+            managers = []
+        for manager_uri in managers:
+            manager = self._get(manager_uri, do_async) or {}
+            links = manager.get("Links") if isinstance(manager, dict) else {}
+            oem = links.get("Oem") if isinstance(links, dict) else {}
+            dell_links = oem.get("Dell") if isinstance(oem, dict) else {}
+            if isinstance(dell_links, dict):
+                self._append_unique(
+                    candidates, self._link(dell_links, "DellLCService")
+                )
+            manager_id = self._manager_id(manager_uri)
+            if manager_id:
+                self._append_unique(
+                    candidates,
+                    f"{manager_uri.rstrip('/')}/Oem/Dell/DellLCService",
+                )
+                self._append_unique(
+                    candidates,
+                    f"/redfish/v1/Dell/Managers/{manager_id}/DellLCService",
+                )
+        self._append_unique(
+            candidates,
+            "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService",
+        )
+        self._append_unique(
+            candidates,
+            "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService",
+        )
+        return candidates
+
+    @staticmethod
+    def _allowed_args(action):
+        """Return advertised allowable values for a discovered action.
+
+        :param action: discovered RedfishAction.
+        :return: dict of argument name to sorted allowable values.
+        """
+        args = getattr(action, "args", None) or {}
+        return {key: sorted(values or []) for key, values in sorted(args.items())}
+
+    def _service_metadata(self, do_async):
+        """Discover DellLCService SupportAssist export metadata.
+
+        :param do_async: issue service queries through the async path when True.
+        :return: CommandResult containing target metadata or an error.
+        """
+        checked = []
+        for service_uri in self._candidate_lc_uris(do_async):
+            service = self._get(service_uri, do_async)
+            if not service:
+                checked.append(service_uri)
+                continue
+            actions = self.discover_redfish_actions(self, service)
+            target = self._flatten_action_targets(service).get(
+                _SUPPORTASSIST_EXPORT_ACTION
+            )
+            if target:
+                action = actions.get("SupportAssistExportLastCollection")
+                return CommandResult(
+                    {
+                        "lc_service": service_uri,
+                        "action": _SUPPORTASSIST_EXPORT_ACTION,
+                        "target": target,
+                        "allowed": self._allowed_args(action),
+                    },
+                    actions,
+                    None,
+                    None,
+                )
+            checked.append(service_uri)
+        return CommandResult(
+            {
+                "action": _SUPPORTASSIST_EXPORT_ACTION,
+                "checked": checked,
+            },
+            None,
+            None,
+            f"action '{_SUPPORTASSIST_EXPORT_ACTION}' not found",
+        )
+
+    @staticmethod
+    def _optional_payload_value(value):
+        """Normalize optional payload values and drop empty strings.
+
+        :param value: optional action payload value.
+        :return: stripped string, original non-string value, or None.
+        """
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    @staticmethod
+    def _password_from_source(password_env=None, password_file=None):
+        """Read a share password from a named environment variable or file.
+
+        :param password_env: environment variable name to read.
+        :param password_file: path to a file containing the password.
+        :return: password string, or None when no source is provided.
+        :raises InvalidArgument: when the source is invalid or unavailable.
+        """
+        if password_env and password_file:
+            raise InvalidArgument(
+                "use only one of --password-env or --password-file"
+            )
+        if password_env is not None:
+            env_name = password_env.strip()
+            if not env_name:
+                raise InvalidArgument(
+                    "password environment variable name cannot be empty"
+                )
+            if env_name not in os.environ:
+                raise InvalidArgument(
+                    f"password environment variable '{env_name}' is not set"
+                )
+            return os.environ[env_name]
+        if password_file is not None:
+            path = Path(password_file).expanduser()
+            try:
+                return path.read_text(encoding="utf-8").rstrip("\r\n")
+            except OSError as exc:
+                raise InvalidArgument(
+                    f"failed to read password file '{path}': {exc}"
+                ) from exc
+        return None
+
+    @staticmethod
+    def _payload(**kwargs):
+        """Build the SupportAssist export action payload.
+
+        :param kwargs: normalized command arguments.
+        :return: JSON-serializable payload with empty values removed.
+        """
+        fields = {
+            "ShareType": kwargs.get("share_type"),
+            "IPAddress": kwargs.get("ip_address"),
+            "ShareName": kwargs.get("share_name"),
+            "FileName": kwargs.get("file_name"),
+            "UserName": kwargs.get("share_username"),
+            "Password": kwargs.get("share_password"),
+            "Workgroup": kwargs.get("workgroup"),
+            "IgnoreCertWarning": kwargs.get("ignore_cert_warning"),
+            "ProxySupport": kwargs.get("proxy_support"),
+            "ProxyType": kwargs.get("proxy_type"),
+        }
+        payload = {
+            key: DellLcSupportAssistExport._optional_payload_value(value)
+            for key, value in fields.items()
+        }
+        return {key: value for key, value in payload.items() if value is not None}
+
+    @staticmethod
+    def _has_export_request(**kwargs):
+        """Return True when invocation options request an action preview/POST.
+
+        :param kwargs: normalized execute arguments.
+        :return: True when the command should resolve and invoke the action.
+        """
+        if kwargs.get("confirm") or kwargs.get("dry_run"):
+            return True
+        payload_keys = (
+            "share_type",
+            "ip_address",
+            "share_name",
+            "file_name",
+            "share_username",
+            "share_password_env",
+            "share_password_file",
+            "workgroup",
+            "ignore_cert_warning",
+            "proxy_support",
+            "proxy_type",
+        )
+        return any(kwargs.get(key) is not None for key in payload_keys)
+
+    @staticmethod
+    def _redact_password(result):
+        """Mask a share password in returned preview payloads.
+
+        :param result: CommandResult from ``invoke_action``.
+        :return: CommandResult with any payload password redacted.
+        """
+        if not isinstance(result.data, dict):
+            return result
+        payload = result.data.get("payload")
+        if isinstance(payload, dict) and "Password" in payload:
+            payload = dict(payload)
+            payload["Password"] = "********"
+            result.data["payload"] = payload
+        return result
+
+    def execute(self,
+                share_type: Optional[str] = None,
+                ip_address: Optional[str] = None,
+                share_name: Optional[str] = None,
+                file_name: Optional[str] = None,
+                share_username: Optional[str] = None,
+                share_password_env: Optional[str] = None,
+                share_password_file: Optional[str] = None,
+                workgroup: Optional[str] = None,
+                ignore_cert_warning: Optional[str] = None,
+                proxy_support: Optional[str] = None,
+                proxy_type: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List, preview, or run SupportAssistExportLastCollection.
+
+        :param share_type: optional ShareType payload value.
+        :param ip_address: optional IPAddress payload value.
+        :param share_name: optional ShareName payload value.
+        :param file_name: optional FileName payload value.
+        :param share_username: optional UserName payload value.
+        :param share_password_env: environment variable holding an optional password.
+        :param share_password_file: file holding an optional password.
+        :param workgroup: optional Workgroup payload value.
+        :param ignore_cert_warning: optional IgnoreCertWarning payload value.
+        :param proxy_support: optional ProxySupport payload value.
+        :param proxy_type: optional ProxyType payload value.
+        :param confirm: authorize the export POST to actually fire.
+        :param dry_run: resolve the target and show the payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying queries/POST through the async path.
+        :return: CommandResult with target metadata, preview, or POST result.
+        """
+        options = {
+            "share_type": share_type,
+            "ip_address": ip_address,
+            "share_name": share_name,
+            "file_name": file_name,
+            "share_username": share_username,
+            "share_password_env": share_password_env,
+            "share_password_file": share_password_file,
+            "workgroup": workgroup,
+            "ignore_cert_warning": ignore_cert_warning,
+            "proxy_support": proxy_support,
+            "proxy_type": proxy_type,
+            "confirm": confirm,
+            "dry_run": dry_run,
+        }
+        metadata = self._service_metadata(bool(do_async))
+        if metadata.error or not self._has_export_request(**options):
+            return metadata
+
+        payload = self._payload(
+            share_type=share_type,
+            ip_address=ip_address,
+            share_name=share_name,
+            file_name=file_name,
+            share_username=share_username,
+            share_password=self._password_from_source(
+                share_password_env,
+                share_password_file,
+            ),
+            workgroup=workgroup,
+            ignore_cert_warning=ignore_cert_warning,
+            proxy_support=proxy_support,
+            proxy_type=proxy_type,
+        )
+        result = self.invoke_action(
+            metadata.data["lc_service"],
+            "SupportAssistExportLastCollection",
+            payload=payload,
+            full_action_type=_SUPPORTASSIST_EXPORT_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )
+        return self._redact_password(result)

--- a/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_schedule.py
+++ b/redfish_ctl/dell_lc/cmd_dell_lc_supportassist_schedule.py
@@ -1,0 +1,280 @@
+"""Preview or update Dell Lifecycle Controller SupportAssist schedules.
+
+    redfish_ctl dell-lc-supportassist-schedule
+    redfish_ctl dell-lc-supportassist-schedule --action set --recurrence Weekly
+    redfish_ctl dell-lc-supportassist-schedule --action clear --confirm
+
+The command resolves the SupportAssist auto-collection schedule actions from
+the Dell Lifecycle Controller service. Without ``--action`` it lists available
+targets. Set and clear operations preview by default; ``--confirm`` is required
+before a POST is sent.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_SERVICE_NAME = "DellLCService"
+_DEFAULT_SERVICE_URI = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+_ACTION_SPECS = {
+    "clear": {
+        "type": "#DellLCService.SupportAssistClearAutoCollectSchedule",
+        "name": "SupportAssistClearAutoCollectSchedule",
+    },
+    "set": {
+        "type": "#DellLCService.SupportAssistSetAutoCollectSchedule",
+        "name": "SupportAssistSetAutoCollectSchedule",
+    },
+}
+
+
+class DellLcSupportAssistSchedule(
+        RedfishManagerBase,
+        scm_type=ApiRequestType.DellLcSupportAssistSchedule,
+        name="dell-lc-supportassist-schedule",
+        metaclass=Singleton):
+    """Discover and invoke DellLCService SupportAssist schedule actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-lc-supportassist-schedule command."""
+        super(DellLcSupportAssistSchedule, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-lc-supportassist-schedule`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=tuple(_ACTION_SPECS),
+            default=None,
+            help="SupportAssist schedule action to preview or run",
+        )
+        cmd_parser.add_argument(
+            "--recurrence",
+            default=None,
+            help="recurrence for --action set; allowed values come from Redfish",
+        )
+        cmd_parser.add_argument(
+            "--resource-uri",
+            dest="resource_uri",
+            default=None,
+            help="specific DellLCService URI when discovery needs override",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            default=False,
+            help="POST the schedule action instead of previewing it",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-lc-supportassist-schedule",
+            "command update Dell Lifecycle Controller SupportAssist schedule",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_oem_links(manager):
+        """Return the Dell block under ``Manager.Links.Oem``.
+
+        :param manager: Redfish Manager resource body.
+        :return: Dell OEM links dict, or an empty dict.
+        """
+        links = manager.get("Links") if isinstance(manager, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, tolerating optional-resource misses.
+
+        :param uri: Redfish resource URI.
+        :param do_async: issue the query on the async path when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _service_uris(self, do_async):
+        """Return candidate DellLCService URIs in discovery-first order.
+
+        :param do_async: issue manager queries on the async path when True.
+        :return: de-duplicated candidate service URIs.
+        """
+        uris = []
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(self._dell_oem_links(manager), _SERVICE_NAME)
+            if service_uri:
+                uris.append(service_uri)
+            uris.append(manager_uri.rstrip("/") + f"/Oem/Dell/{_SERVICE_NAME}")
+        uris.append(_DEFAULT_SERVICE_URI)
+        return list(dict.fromkeys(uri for uri in uris if uri))
+
+    @staticmethod
+    def _allowed_recurrences(actions):
+        """Return advertised SupportAssist schedule recurrence values.
+
+        :param actions: discovered Redfish action map for a DellLCService body.
+        :return: sorted list of allowed recurrence strings.
+        """
+        action = actions.get(_ACTION_SPECS["set"]["name"])
+        allowed = tuple(getattr(action, "args", {}).get("Recurrence", ()) or ())
+        return sorted(allowed)
+
+    def _rows_for(self, resource_uri, do_async):
+        """Build discovered SupportAssist schedule rows for one service URI.
+
+        :param resource_uri: candidate DellLCService URI.
+        :param do_async: issue the service query on the async path when True.
+        :return: discovered rows, possibly empty when actions are absent.
+        """
+        service = self._get(resource_uri, do_async)
+        if not service:
+            return []
+        targets = self._flatten_action_targets(service)
+        actions = self.discover_redfish_actions(self, service)
+        allowed_recurrences = self._allowed_recurrences(actions)
+        rows = []
+        for selector, spec in _ACTION_SPECS.items():
+            target = targets.get(spec["type"])
+            if not target:
+                continue
+            row = {
+                "Resource": resource_uri,
+                "Selector": selector,
+                "Action": spec["type"],
+                "Target": target,
+            }
+            if selector == "set":
+                row["AllowedRecurrences"] = allowed_recurrences
+            rows.append(row)
+        return rows
+
+    def _discover_rows(self, do_async, resource_uri=None):
+        """Discover Dell LC SupportAssist schedule action targets.
+
+        :param do_async: issue Redfish reads on the async path when True.
+        :param resource_uri: optional direct DellLCService URI.
+        :return: list of discovered target rows.
+        """
+        uris = [resource_uri] if resource_uri else self._service_uris(do_async)
+        rows = []
+        for uri in dict.fromkeys(uris):
+            rows.extend(self._rows_for(uri, do_async))
+        return rows
+
+    @staticmethod
+    def _select_row(rows, action):
+        """Return the discovered row for a requested schedule action.
+
+        :param rows: discovered SupportAssist schedule rows.
+        :param action: requested action selector.
+        :return: row dict, or None when absent.
+        """
+        for row in rows:
+            if row["Selector"] == action:
+                return row
+        return None
+
+    def execute(self,
+                action: Optional[str] = None,
+                recurrence: Optional[str] = None,
+                resource_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke SupportAssist schedule actions.
+
+        :param action: optional action selector, ``set`` or ``clear``.
+        :param recurrence: recurrence value required by ``--action set``.
+        :param resource_uri: optional DellLCService URI override.
+        :param confirm: authorize the action POST.
+        :param dry_run: force a preview even when ``confirm`` is true.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue underlying Redfish calls on the async path.
+        :return: CommandResult with discovered targets, preview, or POST result.
+        """
+        rows = self._discover_rows(bool(do_async), resource_uri=resource_uri)
+        if action is None:
+            return CommandResult(
+                {"supportassist_schedule_targets": rows},
+                None,
+                None,
+                None,
+            )
+        if action not in _ACTION_SPECS:
+            return CommandResult(
+                {"valid_actions": sorted(_ACTION_SPECS)},
+                None,
+                None,
+                f"invalid SupportAssist schedule action: {action}",
+            )
+        row = self._select_row(rows, action)
+        if row is None:
+            return CommandResult(
+                {"action": _ACTION_SPECS[action]["type"], "available": rows},
+                None,
+                None,
+                "Dell LC SupportAssist schedule action not found",
+            )
+        if action == "set" and not recurrence:
+            return CommandResult(
+                {"required": ["Recurrence"], "action": row["Action"]},
+                None,
+                None,
+                "SupportAssist schedule set requires --recurrence",
+            )
+
+        payload = {"Recurrence": recurrence} if action == "set" else {}
+        spec = _ACTION_SPECS[action]
+        return self.invoke_action(
+            row["Resource"],
+            spec["name"],
+            payload=payload,
+            full_action_type=spec["type"],
+            do_async=do_async,
+            dry_run=bool(dry_run) or not bool(confirm),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/oem/cmd_dell_persistent_partition.py
+++ b/redfish_ctl/oem/cmd_dell_persistent_partition.py
@@ -1,0 +1,771 @@
+"""Preview or invoke DellPersistentStorageService partition actions.
+
+    redfish_ctl dell-vflash-partition
+    redfish_ctl dell-vflash-partition --action attach --partition-index 1
+    redfish_ctl dell-vflash-partition --action delete --partition-index 1 --confirm
+        --i-understand-irreversible
+
+The command resolves Dell's PersistentStorageService from Manager OEM links and
+uses the advertised action targets from the resource body. Mutating actions
+preview by default; erase-class actions require both confirmation flags.
+"""
+import os
+from abc import abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from ..actions.action_policy import classify
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_SERVICE_FALLBACK = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DellPersistentStorageService"
+)
+
+
+@dataclass(frozen=True)
+class _PartitionActionSpec:
+    """Static selector metadata for one Dell persistent-storage action."""
+
+    selector: str
+    full_type: str
+    action_name: str
+    required: tuple[str, ...]
+    optional: tuple[str, ...]
+    description: str
+
+
+_ACTION_SPECS = {
+    "attach": _PartitionActionSpec(
+        selector="attach",
+        full_type="#DellPersistentStorageService.AttachPartition",
+        action_name="AttachPartition",
+        required=("PartitionIndex",),
+        optional=(),
+        description="attach an existing VFlash partition",
+    ),
+    "create": _PartitionActionSpec(
+        selector="create",
+        full_type="#DellPersistentStorageService.CreatePartition",
+        action_name="CreatePartition",
+        required=(
+            "PartitionIndex",
+            "PartitionType",
+            "Size",
+            "SizeUnit",
+            "OSVolumeLabel",
+        ),
+        optional=(),
+        description="create a blank VFlash partition",
+    ),
+    "create-from-image": _PartitionActionSpec(
+        selector="create-from-image",
+        full_type="#DellPersistentStorageService.CreatePartitionUsingImage",
+        action_name="CreatePartitionUsingImage",
+        required=(
+            "PartitionIndex",
+            "PartitionType",
+            "OSVolumeLabel",
+            "ShareType",
+        ),
+        optional=(
+            "IPAddress",
+            "ImageName",
+            "SharePath",
+            "URI",
+            "HashType",
+            "HashValue",
+            "Username",
+            "Password",
+            "Port",
+            "Workgroup",
+        ),
+        description="create a VFlash partition from an image on a share or URI",
+    ),
+    "delete": _PartitionActionSpec(
+        selector="delete",
+        full_type="#DellPersistentStorageService.DeletePartition",
+        action_name="DeletePartition",
+        required=("PartitionIndex",),
+        optional=(),
+        description="delete a VFlash partition",
+    ),
+    "detach": _PartitionActionSpec(
+        selector="detach",
+        full_type="#DellPersistentStorageService.DetachPartition",
+        action_name="DetachPartition",
+        required=("PartitionIndex",),
+        optional=(),
+        description="detach a VFlash partition",
+    ),
+    "export": _PartitionActionSpec(
+        selector="export",
+        full_type="#DellPersistentStorageService.ExportDataFromPartition",
+        action_name="ExportDataFromPartition",
+        required=("PartitionIndex", "ShareType", "ImageName"),
+        optional=(
+            "IPAddress",
+            "SharePath",
+            "Username",
+            "Password",
+            "Port",
+            "Workgroup",
+        ),
+        description="export VFlash partition data to a remote share",
+    ),
+    "format": _PartitionActionSpec(
+        selector="format",
+        full_type="#DellPersistentStorageService.FormatPartition",
+        action_name="FormatPartition",
+        required=("PartitionIndex", "FormatType"),
+        optional=(),
+        description="format a VFlash partition",
+    ),
+    "initialize": _PartitionActionSpec(
+        selector="initialize",
+        full_type="#DellPersistentStorageService.InitializeMedia",
+        action_name="InitializeMedia",
+        required=(),
+        optional=(),
+        description="initialize VFlash media",
+    ),
+    "modify": _PartitionActionSpec(
+        selector="modify",
+        full_type="#DellPersistentStorageService.ModifyPartition",
+        action_name="ModifyPartition",
+        required=("PartitionIndex", "AccessType"),
+        optional=(),
+        description="change a VFlash partition access mode",
+    ),
+}
+
+_PAYLOAD_SOURCES = {
+    "PartitionIndex": "partition_index",
+    "PartitionType": "partition_type",
+    "Size": "size",
+    "SizeUnit": "size_unit",
+    "OSVolumeLabel": "os_volume_label",
+    "FormatType": "format_type",
+    "AccessType": "access_type",
+    "ShareType": "share_type",
+    "IPAddress": "ip_address",
+    "ImageName": "image_name",
+    "SharePath": "share_path",
+    "URI": "uri",
+    "HashType": "hash_type",
+    "HashValue": "hash_value",
+    "Username": "share_username",
+    "Password": "password",
+    "Port": "share_port",
+    "Workgroup": "workgroup",
+}
+
+_FLAG_NAMES = {
+    "PartitionIndex": "--partition-index",
+    "PartitionType": "--partition-type",
+    "Size": "--size",
+    "SizeUnit": "--size-unit",
+    "OSVolumeLabel": "--os-volume-label",
+    "FormatType": "--format-type",
+    "AccessType": "--access-type",
+    "ShareType": "--share-type",
+    "IPAddress": "--ip-address",
+    "ImageName": "--image-name",
+    "SharePath": "--share-path",
+    "URI": "--uri",
+    "HashType": "--hash-type",
+    "HashValue": "--hash-value",
+    "Username": "--username",
+    "Password": "--password-env or --password-file",
+    "Port": "--port",
+    "Workgroup": "--workgroup",
+}
+
+
+class DellPersistentPartitionActions(RedfishManagerBase,
+                                     scm_type=ApiRequestType.DellPersistentPartitionActions,
+                                     name="dell-vflash-partition",
+                                     metaclass=Singleton):
+    """Discover and invoke Dell VFlash partition actions."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-vflash-partition command."""
+        super(DellPersistentPartitionActions, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the ``dell-vflash-partition`` subcommand.
+
+        :param cls: command class used to build the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--action",
+            choices=sorted(_ACTION_SPECS),
+            default=None,
+            help="partition action to preview or run; omit to list available targets",
+        )
+        cmd_parser.add_argument(
+            "--partition-index",
+            dest="partition_index",
+            type=int,
+            default=None,
+            help="Dell VFlash partition index, in the range 1-16",
+        )
+        cmd_parser.add_argument(
+            "--partition-type",
+            dest="partition_type",
+            type=str,
+            default=None,
+            help="partition type for create operations",
+        )
+        cmd_parser.add_argument(
+            "--size",
+            dest="size",
+            type=int,
+            default=None,
+            help="new blank partition size",
+        )
+        cmd_parser.add_argument(
+            "--size-unit",
+            dest="size_unit",
+            type=str,
+            default=None,
+            help="unit for --size, such as MB or GB",
+        )
+        cmd_parser.add_argument(
+            "--os-volume-label",
+            dest="os_volume_label",
+            type=str,
+            default=None,
+            help="OS volume label used when creating a partition",
+        )
+        cmd_parser.add_argument(
+            "--format-type",
+            dest="format_type",
+            type=str,
+            default=None,
+            help="filesystem type for format, such as FAT32",
+        )
+        cmd_parser.add_argument(
+            "--access-type",
+            dest="access_type",
+            type=str,
+            default=None,
+            help="access mode for modify, such as Read-Only or Read-Write",
+        )
+        cmd_parser.add_argument(
+            "--share-type",
+            dest="share_type",
+            type=str,
+            default=None,
+            help="remote share type for image import/export actions",
+        )
+        cmd_parser.add_argument(
+            "--ip-address",
+            dest="ip_address",
+            type=str,
+            default=None,
+            help="remote share IP address or host name",
+        )
+        cmd_parser.add_argument(
+            "--image-name",
+            dest="image_name",
+            type=str,
+            default=None,
+            help="remote image file name for import/export actions",
+        )
+        cmd_parser.add_argument(
+            "--share-path",
+            dest="share_path",
+            type=str,
+            default=None,
+            help="remote share path for import/export actions",
+        )
+        cmd_parser.add_argument(
+            "--uri",
+            dest="uri",
+            type=str,
+            default=None,
+            help="direct image URI for create-from-image",
+        )
+        cmd_parser.add_argument(
+            "--hash-type",
+            dest="hash_type",
+            type=str,
+            default=None,
+            help="image hash algorithm for create-from-image",
+        )
+        cmd_parser.add_argument(
+            "--hash-value",
+            dest="hash_value",
+            type=str,
+            default=None,
+            help="image hash value for create-from-image",
+        )
+        cmd_parser.add_argument(
+            "--username",
+            dest="share_username",
+            type=str,
+            default=None,
+            help="optional remote share username",
+        )
+        password_group = cmd_parser.add_mutually_exclusive_group(required=False)
+        password_group.add_argument(
+            "--password-env",
+            dest="password_env",
+            type=str,
+            default=None,
+            help="environment variable containing the remote share password",
+        )
+        password_group.add_argument(
+            "--password-file",
+            dest="password_file",
+            type=str,
+            default=None,
+            help="file containing the remote share password",
+        )
+        cmd_parser.add_argument(
+            "--port",
+            dest="share_port",
+            type=int,
+            default=None,
+            help="remote share port",
+        )
+        cmd_parser.add_argument(
+            "--workgroup",
+            dest="workgroup",
+            type=str,
+            default=None,
+            help="remote share workgroup",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="POST the selected partition action; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--i-understand-irreversible",
+            action="store_true",
+            dest="confirm_irreversible",
+            default=False,
+            help="required with --confirm for delete, format, and initialize",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing",
+        )
+        return (
+            cmd_parser,
+            "dell-vflash-partition",
+            "command manage Dell VFlash partitions",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return an ``@odata.id`` link value from a Redfish object.
+
+        :param data: Redfish resource body.
+        :param key: link property name.
+        :return: linked URI, or None when absent or malformed.
+        """
+        link = data.get(key) if isinstance(data, dict) else None
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @staticmethod
+    def _dell_links(data):
+        """Return ``Links.Oem.Dell`` from a Manager resource.
+
+        :param data: Manager resource body.
+        :return: Dell OEM link block, or an empty dict.
+        """
+        links = data.get("Links") if isinstance(data, dict) else None
+        oem = links.get("Oem") if isinstance(links, dict) else None
+        dell = oem.get("Dell") if isinstance(oem, dict) else None
+        return dell if isinstance(dell, dict) else {}
+
+    def _get(self, uri, do_async):
+        """GET a Redfish resource body, returning an empty dict on failures.
+
+        :param uri: Redfish resource URI.
+        :param do_async: run the query asynchronously when True.
+        :return: parsed resource body, or an empty dict when the read fails.
+        """
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception:
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _persistent_storage_uri(self, do_async):
+        """Resolve DellPersistentStorageService from Manager OEM links.
+
+        :param do_async: issue the Manager reads asynchronously when True.
+        :return: discovered service URI, or the standard iDRAC fallback.
+        """
+        manager_ids = []
+        try:
+            manager_ids = self.discover_manager_ids() or []
+        except Exception:
+            manager_ids = []
+        for manager_uri in manager_ids:
+            manager = self._get(manager_uri, do_async)
+            service_uri = self._link(
+                self._dell_links(manager),
+                "DellPersistentStorageService",
+            )
+            if service_uri:
+                return service_uri
+        return _SERVICE_FALLBACK
+
+    def _persistent_storage_service(self, do_async):
+        """Read DellPersistentStorageService.
+
+        :param do_async: issue the service read asynchronously when True.
+        :return: tuple of ``(uri, body)`` or ``(uri, CommandResult)`` on error.
+        """
+        uri = self._persistent_storage_uri(do_async)
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return uri, CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+        return uri, data if isinstance(data, dict) else {}
+
+    def _partition_action_rows(self, service):
+        """Return available partition action rows and the discovered action map.
+
+        :param service: DellPersistentStorageService resource body.
+        :return: tuple of (rows, discovered actions).
+        """
+        actions = self.discover_redfish_actions(self, service)
+        targets = self._flatten_action_targets(service)
+        rows = []
+        for spec in _ACTION_SPECS.values():
+            target = targets.get(spec.full_type)
+            if not target:
+                continue
+            action = actions.get(spec.action_name)
+            allowed = {
+                key: sorted(values or ())
+                for key, values in (getattr(action, "args", {}) or {}).items()
+            }
+            rows.append({
+                "Action": spec.selector,
+                "FullType": spec.full_type,
+                "Target": target,
+                "Level": classify(spec.full_type).value,
+                "RequiredParameters": list(spec.required),
+                "OptionalParameters": list(spec.optional),
+                "AllowableValues": allowed,
+                "Description": spec.description,
+            })
+        return rows, actions
+
+    @staticmethod
+    def _optional_payload_value(value):
+        """Strip optional string payload values and drop empty values.
+
+        :param value: optional Redfish action payload value.
+        :return: stripped string, original non-string value, or None.
+        """
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+    @staticmethod
+    def _required_payload_value(value, selector, parameter):
+        """Return a required non-empty payload value.
+
+        :param value: value supplied for a payload parameter.
+        :param selector: selected action name for error text.
+        :param parameter: Redfish action parameter name.
+        :return: normalized value.
+        :raises InvalidArgument: when the required value is missing or blank.
+        """
+        normalized = DellPersistentPartitionActions._optional_payload_value(value)
+        if normalized is None:
+            raise InvalidArgument(f"{selector} requires {_FLAG_NAMES[parameter]}")
+        return normalized
+
+    @staticmethod
+    def _positive_int(value, selector, parameter, required=False):
+        """Return a positive integer payload value.
+
+        :param value: value supplied for an integer payload parameter.
+        :param selector: selected action name for error text.
+        :param parameter: Redfish action parameter name.
+        :param required: when True, missing values raise InvalidArgument.
+        :return: positive integer value, or None when optional and absent.
+        :raises InvalidArgument: when the value is missing, non-integer, or non-positive.
+        """
+        if value is None:
+            if required:
+                raise InvalidArgument(f"{selector} requires {_FLAG_NAMES[parameter]}")
+            return None
+        try:
+            number = int(value)
+        except (TypeError, ValueError) as exc:
+            raise InvalidArgument(
+                f"{_FLAG_NAMES[parameter]} must be a positive integer"
+            ) from exc
+        if number < 1:
+            raise InvalidArgument(f"{_FLAG_NAMES[parameter]} must be a positive integer")
+        return number
+
+    @staticmethod
+    def _partition_index(value, selector):
+        """Return a validated Dell VFlash partition index.
+
+        :param value: supplied partition index.
+        :param selector: selected action name for error text.
+        :return: integer partition index.
+        :raises InvalidArgument: when missing or outside Dell's 1-16 range.
+        """
+        number = DellPersistentPartitionActions._positive_int(
+            value,
+            selector,
+            "PartitionIndex",
+            required=True,
+        )
+        if number > 16:
+            raise InvalidArgument("--partition-index must be between 1 and 16")
+        return number
+
+    @staticmethod
+    def _password_from_source(password_env=None, password_file=None):
+        """Read a remote-share password from a named environment variable or file.
+
+        :param password_env: name of the environment variable to read.
+        :param password_file: path to a file containing the password.
+        :return: the password string, or None when no source was provided.
+        :raises InvalidArgument: when both sources are provided, the source is
+            empty, the environment variable is absent, or the file cannot be read.
+        """
+        if password_env and password_file:
+            raise InvalidArgument("use only one of --password-env or --password-file")
+        if password_env is not None:
+            env_name = password_env.strip()
+            if not env_name:
+                raise InvalidArgument("password environment variable name cannot be empty")
+            if env_name not in os.environ:
+                raise InvalidArgument(f"password environment variable '{env_name}' is not set")
+            return os.environ[env_name]
+        if password_file is not None:
+            path = Path(password_file).expanduser()
+            try:
+                return path.read_text(encoding="utf-8").rstrip("\r\n")
+            except OSError as exc:
+                raise InvalidArgument(
+                    f"failed to read password file '{path}': {exc}"
+                ) from exc
+        return None
+
+    @staticmethod
+    def _payload(spec, values):
+        """Build a DellPersistentStorageService action payload.
+
+        :param spec: action selector metadata.
+        :param values: normalized command arguments keyed by internal names.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when a required parameter is missing or invalid.
+        """
+        payload = {}
+        for parameter in spec.required:
+            value = values.get(_PAYLOAD_SOURCES[parameter])
+            if parameter == "PartitionIndex":
+                payload[parameter] = DellPersistentPartitionActions._partition_index(
+                    value,
+                    spec.selector,
+                )
+            elif parameter == "Size":
+                payload[parameter] = DellPersistentPartitionActions._positive_int(
+                    value,
+                    spec.selector,
+                    parameter,
+                    required=True,
+                )
+            else:
+                payload[parameter] = (
+                    DellPersistentPartitionActions._required_payload_value(
+                        value,
+                        spec.selector,
+                        parameter,
+                    )
+                )
+        for parameter in spec.optional:
+            value = values.get(_PAYLOAD_SOURCES[parameter])
+            if parameter == "Port":
+                value = DellPersistentPartitionActions._positive_int(
+                    value,
+                    spec.selector,
+                    parameter,
+                )
+            else:
+                value = DellPersistentPartitionActions._optional_payload_value(value)
+            if value is not None:
+                payload[parameter] = value
+        return payload
+
+    @staticmethod
+    def _redact_password(result):
+        """Mask Password in dry-run payloads before returning to callers.
+
+        :param result: CommandResult from ``invoke_action``.
+        :return: CommandResult with any dry-run password masked.
+        """
+        if not isinstance(result.data, dict):
+            return result
+        payload = result.data.get("payload")
+        if isinstance(payload, dict) and "Password" in payload:
+            payload = dict(payload)
+            payload["Password"] = "********"
+            result.data["payload"] = payload
+        return result
+
+    def execute(self,
+                action: Optional[str] = None,
+                partition_index: Optional[int] = None,
+                partition_type: Optional[str] = None,
+                size: Optional[int] = None,
+                size_unit: Optional[str] = None,
+                os_volume_label: Optional[str] = None,
+                format_type: Optional[str] = None,
+                access_type: Optional[str] = None,
+                share_type: Optional[str] = None,
+                ip_address: Optional[str] = None,
+                image_name: Optional[str] = None,
+                share_path: Optional[str] = None,
+                uri: Optional[str] = None,
+                hash_type: Optional[str] = None,
+                hash_value: Optional[str] = None,
+                share_username: Optional[str] = None,
+                password_env: Optional[str] = None,
+                password_file: Optional[str] = None,
+                share_port: Optional[int] = None,
+                workgroup: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                confirm_irreversible: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List or invoke DellPersistentStorageService partition actions.
+
+        :param action: selected action from ``_ACTION_SPECS``; omit to list targets.
+        :param partition_index: Dell VFlash partition index, 1-16.
+        :param partition_type: partition type for create operations.
+        :param size: blank partition size.
+        :param size_unit: size unit for create.
+        :param os_volume_label: OS volume label for create operations.
+        :param format_type: filesystem type for format.
+        :param access_type: access mode for modify.
+        :param share_type: remote share type for image import/export.
+        :param ip_address: remote share IP address or host.
+        :param image_name: remote image name for image import/export.
+        :param share_path: remote share path.
+        :param uri: direct image URI for create-from-image.
+        :param hash_type: image hash algorithm.
+        :param hash_value: image hash value.
+        :param share_username: optional remote share username.
+        :param password_env: environment variable containing a remote share password.
+        :param password_file: file containing a remote share password.
+        :param share_port: optional remote share port.
+        :param workgroup: optional remote share workgroup.
+        :param confirm: authorize destructive actions to POST.
+        :param confirm_irreversible: extra token for erase-class actions.
+        :param dry_run: force preview mode even when confirmation is supplied.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path when True.
+        :return: CommandResult with listing, preview, execution result, or error.
+        """
+        service_uri, service = self._persistent_storage_service(bool(do_async))
+        if isinstance(service, CommandResult):
+            return service
+
+        rows, actions = self._partition_action_rows(service)
+        if action is None:
+            return CommandResult(
+                {
+                    "persistent_storage_service": service_uri,
+                    "partition_actions": rows,
+                },
+                actions,
+                None,
+                None,
+            )
+
+        if action not in _ACTION_SPECS:
+            return CommandResult(
+                {
+                    "persistent_storage_service": service_uri,
+                    "available": rows,
+                },
+                actions,
+                None,
+                f"unknown Dell persistent-storage partition action: {action}",
+            )
+
+        spec = _ACTION_SPECS[action]
+        if not any(row["Action"] == action for row in rows):
+            return CommandResult(
+                {
+                    "persistent_storage_service": service_uri,
+                    "available": rows,
+                },
+                actions,
+                None,
+                f"Dell persistent-storage partition action not found: {action}",
+            )
+
+        payload = self._payload(
+            spec,
+            {
+                "partition_index": partition_index,
+                "partition_type": partition_type,
+                "size": size,
+                "size_unit": size_unit,
+                "os_volume_label": os_volume_label,
+                "format_type": format_type,
+                "access_type": access_type,
+                "share_type": share_type,
+                "ip_address": ip_address,
+                "image_name": image_name,
+                "share_path": share_path,
+                "uri": uri,
+                "hash_type": hash_type,
+                "hash_value": hash_value,
+                "share_username": share_username,
+                "password": self._password_from_source(password_env, password_file),
+                "share_port": share_port,
+                "workgroup": workgroup,
+            },
+        )
+        result = self.invoke_action(
+            service_uri,
+            spec.action_name,
+            payload=payload,
+            full_action_type=spec.full_type,
+            do_async=bool(do_async),
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+            confirm_irreversible=bool(confirm_irreversible),
+        )
+        return self._redact_password(result)

--- a/redfish_ctl/oem/cmd_dell_vflash_state.py
+++ b/redfish_ctl/oem/cmd_dell_vflash_state.py
@@ -1,0 +1,239 @@
+"""Change Dell vFlash state through DellPersistentStorageService.
+
+    redfish_ctl dell-vflash-state
+    redfish_ctl dell-vflash-state --requested-state Enable --dry_run
+    redfish_ctl dell-vflash-state --requested-state Disable --confirm
+
+The command discovers ``#DellPersistentStorageService.VFlashStateChange`` from
+the Manager OEM Dell persistent-storage link. With no requested state it lists
+the discovered target and advertised states. Changing vFlash state rewrites BMC
+configuration, so the action previews by default and only POSTs with
+``--confirm``.
+
+Author Mus spyroot@gmail.com
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+from ..redfish_shared import RedfishApi
+
+_VFLASH_STATE_ACTION = "#DellPersistentStorageService.VFlashStateChange"
+_PERSISTENT_STORAGE_FALLBACK = (
+    f"{RedfishApi.Version}/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DellPersistentStorageService"
+)
+
+
+class DellVFlashStateChange(RedfishManagerBase,
+                            scm_type=ApiRequestType.DellVFlashStateChange,
+                            name="dell-vflash-state",
+                            metaclass=Singleton):
+    """Discover and change Dell vFlash state."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-vflash-state command."""
+        super(DellVFlashStateChange, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-vflash-state`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--requested-state",
+            required=False,
+            dest="requested_state",
+            type=str,
+            default=None,
+            help="Dell vFlash state to request, such as Enable or Disable; "
+                 "omit to list the discovered action target",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the VFlashStateChange POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and payload without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-vflash-state",
+            "command change Dell vFlash state",
+        )
+
+    @staticmethod
+    def _link(data, key):
+        """Return a Redfish link target from a ``{key: {@odata.id}}`` property.
+
+        :param data: resource body containing the link.
+        :param key: property name whose ``@odata.id`` to extract.
+        :return: the linked URI, or None when absent or malformed.
+        """
+        link = (data or {}).get(key)
+        return link.get("@odata.id") if isinstance(link, dict) else None
+
+    @classmethod
+    def _dell_oem_link(cls, manager, key):
+        """Return an OEM Dell link from a Manager resource.
+
+        :param manager: Manager resource body.
+        :param key: OEM Dell link name, such as ``DellPersistentStorageService``.
+        :return: the linked URI, or None when absent.
+        """
+        links = (manager or {}).get("Links", {})
+        if not isinstance(links, dict):
+            return None
+        oem_links = links.get("Oem", {})
+        if not isinstance(oem_links, dict):
+            return None
+        dell_links = oem_links.get("Dell", {})
+        if not isinstance(dell_links, dict):
+            return None
+        return cls._link(dell_links, key)
+
+    def _persistent_storage_uri(self, do_async):
+        """Resolve DellPersistentStorageService from Manager OEM links.
+
+        :param do_async: issue Manager queries over the async Redfish path.
+        :return: discovered persistent-storage service URI, or the legacy fallback.
+        """
+        try:
+            manager_uris = self.discover_manager_ids() or []
+        except Exception:
+            manager_uris = []
+        for manager_uri in manager_uris:
+            try:
+                manager = self.base_query(
+                    manager_uri.rstrip("/"),
+                    do_async=do_async,
+                ).data or {}
+            except Exception:
+                continue
+            target = self._dell_oem_link(manager, "DellPersistentStorageService")
+            if target:
+                return target
+        return _PERSISTENT_STORAGE_FALLBACK
+
+    def _persistent_storage_service(self, do_async):
+        """Read the DellPersistentStorageService resource.
+
+        :param do_async: issue the query over the async Redfish path.
+        :return: tuple of ``(uri, body)`` or ``(uri, CommandResult)`` on error.
+        """
+        uri = self._persistent_storage_uri(do_async)
+        try:
+            data = self.base_query(uri, do_async=do_async).data or {}
+        except Exception as exc:
+            return uri, CommandResult(None, None, None, f"failed to read {uri}: {exc}")
+        return uri, data
+
+    def _state_metadata(self, do_async):
+        """Return discovered VFlashStateChange target metadata.
+
+        :param do_async: issue the persistent-storage query over the async Redfish path.
+        :return: CommandResult with service, action target, and advertised states.
+        """
+        uri, service = self._persistent_storage_service(do_async)
+        if isinstance(service, CommandResult):
+            return service
+        actions = self.discover_redfish_actions(self, service)
+        action = actions.get("VFlashStateChange")
+        requested_states = sorted((getattr(action, "args", {}) or {}).get(
+            "RequestedState", []
+        ))
+        target = self._flatten_action_targets(service).get(_VFLASH_STATE_ACTION)
+        if target is None:
+            available = sorted(set(list(actions.keys())
+                                   + list(self._flatten_action_targets(service).keys())))
+            return CommandResult(
+                {
+                    "persistent_storage_service": uri,
+                    "action": _VFLASH_STATE_ACTION,
+                    "available": available,
+                },
+                actions,
+                None,
+                f"action '{_VFLASH_STATE_ACTION}' not found on {uri}",
+            )
+        return CommandResult(
+            {
+                "persistent_storage_service": uri,
+                "action": _VFLASH_STATE_ACTION,
+                "target": target,
+                "requested_states": requested_states,
+            },
+            actions,
+            None,
+            None,
+        )
+
+    @staticmethod
+    def _payload(requested_state):
+        """Build a VFlashStateChange payload.
+
+        :param requested_state: requested Dell vFlash state.
+        :return: JSON-serializable action payload.
+        :raises InvalidArgument: when ``requested_state`` is empty.
+        """
+        state = (requested_state or "").strip()
+        if not state:
+            raise InvalidArgument("requested state cannot be empty")
+        return {"RequestedState": state}
+
+    def execute(self,
+                requested_state: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """List the Dell vFlash target, or change the requested state.
+
+        With no ``--requested-state`` the command returns discovered
+        VFlashStateChange metadata without mutating. With a requested state it
+        resolves and invokes the action; because this rewrites BMC
+        configuration, the POST only fires with ``--confirm``. ``--dry_run``
+        remains a no-POST override even when ``--confirm`` is also set.
+
+        :param requested_state: requested Dell vFlash state; None lists target
+            metadata.
+        :param confirm: authorize the VFlashStateChange POST to actually fire.
+        :param dry_run: resolve the target and payload without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying queries/POST on the async path.
+        :return: a CommandResult with target metadata, dry-run preview, or POST
+            result.
+        :raises InvalidArgument: when ``requested_state`` is empty after trimming.
+        """
+        if requested_state is None:
+            return self._state_metadata(do_async)
+
+        return self.invoke_action(
+            self._persistent_storage_uri(do_async),
+            "VFlashStateChange",
+            payload=self._payload(requested_state),
+            full_action_type=_VFLASH_STATE_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -121,6 +121,7 @@ class ApiRequestType(Enum):
     LogClear = auto()
     LogCollectDiagnosticData = auto()
     LicenseInstall = auto()
+    DellPersistentPartitionActions = auto()
     EthernetInterfaces = auto()
     SecureBoot = auto()
     CertificatesQuery = auto()

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcSupportAssistExport = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcLogComment = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -37,6 +37,7 @@ class ApiRequestType(Enum):
     # dell oem
     DellOemTask = auto()
     DellLcQuery = auto()
+    DellLcSupportAssistSchedule = auto()
     DellOemDisconnect = auto()
 
     RemoteServicesRssAPIStatus = auto()

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -105,6 +105,7 @@ class ApiRequestType(Enum):
     TelemetryClearReports = auto()
     ComponentIntegrity = auto()
     SpdmMeasurements = auto()
+    DellSystemLcdErrors = auto()
     NetworkAdapters = auto()
     NicFirmware = auto()
     NvLinkPorts = auto()

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -129,6 +129,7 @@ class ApiRequestType(Enum):
     Triggers = auto()
     NetworkPorts = auto()
     OemInfo = auto()
+    DellVFlashStateChange = auto()
     ConsoleInfo = auto()
     SerialConsoleConfig = auto()
     BiosSnapshot = auto()

--- a/redfish_ctl/system/cmd_dell_system_lcd_errors.py
+++ b/redfish_ctl/system/cmd_dell_system_lcd_errors.py
@@ -1,0 +1,226 @@
+"""Show Dell system errors on the chassis LCD.
+
+    redfish_ctl dell-system-lcd-errors
+    redfish_ctl dell-system-lcd-errors --system-uri /redfish/v1/Systems/System.Embedded.1
+    redfish_ctl dell-system-lcd-errors --confirm
+
+The command resolves ``#DellSystemManagementService.ShowErrorsOnLCD`` from the
+Dell SystemManagementService resource beneath a ComputerSystem. The action is
+treated as destructive by the shared policy, so the default invocation previews
+the target and payload without POSTing.
+"""
+from abc import abstractmethod
+from typing import Optional
+
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_SHOW_ERRORS_ON_LCD_ACTION = "#DellSystemManagementService.ShowErrorsOnLCD"
+_DELL_SYSTEM_MANAGEMENT_SERVICE = "Oem/Dell/DellSystemManagementService"
+
+
+class DellSystemLcdErrors(RedfishManagerBase,
+                          scm_type=ApiRequestType.DellSystemLcdErrors,
+                          name="dell-system-lcd-errors",
+                          metaclass=Singleton):
+    """Preview or invoke DellSystemManagementService.ShowErrorsOnLCD."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dell-system-lcd-errors command."""
+        super(DellSystemLcdErrors, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded ``dell-system-lcd-errors`` subcommand.
+
+        :param cls: command class supplying the shared base parser.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            "--system-uri",
+            required=False,
+            dest="system_uri",
+            type=str,
+            default=None,
+            help="ComputerSystem URI that owns DellSystemManagementService; "
+                 "omitted value probes discovered systems",
+        )
+        cmd_parser.add_argument(
+            "--confirm",
+            action="store_true",
+            dest="confirm",
+            default=False,
+            help="fire the ShowErrorsOnLCD POST; without it the command previews",
+        )
+        cmd_parser.add_argument(
+            "--dry_run",
+            action="store_true",
+            dest="dry_run",
+            default=False,
+            help="resolve the target and show it without POSTing; overrides --confirm",
+        )
+        return (
+            cmd_parser,
+            "dell-system-lcd-errors",
+            "command show Dell system errors on the chassis LCD",
+        )
+
+    @staticmethod
+    def _normalize_uri(uri):
+        """Return a Redfish URI without a trailing slash.
+
+        :param uri: Redfish resource URI.
+        :return: normalized URI, or None for a blank value.
+        """
+        if uri is None:
+            return None
+        normalized = uri.strip().rstrip("/")
+        return normalized or None
+
+    @classmethod
+    def _service_uri(cls, system_uri):
+        """Return the DellSystemManagementService URI below a ComputerSystem.
+
+        :param system_uri: normalized ComputerSystem URI.
+        :return: SystemManagementService URI.
+        """
+        return f"{system_uri}/{_DELL_SYSTEM_MANAGEMENT_SERVICE}"
+
+    def _candidate_systems(self, system_uri=None):
+        """Return ComputerSystem URIs to probe for the Dell service.
+
+        :param system_uri: optional explicit ComputerSystem URI.
+        :return: de-duplicated list of normalized system URIs.
+        """
+        explicit = self._normalize_uri(system_uri)
+        if explicit is not None:
+            return [explicit]
+
+        candidates = []
+        try:
+            candidates.extend(self.discover_computer_system_ids())
+        except Exception:
+            pass
+        try:
+            candidates.append(self.idrac_manage_servers)
+        except Exception:
+            pass
+
+        seen = set()
+        normalized = []
+        for candidate in candidates:
+            value = self._normalize_uri(candidate)
+            if value is not None and value not in seen:
+                normalized.append(value)
+                seen.add(value)
+        return normalized
+
+    def _show_errors_metadata(self, do_async, system_uri=None):
+        """Resolve the Dell ShowErrorsOnLCD action target.
+
+        :param do_async: issue Redfish queries on the async path.
+        :param system_uri: optional explicit ComputerSystem URI.
+        :return: CommandResult with target metadata, or an error.
+        """
+        candidates = self._candidate_systems(system_uri)
+        if not candidates:
+            return CommandResult(
+                {
+                    "action": _SHOW_ERRORS_ON_LCD_ACTION,
+                    "available": [],
+                },
+                None,
+                None,
+                "no ComputerSystem URI available for DellSystemManagementService",
+            )
+
+        attempts = []
+        last_actions = None
+        for candidate in candidates:
+            service_uri = self._service_uri(candidate)
+            attempts.append(service_uri)
+            try:
+                service = self.base_query(service_uri, do_async=do_async).data or {}
+            except Exception:
+                continue
+            actions = self.discover_redfish_actions(self, service)
+            targets = self._flatten_action_targets(service)
+            target = targets.get(_SHOW_ERRORS_ON_LCD_ACTION)
+            if target is None:
+                last_actions = actions
+                continue
+            return CommandResult(
+                {
+                    "system": candidate,
+                    "system_management_service": service_uri,
+                    "action": _SHOW_ERRORS_ON_LCD_ACTION,
+                    "target": target,
+                },
+                actions,
+                None,
+                None,
+            )
+
+        available = []
+        if last_actions is not None:
+            available = sorted(
+                set(list(last_actions.keys()) + list(targets.keys()))
+            )
+        return CommandResult(
+            {
+                "action": _SHOW_ERRORS_ON_LCD_ACTION,
+                "attempted": attempts,
+                "available": available,
+            },
+            last_actions,
+            None,
+            (
+                f"action '{_SHOW_ERRORS_ON_LCD_ACTION}' not found on "
+                "DellSystemManagementService"
+            ),
+        )
+
+    def execute(self,
+                system_uri: Optional[str] = None,
+                confirm: Optional[bool] = False,
+                dry_run: Optional[bool] = False,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or run DellSystemManagementService.ShowErrorsOnLCD.
+
+        :param system_uri: optional ComputerSystem URI owning the Dell service.
+        :param confirm: authorize the ShowErrorsOnLCD POST to actually fire.
+        :param dry_run: resolve the target and show it without POSTing.
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: issue the underlying query and POST on the async path.
+        :return: CommandResult with target metadata, preview, or POST result.
+        """
+        metadata = self._show_errors_metadata(do_async, system_uri=system_uri)
+        if metadata.error is not None:
+            return metadata
+
+        result = self.invoke_action(
+            metadata.data["system_management_service"],
+            "ShowErrorsOnLCD",
+            payload={},
+            full_action_type=_SHOW_ERRORS_ON_LCD_ACTION,
+            do_async=do_async,
+            expected_status=202,
+            dry_run=bool(dry_run),
+            confirm=bool(confirm),
+        )
+        if isinstance(result.data, dict):
+            result.data.setdefault("system", metadata.data["system"])
+            result.data.setdefault(
+                "system_management_service",
+                metadata.data["system_management_service"],
+            )
+        return result

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -31,6 +31,9 @@ def test_policy_classifies_known_and_unknown():
         assert classify(action) is Destructiveness.REVERSIBLE
     assert classify("#ComponentIntegrity.SPDMGetSignedMeasurements") is Destructiveness.READ_ONLY
     assert classify("#LicenseService.Install") is Destructiveness.DESTRUCTIVE
+    assert classify("#DellLCService.SupportAssistExportLastCollection") is (
+        Destructiveness.DESTRUCTIVE
+    )
     assert classify("#TelemetryService.ClearMetricReports") is Destructiveness.DESTRUCTIVE
     # unmapped / empty -> DESTRUCTIVE (cannot fire without --confirm)
     assert classify("#Some.BrandNewAction") is Destructiveness.DESTRUCTIVE

--- a/tests/test_dell_lc_log_comment_dualmode.py
+++ b/tests/test_dell_lc_log_comment_dualmode.py
@@ -1,0 +1,214 @@
+"""Dual-mode-style coverage for DellLCService.InsertCommentInLCLog."""
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.dell_lc.cmd_dell_lc_log_comment import DellLcLogComment
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+LC_SERVICE = "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+INSERT_TARGET = f"{LC_SERVICE}/Actions/DellLCService.InsertCommentInLCLog"
+INSERT_ACTION = "#DellLCService.InsertCommentInLCLog"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_lc_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase and recorded requests list.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/lclog-comment-1"
+        return json.dumps({
+            "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/lclog-comment-1"}
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-lc",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_lc_log_comment_lists_target_without_mutating(dell_lc_manager):
+    """Without a comment, the command lists the target and never POSTs."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "lc_service": LC_SERVICE,
+        "action": INSERT_ACTION,
+        "target": INSERT_TARGET,
+    }
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_without_confirm_is_preview_only(dell_lc_manager):
+    """InsertCommentInLCLog resolves the target but does not POST by default."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment=" maintenance note ",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == INSERT_ACTION
+    assert result.data["target"] == INSERT_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {"Comment": "maintenance note"}
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_confirm_posts_payload(dell_lc_manager):
+    """--confirm POSTs the comment payload to the discovered action target."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment="Investigated PSU event",
+        log_sequence_number="42",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == INSERT_ACTION
+    assert result.data["target"] == INSERT_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "lclog-comment-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == INSERT_TARGET.lower()
+    assert posts[0].json() == {
+        "Comment": "Investigated PSU event",
+        "LogSequenceNumber": "42",
+    }
+
+
+def test_lc_log_comment_confirm_dry_run_still_does_not_post(dell_lc_manager):
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment="do not send",
+        confirm=True,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"Comment": "do not send"}
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_rejects_empty_comment(dell_lc_manager):
+    """A blank comment is rejected before any action POST can fire."""
+    manager, requests = dell_lc_manager
+
+    with pytest.raises(InvalidArgument, match="comment cannot be empty"):
+        manager.sync_invoke(
+            ApiRequestType.DellLcLogComment,
+            "dell-lc-log-comment",
+            comment="   ",
+            confirm=True,
+        )
+
+    assert _post_requests(requests) == []
+
+
+def test_lc_log_comment_reports_missing_action_without_post(redfish_mock):
+    """Older Dell fixtures without InsertCommentInLCLog return a target error."""
+    result = redfish_mock.sync_invoke(
+        ApiRequestType.DellLcLogComment,
+        "dell-lc-log-comment",
+        comment="maintenance note",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#DellLCService.InsertCommentInLCLog' not found on "
+        "/redfish/v1/Dell/Managers/iDRAC.Embedded.1/DellLCService"
+    )
+    assert result.data["action"] == INSERT_ACTION
+    assert "GetRSStatus" in result.data["available"]
+
+
+def test_lc_log_comment_exposes_cli_entrypoint():
+    """The dell-lc-log-comment command is wired into the package registry."""
+    registry = RedfishManagerBase._registry
+    assert registry[ApiRequestType.DellLcLogComment]["dell-lc-log-comment"] is (
+        DellLcLogComment
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellLcLogComment.register_subcommand(
+        DellLcLogComment
+    )
+
+    assert cmd_name == "dell-lc-log-comment"
+    assert "comment" in cmd_help
+    assert any(action.dest == "comment" for action in cmd_parser._actions)

--- a/tests/test_dell_lc_supportassist_export_dualmode.py
+++ b/tests/test_dell_lc_supportassist_export_dualmode.py
@@ -1,0 +1,237 @@
+"""Dual-mode tests for Dell SupportAssist export actions."""
+import copy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_supportassist_export import (
+    DellLcSupportAssistExport,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+EXPORT_TARGET = (
+    f"{LC_SERVICE}/Actions/"
+    "DellLCService.SupportAssistExportLastCollection"
+)
+
+
+@pytest.fixture
+def dell_lc_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-lc",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _overlay_lc_service(service, body):
+    """Overlay DellLCService under both common request casings."""
+    service._overlay[LC_SERVICE] = body
+    service._overlay[LC_SERVICE.lower()] = body
+
+
+def test_supportassist_export_lists_corpus_target_without_post(dell_lc_mock):
+    """Listing discovers SupportAssistExportLastCollection and never POSTs."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistExport,
+        "dell-lc-supportassist-export",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["lc_service"] == LC_SERVICE
+    assert result.data["action"] == (
+        "#DellLCService.SupportAssistExportLastCollection"
+    )
+    assert result.data["target"] == EXPORT_TARGET
+    assert result.data["allowed"]["ShareType"] == [
+        "CIFS",
+        "FTP",
+        "HTTP",
+        "HTTPS",
+        "NFS",
+        "TFTP",
+    ]
+    assert result.data["allowed"]["ProxySupport"] == [
+        "DefaultProxy",
+        "Off",
+        "ParametersProxy",
+    ]
+    assert _post_requests(service) == []
+
+
+def test_supportassist_export_dry_run_redacts_share_password(
+    dell_lc_mock,
+    monkeypatch,
+):
+    """Preview output masks the share password and sends no POST."""
+    manager, service = dell_lc_mock
+    monkeypatch.setenv("DELL_SUPPORTASSIST_PASSWORD", "placeholder-password")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistExport,
+        "dell-lc-supportassist-export",
+        share_type="HTTPS",
+        ip_address="repo.example.test",
+        share_name="/support",
+        file_name="last-collection.zip",
+        share_username="report-user",
+        share_password_env="DELL_SUPPORTASSIST_PASSWORD",
+        ignore_cert_warning="On",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["action"] == (
+        "#DellLCService.SupportAssistExportLastCollection"
+    )
+    assert result.data["target"] == EXPORT_TARGET
+    assert result.data["payload"] == {
+        "ShareType": "HTTPS",
+        "IPAddress": "repo.example.test",
+        "ShareName": "/support",
+        "FileName": "last-collection.zip",
+        "UserName": "report-user",
+        "Password": "********",
+        "IgnoreCertWarning": "On",
+    }
+    assert _post_requests(service) == []
+
+
+def test_supportassist_export_confirm_posts_payload(dell_lc_mock):
+    """--confirm POSTs one export request to the discovered target."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistExport,
+        "dell-lc-supportassist-export",
+        share_type="NFS",
+        ip_address="192.0.2.10",
+        share_name="/exports",
+        file_name="last-collection.zip",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == EXPORT_TARGET.lower()
+    assert posts[0].json() == {
+        "ShareType": "NFS",
+        "IPAddress": "192.0.2.10",
+        "ShareName": "/exports",
+        "FileName": "last-collection.zip",
+    }
+
+
+def test_supportassist_export_rejects_invalid_share_type(dell_lc_mock):
+    """Inline Dell allowable values reject unsupported ShareType input."""
+    manager, service = dell_lc_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistExport,
+        "dell-lc-supportassist-export",
+        share_type="SMTP",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.SupportAssistExportLastCollection "
+        "ShareType: SMTP; allowed: CIFS, FTP, HTTP, HTTPS, NFS, TFTP"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "ShareType",
+            "value": "SMTP",
+            "allowed": ["CIFS", "FTP", "HTTP", "HTTPS", "NFS", "TFTP"],
+        }
+    ]
+    assert _post_requests(service) == []
+
+
+def test_supportassist_export_reports_missing_action_without_post(dell_lc_mock):
+    """A service missing SupportAssistExportLastCollection reports the miss."""
+    manager, service = dell_lc_mock
+    body = copy.deepcopy(service._state(LC_SERVICE))
+    body["Actions"].pop("#DellLCService.SupportAssistExportLastCollection")
+    _overlay_lc_service(service, body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistExport,
+        "dell-lc-supportassist-export",
+        share_type="NFS",
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "action '#DellLCService.SupportAssistExportLastCollection' not found"
+    )
+    assert result.data["action"] == (
+        "#DellLCService.SupportAssistExportLastCollection"
+    )
+    assert LC_SERVICE in result.data["checked"]
+    assert _post_requests(service) == []
+
+
+def test_supportassist_export_is_registered_and_classified():
+    """The command is registered and classified as guarded."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellLcSupportAssistExport][
+        "dell-lc-supportassist-export"
+    ] is DellLcSupportAssistExport
+
+    assert classify("#DellLCService.SupportAssistExportLastCollection") is (
+        Destructiveness.DESTRUCTIVE
+    )

--- a/tests/test_dell_lc_supportassist_schedule_dualmode.py
+++ b/tests/test_dell_lc_supportassist_schedule_dualmode.py
@@ -1,0 +1,343 @@
+"""Dual-mode-style coverage for DellLCService SupportAssist schedules."""
+
+import json
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.dell_lc.cmd_dell_lc_supportassist_schedule import (
+    DellLcSupportAssistSchedule,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+DELL_LC_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/DellLCService"
+)
+CLEAR_TARGET = (
+    f"{DELL_LC_SERVICE}/Actions/"
+    "DellLCService.SupportAssistClearAutoCollectSchedule"
+)
+SET_TARGET = (
+    f"{DELL_LC_SERVICE}/Actions/"
+    "DellLCService.SupportAssistSetAutoCollectSchedule"
+)
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@pytest.fixture
+def dell_lc_manager():
+    """Serve the committed Dell corpus over requests-mock.
+
+    :return: tuple of RedfishManagerBase and recorded requests list.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        return fixture.read_text()
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/supportassist-1"
+        return json.dumps(
+            {"Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/supportassist-1"}}
+        )
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-lc-supportassist",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_lc_supportassist_schedule_policy_is_reversible():
+    """The SupportAssist schedule actions are classified as reversible."""
+    assert (
+        classify("#DellLCService.SupportAssistClearAutoCollectSchedule")
+        is Destructiveness.REVERSIBLE
+    )
+    assert (
+        classify("#DellLCService.SupportAssistSetAutoCollectSchedule")
+        is Destructiveness.REVERSIBLE
+    )
+
+
+def test_dell_lc_supportassist_schedule_lists_targets_without_post(
+    dell_lc_manager,
+):
+    """Listing discovers schedule actions and does not POST."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["supportassist_schedule_targets"] == [
+        {
+            "Resource": DELL_LC_SERVICE,
+            "Selector": "clear",
+            "Action": "#DellLCService.SupportAssistClearAutoCollectSchedule",
+            "Target": CLEAR_TARGET,
+        },
+        {
+            "Resource": DELL_LC_SERVICE,
+            "Selector": "set",
+            "Action": "#DellLCService.SupportAssistSetAutoCollectSchedule",
+            "Target": SET_TARGET,
+            "AllowedRecurrences": ["Monthly", "Quarterly", "Weekly"],
+        },
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_set_previews_by_default(
+    dell_lc_manager,
+):
+    """Setting a recurrence does not POST unless --confirm is present."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Weekly",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.SupportAssistSetAutoCollectSchedule"
+    assert result.data["target"] == SET_TARGET
+    assert result.data["level"] == "reversible"
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"Recurrence": "Weekly"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_set_confirm_posts_payload(
+    dell_lc_manager,
+):
+    """--confirm POSTs the recurrence payload to the set action target."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Weekly",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == "#DellLCService.SupportAssistSetAutoCollectSchedule"
+    assert result.data["target"] == SET_TARGET
+    assert result.data["level"] == "reversible"
+    assert result.data["task_id"] == "supportassist-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == SET_TARGET.lower()
+    assert posts[0].json() == {"Recurrence": "Weekly"}
+
+
+def test_dell_lc_supportassist_schedule_clear_previews_by_default(
+    dell_lc_manager,
+):
+    """Clearing the schedule resolves the target but does not POST by default."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="clear",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellLCService.SupportAssistClearAutoCollectSchedule"
+    assert result.data["target"] == CLEAR_TARGET
+    assert result.data["payload"] == {}
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_clear_confirm_posts_empty_payload(
+    dell_lc_manager,
+):
+    """--confirm POSTs an empty payload to the clear action target."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="clear",
+        confirm=True,
+    )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["target"] == CLEAR_TARGET
+    assert len(posts) == 1
+    assert posts[0].path.lower() == CLEAR_TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_lc_supportassist_schedule_dry_run_overrides_confirm(
+    dell_lc_manager,
+):
+    """--dry_run keeps the command preview-only even with --confirm."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Monthly",
+        dry_run=True,
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["payload"] == {"Recurrence": "Monthly"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_rejects_invalid_recurrence(
+    dell_lc_manager,
+):
+    """Inline allowable values reject unsupported recurrences before POST."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        recurrence="Yearly",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellLCService.SupportAssistSetAutoCollectSchedule "
+        "Recurrence: Yearly; allowed: Monthly, Quarterly, Weekly"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "Recurrence",
+            "value": "Yearly",
+            "allowed": ["Monthly", "Quarterly", "Weekly"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_set_requires_recurrence(
+    dell_lc_manager,
+):
+    """The set action fails closed when Recurrence is omitted."""
+    manager, requests = dell_lc_manager
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="set",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "SupportAssist schedule set requires --recurrence"
+    assert result.data == {
+        "required": ["Recurrence"],
+        "action": "#DellLCService.SupportAssistSetAutoCollectSchedule",
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_lc_supportassist_schedule_missing_action_does_not_post(
+    redfish_mock_factory,
+):
+    """A non-Dell fixture reports no schedule target and no POST."""
+    manager, service = redfish_mock_factory("generic")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellLcSupportAssistSchedule,
+        "dell-lc-supportassist-schedule",
+        action="clear",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == "Dell LC SupportAssist schedule action not found"
+    assert result.data == {
+        "action": "#DellLCService.SupportAssistClearAutoCollectSchedule",
+        "available": [],
+    }
+    assert _post_requests(service.requests) == []
+
+
+def test_dell_lc_supportassist_schedule_exposes_cli_entrypoint():
+    """The command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert (
+        registry[ApiRequestType.DellLcSupportAssistSchedule][
+            "dell-lc-supportassist-schedule"
+        ]
+        is DellLcSupportAssistSchedule
+    )
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellLcSupportAssistSchedule.register_subcommand(
+            DellLcSupportAssistSchedule
+        )
+    )
+
+    assert "--recurrence" in cmd_parser.format_help()
+    assert cmd_name == "dell-lc-supportassist-schedule"
+    assert "SupportAssist schedule" in cmd_help

--- a/tests/test_dell_persistent_partition_dualmode.py
+++ b/tests/test_dell_persistent_partition_dualmode.py
@@ -1,0 +1,336 @@
+"""Dual-mode tests for Dell VFlash partition actions."""
+import copy
+from pathlib import Path
+
+import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.oem.cmd_dell_persistent_partition import (
+    DellPersistentPartitionActions,
+)
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DELL_CORPUS = corpus_dir(
+    REPO_ROOT / "tests" / "dell_xr8620t_corpus.tar.gz",
+    "10.252.252.209",
+)
+PERSISTENT_STORAGE_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DellPersistentStorageService"
+)
+ATTACH_TARGET = (
+    f"{PERSISTENT_STORAGE_SERVICE}/Actions/"
+    "DellPersistentStorageService.AttachPartition"
+)
+DELETE_TARGET = (
+    f"{PERSISTENT_STORAGE_SERVICE}/Actions/"
+    "DellPersistentStorageService.DeletePartition"
+)
+
+
+@pytest.fixture
+def dell_persistent_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus.
+
+    :return: tuple of Redfish manager and mock service.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            RedfishManagerBase(
+                idrac_ip="mock-dell-persistent",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
+
+
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
+
+    :param service: mock Redfish service.
+    :return: recorded POST requests.
+    """
+    return [request for request in service.requests if request.method == "POST"]
+
+
+def _overlay_persistent_service(service, body):
+    """Overlay DellPersistentStorageService under both common request casings."""
+    service._overlay[PERSISTENT_STORAGE_SERVICE] = body
+    service._overlay[PERSISTENT_STORAGE_SERVICE.lower()] = body
+
+
+def test_dell_vflash_partition_lists_corpus_actions_without_post(dell_persistent_mock):
+    """Listing discovers partition actions and never POSTs."""
+    manager, service = dell_persistent_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["persistent_storage_service"] == PERSISTENT_STORAGE_SERVICE
+    actions = {row["Action"]: row for row in result.data["partition_actions"]}
+    assert set(actions) == {
+        "attach",
+        "create",
+        "create-from-image",
+        "delete",
+        "detach",
+        "export",
+        "format",
+        "initialize",
+        "modify",
+    }
+    assert actions["create-from-image"]["AllowableValues"]["ShareType"] == [
+        "CIFS",
+        "FTP",
+        "HTTP",
+        "NFS",
+        "TFTP",
+    ]
+    assert actions["format"]["Level"] == "irreversible"
+    assert _post_requests(service) == []
+
+
+def test_dell_vflash_partition_attach_defaults_to_dry_run(dell_persistent_mock):
+    """Attach resolves the Dell target but does not POST without --confirm."""
+    manager, service = dell_persistent_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+        action="attach",
+        partition_index=2,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellPersistentStorageService.AttachPartition"
+    assert result.data["target"] == ATTACH_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {"PartitionIndex": 2}
+    assert _post_requests(service) == []
+
+
+def test_dell_vflash_partition_attach_confirm_posts_payload(dell_persistent_mock):
+    """--confirm POSTs one AttachPartition request to the discovered target."""
+    manager, service = dell_persistent_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+        action="attach",
+        partition_index=2,
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "destructive"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == ATTACH_TARGET.lower()
+    assert posts[0].json() == {"PartitionIndex": 2}
+
+
+def test_dell_vflash_partition_delete_needs_irreversible_token(dell_persistent_mock):
+    """DeletePartition dry-runs until both confirmation flags are supplied."""
+    manager, service = dell_persistent_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+        action="delete",
+        partition_index=3,
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == "#DellPersistentStorageService.DeletePartition"
+    assert result.data["target"] == DELETE_TARGET
+    assert result.data["level"] == "irreversible"
+    assert result.data["blocked"] == (
+        "irreversible action requires --confirm and --i-understand-irreversible"
+    )
+    assert _post_requests(service) == []
+
+
+def test_dell_vflash_partition_delete_with_both_tokens_posts(dell_persistent_mock):
+    """DeletePartition POSTs only after both confirmation flags are supplied."""
+    manager, service = dell_persistent_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+        action="delete",
+        partition_index=3,
+        confirm=True,
+        confirm_irreversible=True,
+    )
+
+    posts = _post_requests(service)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["level"] == "irreversible"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == DELETE_TARGET.lower()
+    assert posts[0].json() == {"PartitionIndex": 3}
+
+
+def test_dell_vflash_partition_rejects_invalid_allowable_value(dell_persistent_mock):
+    """Inline Dell allowable values reject unsupported CreatePartition input."""
+    manager, service = dell_persistent_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+        action="create",
+        partition_index=1,
+        partition_type="Tape",
+        size=1,
+        size_unit="GB",
+        os_volume_label="BOOT",
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellPersistentStorageService.CreatePartition "
+        "PartitionType: Tape; allowed: Floppy, HardDisk"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "PartitionType",
+            "value": "Tape",
+            "allowed": ["Floppy", "HardDisk"],
+        }
+    ]
+    assert _post_requests(service) == []
+
+
+def test_dell_vflash_partition_redacts_share_password(dell_persistent_mock, monkeypatch):
+    """Dry-run output does not echo a share password read from the environment."""
+    manager, service = dell_persistent_mock
+    monkeypatch.setenv("DELL_VFLASH_PASSWORD", "placeholder-value")
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+        action="export",
+        partition_index=1,
+        share_type="CIFS",
+        image_name="partition.img",
+        share_username="share-user",
+        password_env="DELL_VFLASH_PASSWORD",
+        share_port=445,
+        dry_run=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["payload"]["Username"] == "share-user"
+    assert result.data["payload"]["Password"] == "********"
+    assert result.data["payload"]["Port"] == 445
+    assert result.data["payload"]["ShareType"] == "CIFS"
+    assert _post_requests(service) == []
+
+
+def test_dell_vflash_partition_reports_missing_action_without_post(dell_persistent_mock):
+    """A service missing the selected action reports available actions."""
+    manager, service = dell_persistent_mock
+    body = copy.deepcopy(service._state(PERSISTENT_STORAGE_SERVICE))
+    body["Actions"].pop("#DellPersistentStorageService.AttachPartition")
+    _overlay_persistent_service(service, body)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellPersistentPartitionActions,
+        "dell-vflash-partition",
+        action="attach",
+        partition_index=1,
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "Dell persistent-storage partition action not found: attach"
+    )
+    available = {row["Action"] for row in result.data["available"]}
+    assert "attach" not in available
+    assert "delete" in available
+    assert _post_requests(service) == []
+
+
+def test_dell_vflash_partition_rejects_out_of_range_index(dell_persistent_mock):
+    """Partition index validation rejects values outside Dell's 1-16 range."""
+    manager, service = dell_persistent_mock
+
+    with pytest.raises(
+        InvalidArgument,
+        match="--partition-index must be between 1 and 16",
+    ):
+        manager.sync_invoke(
+            ApiRequestType.DellPersistentPartitionActions,
+            "dell-vflash-partition",
+            action="attach",
+            partition_index=17,
+            confirm=True,
+        )
+
+    assert _post_requests(service) == []
+
+
+def test_dell_vflash_partition_is_registered_and_classified():
+    """The command is registered and Dell partition actions are classified."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellPersistentPartitionActions][
+        "dell-vflash-partition"
+    ] is DellPersistentPartitionActions
+
+    assert classify("#DellPersistentStorageService.AttachPartition") is (
+        Destructiveness.DESTRUCTIVE
+    )
+    assert classify("#DellPersistentStorageService.DeletePartition") is (
+        Destructiveness.IRREVERSIBLE
+    )
+    assert classify("#DellPersistentStorageService.FormatPartition") is (
+        Destructiveness.IRREVERSIBLE
+    )
+
+    cmd_parser, cmd_name, cmd_help = (
+        DellPersistentPartitionActions.register_subcommand(
+            DellPersistentPartitionActions
+        )
+    )
+    help_text = cmd_parser.format_help()
+
+    assert cmd_name == "dell-vflash-partition"
+    assert "VFlash" in cmd_help
+    assert "--action" in help_text
+    assert "--i-understand-irreversible" in help_text

--- a/tests/test_dell_system_lcd_errors_dualmode.py
+++ b/tests/test_dell_system_lcd_errors_dualmode.py
@@ -1,0 +1,183 @@
+"""Dual-mode-style coverage for DellSystemManagementService.ShowErrorsOnLCD."""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+from redfish_ctl.system.cmd_dell_system_lcd_errors import DellSystemLcdErrors
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+SYSTEM = "/redfish/v1/Systems/System.Embedded.1"
+SERVICE = f"{SYSTEM}/Oem/Dell/DellSystemManagementService"
+ACTION = "#DellSystemManagementService.ShowErrorsOnLCD"
+TARGET = f"{SERVICE}/Actions/DellSystemManagementService.ShowErrorsOnLCD"
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@contextmanager
+def _dell_system_lcd_manager(remove_action=False):
+    """Serve the Dell corpus over requests-mock.
+
+    :param remove_action: drop ShowErrorsOnLCD from the service fixture.
+    :return: tuple of RedfishManagerBase and recorded requests.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        context.status_code = 200
+        data = json.loads(fixture.read_text())
+        if remove_action and request.path.lower() == SERVICE.lower():
+            data["Actions"].pop(ACTION, None)
+        return json.dumps(data)
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/lcd-1"
+        return json.dumps(
+            {"Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/lcd-1"}}
+        )
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-system-lcd",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport."""
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_system_lcd_errors_without_confirm_is_preview_only():
+    """ShowErrorsOnLCD resolves its target but does not POST without --confirm."""
+    with _dell_system_lcd_manager() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == ACTION
+    assert result.data["target"] == TARGET
+    assert result.data["system"] == SYSTEM
+    assert result.data["system_management_service"] == SERVICE
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {}
+    assert _post_requests(requests) == []
+
+
+def test_dell_system_lcd_errors_confirm_posts_empty_payload():
+    """--confirm POSTs the empty ShowErrorsOnLCD payload to the action target."""
+    with _dell_system_lcd_manager() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+            confirm=True,
+        )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == ACTION
+    assert result.data["target"] == TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "lcd-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == TARGET.lower()
+    assert posts[0].json() == {}
+
+
+def test_dell_system_lcd_errors_confirm_dry_run_still_does_not_post():
+    """--dry_run remains a no-POST preview even when --confirm is also present."""
+    with _dell_system_lcd_manager() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+            confirm=True,
+            dry_run=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["blocked"] is None
+    assert result.data["target"] == TARGET
+    assert _post_requests(requests) == []
+
+
+def test_dell_system_lcd_errors_reports_missing_action_without_post():
+    """A Dell service without ShowErrorsOnLCD reports the absent action."""
+    with _dell_system_lcd_manager(remove_action=True) as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellSystemLcdErrors,
+            "dell-system-lcd-errors",
+            system_uri=SYSTEM,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        f"action '{ACTION}' not found on DellSystemManagementService"
+    )
+    assert result.data["action"] == ACTION
+    assert result.data["attempted"] == [SERVICE]
+    assert "RebootChassisManager" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_system_lcd_errors_policy_is_destructive():
+    """ShowErrorsOnLCD cannot fire unless explicitly confirmed."""
+    assert classify(ACTION) is Destructiveness.DESTRUCTIVE
+
+
+def test_dell_system_lcd_errors_exposes_cli_entrypoint():
+    """The dell-system-lcd-errors command is wired into the package registry."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellSystemLcdErrors]["dell-system-lcd-errors"] is (
+        DellSystemLcdErrors
+    )
+
+    cmd_parser, cmd_name, cmd_help = DellSystemLcdErrors.register_subcommand(
+        DellSystemLcdErrors
+    )
+
+    assert "--system-uri" in cmd_parser.format_help()
+    assert "--confirm" in cmd_parser.format_help()
+    assert cmd_name == "dell-system-lcd-errors"
+    assert "Dell" in cmd_help

--- a/tests/test_dell_vflash_state_dualmode.py
+++ b/tests/test_dell_vflash_state_dualmode.py
@@ -1,0 +1,230 @@
+"""Dual-mode-style coverage for Dell vFlash state changes."""
+
+import json
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+from vendor_corpus import corpus_dir
+
+from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.oem.cmd_dell_vflash_state import DellVFlashStateChange
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
+DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
+PERSISTENT_STORAGE_SERVICE = (
+    "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/"
+    "DellPersistentStorageService"
+)
+VFLASH_ACTION = "#DellPersistentStorageService.VFlashStateChange"
+VFLASH_TARGET = (
+    f"{PERSISTENT_STORAGE_SERVICE}/Actions/"
+    "DellPersistentStorageService.VFlashStateChange"
+)
+
+
+def _fixture_for_path(path):
+    """Return the extracted Dell fixture matching a Redfish path.
+
+    :param path: request path from requests-mock.
+    :return: fixture path, or None when the corpus lacks the resource.
+    """
+    name = "_" + path.strip("/").replace("/", "_") + ".json"
+    return DELL_INDEX.get(name.lower())
+
+
+@contextmanager
+def _mock_dell_vflash(persistent_storage_transform=None):
+    """Serve the committed Dell corpus over requests-mock.
+
+    :param persistent_storage_transform: optional mutator for the service fixture.
+    :return: context yielding RedfishManagerBase and recorded requests.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    requests = []
+
+    def get_cb(request, context):
+        requests.append(request)
+        fixture = _fixture_for_path(request.path)
+        if fixture is None:
+            context.status_code = 404
+            return json.dumps({"error": f"no fixture for {request.path}"})
+        data = json.loads(fixture.read_text())
+        is_service = request.path.rstrip("/").lower() == (
+            PERSISTENT_STORAGE_SERVICE.lower()
+        )
+        if is_service and persistent_storage_transform:
+            data = persistent_storage_transform(data)
+        context.status_code = 200
+        return json.dumps(data)
+
+    def post_cb(request, context):
+        requests.append(request)
+        context.status_code = 202
+        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/vflash-1"
+        return json.dumps({
+            "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/vflash-1"}
+        })
+
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=get_cb)
+        mocker.post(requests_mock.ANY, text=post_cb)
+        manager = RedfishManagerBase(
+            idrac_ip="mock-dell-vflash",
+            idrac_username="root",
+            idrac_password="mock",
+            insecure=True,
+            is_debug=False,
+        )
+        yield manager, requests
+
+
+def _post_requests(requests):
+    """Return POST requests recorded by the mock Redfish transport.
+
+    :param requests: recorded requests-mock request objects.
+    :return: list of POST requests.
+    """
+    return [request for request in requests if request.method == "POST"]
+
+
+def test_dell_vflash_state_lists_target_without_posting():
+    """With no requested state, the command lists the VFlash target only."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data == {
+        "persistent_storage_service": PERSISTENT_STORAGE_SERVICE,
+        "action": VFLASH_ACTION,
+        "target": VFLASH_TARGET,
+        "requested_states": ["Disable", "Enable"],
+    }
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_without_confirm_is_preview_only():
+    """VFlashStateChange resolves the target but does not POST without confirm."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Enable",
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["action"] == VFLASH_ACTION
+    assert result.data["target"] == VFLASH_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["blocked"] == "destructive action requires --confirm"
+    assert result.data["payload"] == {"RequestedState": "Enable"}
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_confirm_posts_requested_state():
+    """--confirm POSTs the requested state to the discovered action target."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Disable",
+            confirm=True,
+        )
+
+    posts = _post_requests(requests)
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["action"] == VFLASH_ACTION
+    assert result.data["target"] == VFLASH_TARGET
+    assert result.data["level"] == "destructive"
+    assert result.data["task_id"] == "vflash-1"
+    assert len(posts) == 1
+    assert posts[0].path.lower() == VFLASH_TARGET.lower()
+    assert posts[0].json() == {"RequestedState": "Disable"}
+
+
+def test_dell_vflash_state_rejects_invalid_requested_state():
+    """Inline allowable values reject an unsupported RequestedState before POST."""
+    with _mock_dell_vflash() as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Suspend",
+            confirm=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        "invalid value for DellPersistentStorageService.VFlashStateChange "
+        "RequestedState: Suspend; allowed: Disable, Enable"
+    )
+    assert result.data["validation_errors"] == [
+        {
+            "parameter": "RequestedState",
+            "value": "Suspend",
+            "allowed": ["Disable", "Enable"],
+        }
+    ]
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_reports_missing_action_without_posting():
+    """A persistent-storage resource without VFlashStateChange fails closed."""
+
+    def without_vflash_action(data):
+        data.get("Actions", {}).pop(VFLASH_ACTION, None)
+        return data
+
+    with _mock_dell_vflash(without_vflash_action) as (manager, requests):
+        result = manager.sync_invoke(
+            ApiRequestType.DellVFlashStateChange,
+            "dell-vflash-state",
+            requested_state="Enable",
+            confirm=True,
+        )
+
+    assert isinstance(result, CommandResult)
+    assert result.error == (
+        f"action '{VFLASH_ACTION}' not found on {PERSISTENT_STORAGE_SERVICE}"
+    )
+    assert VFLASH_ACTION not in result.data["available"]
+    assert "AttachPartition" in result.data["available"]
+    assert _post_requests(requests) == []
+
+
+def test_dell_vflash_state_exposes_cli_entrypoint_and_policy():
+    """The command is registered and classified as a guarded state change."""
+    registry = RedfishManagerBase().get_registry()
+    assert registry[ApiRequestType.DellVFlashStateChange][
+        "dell-vflash-state"
+    ] is DellVFlashStateChange
+    assert classify(VFLASH_ACTION) is Destructiveness.DESTRUCTIVE
+
+    cmd_parser, cmd_name, cmd_help = DellVFlashStateChange.register_subcommand(
+        DellVFlashStateChange
+    )
+
+    assert "--requested-state" in cmd_parser.format_help()
+    assert "--confirm" in cmd_parser.format_help()
+    assert "--dry_run" in cmd_parser.format_help()
+    assert cmd_name == "dell-vflash-state"
+    assert "vFlash" in cmd_help
+
+
+def test_dell_vflash_state_rejects_blank_requested_state():
+    """Blank requested-state input is rejected before any POST can be made."""
+    with pytest.raises(InvalidArgument, match="requested state cannot be empty"):
+        DellVFlashStateChange._payload("  ")

--- a/tools/generate_telemetry_metrics_doc.py
+++ b/tools/generate_telemetry_metrics_doc.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Generate the GB300 telemetry metric catalog markdown.
+
+Audience: both humans and scripted callers. The tool is non-interactive and deterministic:
+it reads the committed GB300 corpus tarball, asks the exporter mapper which
+metric each observed MetricReport row emits, and either rewrites the catalog or
+checks that the checked-in catalog is current.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+import tarfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from redfish_ctl.telemetry import exporter  # noqa: E402
+
+DEFAULT_CORPUS = REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "telemetry-metrics.md"
+DEFAULT_LEAF = "172.25.230.37"
+IDENTITY = exporter.build_identity_dimensions(DEFAULT_LEAF, vendor="supermicro")
+
+
+@dataclass(frozen=True)
+class ReportDefinition:
+    """One MetricReportDefinition from the corpus."""
+
+    report: str
+    definition_type: str
+    metric_properties: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReportData:
+    """One MetricReport from the corpus."""
+
+    report: str
+    values: tuple[Mapping[str, object], ...]
+
+
+@dataclass(frozen=True)
+class CatalogRow:
+    """One rendered catalog row."""
+
+    metric_name: str
+    context: str
+    unit: str
+    observed_type: str
+    expanded_rows: int
+    exporter_metric: str
+
+
+def _load_json_members(tarball: Path, leaf: str) -> dict[str, Mapping[str, object]]:
+    """Return JSON payloads under ``leaf`` from ``tarball``, keyed by basename."""
+    payloads: dict[str, Mapping[str, object]] = {}
+    with tarfile.open(tarball) as tar:
+        for member in tar.getmembers():
+            if not member.isfile() or not member.name.endswith(".json"):
+                continue
+            if not member.name.startswith(f"{leaf}/"):
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                continue
+            payloads[Path(member.name).name] = json.load(extracted)
+    return payloads
+
+
+def _report_name_from_payload(payload: Mapping[str, object], fallback: str) -> str:
+    """Return the report id/name from a MetricReport or MetricReportDefinition."""
+    for key in ("Id", "Name"):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return fallback
+
+
+def _load_definitions(payloads: Mapping[str, Mapping[str, object]]) -> list[ReportDefinition]:
+    """Load concrete MetricReportDefinition payloads."""
+    prefix = "_redfish_v1_TelemetryService_MetricReportDefinitions_"
+    definitions = []
+    for name, payload in sorted(payloads.items()):
+        if not name.startswith(prefix):
+            continue
+        report = _report_name_from_payload(payload, name.removeprefix(prefix).removesuffix(".json"))
+        metric_properties = tuple(str(item) for item in payload.get("MetricProperties", []) or [])
+        definitions.append(
+            ReportDefinition(
+                report=report,
+                definition_type=str(payload.get("MetricReportDefinitionType") or "unknown"),
+                metric_properties=metric_properties,
+            )
+        )
+    return definitions
+
+
+def _load_reports(payloads: Mapping[str, Mapping[str, object]]) -> dict[str, ReportData]:
+    """Load concrete MetricReport payloads."""
+    prefix = "_redfish_v1_TelemetryService_MetricReports_"
+    reports = {}
+    for name, payload in sorted(payloads.items()):
+        if not name.startswith(prefix):
+            continue
+        report = _report_name_from_payload(payload, name.removeprefix(prefix).removesuffix(".json"))
+        values = []
+        for value in payload.get("MetricValues", []) or []:
+            if isinstance(value, Mapping):
+                values.append(dict(value) | {"Report": report})
+        reports[report] = ReportData(report=report, values=tuple(values))
+    return reports
+
+
+def _value_type(value: object) -> str:
+    """Classify a Redfish MetricValue string for the catalog."""
+    if isinstance(value, bool):
+        return "boolean"
+    text = str(value).strip()
+    if text.lower() in {"true", "false"}:
+        return "boolean"
+    try:
+        float(text)
+    except ValueError:
+        return "string"
+    return "number"
+
+
+def _value_type_summary(values: Iterable[Mapping[str, object]]) -> str:
+    """Return a compact type-count summary."""
+    counts = Counter(_value_type(row.get("MetricValue")) for row in values)
+    if not counts:
+        return "-"
+    order = ("boolean", "number", "string")
+    return ", ".join(f"{name}:{counts[name]}" for name in order if counts[name])
+
+
+def _template_regex(template: str) -> re.Pattern[str]:
+    """Compile a MetricProperty template with ``{Wildcards}`` into a full regex."""
+    pieces = []
+    cursor = 0
+    for match in re.finditer(r"\{[^}]+\}", template):
+        pieces.append(re.escape(template[cursor:match.start()]))
+        pieces.append(r"[^/#]+")
+        cursor = match.end()
+    pieces.append(re.escape(template[cursor:]))
+    return re.compile("^" + "".join(pieces) + "$")
+
+
+def _matching_values(
+    template: str,
+    rows: Iterable[Mapping[str, object]],
+) -> list[Mapping[str, object]]:
+    """Return MetricReport rows whose MetricProperty matches a definition template."""
+    pattern = _template_regex(template)
+    return [
+        row for row in rows
+        if pattern.match(str(row.get("MetricProperty") or ""))
+    ]
+
+
+def _property_parts(metric_property: str) -> tuple[list[str], list[str]]:
+    """Split a MetricProperty into path and fragment parts."""
+    path, _, fragment = metric_property.partition("#")
+    path_parts = [part for part in path.strip("/").split("/") if part]
+    fragment_parts = [part for part in fragment.strip("/").split("/") if part]
+    return path_parts, fragment_parts
+
+
+def _metric_name(metric_property: str) -> str:
+    """Return the display metric name from a MetricProperty template."""
+    path_parts, fragment_parts = _property_parts(metric_property)
+    parts = fragment_parts or path_parts
+    if not parts:
+        return "metric"
+    if parts[-1].isdigit() and len(parts) > 1:
+        return parts[-2]
+    return parts[-1]
+
+
+def _context(metric_property: str) -> str:
+    """Return a compact context for a MetricProperty template."""
+    path_parts, fragment_parts = _property_parts(metric_property)
+    if fragment_parts:
+        context_parts = fragment_parts[:-1]
+        if context_parts and context_parts[-1].isdigit():
+            context_parts = context_parts[:-1]
+        if context_parts:
+            return "/".join(context_parts)
+    if "redfish" in path_parts:
+        path_parts = path_parts[path_parts.index("redfish") + 2:]
+    return "/".join(path_parts[:-1]) or "-"
+
+
+def _unit_hint(metric_name: str) -> str:
+    """Return a human-readable unit hint when Redfish omits a declared unit."""
+    lowered = metric_name.lower()
+    if "gbps" in lowered:
+        return "Gbps"
+    if lowered.endswith("bytes") or lowered.endswith("txbytes") or lowered.endswith("rxbytes"):
+        return "By"
+    if "mhz" in lowered or "freq" in lowered:
+        return "name hint: MHz"
+    if "percent" in lowered:
+        return "name hint: percent"
+    if "temp" in lowered or "temperature" in lowered:
+        return "name hint: temperature"
+    if "power" in lowered:
+        return "name hint: power"
+    if "energy" in lowered:
+        return "name hint: energy"
+    if "voltage" in lowered:
+        return "name hint: voltage"
+    if "count" in lowered or "errors" in lowered:
+        return "name hint: count"
+    return "not declared"
+
+
+def _generic_exporter_name(metric_name: str) -> str:
+    """Return the stable generated-metric display name for a definition row."""
+    if metric_name.startswith("{") and metric_name.endswith("}"):
+        return "`hw.gb300.<resolved_metric_property>`"
+    return f"`{exporter._generic_metric_name(metric_name)}`"
+
+
+def _exporter_metric(
+    values: list[Mapping[str, object]],
+    metric_name: str,
+) -> tuple[str, str]:
+    """Return rendered exporter metric names and units for matched rows."""
+    if not values:
+        return "not observed in fixture", "-"
+    samples = exporter.samples_from_metric_report_rows(values, IDENTITY)
+    metrics = sorted({sample.metric for sample in samples})
+    units = sorted({sample.unit for sample in samples if sample.unit})
+    if not metrics:
+        rendered_metrics = "not exported by exporter"
+    else:
+        rendered = []
+        if any(metric.startswith("hw.gb300.") for metric in metrics):
+            rendered.append(_generic_exporter_name(metric_name))
+        rendered.extend(f"`{metric}`" for metric in metrics if not metric.startswith("hw.gb300."))
+        rendered_metrics = ", ".join(rendered)
+    return rendered_metrics, (", ".join(units) if units else "-")
+
+
+def _catalog_rows(definition: ReportDefinition, report: ReportData | None) -> list[CatalogRow]:
+    """Build rendered catalog rows for one report."""
+    values = report.values if report is not None else ()
+    rows = []
+    for metric_property in definition.metric_properties:
+        matched = _matching_values(metric_property, values)
+        name = _metric_name(metric_property)
+        exporter_metric, exporter_unit = _exporter_metric(matched, name)
+        unit = exporter_unit if exporter_unit != "-" else _unit_hint(name)
+        rows.append(
+            CatalogRow(
+                metric_name=name,
+                context=_context(metric_property),
+                unit=unit,
+                observed_type=_value_type_summary(matched),
+                expanded_rows=len(matched),
+                exporter_metric=exporter_metric,
+            )
+        )
+    return rows
+
+
+def _inventory_row(definition: ReportDefinition, report: ReportData | None) -> str:
+    """Render one report inventory table row."""
+    values = report.values if report is not None else ()
+    return (
+        f"| `{definition.report}` | {definition.definition_type} | "
+        f"{len(definition.metric_properties)} | {len(values)} | "
+        f"{_value_type_summary(values)} |"
+    )
+
+
+def _md_escape(value: str) -> str:
+    """Escape Markdown table syntax in a cell."""
+    return value.replace("|", r"\|").replace("\n", " ")
+
+
+def render_document(
+    definitions: list[ReportDefinition],
+    reports: Mapping[str, ReportData],
+    *,
+    corpus: Path,
+) -> str:
+    """Render the full markdown catalog."""
+    lines = [
+        "# GB300 Telemetry Metrics",
+        "",
+        "Author: Mus <spyroot@gmail.com>",
+        "",
+        "This reference is generated from the Supermicro GB300 fixture files packed in",
+        f"`{corpus.relative_to(REPO_ROOT)}`, the captured Redfish JSON corpus used by",
+        "the offline tests, so this page does not require a live BMC or private endpoint.",
+        "",
+        "Regenerate it with `python tools/generate_telemetry_metrics_doc.py`; use",
+        "`python tools/generate_telemetry_metrics_doc.py --check` in gates to verify",
+        "that the checked-in copy matches the exporter mapper.",
+        "",
+        "## How To Read This",
+        "",
+        "`MetricReports`, the Redfish collection represented by the fixture files named",
+        "`_redfish_v1_TelemetryService_MetricReports*.json`, carries the observed rows.",
+        "`MetricReportDefinitions`, the Redfish collection represented by the fixture",
+        "files named `_redfish_v1_TelemetryService_MetricReportDefinitions*.json`,",
+        "carries the source metric templates.",
+        "",
+        "`MetricValue`, the value field in each Redfish `MetricReport` row, is a string",
+        "in this corpus. The observed type column below is inferred from those fixture",
+        "strings. Units are shown only when the exporter declares one, or as a name",
+        "hint when the Redfish report omits a unit. Treat `name hint` entries as",
+        "operator guidance, not schema-declared units.",
+        "",
+        "`Context` is the parent Redfish fragment or path segment that disambiguates",
+        "repeated source metric names without copying the full fixture path.",
+        "",
+        "`redfish_ctl exporter`, defined in `redfish_ctl/telemetry/cmd_exporter.py`,",
+        "emits the metrics shown in the `Exporter metric` column. Fabric properties use",
+        "curated `hw.fabric.*` names. GPU temperature, processor, throttle, clock, and",
+        "memory rows use curated `hw.gpu.*` names. Bounded categorical rows use",
+        "`hw.component.*`, `hw.fabric.link_down_reason`, or `hw.power.*` state gauges.",
+        "Remaining numeric rows become generated `hw.gb300.*` metric names derived from",
+        "the source metric name.",
+        "",
+        "## Safe Consumption",
+        "",
+        "Start with direct read-only Redfish GET paths before running a long-lived",
+        "exporter process:",
+        "",
+        "```bash",
+        "redfish_ctl metric-definitions",
+        "redfish_ctl metric-reports --report HGX_ProcessorPortMetrics_0",
+        "```",
+        "",
+        "Then run a one-shot Prometheus render from `redfish_ctl exporter`, which reads",
+        "the BMC and prints text instead of opening a listener:",
+        "",
+        "```bash",
+        "redfish_ctl exporter --vendor supermicro --once --output prometheus",
+        "```",
+        "",
+        "For SignalFx, `SPLUNK_ACCESS_TOKEN`, the ingest token read by the exporter",
+        "from the process environment, and `SPLUNK_INGEST_URL`, the full",
+        "`/v2/datapoint` URL read by the exporter, are required only when pushing.",
+        "Use `--once --output signalfx` first to inspect the datapoint envelope",
+        "without posting externally.",
+        "",
+        "## Checking Live Data In Splunk",
+        "",
+        "SignalFx is Splunk Observability Cloud, so the exporter's `signalfx` output pushes",
+        "these metrics straight into Splunk Observability; no extra bridge is required.",
+        "",
+        "1. Push to your org. `SPLUNK_INGEST_URL`, the SignalFx `/v2/datapoint` ingest",
+        "   URL read by the exporter, and `SPLUNK_ACCESS_TOKEN`, the org access token",
+        "   read by the exporter, must come from the environment:",
+        "",
+        "```bash",
+        "export SPLUNK_ACCESS_TOKEN='<org access token>'",
+        "export SPLUNK_INGEST_URL='https://ingest.<realm>.signalfx.com/v2/datapoint'",
+        "redfish_ctl exporter --vendor supermicro --output signalfx --push-signalfx",
+        "```",
+        "",
+        "2. Find the data in Splunk Observability. Under **Metrics -> Metric Finder**,",
+        "   search the metric names this exporter emits: `hw.fabric.*` (NVLink/port",
+        "   link state, BER, RX/TX throughput and errors), `hw.gpu.*` (GPU temperature,",
+        "   processor, clock, throttle, and memory gauges), `hw.component.*` and",
+        "   `hw.power.*` state gauges, `hw.gb300.*` (remaining GB300-specific numeric",
+        "   rows), plus `hw.temperature`, `hw.energy_kwh`, and `hw.leak.state` from",
+        "   the non-MetricReport samplers. Every datapoint carries these dimensions",
+        "   for filtering/grouping: `host.name`, `node`, `server.address`, `bmc.ip`,",
+        "   and `vendor`; report-derived datapoints also carry `report` and any",
+        "   applicable `gpu`, `port`, `sensor`, `memory`, or state label.",
+        "",
+        "3. Confirm points are arriving with a chart or SignalFlow query, for example",
+        "   fabric receive rate per port on one host:",
+        "",
+        "```",
+        "data('hw.fabric.raw_rx_gbps', filter=filter('host.name', '<bmc-host>')).publish()",
+        "```",
+        "",
+        "Datapoints land within a few seconds of the push; when the Metric Finder shows",
+        "the `hw.*` names carrying your `host.name` and `vendor` dimensions, live data",
+        "is flowing.",
+        "",
+        "For **Splunk Enterprise/Cloud (HEC)** rather than Observability: run the Prometheus",
+        "listener (`redfish_ctl exporter --output prometheus`, no `--once`) and point a",
+        "Splunk OpenTelemetry Collector (prometheus receiver -> `splunk_hec` exporter) at",
+        "it, which lands the same metrics in a HEC index.",
+        "",
+        "For a **native OTLP** pipeline, use `redfish_ctl exporter --output otlp` to push",
+        "these same `hw.*` series over OTLP. It honors the standard",
+        "`OTEL_EXPORTER_OTLP_*` environment variables and needs the `redfish_ctl[otlp]`",
+        "extra. See [Telemetry exporter](telemetry-exporter.md#otlp-opentelemetry).",
+        "",
+        "> Live verification of the push needs a real `SPLUNK_ACCESS_TOKEN` and your",
+        "> realm's `SPLUNK_INGEST_URL`; without them, use `--once --output signalfx`",
+        "> to validate the datapoint envelope offline.",
+        "",
+        "## Report Inventory",
+        "",
+        "| Report | Definition type | Definition metrics | Observed rows | Observed value types |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for definition in definitions:
+        lines.append(_inventory_row(definition, reports.get(definition.report)))
+    lines.extend([
+        "",
+        "## Metric Catalog",
+        "",
+        "Rows are grouped by Redfish report. `Expanded rows` is the count of concrete",
+        "fixture `MetricValue` rows matched by the definition template. `0` means the",
+        "definition exists but the current fixture did not include a matching sample.",
+        "",
+    ])
+    for definition in definitions:
+        lines.extend([
+            f"### `{definition.report}`",
+            "",
+            "| Metric name | Context | Unit | Observed value type | Expanded rows | Exporter metric |",
+            "|---|---|---|---:|---:|---|",
+        ])
+        for row in _catalog_rows(definition, reports.get(definition.report)):
+            lines.append(
+                f"| `{_md_escape(row.metric_name)}` | {_md_escape(row.context)} | "
+                f"{_md_escape(row.unit)} | {_md_escape(row.observed_type)} | "
+                f"{row.expanded_rows} | {_md_escape(row.exporter_metric)} |"
+            )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate docs/telemetry-metrics.md from the committed GB300 corpus. "
+            "Audience: both humans and scripted callers."
+        )
+    )
+    parser.add_argument("--corpus", type=Path, default=DEFAULT_CORPUS,
+                        help="GB300 corpus tarball")
+    parser.add_argument("--leaf", default=DEFAULT_LEAF,
+                        help="top-level corpus directory inside the tarball")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT,
+                        help="markdown output path")
+    parser.add_argument("--check", action="store_true",
+                        help="fail if the output path is not already current")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = build_parser().parse_args(argv)
+    payloads = _load_json_members(args.corpus, args.leaf)
+    definitions = _load_definitions(payloads)
+    reports = _load_reports(payloads)
+    rendered = render_document(definitions, reports, corpus=args.corpus)
+
+    if args.check:
+        existing = args.output.read_text(encoding="utf-8") if args.output.exists() else ""
+        if existing != rendered:
+            diff = difflib.unified_diff(
+                existing.splitlines(),
+                rendered.splitlines(),
+                fromfile=str(args.output),
+                tofile="generated telemetry metrics",
+                lineterm="",
+            )
+            print("\n".join(diff), file=sys.stderr)
+            print("BLOCKER: docs/telemetry-metrics.md is stale; regenerate it",
+                  file=sys.stderr)
+            return 1
+        return 0
+
+    args.output.write_text(rendered, encoding="utf-8")
+    print(f"wrote {args.output.relative_to(REPO_ROOT)}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Second convergence round: 7 more approved command PRs (#312 #316 #286 #288 #291 #299 #302) union-merged onto main. #286/#288/#291/#299/#302 had only Brain's refuted false-positive (the discover_redfish_actions double-self non-bug, confirmed against source); #312/#316 were clean.

Union rules kept in .git/info/attributes (never committed), so the LFS .gitattributes is untouched this time. Validated: syntax (redfish_ctl + tests), import, LFS filter intact, mutation-policy gate clean, event-loop audit + action-foundation collect.

Excluded from this round (real conflicts, handle individually): #322 (Makefile), #284 (fixture JSON).