### PR TITLE
Point the gb300 tooling at .internal/inventory/gb300-fleet.env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ clean: ## Remove local build, test, and type-check artifacts.
 
 # ---------------------------------------------------------------------------
 # GB300 remote docker test fleet — ALL gates run there, never on a laptop.
-# Slot/host resolution comes from scripts/gb300.sh + .internal/gb300-fleet.env
+# Slot/host resolution comes from scripts/gb300.sh + .internal/inventory/gb300-fleet.env
 # (gitignored; see TEAM_GUIDE.md "GB300 Docker test environment"). The env
 # file is also included here so a locally defined image name (for example an
 # internal agent image layered on the public base) wins over the default.
@@ -108,7 +108,7 @@ clean: ## Remove local build, test, and type-check artifacts.
 #   AGENT = your agent name; isolates your /work volume and container
 #   REF   = git ref to test (default main); any pushed branch works
 # ---------------------------------------------------------------------------
--include .internal/gb300-fleet.env
+-include .internal/inventory/gb300-fleet.env
 GB300_SH    := ./scripts/gb300.sh
 GB300_HOSTC  = $$($(GB300_SH) host $(SLOT))
 AGENT      ?= $(shell whoami)

--- a/scripts/gb300.sh
+++ b/scripts/gb300.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # Shared resolver for the remote docker test fleet ("GB300" targets in the
 # Makefile). Committed code carries NO internal addresses: the concrete
-# values live in the gitignored .internal/gb300-fleet.env next to this repo
+# values live in the gitignored .internal/inventory/gb300-fleet.env next to this repo
 # (see TEAM_GUIDE.md, "GB300 Docker test environment"), or come from the
 # caller's environment.
 #
-#   .internal/gb300-fleet.env defines:
+#   .internal/inventory/gb300-fleet.env defines:
 #     GB300_USER        ssh login on the nodes
 #     GB300_IP_BASE     first three octets of the node subnet
 #     GB300_SLOT0_OCTET last octet of slot 0 (slot N = SLOT0_OCTET + N)
@@ -23,7 +23,7 @@
 set -euo pipefail
 
 _repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-_env_file="${GB300_ENV_FILE:-$_repo_root/.internal/gb300-fleet.env}"
+_env_file="${GB300_ENV_FILE:-$_repo_root/.internal/inventory/gb300-fleet.env}"
 if [ -f "$_env_file" ]; then
     # The env file supplies DEFAULTS: values already set in the caller's
     # environment (for example `make gb300-test GB300_IMAGE=...`) win over
@@ -45,7 +45,7 @@ fi
 _require() {
     local name="$1"
     if [ -z "${!name:-}" ]; then
-        echo "gb300.sh: $name is not set — create .internal/gb300-fleet.env" \
+        echo "gb300.sh: $name is not set — create .internal/inventory/gb300-fleet.env" \
              "(see TEAM_GUIDE.md, GB300 Docker test environment) or export it" >&2
         exit 2
     fi


### PR DESCRIPTION
The gb300 fleet env file moved into `.internal/inventory/` with the rest of the environment inventory (iLO, local BMC endpoints, gb300). This updates the two committed references — `Makefile` (`-include`) and `scripts/gb300.sh` (default path) — so `make gb300-*` resolves it at the new location. `GB300_ENV_FILE` override still works.