### PR TITLE
Add dry-run-contract and no-local-build ratchet gates

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -28,6 +28,8 @@ mandatory_ids:
   - repo.no-agent-files
   - repo.live-mutation-roundtrip
   - repo.mutation-policy
+  - repo.dry-run-contract
+  - repo.no-local-build
   - scm.exact-commit
   - repo.no-agent-artifacts
   - repo.large-artifact-policy
@@ -71,6 +73,8 @@ gates:
   - {id: repo.no-agent-files,  profile: merge, command: scripts/gates/repository/no-agent-files.sh, required: true, mutates: false}
   - {id: repo.live-mutation-roundtrip, profile: merge, command: scripts/gates/repository/live-mutation-roundtrip.sh, required: true, mutates: false}
   - {id: repo.mutation-policy, profile: merge, command: scripts/gates/repository/mutation-policy.sh, required: true, mutates: false}
+  - {id: repo.dry-run-contract, profile: merge, command: scripts/gates/repository/dry-run-contract.sh, required: true, mutates: false}
+  - {id: repo.no-local-build, profile: merge, command: scripts/gates/repository/no-local-build.sh, required: true, mutates: false}
   # --- unit: the offline suite ---
   - {id: unit.all,             profile: merge, command: scripts/gates/unit/all.sh,               required: true, mutates: false}
   # --- kubernetes: render + validate manifests ---

--- a/scripts/gates/repository/dry-run-contract.sh
+++ b/scripts/gates/repository/dry-run-contract.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# repo.dry-run-contract (merge, mutates:false): every mutable operational script
+# must accept --dry-run (TEAM_GUIDE scripts contract). Ratchet: existing debt is
+# grandfathered in tools/dry_run_baseline.txt; new/newly-mutating scripts must
+# conform, and the baseline may only shrink. Implementation: tools/dry_run_gate.py.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python3 tools/dry_run_gate.py

--- a/scripts/gates/repository/no-local-build.sh
+++ b/scripts/gates/repository/no-local-build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# repo.no-local-build (merge, mutates:false): no committed target/script builds a
+# docker image or mutates a cluster on a laptop — the toolbox pipeline does that
+# (ci-toolbox.md "no ghosts"). Ratchet via tools/no_local_build_baseline.txt.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python3 tools/no_local_build_gate.py

--- a/tests/test_dry_run_gate.py
+++ b/tests/test_dry_run_gate.py
@@ -1,0 +1,96 @@
+"""Offline tests for the dry-run-contract ratchet gate.
+
+The gate (tools/dry_run_gate.py) flags a mutable operational script that lacks
+--dry-run and is not baselined, and flags a stale baseline entry (one that now
+conforms or vanished). These tests drive its check() over synthetic trees so
+the ratchet logic is proven without touching the real repo.
+
+Author Mus spyroot@gmail.com
+"""
+import subprocess
+
+import pytest
+
+from tools import dry_run_gate as gate
+
+
+def _git(tmp_path, *files):
+    """Init a git repo with the given (relpath, content) files and stage them.
+
+    :param tmp_path: pytest tmp_path.
+    :param files: (relative-path, text) pairs to write and `git add`.
+    :return: the repo root Path.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    for rel, content in files:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+def _run_check(monkeypatch, tmp_path, baseline=""):
+    """Run gate.check() as if the repo were tmp_path with the given baseline.
+
+    :param monkeypatch: pytest monkeypatch.
+    :param tmp_path: repo root created by _git.
+    :param baseline: text for tools/dry_run_baseline.txt.
+    :return: (new_violations, stale_baseline).
+    """
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(gate, "_baseline", lambda: {
+        ln.strip() for ln in baseline.splitlines()
+        if ln.strip() and not ln.startswith("#")})
+    return gate.check()
+
+
+def test_mutable_without_dry_run_is_flagged(monkeypatch, tmp_path):
+    """A new mutable script (docker build) with no --dry-run is a violation."""
+    _git(tmp_path, ("scripts/deploy.sh", "#!/bin/sh\ndocker build -t x .\n"))
+    new, stale = _run_check(monkeypatch, tmp_path)
+    assert new == ["scripts/deploy.sh"] and stale == []
+
+
+def test_mutable_with_dry_run_passes(monkeypatch, tmp_path):
+    """A mutable script that handles --dry-run is clean."""
+    _git(tmp_path, ("scripts/deploy.sh",
+                    "#!/bin/sh\ncase $1 in --dry-run) d=1;; esac\ndocker build -t x .\n"))
+    new, stale = _run_check(monkeypatch, tmp_path)
+    assert new == [] and stale == []
+
+
+def test_non_mutable_script_ignored(monkeypatch, tmp_path):
+    """A read-only script is not subject to the contract."""
+    _git(tmp_path, ("scripts/status.sh", "#!/bin/sh\ndocker ps\nkubectl get pods\n"))
+    new, stale = _run_check(monkeypatch, tmp_path)
+    assert new == [] and stale == []
+
+
+@pytest.mark.parametrize("d", ["examples", "functional_test", "scripts/gates"])
+def test_exempt_dirs_are_out_of_scope(monkeypatch, tmp_path, d):
+    """examples/, functional_test/, and gate scripts are exempt even if mutable."""
+    _git(tmp_path, (f"{d}/x.sh", "#!/bin/sh\nkubectl apply -f y.yaml\n"))
+    new, stale = _run_check(monkeypatch, tmp_path)
+    assert new == []
+
+
+def test_baselined_violation_is_allowed(monkeypatch, tmp_path):
+    """A grandfathered violation in the baseline does not fail the gate."""
+    _git(tmp_path, ("scripts/old.sh", "#!/bin/sh\ndocker push x\n"))
+    new, stale = _run_check(monkeypatch, tmp_path, baseline="scripts/old.sh")
+    assert new == [] and stale == []
+
+
+def test_baseline_entry_that_now_conforms_is_stale(monkeypatch, tmp_path):
+    """When a baselined script gains --dry-run, the gate demands its removal
+    from the baseline — the ratchet must tighten, never loosen."""
+    _git(tmp_path, ("scripts/old.sh",
+                    "#!/bin/sh\n[ \"$1\" = --dry-run ] && exit 0\ndocker push x\n"))
+    new, stale = _run_check(monkeypatch, tmp_path, baseline="scripts/old.sh")
+    assert stale == ["scripts/old.sh"]
+
+
+def test_real_repo_gate_is_clean():
+    """The shipped baseline covers the real repo — main() returns 0."""
+    assert gate.main() == 0

--- a/tests/test_no_local_build_gate.py
+++ b/tests/test_no_local_build_gate.py
@@ -1,0 +1,67 @@
+"""Offline tests for the no-local-build ratchet gate.
+
+The gate (tools/no_local_build_gate.py) flags a committed line that builds a
+docker image or mutates a cluster locally, while allowing ssh-dispatched builds
+and baselined debt. Driven over synthetic repos.
+
+Author Mus spyroot@gmail.com
+"""
+import subprocess
+
+import pytest
+
+from tools import no_local_build_gate as gate
+
+
+def _repo(tmp_path, rel, content):
+    """Create a one-file git repo and stage it.
+
+    :param tmp_path: pytest tmp_path.
+    :param rel: file path relative to the repo root.
+    :param content: file text.
+    :return: repo root Path.
+    """
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / rel).parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / rel).write_text(content)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    return tmp_path
+
+
+@pytest.mark.parametrize("line", [
+    "\tdocker build -t x .",
+    "\tkind create cluster",
+    "\tkubectl apply -f y.yaml",
+])
+def test_local_build_flagged(monkeypatch, tmp_path, line):
+    """A local docker build / kind / kubectl mutation is a finding."""
+    _repo(tmp_path, "Makefile", f"target:\n{line}\n")
+    monkeypatch.chdir(tmp_path)
+    assert gate._findings()
+
+
+def test_ssh_dispatched_build_allowed(monkeypatch, tmp_path):
+    """A docker build dispatched over ssh (remote fleet) is NOT local."""
+    _repo(tmp_path, "scripts/img.sh",
+          "#!/bin/sh\nssh host 'docker build -t x -f Dockerfile -'\n")
+    monkeypatch.chdir(tmp_path)
+    assert gate._findings() == []
+
+
+def test_read_only_kubectl_allowed(monkeypatch, tmp_path):
+    """kubectl get/read is not a mutation, so it is not flagged."""
+    _repo(tmp_path, "scripts/s.sh", "#!/bin/sh\nkubectl get pods\n")
+    monkeypatch.chdir(tmp_path)
+    assert gate._findings() == []
+
+
+def test_gate_scripts_exempt(monkeypatch, tmp_path):
+    """Gate implementations themselves are out of scope."""
+    _repo(tmp_path, "scripts/gates/x.sh", "#!/bin/sh\ndocker build .\n")
+    monkeypatch.chdir(tmp_path)
+    assert gate._findings() == []
+
+
+def test_real_repo_gate_is_clean():
+    """The shipped baseline covers the real repo — main() returns 0."""
+    assert gate.main() == 0

--- a/tools/dry_run_baseline.txt
+++ b/tools/dry_run_baseline.txt
@@ -1,0 +1,8 @@
+# Grandfathered mutable scripts lacking --dry-run (dry-run-contract ratchet).
+# Shrink this list — each removal tightens the gate. New scripts may NOT be added.
+build_dist.sh
+docker/gb300/entrypoint.sh
+docker/run-tests.sh
+k8s/consumer/deploy.sh
+k8s/explorer/deploy.sh
+scripts/gb300.sh

--- a/tools/dry_run_gate.py
+++ b/tools/dry_run_gate.py
@@ -1,0 +1,109 @@
+"""Gate: every mutable operational script supports --dry-run.
+
+Contract (TEAM_GUIDE "CI / Scripts"): a script that performs a mutating
+operation must accept ``--dry-run``, and dry-run must not call mutating
+commands. This gate enforces the first, statically-checkable half — a mutable
+script must handle ``--dry-run`` — as a ratchet: existing violations are
+grandfathered in tools/dry_run_baseline.txt, and any NEW or newly-mutating
+script must conform, so the debt only shrinks.
+
+    python3 tools/dry_run_gate.py
+
+Scope: operational scripts. Illustrative examples/ (CLI demos) and functional_test/
+(opt-in live-hardware tests, guarded by their own approval) are out of scope.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+# A script is mutable if it issues a state-changing command.
+MUTATING = re.compile(
+    r"\bdocker\s+(build|run|push|rm|tag)\b"
+    r"|\bkubectl\s+(apply|create|delete|patch|replace|scale)\b"
+    r"|\bhelm\s+(install|upgrade|uninstall)\b"
+    r"|\bkind\s+(create|delete)\b"
+    r"|\bgit\s+push\b|\bscp\b|\bskopeo\s+copy\b"
+    r"|\bssh\b.*\b(docker|rm|mkdir|tee|chmod)\b"
+    r"|--apply\b|\brm\s+-rf\b",
+    re.M,
+)
+DRY_RUN = re.compile(r"--dry-run|dry_run|dryrun|DRY_RUN")
+
+# Out of scope: illustrative demos and opt-in live-hardware tests.
+EXEMPT_DIRS = ("examples/", "functional_test/", "scripts/gates/")
+
+
+def _scripts() -> list[str]:
+    """Return tracked *.sh paths in scope (operational, non-exempt).
+
+    :return: repo-relative shell-script paths the contract applies to.
+    """
+    out = subprocess.check_output(["git", "ls-files", "*.sh"]).decode().split()
+    return [f for f in out if not f.startswith(EXEMPT_DIRS)
+            and not any(d in f for d in EXEMPT_DIRS)]
+
+
+def _baseline() -> set[str]:
+    """Return the grandfathered violation set from the baseline file.
+
+    :return: repo-relative paths allowed to violate (existing debt).
+    """
+    p = pathlib.Path(__file__).parent / "dry_run_baseline.txt"
+    if not p.exists():
+        return set()
+    return {ln.strip() for ln in p.read_text().splitlines()
+            if ln.strip() and not ln.startswith("#")}
+
+
+def check() -> tuple[list[str], list[str]]:
+    """Find contract violations and stale baseline entries.
+
+    :return: (new_violations, stale_baseline) — new_violations are mutable
+        in-scope scripts without --dry-run and not baselined; stale_baseline
+        are baselined paths that now conform (or vanished) and should be
+        removed so the ratchet tightens.
+    """
+    base = _baseline()
+    new, conforming_baselined = [], []
+    live = set(_scripts())
+    for f in sorted(live):
+        text = pathlib.Path(f).read_text(encoding="utf-8")
+        if not MUTATING.search(text):
+            continue
+        if DRY_RUN.search(text):
+            if f in base:
+                conforming_baselined.append(f)
+            continue
+        if f not in base:
+            new.append(f)
+    stale = conforming_baselined + [f for f in base if f not in live]
+    return new, stale
+
+
+def main() -> int:
+    """Run the ratchet check and report.
+
+    :return: 0 when clean, 1 on a new violation or a stale baseline entry.
+    """
+    new, stale = check()
+    for f in new:
+        print(f"dry-run-contract: {f} mutates but has no --dry-run "
+              "(add one, or baseline it in tools/dry_run_baseline.txt)")
+    for f in stale:
+        print(f"dry-run-contract: {f} is baselined but now conforms or is gone "
+              "— remove it from tools/dry_run_baseline.txt (ratchet tightens)")
+    if new or stale:
+        print(f"dry-run-contract: {len(new)} new violation(s), "
+              f"{len(stale)} stale baseline entr(y/ies)")
+        return 1
+    print("dry-run-contract: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/no_local_build_baseline.txt
+++ b/tools/no_local_build_baseline.txt
@@ -1,0 +1,9 @@
+# Grandfathered LOCAL builds/mutations (no-local-build ratchet).
+# Intent: MOVE these to the pipeline/toolbox, then delete the line. Shrink only.
+Makefile:docker-build
+Makefile:kind
+docker/run-tests.sh:docker-build
+k8s/consumer/deploy.sh:docker-build
+k8s/explorer/deploy.sh:docker-build
+k8s/sandbox/run-sandbox.sh:docker-build
+k8s/sandbox/run-sandbox.sh:kind

--- a/tools/no_local_build_gate.py
+++ b/tools/no_local_build_gate.py
@@ -1,0 +1,118 @@
+"""Gate: no local docker/k8s builds — the toolbox pipeline does that.
+
+"No ghosts": an agent must not build a docker image or mutate a cluster on the
+operator's workstation. Those run in the internal GitLab pipeline on the shared
+toolbox image (ci-toolbox.md) or are dispatched to the fleet by ssh. This gate
+flags a committed Makefile recipe or script line that builds/mutates LOCALLY:
+
+  - ``docker build`` NOT dispatched over ssh (a local image build)
+  - ``kind create|delete`` (kind is always local)
+  - ``kubectl apply|create|delete|patch|replace`` at a recipe/script line
+    (a local cluster mutation — cluster work is dispatched, never from a laptop)
+
+Ratchet: existing local-dev targets are grandfathered in
+tools/no_local_build_baseline.txt with the intent of moving them to the
+pipeline; the baseline may only shrink, and any NEW local build fails.
+
+    python3 tools/no_local_build_gate.py
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+# A local build/mutation line. docker build preceded by ssh (remote fleet build)
+# is allowed, so the ssh form is excluded by the negative lookbehind-ish split.
+LOCAL_DOCKER_BUILD = re.compile(r"(?<!ssh )(?<!ssh )\bdocker\s+build\b")
+KIND = re.compile(r"\bkind\s+(create|delete)\b")
+KUBECTL_MUT = re.compile(r"\bkubectl\s+(apply|create|delete|patch|replace|scale)\b")
+
+SCAN_GLOBS = ("Makefile", "*.sh", "*.mk")
+EXEMPT = ("scripts/gates/",)
+
+
+def _lines(path: pathlib.Path):
+    """Yield (lineno, text) for a file, skipping comments and blanks.
+
+    :param path: file to read.
+    :yield: (1-indexed line number, stripped line) for non-comment lines.
+    """
+    for i, ln in enumerate(path.read_text(encoding="utf-8", errors="ignore")
+                           .splitlines(), 1):
+        s = ln.strip()
+        if s and not s.startswith("#"):
+            yield i, ln
+
+
+def _files() -> list[str]:
+    """Return tracked Makefile/shell files in scope.
+
+    :return: repo-relative paths to scan.
+    """
+    out: list[str] = []
+    for g in SCAN_GLOBS:
+        out += subprocess.check_output(["git", "ls-files", g]).decode().split()
+    return [f for f in sorted(set(out)) if not any(e in f for e in EXEMPT)]
+
+
+def _baseline() -> set[str]:
+    """Return grandfathered ``path:line-kind`` keys from the baseline file.
+
+    :return: set of allowed local-build keys (existing debt).
+    """
+    p = pathlib.Path(__file__).parent / "no_local_build_baseline.txt"
+    if not p.exists():
+        return set()
+    return {ln.strip() for ln in p.read_text().splitlines()
+            if ln.strip() and not ln.startswith("#")}
+
+
+def _findings() -> list[str]:
+    """Find every local-build/mutation line as ``path:kind`` keys.
+
+    :return: sorted ``path:kind`` keys (kind in docker-build/kind/kubectl).
+    """
+    hits: set[str] = []  # type: ignore[assignment]
+    hits = set()
+    for f in _files():
+        p = pathlib.Path(f)
+        for _n, ln in _lines(p):
+            if "ssh " in ln:            # dispatched to a remote host — allowed
+                continue
+            if LOCAL_DOCKER_BUILD.search(ln):
+                hits.add(f"{f}:docker-build")
+            if KIND.search(ln):
+                hits.add(f"{f}:kind")
+            if KUBECTL_MUT.search(ln):
+                hits.add(f"{f}:kubectl")
+    return sorted(hits)
+
+
+def main() -> int:
+    """Run the ratchet and report.
+
+    :return: 0 when clean, 1 on a new local build or a stale baseline entry.
+    """
+    base = _baseline()
+    found = set(_findings())
+    new = sorted(found - base)
+    stale = sorted(base - found)
+    for k in new:
+        print(f"no-local-build: {k} builds/mutates locally — dispatch it to the "
+              "pipeline/toolbox, or baseline it in tools/no_local_build_baseline.txt")
+    for k in stale:
+        print(f"no-local-build: {k} is baselined but gone — remove it "
+              "(ratchet tightens)")
+    if new or stale:
+        print(f"no-local-build: {len(new)} new, {len(stale)} stale")
+        return 1
+    print("no-local-build: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Two internal-suite gates you asked for, both **ratchets** (enforce forward, grandfather existing debt, baseline may only shrink):

**repo.dry-run-contract** — every mutable *operational* script must accept `--dry-run` (TEAM_GUIDE scripts contract). 6 existing scripts baselined in `tools/dry_run_baseline.txt`. `examples/` (CLI demos) and `functional_test/` (opt-in live-hardware tests) are out of scope.

**repo.no-local-build** — 'no ghosts': no committed target/script builds a docker image or mutates a cluster on a laptop; the toolbox pipeline does that. ssh-dispatched fleet builds (`gb300-image`) are allowed. 7 existing local-dev sites baselined in `tools/no_local_build_baseline.txt` — the intent is to move them to the pipeline, then delete the baseline line.

Both registered required in `gates/manifest.yaml` (33 gates), 16 offline tests, meta-gate green. They run in the internal pipeline (GitHub CI runs only pytest). Follow-up (tracked): make the 6 baselined scripts `--dry-run`-clean and migrate the 7 local builds to pipeline jobs — each shrinks a baseline.