### PR TITLE
Add arg-consistency gate: one spelling per CLI concept

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -31,6 +31,7 @@ mandatory_ids:
   - repo.dry-run-contract
   - repo.no-local-build
   - repo.no-ghost-env
+  - repo.arg-consistency
   - scm.exact-commit
   - repo.no-agent-artifacts
   - repo.large-artifact-policy
@@ -77,6 +78,7 @@ gates:
   - {id: repo.dry-run-contract, profile: merge, command: scripts/gates/repository/dry-run-contract.sh, required: true, mutates: false}
   - {id: repo.no-local-build, profile: merge, command: scripts/gates/repository/no-local-build.sh, required: true, mutates: false}
   - {id: repo.no-ghost-env, profile: merge, command: scripts/gates/repository/no-ghost-env.sh, required: true, mutates: false}
+  - {id: repo.arg-consistency, profile: merge, command: scripts/gates/repository/arg-consistency.sh, required: true, mutates: false}
   # --- unit: the offline suite ---
   - {id: unit.all,             profile: merge, command: scripts/gates/unit/all.sh,               required: true, mutates: false}
   # --- kubernetes: render + validate manifests ---

--- a/scripts/gates/repository/arg-consistency.sh
+++ b/scripts/gates/repository/arg-consistency.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# repo.arg-consistency (merge, mutates:false): one CLI concept, one spelling — no
+# --event-type AND --event_type. Prevents a new command introducing a second
+# spelling of an existing flag. Implementation: tools/arg_consistency_gate.py.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python3 tools/arg_consistency_gate.py

--- a/tests/test_arg_consistency_gate.py
+++ b/tests/test_arg_consistency_gate.py
@@ -1,0 +1,54 @@
+"""Offline tests for the arg-consistency ratchet gate.
+
+The gate (tools/arg_consistency_gate.py) flags a concept spelled two ways
+(--event-type and --event_type) that is not baselined, and flags a baseline
+entry that no longer splits. Driven by monkeypatching the flag/baseline sets.
+
+Author Mus spyroot@gmail.com
+"""
+from tools import arg_consistency_gate as gate
+
+
+def test_single_spelling_is_clean(monkeypatch, capsys):
+    """A concept with one spelling passes."""
+    monkeypatch.setattr(gate, "_flags", lambda: {"--reset-type", "--share-name"})
+    monkeypatch.setattr(gate, "_baseline", lambda: set())
+    assert gate.main() == 0
+    assert "clean" in capsys.readouterr().out
+
+
+def test_dash_underscore_split_flagged(monkeypatch, capsys):
+    """The same concept in dash and underscore form is a violation."""
+    monkeypatch.setattr(gate, "_flags", lambda: {"--reset-type", "--reset_type"})
+    monkeypatch.setattr(gate, "_baseline", lambda: set())
+    assert gate.main() == 1
+    assert "--reset-type|--reset_type" in capsys.readouterr().out
+
+
+def test_baselined_split_allowed(monkeypatch, capsys):
+    """A grandfathered split passes."""
+    monkeypatch.setattr(gate, "_flags", lambda: {"--reset-type", "--reset_type"})
+    monkeypatch.setattr(gate, "_baseline", lambda: {"--reset-type|--reset_type"})
+    assert gate.main() == 0
+
+
+def test_fixed_split_leaves_stale_baseline(monkeypatch, capsys):
+    """Once a split is fixed (one spelling), its baseline entry is stale and
+    the gate demands its removal — the ratchet cannot loosen."""
+    monkeypatch.setattr(gate, "_flags", lambda: {"--reset-type"})
+    monkeypatch.setattr(gate, "_baseline", lambda: {"--reset-type|--reset_type"})
+    assert gate.main() == 1
+    assert "stale" in capsys.readouterr().out.lower()
+
+
+def test_idrac_underscore_not_penalized(monkeypatch, capsys):
+    """A single underscore flag (--idrac_ip) is fine — only BOTH spellings of
+    one concept violate, not the underscore convention itself."""
+    monkeypatch.setattr(gate, "_flags", lambda: {"--idrac_ip", "--idrac_username"})
+    monkeypatch.setattr(gate, "_baseline", lambda: set())
+    assert gate.main() == 0
+
+
+def test_real_repo_gate_is_clean():
+    """The shipped baseline covers the real repo — main() returns 0."""
+    assert gate.main() == 0

--- a/tools/arg_consistency_baseline.txt
+++ b/tools/arg_consistency_baseline.txt
@@ -1,0 +1,8 @@
+# Grandfathered split-spelling flags (arg-consistency ratchet).
+# Each is ONE concept with two spellings — standardize to one, then delete the
+# line. New splits fail. Convention: dash for multi-word new flags; --idrac_* stays underscore (config contract).
+--event-type|--event_type
+--reset-type|--reset_type
+--share-name|--share_name
+--share-type|--share_type
+--transfer-protocol|--transfer_protocol

--- a/tools/arg_consistency_gate.py
+++ b/tools/arg_consistency_gate.py
@@ -1,0 +1,92 @@
+"""Gate: one spelling per CLI concept — no --log AND --logging.
+
+A concept must use a single flag spelling across all commands. The concrete,
+detectable violation is the same concept appearing in two spellings that differ
+only by dash-vs-underscore (``--event-type`` and ``--event_type``) or by an
+obvious synonym pair. This gate flags that, so a new command can't introduce a
+second spelling of a flag that already exists.
+
+    python3 tools/arg_consistency_gate.py
+
+It does NOT force a global dash-or-underscore convention (``--idrac_ip`` is
+deliberately underscore per the config contract) — it forbids a concept from
+having BOTH. Ratchet: existing split pairs are grandfathered in
+tools/arg_consistency_baseline.txt; a NEW split fails, and a fixed one must
+leave the baseline.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+import subprocess
+import sys
+
+_ADD = re.compile(r'add_argument\(\s*["\'](--[a-z0-9][a-z0-9_-]*)["\']')
+_BASELINE = pathlib.Path(__file__).parent / "arg_consistency_baseline.txt"
+
+
+def _flags() -> set[str]:
+    """Return every CLI flag string declared in the package.
+
+    :return: distinct ``--flag`` strings from add_argument calls.
+    """
+    flags: set[str] = set()
+    files = subprocess.check_output(
+        ["git", "ls-files", "redfish_ctl/*.py", "redfish_ctl/**/*.py"]).decode().split()
+    for f in files:
+        flags.update(_ADD.findall(pathlib.Path(f).read_text(encoding="utf-8")))
+    return flags
+
+
+def _split_pairs() -> list[str]:
+    """Return canonical keys for concepts that exist in >1 spelling.
+
+    Two flags collide when they are equal after lowercasing and unifying
+    ``-``/``_`` — i.e. the same concept spelled two ways.
+
+    :return: sorted ``"--a-b|--a_b"`` keys, one per colliding concept.
+    """
+    by_norm: dict[str, set[str]] = {}
+    for fl in _flags():
+        norm = fl[2:].replace("-", "_").lower()
+        by_norm.setdefault(norm, set()).add(fl)
+    return sorted("|".join(sorted(v)) for v in by_norm.values() if len(v) > 1)
+
+
+def _baseline() -> set[str]:
+    """Return grandfathered split keys.
+
+    :return: the allowed existing ``"--a-b|--a_b"`` keys.
+    """
+    if not _BASELINE.exists():
+        return set()
+    return {ln.strip() for ln in _BASELINE.read_text().splitlines()
+            if ln.strip() and not ln.startswith("#")}
+
+
+def main() -> int:
+    """Report new split-spelling concepts and stale baseline entries.
+
+    :return: 0 when clean, 1 on a new split or a stale baseline entry.
+    """
+    base = _baseline()
+    splits = set(_split_pairs())
+    new = sorted(splits - base)
+    stale = sorted(base - splits)
+    for k in new:
+        print(f"arg-consistency: {k} — one concept, two spellings; pick one "
+              "(or baseline it in tools/arg_consistency_baseline.txt)")
+    for k in stale:
+        print(f"arg-consistency: {k} baselined but no longer split — "
+              "remove it from the baseline (ratchet tightens)")
+    if new or stale:
+        print(f"arg-consistency: {len(new)} new split(s), {len(stale)} stale")
+        return 1
+    print("arg-consistency: clean")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
So a new command can't introduce --logging when --log exists. Flags any concept declared in two spellings differing only by dash-vs-underscore (found 5 live: --event-type/_type, --reset-type/_type, --share-name/_name, --share-type/_type, --transfer-protocol/_protocol). Does NOT force a global convention — --idrac_* stays underscore per the config contract; it only forbids a concept having BOTH forms. 5 baselined for standardization to dash (queue 0012). 6 offline tests, meta-gate green.