### PR TITLE
Normalize SignalFx ingest host to prevent silent datapoint loss (#363)

### DIFF
--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -1015,17 +1015,39 @@ def to_signalfx_body(samples: Iterable[MetricSample]) -> dict[str, list[dict]]:
     }
 
 
+# Splunk Observability ingest host: accepts a datapoint POST and returns 200/"OK"
+# but never records the metric time series. SignalFx datapoint ingest requires the
+# ingest.<realm>.signalfx.com host instead.
+_OBSERVABILITY_INGEST_HOST = re.compile(
+    r"ingest\.([a-z0-9-]+)\.observability\.splunkcloud\.com", re.IGNORECASE)
+
+
+def _normalize_signalfx_ingest_url(ingest_url: str) -> str:
+    """Rewrite a Splunk Observability ingest host to the SignalFx datapoint host.
+
+    ``ingest.<realm>.observability.splunkcloud.com`` is replaced with
+    ``ingest.<realm>.signalfx.com``; the realm, scheme, path, and port are kept.
+    Any other host is returned unchanged.
+
+    :param ingest_url: the ingest URL to normalize.
+    :return: the URL with the observability host rewritten, else unchanged.
+    """
+    return _OBSERVABILITY_INGEST_HOST.sub(r"ingest.\1.signalfx.com", ingest_url or "")
+
+
 def _require_datapoint_url(ingest_url: str) -> str:
     """Return ``ingest_url`` when it is a full SignalFx datapoint endpoint, else raise.
 
     ``push_signalfx`` POSTs the URL as-is (it does not append a path), so a bare
     host such as ``https://ingest.us1.observability.splunkcloud.com`` accepts the
     request context but silently drops every datapoint. Require the full
-    ``…/v2/datapoint`` endpoint so misconfiguration fails loudly instead.
+    ``…/v2/datapoint`` endpoint, and reject the Observability ingest host outright,
+    so misconfiguration fails loudly instead.
 
     :param ingest_url: the SignalFx ingest URL to validate.
     :return: ``ingest_url`` unchanged when it is a full datapoint endpoint.
-    :raises ValueError: if the URL is not a full ``…/v2/datapoint`` endpoint.
+    :raises ValueError: if the URL is not a full ``…/v2/datapoint`` endpoint, or it
+        targets the Observability ingest host that silently drops datapoints.
     """
     if SIGNALFX_DATAPOINT_PATH not in (ingest_url or ""):
         raise ValueError(
@@ -1033,6 +1055,13 @@ def _require_datapoint_url(ingest_url: str) -> str:
             f"{SIGNALFX_DATAPOINT_PATH} (e.g. "
             "https://ingest.us1.signalfx.com/v2/datapoint), not a bare host like "
             f"https://ingest.us1.observability.splunkcloud.com; got {ingest_url!r}"
+        )
+    if _OBSERVABILITY_INGEST_HOST.search(ingest_url):
+        raise ValueError(
+            "SignalFx ingest URL targets the Splunk Observability host "
+            "(ingest.<realm>.observability.splunkcloud.com), which returns 200/OK "
+            "but drops every datapoint; use ingest.<realm>.signalfx.com instead; "
+            f"got {ingest_url!r}"
         )
     return ingest_url
 
@@ -1072,13 +1101,22 @@ def resolve_signalfx_ingest_url(ingest_url: Optional[str] = None) -> str:
     full ``…/v2/datapoint`` endpoint (see ``_require_datapoint_url``).
 
     :param ingest_url: explicit ingest URL; falls back to ``SPLUNK_INGEST_URL``.
-    :return: a validated full ``…/v2/datapoint`` ingest URL.
+    :return: a validated full ``…/v2/datapoint`` ingest URL (Observability host
+        normalized to the SignalFx datapoint host).
     :raises ValueError: if no URL is set or it is not a full datapoint endpoint.
     """
     url = ingest_url or os.environ.get("SPLUNK_INGEST_URL", "")
     if not url:
         raise ValueError("SPLUNK_INGEST_URL is not set")
-    return _require_datapoint_url(url)
+    normalized = _normalize_signalfx_ingest_url(url)
+    if normalized != url:
+        # Never silent: surface the rewrite so a deploy dry-run shows the real target.
+        print(
+            f"note: rewrote SignalFx ingest host to the datapoint host {normalized} "
+            "(the observability.splunkcloud.com host returns OK but drops datapoints)",
+            file=sys.stderr,
+        )
+    return _require_datapoint_url(normalized)
 
 
 def push_signalfx(body: Mapping, token: str, ingest_url: str, timeout: float = 20.0) -> int:

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -22,6 +22,7 @@ from redfish_ctl.telemetry.exporter import (
     resolve_signalfx_token,
     to_signalfx_body,
 )
+from redfish_ctl.telemetry.exporter import _require_datapoint_url
 
 REQUIRED_DIMS = {"host.name", "node", "server.address", "bmc.ip", "vendor"}
 GB300_CORPUS = corpus_dir(
@@ -876,6 +877,29 @@ def test_resolve_signalfx_ingest_url_validates_full_datapoint_endpoint(monkeypat
     monkeypatch.delenv("SPLUNK_INGEST_URL", raising=False)
     with pytest.raises(ValueError, match="SPLUNK_INGEST_URL is not set"):
         resolve_signalfx_ingest_url()
+
+
+def test_resolve_signalfx_normalizes_observability_ingest_host(monkeypatch, capsys):
+    """The Observability ingest host returns 200/OK but drops datapoints, so it is
+    rewritten to the SignalFx datapoint host, preserving realm and path (#363)."""
+    monkeypatch.delenv("SPLUNK_INGEST_URL", raising=False)
+    out = resolve_signalfx_ingest_url(
+        "https://ingest.us1.observability.splunkcloud.com/v2/datapoint")
+    assert out == "https://ingest.us1.signalfx.com/v2/datapoint"
+    # the rewrite is surfaced, not silent, so a deploy dry-run shows the real target
+    assert "rewrote SignalFx ingest host" in capsys.readouterr().err
+    monkeypatch.setenv("SPLUNK_INGEST_URL",
+                       "https://ingest.eu0.observability.splunkcloud.com/v2/datapoint")
+    assert (resolve_signalfx_ingest_url()
+            == "https://ingest.eu0.signalfx.com/v2/datapoint")
+
+
+def test_require_datapoint_url_rejects_observability_host_directly():
+    """The validator rejects the Observability host even with the /v2/datapoint
+    path, so a direct push_signalfx call cannot bypass the normalization (#363)."""
+    with pytest.raises(ValueError, match="Observability"):
+        _require_datapoint_url(
+            "https://ingest.us1.observability.splunkcloud.com/v2/datapoint")
 
 
 def _report_row(source_property, value, report="HGX_HealthMetrics_0"):

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -12,6 +12,7 @@ from redfish_ctl.redfish_manager_base import RedfishManagerBase
 from redfish_ctl.redfish_manager_shared import ApiRequestType
 from redfish_ctl.telemetry.exporter import (
     MetricSample,
+    _require_datapoint_url,
     apply_exporter_env_file,
     build_identity_dimensions,
     build_metric_samples,
@@ -22,7 +23,6 @@ from redfish_ctl.telemetry.exporter import (
     resolve_signalfx_token,
     to_signalfx_body,
 )
-from redfish_ctl.telemetry.exporter import _require_datapoint_url
 
 REQUIRED_DIMS = {"host.name", "node", "server.address", "bmc.ip", "vendor"}
 GB300_CORPUS = corpus_dir(

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -32,8 +32,8 @@ redfish_ctl/redfish_manager.py:273
 redfish_ctl/redfish_manager.py:275
 redfish_ctl/redfish_manager.py:302
 redfish_ctl/redfish_manager_base.py:412
-redfish_ctl/telemetry/exporter.py:1062
-redfish_ctl/telemetry/exporter.py:1078
+redfish_ctl/telemetry/exporter.py:1091
+redfish_ctl/telemetry/exporter.py:1108
 redfish_ctl/telemetry/exporter.py:280
 redfish_ctl/telemetry/exporter.py:385
 redfish_ctl/telemetry/exporter.py:386


### PR DESCRIPTION
Fixes #363. The SignalFx ingest validator accepted `ingest.<realm>.observability.splunkcloud.com` — which returns 200/"OK" but silently drops every datapoint — because it only checked for `/v2/datapoint`, never the host.

**Fix:** `resolve_signalfx_ingest_url` normalizes `ingest.<realm>.observability.splunkcloud.com` → `ingest.<realm>.signalfx.com` (realm/scheme/path/port preserved) and prints the rewrite to stderr so a deploy dry-run shows the real target; `_require_datapoint_url` additionally rejects the Observability host outright, so a direct `push_signalfx` can't bypass the normalization.

Commit 1 is the regression test **alone** (red on current code, per the repair-path rule); commit 2 is the fix (green).