### PR TITLE
Lock DMTF Redfish error and telemetry contracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,4 @@
 *.npy filter=lfs diff=lfs merge=lfs -text
 *.gz filter=lfs diff=lfs merge=lfs -text
 *.zip filter=lfs diff=lfs merge=lfs -text
+spec/dmtf/redfish/2026.1/mockups/DSP2043_2026.1.zip -filter -diff -merge -text

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,8 +20,9 @@ default:
   image: harbor.rnd.embedings.ai:30443/spyroot/builder/toolbox:latest
   tags: [homelab-k8s]
   before_script:
-    # Corpora are Git LFS; without this the suite runs against pointer files.
-    - git lfs install --local && git lfs pull --include='tests/*_corpus.tar.gz'
+    # Corpora and the DMTF spec bundles are Git LFS; without this the suite runs
+    # against pointer files and the bundle/corpus tests fail with BadZipFile/ReadError.
+    - git lfs install --local && git lfs pull --include='tests/*_corpus.tar.gz,full_corpus/*.tar.gz,spec/dmtf/**/*.zip'
     # Bootstrap the project environment from its own declaration. conda env
     # create IS the dependency test: an unresolvable or malformed environment.yml
     # fails here, before any gate runs.

--- a/docs/external/redfish-error-contract.md
+++ b/docs/external/redfish-error-contract.md
@@ -1,0 +1,194 @@
+# Redfish Error Contract
+
+Redfish error handling is a protocol contract, not a local formatting choice.
+`redfish_ctl` must follow the DMTF Redfish protocol and schema model when a
+service returns an error, including for unsupported operations.
+
+## Binding Rule
+
+Every HTTP error response that is a Redfish error must be normalized from the
+service payload and schema/registry evidence. Do not replace it with a
+hand-built string, a vendor-only shortcut, or a generic unsupported marker.
+
+The normalized error keeps:
+
+- HTTP status code.
+- Top-level `error.code` and `error.message`.
+- Every `error.@Message.ExtendedInfo` entry.
+- `MessageId`, `Message`, `MessageArgs`, `MessageSeverity` or `Severity`, and
+  `Resolution` when present.
+- The error/resource schema descriptor when known, including `Schema`,
+  `PublicationUri`, and local BMC `Uri`.
+- The message registry descriptor when known, including `Registry`,
+  `PublicationUri`, and local BMC `Uri`.
+- The original target URI and raw error body when the body cannot be classified.
+
+String rendering is only a human-readable projection of this object. It must
+never be the authoritative data path for JSON, YAML, tests, or downstream
+consumers.
+
+## DMTF Anchors
+
+The contract follows:
+
+- DSP0266, the Redfish protocol specification, which defines the Redfish error
+  response envelope and HTTP status behavior.
+- DSP0268, the Redfish data model specification, which binds Redfish payloads to
+  schemas through `@odata.type` and schema-defined properties.
+- DSP8010, the Redfish schema bundle, which publishes JSON schema artifacts such
+  as `Resource`, `Message`, `RedfishError`, and `redfish-error`.
+- DSP8011, the Redfish registry bundle, which publishes message registries such
+  as `Base`.
+
+The service-local schema descriptor and registry descriptor are part of the
+contract. A descriptor such as `/redfish/v1/JsonSchemas/Resource` or
+`/redfish/v1/JsonSchemas/redfish-error` must keep its DMTF `PublicationUri`,
+local `Uri`, and `Schema` identity.
+
+The pinned local release contract is
+`spec/dmtf/redfish/2026.1/manifest.yaml`. It names every DMTF 2026.1 artifact
+that the implementation, tests, simulator, and automation rules use. Agents and
+contributors must update that manifest and its gate tests when adding a new
+schema bundle, registry bundle, mockup bundle, profile bundle, or simulator
+corpus source.
+
+Agent-readable protocol summaries live next to the manifest:
+
+- `spec/dmtf/redfish/2026.1/reference/http-status-and-error-contract.md`
+  summarizes response-code and error-envelope handling from the DMTF protocol
+  documents.
+- `spec/dmtf/redfish/2026.1/reference/telemetry-contract.md` summarizes the
+  DMTF telemetry resource, registry, mockup, and exporter boundary.
+- `spec/dmtf/redfish/2026.1/reference/output-adapter-plan.md` records the
+  planned kubectl-style output adapter contract for human, JSON, and YAML
+  rendering.
+
+Canonical DMTF publication surfaces include:
+
+| Surface | URL |
+| --- | --- |
+| DSP2043 mockups bundle, Redfish 2026.1 | `https://www.dmtf.org/sites/default/files/standards/documents/DSP2043_2026.1.zip` |
+| DSP8010 schema bundle baseline, Redfish 2025.4 | `https://www.dmtf.org/sites/default/files/standards/documents/DSP8010_2025.4.zip` |
+| DSP8010 schema bundle latest checked baseline, Redfish 2026.1 | `https://www.dmtf.org/sites/default/files/standards/documents/DSP8010_2026.1.zip` |
+| DSP8011 standard registries bundle, Redfish 2026.1 | `https://www.dmtf.org/sites/default/files/standards/documents/DSP8011_2026.1.zip` |
+| Schema index | `https://redfish.dmtf.org/redfish/schema_index` |
+| JSON schema directory | `https://redfish.dmtf.org/schemas/v1/` |
+| CSDL/XML schema example | `https://redfish.dmtf.org/schemas/v1/AccelerationFunction_v1.xml` |
+| JSON schema example | `https://redfish.dmtf.org/schemas/v1/AccelerationFunction.v1_0_5.json` |
+| YAML schema example | `https://redfish.dmtf.org/schemas/v1/AccelerationFunction.yaml` |
+| Standard registries directory | `https://redfish.dmtf.org/registries/` |
+
+DSP8010 is the baseline bundle class for schema validation. A release pin such
+as `DSP8010_2025.4.zip` or `DSP8010_2026.1.zip` defines the reference schema
+set for that Redfish release, but service payloads can still point at older
+schema versions. The implementation must accept the service-observed
+`PublicationUri`/`Schema` version and normalize it against the pinned bundle
+instead of assuming one global latest version.
+
+Implementations must not assume every DMTF pointer is the same file shape. A
+service can expose JSON-schema descriptors, versioned JSON schema files,
+unversioned JSON schema files, CSDL/XML schema files, or registry JSON files.
+The parser keeps the publication URL and local service URL, then normalizes the
+error data without crashing on version or format differences.
+
+The DMTF schema index presents primary schemas by logical schema name and, when
+available, links multiple representations such as `[csdl]`, `[json-schema]`,
+and `[yaml]`. `redfish_ctl` must bind to the logical schema identity and
+preserve the publication URI it observed; it must not assume a single canonical
+extension or a single latest version.
+
+`DSP2043` has a different role from `DSP8010`: it is a public DMTF mockup
+payload bundle for simulator seeding, not a schema authority. The simulator may
+load mockup payloads from `DSP2043`, but protocol validation still binds those
+payloads to schemas and registries through `DSP8010`, `DSP8011`, and the
+service-observed Redfish descriptors.
+
+`DSP8011` is the DMTF registry bundle. It carries the Base registry versions
+observed in current corpora, including Dell iDRAC `Base.1.12.1` and
+GB300/OpenBMC-era `Base.1.18.1`, plus newer Base versions and Telemetry
+registries. It is required local input for offline `MessageId` template
+expansion, registry membership checks, and telemetry message validation.
+
+## Vendor And Version Shape
+
+Vendor/version differences are expected and must be normalized, not flattened.
+
+- Dell iDRAC can expose the error schema as `RedfishError.v1_0_1` and point to
+  DMTF `RedfishError.v1_0_1.json`.
+- GB300/OpenBMC-era systems can expose `redfish-error.v1_0_2` and point to DMTF
+  `redfish-error.v1_0_2.json`.
+- Dell iDRAC can expose unversioned schema descriptor publication links such as
+  `http://redfish.dmtf.org/schemas/v1/Resource.json` and
+  `http://redfish.dmtf.org/schemas/v1/Message.json`.
+- GB300/OpenBMC-era systems can expose versioned descriptor publication links
+  such as `http://redfish.dmtf.org/schemas/v1/Resource.v1_19_0.json` and
+  `http://redfish.dmtf.org/schemas/v1/Message.v1_2_1.json`.
+- Message registries can be DMTF `Base` or vendor/OEM registries. The parser
+  must preserve the registry prefix/version from `MessageId` and registry
+  descriptors when available.
+- `Message` can be missing or `null`; a valid message can still be represented
+  by `MessageId` plus `MessageArgs`.
+
+Known corpus-backed examples:
+
+| Vendor/model class | Descriptor | DMTF publication URL |
+| --- | --- | --- |
+| Dell iDRAC | `Resource` | `http://redfish.dmtf.org/schemas/v1/Resource.json` |
+| Dell iDRAC | `RedfishError.v1_0_1` | `http://redfish.dmtf.org/schemas/v1/RedfishError.v1_0_1.json` |
+| Dell iDRAC | `Message` | `http://redfish.dmtf.org/schemas/v1/Message.json` |
+| Dell iDRAC | `BaseMessages` registry `Base.1.12.1` | `https://redfish.dmtf.org/registries/v1/Base.1.12.1.json` |
+| GB300/OpenBMC-era | `Resource` | `http://redfish.dmtf.org/schemas/v1/Resource.v1_19_0.json` |
+| GB300/OpenBMC-era | `redfish-error` | `http://redfish.dmtf.org/schemas/v1/redfish-error.v1_0_2.json` |
+| GB300/OpenBMC-era | `Message` | `http://redfish.dmtf.org/schemas/v1/Message.v1_2_1.json` |
+| GB300/OpenBMC-era | `Base` registry `Base.1.18.1` | `https://redfish.dmtf.org/registries/Base.1.18.1.json` |
+
+Unknown vendor shapes must fail closed into an unclassified Redfish/raw error
+object that preserves status, target, body, and parse exception. They must not
+pretend to be a supported schema-backed result.
+
+## Unsupported Operations
+
+Unsupported is still protocol data. If a BMC returns `501`, `404`, `405`, `409`,
+or another Redfish error for an unsupported operation, the command may add
+operator hints such as `suggested_command`, but it must preserve the normalized
+Redfish error envelope as the primary machine-readable value.
+
+## JSON And YAML Output
+
+`--json` and `--yaml` output must serialize the same normalized object. YAML is
+not allowed to be a second rendering path that drops `@Message.ExtendedInfo`,
+schema pointers, registry pointers, HTTP status, or target. Output must not leak
+Python private fields or Python object tags.
+
+The planned output adapter is `-o/--output human|json|yaml|name|wide`, with
+`--machine` as a stable automation alias for JSON-only, colorless output.
+Telemetry exporter `--output prometheus|signalfx|otlp` is a backend selector and
+must remain scoped to that subcommand or be renamed during the adapter
+transition.
+
+## Telemetry
+
+Telemetry follows the same Redfish-first rule. `TelemetryService`,
+`MetricDefinition`, `MetricReport`, `MetricReportDefinition`, `TelemetryData`,
+`EventService`, `EventDestination`, metric resource schemas, and Telemetry
+message registries are DMTF surfaces. Local Prometheus, SignalFx, and OTLP
+exporters render normalized Redfish telemetry samples; they do not define the
+protocol contract.
+
+## Gate
+
+`tests/test_redfish_error_contract.py` is the hard gate for this contract. It
+pins:
+
+- The DMTF 2026.1 release manifest under `spec/dmtf/redfish/2026.1/`.
+- The local `DSP8010_2026.1.zip` schema bundle central-directory members.
+- The local `DSP8011_2026.1.zip` registry bundle central-directory members.
+- The local `DSP2043_2026.1.zip` mockup bundle central-directory members.
+- The local telemetry WIP bundle central-directory members.
+- DMTF schema and registry pointers in the Dell and GB300 full corpora.
+- Safe parsing and string rendering of DMTF error shapes.
+- JSON/YAML round-trip preservation of normalized error data.
+- The output adapter plan that keeps human, JSON, and YAML on one normalized
+  object.
+- A static guard against command code that builds HTTP error payloads without
+  using the Redfish error parser.

--- a/spec/.gitignore
+++ b/spec/.gitignore
@@ -1,0 +1,3 @@
+# Local extraction scratch for inspecting public DMTF bundles.
+# Tests use ZIP central directories and do not need duplicate extracted payloads.
+/dmtf/redfish/2026.1/mockups/extracted/

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,30 @@
+# Specification Bundles
+
+This directory stores public DMTF Redfish reference bundles used by tests and
+the simulator. The machine-readable release contract is
+`dmtf/redfish/2026.1/manifest.yaml`.
+
+## Layout
+
+| Path | Role |
+| --- | --- |
+| `dmtf/redfish/2026.1/manifest.yaml` | Release contract that names DMTF artifacts, local bundle policy, and gates. |
+| `dmtf/redfish/2026.1/protocol/` | Redfish protocol specification PDFs such as DSP0266. |
+| `dmtf/redfish/2026.1/data-model/` | Redfish data model specification PDFs such as DSP0268. |
+| `dmtf/redfish/2026.1/schemas/` | DSP8010 schema bundle baseline for JSON schema, CSDL/XML, YAML/OpenAPI, and guide checks. |
+| `dmtf/redfish/2026.1/registries/` | DSP8011 standard registry bundle, including Base and Telemetry message registries. |
+| `dmtf/redfish/2026.1/mockups/` | DSP2043 mockups bundle for simulator seed data. |
+| `dmtf/redfish/2026.1/profiles/` | Redfish interoperability profile specification and bundle. |
+| `dmtf/redfish/2026.1/guides/` | Message registry and other guide PDFs that are not only consumed from DSP8010/DSP8011. |
+| `dmtf/redfish/2026.1/reference/` | Agent-readable summaries of protocol status, error, telemetry, and output contracts. |
+| `dmtf/redfish/wip/` | Public DMTF work-in-progress material used only when the manifest names it. |
+| `dmtf/redfish/extensions/` | Public Redfish extension specifications outside the core release. |
+
+`DSP8010` and PDF/registry/profile/WIP archives follow the repository LFS rules.
+`DSP2043` is intentionally stored as a normal binary Git object because the
+checked-in bundle is small enough and should stay easy to fetch in ordinary
+clones for simulator smoke tests.
+
+Do not add ad-hoc root-level `DSP*.zip` or `DSP*.pdf` copies under this
+directory. Add new public DMTF material under the release, WIP, or extension
+path that matches its source, then update the release manifest and its tests.

--- a/spec/dmtf/redfish/2026.1/data-model/DSP0268_2026.1.pdf
+++ b/spec/dmtf/redfish/2026.1/data-model/DSP0268_2026.1.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44e666d5a1b45a0720bc84594fa1bcc8687ea54bd5e45ecebebce6d885e91971
+size 6526404

--- a/spec/dmtf/redfish/2026.1/guides/DSP2065_2026.1.pdf
+++ b/spec/dmtf/redfish/2026.1/guides/DSP2065_2026.1.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:931603433fc621137581151860cf0e3b68dab425a1c22f297b54dfb06f0759b8
+size 1210408

--- a/spec/dmtf/redfish/2026.1/manifest.yaml
+++ b/spec/dmtf/redfish/2026.1/manifest.yaml
@@ -1,0 +1,288 @@
+apiVersion: redfishctl.dev/v1alpha1
+kind: DmtfRedfishBaseline
+metadata:
+  release: "2026.1"
+  publicationDate: "2026-05-17"
+  source: "https://www.dmtf.org/standards/redfish"
+  schemaIndex: "https://redfish.dmtf.org/redfish/schema_index"
+
+artifacts:
+  - id: DSP0266
+    title: Redfish Specification
+    version: "1.24.0"
+    status: Standard
+    role: protocol
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.24.0.pdf"
+    localPath: "protocol/DSP0266_1.24.0.pdf"
+    gitStorage: git-lfs
+    localRequired: true
+
+  - id: DSP0268
+    title: Redfish Data Model Specification
+    version: "2026.1"
+    status: Standard
+    role: data-model
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP0268_2026.1.pdf"
+    localPath: "data-model/DSP0268_2026.1.pdf"
+    gitStorage: git-lfs
+    carriedBy:
+      path: "schemas/DSP8010_2026.1.zip"
+      members:
+        - "DSP8010_2026.1/DSP0268_2026.1.html"
+        - "DSP8010_2026.1/DSP0268_2026.1.pdf"
+    localRequired: true
+
+  - id: DSP0272
+    title: Redfish Interoperability Profiles Specification
+    version: "1.10.0"
+    status: Standard
+    role: interoperability-profile-spec
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP0272_1.10.0.pdf"
+    localPath: "profiles/DSP0272_1.10.0.pdf"
+    gitStorage: git-lfs
+    localRequired: true
+
+  - id: DSP2043
+    title: Redfish Mockups Bundle
+    version: "2026.1"
+    status: Informational
+    role: simulator-corpus
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP2043_2026.1.zip"
+    localPath: "mockups/DSP2043_2026.1.zip"
+    gitStorage: normal-git
+    localRequired: true
+
+  - id: DSP2046
+    title: Redfish Resource and Schema Guide
+    version: "2026.1"
+    status: Informational
+    role: resource-schema-guide
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP2046_2026.1.pdf"
+    carriedBy:
+      path: "schemas/DSP8010_2026.1.zip"
+      members:
+        - "DSP8010_2026.1/DSP2046_2026.1.html"
+        - "DSP8010_2026.1/DSP2046_2026.1.pdf"
+    localRequired: true
+
+  - id: DSP2053
+    title: Redfish Property Guide
+    version: "2026.1"
+    status: Informational
+    role: property-guide
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP2053_2026.1.pdf"
+    carriedBy:
+      path: "schemas/DSP8010_2026.1.zip"
+      members:
+        - "DSP8010_2026.1/DSP2053_2026.1.html"
+    localRequired: true
+
+  - id: DSP2065
+    title: Redfish Message Registry Guide
+    version: "2026.1"
+    status: Informational
+    role: message-registry-guide
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP2065_2026.1.pdf"
+    localPath: "guides/DSP2065_2026.1.pdf"
+    gitStorage: git-lfs
+    carriedBy:
+      path: "registries/DSP8011_2026.1.zip"
+      members:
+        - "DSP2065_2026.1.html"
+        - "DSP2065_2026.1.pdf"
+    localRequired: true
+
+  - id: DSP8010
+    title: Redfish Schema Bundle
+    version: "2026.1"
+    status: Standard
+    role: schema-bundle
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP8010_2026.1.zip"
+    localPath: "schemas/DSP8010_2026.1.zip"
+    gitStorage: git-lfs
+    localRequired: true
+
+  - id: DSP8011
+    title: Redfish Standard Registries Bundle
+    version: "2026.1"
+    status: Standard
+    role: registry-bundle
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP8011_2026.1.zip"
+    localPath: "registries/DSP8011_2026.1.zip"
+    gitStorage: git-lfs
+    requiredMembers:
+      - "Base.1.12.1.json"
+      - "Base.1.18.1.json"
+      - "Base.1.23.0.json"
+      - "Telemetry.1.0.0.json"
+      - "Telemetry.1.1.0.json"
+      - "Telemetry.1.2.0.json"
+      - "DSP2065_2026.1.html"
+      - "DSP2065_2026.1.pdf"
+    localRequired: true
+
+  - id: DSP8013
+    title: Redfish Interoperability Profiles Bundle
+    version: "2026.1"
+    status: Standard
+    role: interoperability-profile-bundle
+    url: "https://www.dmtf.org/sites/default/files/standards/documents/DSP8013_2026.1.zip"
+    localPath: "profiles/DSP8013_2026.1.zip"
+    gitStorage: git-lfs
+    localRequired: true
+
+supplementalArtifacts:
+  - id: DSP-IS0027-WIP80
+    title: Redfish Telemetry Streaming and Reporting WIP
+    role: telemetry-streaming-wip
+    repoPath: "spec/dmtf/redfish/wip/telemetry-streaming/DSP-IS0027_WIP80.zip"
+    gitStorage: git-lfs
+    requiredMembers:
+      - "metadata/TelemetryFeed_v1.xml"
+      - "metadata/TelemetryService_v1.xml"
+      - "mockups/public-pdu/TelemetryService/index.json"
+      - "mockups/public-pdu/TelemetryService/TelemetryFeeds/index.json"
+      - "Redfish Telemetry Streaming and Reporting WIP v0.8.pdf"
+    localRequired: true
+
+  - id: DSP-IS0026-WIP80
+    title: Redfish ART WIP
+    role: telemetry-adjacent-wip
+    repoPath: "spec/dmtf/redfish/wip/art/DSP-IS0026_WIP80.zip"
+    gitStorage: git-lfs
+    requiredMembers:
+      - "csdl/AutomaticRecoveryTrigger_v1.xml"
+      - "mockups/AutomaticRecoveryTrigger-v1-example.json"
+      - "mockups/AutomaticRecoveryTrigger-v1-SendTicket-request-example.json"
+      - "DSPIS0026_WIP80.pdf"
+      - "DSPIS0026_WIP80.html"
+    localRequired: true
+
+  - id: DSP0271-WIP
+    title: Redfish YANG
+    role: yang-wip
+    repoPath: "spec/dmtf/redfish/wip/yang/DSP0271_0.5.6.pdf"
+    gitStorage: git-lfs
+    localRequired: true
+
+  - id: DSP0288
+    title: Redfish CXL Mapping
+    version: "1.3.0"
+    role: extension-cxl
+    repoPath: "spec/dmtf/redfish/extensions/cxl/1.3.0/DSP0288_1.3.0.pdf"
+    gitStorage: git-lfs
+    localRequired: true
+
+contracts:
+  - id: error-envelope-normalization
+    authority:
+      - DSP0266
+      - DSP0268
+      - DSP8010
+      - DSP8011
+    rule: >
+      Redfish HTTP error responses keep status, error.code, error.message,
+      error.@Message.ExtendedInfo, schema pointers, registry pointers, target,
+      and raw body. Human string rendering is never the authoritative data path.
+    enforcedBy:
+      - "tests/test_redfish_error_contract.py::test_parse_error_preserves_dmtf_error_envelope_fields_and_status"
+      - "tests/test_redfish_error_contract.py::test_http_error_command_results_are_parser_backed"
+      - "tests/test_redfish_error_contract.py::test_dsp8011_registry_members_have_message_templates_and_severity_fields"
+
+  - id: schema-pointer-compatibility
+    authority:
+      - DSP0268
+      - DSP8010
+    rule: >
+      Consumers accept service-observed schema names and versions, including
+      older vendor-exposed forms such as RedfishError.v1_0_1 and newer forms
+      such as redfish-error.v1_0_2.
+    enforcedBy:
+      - "tests/test_redfish_error_contract.py::test_dell_full_corpus_exposes_dmtf_error_schema_and_registry_contract"
+      - "tests/test_redfish_error_contract.py::test_gb300_full_corpus_exposes_dmtf_error_schema_and_registry_contract"
+
+  - id: simulator-corpus-baseline
+    authority:
+      - DSP2043
+      - DSP8010
+    rule: >
+      The Redfish simulator uses public DMTF mockups as one seed corpus and
+      validates payload shape against the pinned schema bundle.
+    enforcedBy:
+      - "tests/test_redfish_error_contract.py::test_dsp2043_2026_1_mockups_bundle_contains_simulator_seed_payloads"
+
+  - id: redfish-telemetry-resource-contract
+    authority:
+      - DSP0268
+      - DSP8010
+      - DSP8011
+      - DSP2043
+      - DSP-IS0027-WIP80
+    rule: >
+      Telemetry code binds Redfish telemetry resources, actions, message
+      registries, and mock payloads to DMTF schemas. OTLP export is a rendering
+      of normalized Redfish telemetry samples, not a replacement protocol.
+    enforcedBy:
+      - "tests/test_redfish_error_contract.py::test_dsp8010_2026_1_schema_bundle_contains_telemetry_artifacts"
+      - "tests/test_redfish_error_contract.py::test_dsp8011_2026_1_registry_bundle_contains_base_and_telemetry_messages"
+      - "tests/test_redfish_error_contract.py::test_dsp8011_registry_members_have_message_templates_and_severity_fields"
+      - "tests/test_redfish_error_contract.py::test_dsp2043_2026_1_mockups_bundle_contains_telemetry_examples"
+      - "tests/test_redfish_error_contract.py::test_telemetry_wip_bundle_contains_streaming_schema_and_mockups"
+      - "tests/test_redfish_error_contract.py::test_art_wip_bundle_contains_automatic_recovery_trigger_schema_and_mockups"
+
+  - id: output-rendering-adapter-contract
+    authority:
+      - error-envelope-normalization
+      - redfish-telemetry-resource-contract
+    rule: >
+      Human, JSON, and YAML output modes render one normalized result object.
+      Machine output preserves DMTF fields and never routes through __str__.
+    enforcedBy:
+      - "tests/test_redfish_error_contract.py::test_normalized_error_contract_round_trips_as_json_and_yaml"
+      - "tests/test_redfish_error_contract.py::test_output_adapter_plan_is_documented"
+
+gates:
+  - id: dmtf-release-manifest
+    command: "scripts/check.sh via GitLab homelab-k8s gate; includes pytest tests/test_redfish_error_contract.py"
+    checks:
+      - "tests/test_redfish_error_contract.py::test_dmtf_2026_1_release_manifest_names_required_contracts"
+      - "tests/test_redfish_error_contract.py::test_dmtf_manifest_enforced_by_entries_resolve_to_defined_tests"
+
+  - id: dmtf-schema-bundle
+    command: "scripts/check.sh via GitLab homelab-k8s gate; includes pytest tests/test_redfish_error_contract.py"
+    checks:
+      - "tests/test_redfish_error_contract.py::test_dsp8010_2026_1_schema_bundle_contains_required_error_artifacts"
+
+  - id: dmtf-mockup-bundle
+    command: "scripts/check.sh via GitLab homelab-k8s gate; includes pytest tests/test_redfish_error_contract.py"
+    checks:
+      - "tests/test_redfish_error_contract.py::test_dsp2043_2026_1_mockups_bundle_contains_simulator_seed_payloads"
+
+  - id: dmtf-registry-bundle
+    command: "scripts/check.sh via GitLab homelab-k8s gate; includes pytest tests/test_redfish_error_contract.py"
+    checks:
+      - "tests/test_redfish_error_contract.py::test_dsp8011_2026_1_registry_bundle_contains_base_and_telemetry_messages"
+      - "tests/test_redfish_error_contract.py::test_dsp8011_registry_members_have_message_templates_and_severity_fields"
+
+  - id: dmtf-telemetry-contract
+    command: "scripts/check.sh via GitLab homelab-k8s gate; includes pytest tests/test_redfish_error_contract.py"
+    checks:
+      - "tests/test_redfish_error_contract.py::test_dsp8010_2026_1_schema_bundle_contains_telemetry_artifacts"
+      - "tests/test_redfish_error_contract.py::test_dsp2043_2026_1_mockups_bundle_contains_telemetry_examples"
+      - "tests/test_redfish_error_contract.py::test_telemetry_wip_bundle_contains_streaming_schema_and_mockups"
+      - "tests/test_redfish_error_contract.py::test_art_wip_bundle_contains_automatic_recovery_trigger_schema_and_mockups"
+
+  - id: output-rendering-contract
+    command: "scripts/check.sh via GitLab homelab-k8s gate; includes pytest tests/test_redfish_error_contract.py"
+    checks:
+      - "tests/test_redfish_error_contract.py::test_output_adapter_plan_is_documented"
+
+automationRules:
+  - Do not invent a Redfish error shape when a DMTF error envelope is present.
+  - Do not flatten error.@Message.ExtendedInfo into a single string for JSON or YAML output.
+  - Do not assume one latest schema version; preserve the service-observed PublicationUri and Schema.
+  - Do not treat DSP8011 registries as optional once offline MessageId expansion or registry membership validation is present.
+  - Do not treat OTLP/export formats as the Redfish telemetry protocol contract; bind telemetry reads to DMTF resources first.
+  - Do not add a new user-visible output mode unless it renders the normalized result object shared by human, JSON, and YAML.
+  - Do not extract bundled ZIP archives in unit tests; inspect central-directory members unless a fixture needs a specific file.
+  - Do not add a new simulator seed corpus without adding it to this manifest and a gate that proves it can be discovered.

--- a/spec/dmtf/redfish/2026.1/profiles/DSP0272_1.10.0.pdf
+++ b/spec/dmtf/redfish/2026.1/profiles/DSP0272_1.10.0.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:326c04fbdf8781f87152970197414b7e31f81a7c532b6a44f8782ee01df01502
+size 270828

--- a/spec/dmtf/redfish/2026.1/profiles/DSP8013_2026.1.zip
+++ b/spec/dmtf/redfish/2026.1/profiles/DSP8013_2026.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c771eac344c92d4687272d66cbb06cdab210aeaa92b0e8a4529f8cb6455dfc44
+size 262481

--- a/spec/dmtf/redfish/2026.1/protocol/DSP0266_1.24.0.pdf
+++ b/spec/dmtf/redfish/2026.1/protocol/DSP0266_1.24.0.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e009d0c74955366da633a313fe2ae4285964b501b1407142ab2c788090f8aafa
+size 1221333

--- a/spec/dmtf/redfish/2026.1/reference/http-status-and-error-contract.md
+++ b/spec/dmtf/redfish/2026.1/reference/http-status-and-error-contract.md
@@ -1,0 +1,101 @@
+# HTTP Status And Error Contract
+
+This file is an agent-readable companion to the public DMTF 2026.1 Redfish
+documents stored beside it. It summarizes the behavior that `redfish_ctl` must
+preserve when it normalizes HTTP responses.
+
+## Source Anchors
+
+| Source | Local path | Contract surface |
+| --- | --- | --- |
+| DSP0266 Redfish Specification 1.24.0 | `../protocol/DSP0266_1.24.0.pdf` | Protocol responses, modification responses, task handling, query errors, and error response envelope. |
+| DSP0268 Redfish Data Model Specification 2026.1 | `../data-model/DSP0268_2026.1.pdf` | `@Message.ExtendedInfo`, `@Redfish.AllowableValues`, schema-bound resource properties. |
+| DSP8010 Redfish Schema Bundle 2026.1 | `../schemas/DSP8010_2026.1.zip` | JSON schema, CSDL/XML, YAML/OpenAPI schema files. |
+| DSP8011 Redfish Standard Registries Bundle 2026.1 | `../registries/DSP8011_2026.1.zip` | Base, Telemetry, Event, Task, and OEM-adjacent message registry shapes. |
+
+## Response Classes
+
+| HTTP status | Redfish handling rule |
+| --- | --- |
+| `200 OK` | Success with a response body, or action success with body-level messages. Preserve any `@Message.ExtendedInfo` present. |
+| `201 Created` | Resource creation succeeded. Preserve representation and `Location` when present. |
+| `202 Accepted` | Operation is asynchronous. Preserve `Location`, task monitor URI, task resource data, and `Retry-After` when present. Do not report final success until task status is read back. |
+| `204 No Content` | Operation succeeded with no response body. Do not fabricate a JSON object beyond the command result envelope. |
+| `304 Not Modified` | Conditional GET reports no representation change. Preserve the cache/ETag context. |
+| `400 Bad Request` | Invalid payload, invalid query value, non-updatable property, or other client request error. Parse the Redfish error body. |
+| `401 Unauthorized` | Authentication failure. Terminal unless a documented credential refresh path exists. Parse the Redfish error body when present. |
+| `403 Forbidden` | Authorization failure. Terminal. Parse the Redfish error body when present. |
+| `404 Not Found` | Missing target resource, deleted task monitor, or absent operation target. Parse the Redfish error body when present. |
+| `405 Method Not Allowed` | Unsupported method on the target resource. Preserve `Allow` header and Redfish error body when present. |
+| `409 Conflict` | State conflict. Preserve the Redfish error body and any resolution message. |
+| `412 Precondition Failed` | Conditional request or ETag precondition failed. Preserve precondition context and Redfish error body. |
+| `415 Unsupported Media Type` | Request media type or payload format not supported. Parse the Redfish error body. |
+| `428 Precondition Required` | Service requires a conditional request. Preserve the required-condition context. |
+| `431 Request Header Fields Too Large` | Header envelope rejected. Preserve status and any Redfish error body. |
+| `500 Internal Server Error` | Service failure. Parse the Redfish error body and preserve registry details. |
+| `501 Not Implemented` | Unsupported operation, feature, or query behavior. This is still structured Redfish data when an error envelope is returned. |
+| `503 Service Unavailable` | Service unavailable or temporarily unable to process the request. Preserve retry and availability hints. |
+
+## Error Envelope
+
+Every Redfish error response with an `error` object is normalized with this
+shape:
+
+```json
+{
+  "status_code": 501,
+  "target": "/redfish/v1/Managers/1/VirtualMedia",
+  "error": {
+    "code": "Base.1.18.GeneralError",
+    "message": "A Redfish service error occurred.",
+    "@Message.ExtendedInfo": [
+      {
+        "MessageId": "Base.1.18.ActionNotSupported",
+        "Message": "The action is not supported.",
+        "MessageArgs": ["VirtualMedia"],
+        "Resolution": "Use a supported operation."
+      }
+    ]
+  }
+}
+```
+
+Rules:
+
+- `error.code` and `MessageId` are not interchangeable; preserve both.
+- `@Message.ExtendedInfo` can be present at the top-level error object or as a
+  property annotation such as `ResetType@Message.ExtendedInfo`.
+- `Message` can be absent or `null`; `MessageId`, `MessageArgs`, severity, and
+  resolution still carry protocol data.
+- If registry expansion is available, use DSP8011 by registry prefix and
+  version. Do not assume one latest Base registry.
+- If the body is not recognized, keep status, target, headers, raw body, and
+  parse exception in an unclassified Redfish error object.
+
+## Operation Rules
+
+Modification operations use the protocol response class:
+
+- create: `201`, `202`, or `204` depending on body and async behavior;
+- update: `200`, `202`, or `204`;
+- action: `200`, `201`, `202`, or `204`;
+- error: client `4xx` or service `5xx` with a Redfish error body when the
+  service can return one.
+
+Query handling is also protocol data:
+
+- invalid query parameter values produce a client error;
+- unsupported Redfish query behavior can produce `400` or `501` depending on
+  the protocol case;
+- command code must preserve the returned `@Message.ExtendedInfo` rather than
+  replacing it with a local unsupported string.
+
+## Agent Rules
+
+- Do not create a hand-built `{"error": "...", "status_code": ...}` result for
+  an HTTP failure. Call the Redfish parser and render its normalized object.
+- Do not route JSON or YAML through `str(exception)`.
+- Do not hide `--insecure` SSL suppression behavior inside output formatting.
+  SSL warning suppression belongs to transport setup and must be tested there.
+- Do not report asynchronous mutation success from the initial `202` alone.
+  Read the task state or return a task-pending result with the monitor URI.

--- a/spec/dmtf/redfish/2026.1/reference/output-adapter-plan.md
+++ b/spec/dmtf/redfish/2026.1/reference/output-adapter-plan.md
@@ -1,0 +1,82 @@
+# Output Adapter Plan
+
+The CLI should expose one kubectl-style output adapter that renders normalized
+command results. It should not maintain separate ad-hoc JSON, YAML, and human
+paths for Redfish errors or telemetry.
+
+## Current Flags
+
+Current global output-related flags include:
+
+| Flag | Current meaning |
+| --- | --- |
+| `--json` | Enable JSON-oriented output. Currently defaults on in parser setup. |
+| `--yaml` | Render output as YAML. |
+| `--json_only` | Suppress extra human text around JSON. |
+| `-d`, `--data_only` | Print only data payload where supported. |
+| `--no-stdout`, `--no_stdout` | Suppress stdout rendering. |
+| `--nocolor` | Disable terminal color. |
+| `-f`, `--filename` | Write output to a file for commands that support it. |
+| `--no_extra` | Suppress extra command metadata where supported. |
+| `--no_action` | Avoid action execution for commands that support planning. |
+
+Telemetry exporter subcommands also have `--output prometheus|signalfx|otlp`.
+That flag selects an exporter backend and should remain subcommand-local.
+
+## Target Adapter
+
+Add a global renderer option:
+
+```text
+-o, --output human|json|yaml|name|wide
+```
+
+Expected modes:
+
+| Mode | Contract |
+| --- | --- |
+| `human` | Operator-friendly text rendered from the normalized result. |
+| `json` | Stable machine-readable JSON for the normalized result. |
+| `yaml` | Stable machine-readable YAML for the same normalized result. |
+| `name` | Stable object identity only, where the command naturally returns named resources. |
+| `wide` | Human table with extra columns where command output is tabular. |
+
+Add convenience aliases:
+
+| Alias | Contract |
+| --- | --- |
+| `--machine` | Equivalent to `--output json --json_only --nocolor`. |
+| `--raw` | Payload passthrough for commands that explicitly support raw Redfish response output. |
+
+Legacy compatibility:
+
+- keep `--json` as an alias for `--output json` during transition;
+- keep `--yaml` as an alias for `--output yaml`;
+- keep `--json_only` as a JSON formatting modifier until callers migrate;
+- reject conflicting renderer flags with a usage error.
+
+## Rendering Rules
+
+- Renderer input is a normalized command result object.
+- JSON and YAML never call `str(exception)`.
+- Human rendering may call safe string helpers, but it cannot be the source of
+  machine data.
+- `@Message.ExtendedInfo`, schema pointers, registry pointers, HTTP status,
+  target URI, and raw body fields survive JSON/YAML output.
+- Log redirection stays separate: logs go to stderr or `--log-file`; machine
+  results go to stdout unless `--no-stdout` is selected.
+- `--insecure` only affects TLS verification and warning behavior. It must not
+  change output shape.
+
+## Gates
+
+The transition needs these tests:
+
+- parser rejects conflicting output flags;
+- `--machine` expands to JSON-only, colorless output;
+- JSON/YAML serialize identical normalized data;
+- human output can include safe strings without losing machine fields;
+- `--no-stdout` suppresses result output but not logging redirection;
+- `--log-file` captures logs without contaminating JSON/YAML stdout;
+- async command routes render non-2xx Redfish errors through the same adapter;
+- exporter backend `--output` remains scoped to telemetry export.

--- a/spec/dmtf/redfish/2026.1/reference/telemetry-contract.md
+++ b/spec/dmtf/redfish/2026.1/reference/telemetry-contract.md
@@ -1,0 +1,83 @@
+# Telemetry Contract
+
+Redfish telemetry in `redfish_ctl` has two layers:
+
+- DMTF Redfish telemetry resources and message registries;
+- local exporters and tracing that render normalized samples to Prometheus,
+  SignalFx, or OTLP.
+
+Export and tracing formats do not replace the Redfish protocol contract.
+
+## Source Anchors
+
+| Source | Local path | Contract surface |
+| --- | --- | --- |
+| DSP0268 Redfish Data Model Specification 2026.1 | `../data-model/DSP0268_2026.1.pdf` | `TelemetryService`, `MetricDefinition`, `MetricReport`, `MetricReportDefinition`, `TelemetryData`, `EventService`, and metric resource schemas. |
+| DSP8010 Redfish Schema Bundle 2026.1 | `../schemas/DSP8010_2026.1.zip` | Telemetry JSON schema, CSDL/XML, and YAML/OpenAPI artifacts. |
+| DSP8011 Redfish Standard Registries Bundle 2026.1 | `../registries/DSP8011_2026.1.zip` | `Telemetry.*` and `Base.*` message registries. |
+| DSP2043 Redfish Mockups Bundle 2026.1 | `../mockups/DSP2043_2026.1.zip` | `public-telemetry` mockup and DSP2046 telemetry examples. |
+| DSP-IS0027 WIP80 | `../../wip/telemetry-streaming/DSP-IS0027_WIP80.zip` | `TelemetryFeed` streaming proposal schemas and mockups. |
+
+## DMTF Resource Surface
+
+The current DMTF baseline names these telemetry-relevant resources:
+
+- `TelemetryService`
+- `MetricDefinition`
+- `MetricReport`
+- `MetricReportDefinition`
+- `TelemetryData`
+- `Triggers`
+- `EventService`
+- `EventDestination`
+- `EnvironmentMetrics`
+- `ThermalMetrics`
+- `PowerSupplyMetrics`
+- `ProcessorMetrics`
+- `MemoryMetrics`
+- `Sensor`
+
+The `TelemetryService` action surface includes:
+
+- `ClearMetricReports`
+- `ClearTelemetryData`
+- `CollectTelemetryData`
+- `ResetMetricReportDefinitionsToDefaults`
+- `ResetTriggersToDefaults`
+- `SubmitTestMetricReport`
+
+## Implementation Alignment
+
+| Surface | Current expectation |
+| --- | --- |
+| Redfish read path | Samples are taken from Redfish resource payloads and keep resource identity, BMC identity, vendor, and metric dimensions. |
+| Metric export path | Prometheus, SignalFx, and OTLP render normalized samples. Exporters must not mutate Redfish payload semantics. |
+| OTLP resource attributes | BMC identity and host identity map to OTLP resource attributes. Per-sample dimensions map to datapoint attributes. |
+| OTLP instruments | Counters and cumulative energy metrics become monotonic sums; other sampled values become gauges. |
+| Tracing | Redfish client spans include method, target host, status code, exception data, and error status for `4xx`/`5xx`. |
+| Async route | Context propagation must survive executor/async request boundaries. |
+| Unsupported telemetry | Unsupported resources or actions return normalized Redfish error objects, not local strings. |
+
+## Required Bundle Checks
+
+The contract gate checks these bundle members by central directory:
+
+- DSP8010 telemetry schemas: `TelemetryService`, `MetricDefinition`,
+  `MetricReport`, `MetricReportDefinition`, `TelemetryData`, and `Sensor`;
+- DSP8011 registries: `Telemetry.1.0.0`, `Telemetry.1.1.0`,
+  `Telemetry.1.2.0`, plus Base registries used by live corpora;
+- DSP2043 examples: `public-telemetry/TelemetryService`, `MetricReports`,
+  `MetricReportDefinitions`, `MetricDefinitions`, `TelemetryData`, and
+  DSP2046 telemetry request/response examples;
+- DSP-IS0027 WIP: `TelemetryFeed_v1.xml`, `TelemetryService_v1.xml`, and
+  public PDU telemetry feed mockups.
+
+## Agent Rules
+
+- Bind telemetry implementation to DMTF resources first, exporter schemas
+  second.
+- Do not add a telemetry metric name without a fixture or schema-backed source
+  path.
+- Do not treat an exporter `--output` backend as the CLI output renderer.
+- Do not mark live telemetry smoke as green without status read-back, cleanup
+  evidence, and the exact candidate commit.

--- a/spec/dmtf/redfish/2026.1/registries/DSP8011_2026.1.zip
+++ b/spec/dmtf/redfish/2026.1/registries/DSP8011_2026.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6749cf0f62cc9f6e20db91c365fe20ad333e1fa0377a4130c987cb10537f3e3d
+size 2585935

--- a/spec/dmtf/redfish/2026.1/schemas/DSP8010_2026.1.zip
+++ b/spec/dmtf/redfish/2026.1/schemas/DSP8010_2026.1.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:15e1dfee82208f36d10fb89569dd19e9fa65b1fb22b0a547b9374e2df76ceada
+size 71663774

--- a/spec/dmtf/redfish/extensions/cxl/1.3.0/DSP0288_1.3.0.pdf
+++ b/spec/dmtf/redfish/extensions/cxl/1.3.0/DSP0288_1.3.0.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9292cc32268e2fb5fc11e03d74a414747fc31c89988908887fe0e78982e39c6c
+size 145102

--- a/spec/dmtf/redfish/wip/art/DSP-IS0026_WIP80.zip
+++ b/spec/dmtf/redfish/wip/art/DSP-IS0026_WIP80.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b993675b5169a6d650fba56221b04688e1dd91ce4c3ff995036f1b9e48e2e8a
+size 657499

--- a/spec/dmtf/redfish/wip/telemetry-streaming/DSP-IS0027_WIP80.zip
+++ b/spec/dmtf/redfish/wip/telemetry-streaming/DSP-IS0027_WIP80.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b486958fb0c58b2862d1daaf15c086762eaaf43a7583257bd712b07303ee2677
+size 1388789

--- a/spec/dmtf/redfish/wip/yang/DSP0271_0.5.6.pdf
+++ b/spec/dmtf/redfish/wip/yang/DSP0271_0.5.6.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce29686a77a95ea9173a3d3f4b126f953bdfd68d8182fee0bbcf6d6d096febb8
+size 1035163

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -6,26 +6,10 @@ dead. These pin the success/raise mapping. No network.
 """
 import pytest
 
-from redfish_ctl.cmd_exceptions import (
-    AuthenticationFailed,
-    ResourceNotFound,
-    UnexpectedResponse,
-)
+from redfish_ctl.cmd_exceptions import ResourceNotFound
 from redfish_ctl.redfish_exceptions import RedfishForbidden, RedfishUnauthorized
 from redfish_ctl.redfish_manager import RedfishManager
-from redfish_ctl.redfish_manager_base import RedfishManagerBase
-from redfish_ctl.redfish_respond_error import RedfishError
 from redfish_ctl.redfish_shared import RedfishApiRespond
-
-_DMTF_ERROR_BODY = {
-    "error": {
-        "code": "Base.1.18.GeneralError",
-        "message": "Standard VirtualMedia is not implemented on this BMC.",
-        "@Message.ExtendedInfo": [
-            {"MessageId": "Base.1.18.ActionNotSupported",
-             "Message": "The action is not supported.", "Severity": "Critical"}],
-    }
-}
 
 
 class _Resp:
@@ -36,27 +20,6 @@ class _Resp:
 
     def json(self):
         return {}
-
-
-class _BodyResp:
-    """Fake response carrying a status code and a JSON error body."""
-
-    def __init__(self, status_code: int, body):
-        self.status_code = status_code
-        self._body = body
-
-    def json(self):
-        return self._body
-
-
-def _base_manager():
-    """Return an offline RedfishManagerBase — the class every command subclasses.
-
-    :return: a RedfishManagerBase instance that makes no BMC contact.
-    """
-    return RedfishManagerBase(
-        idrac_ip="mock", idrac_username="root", idrac_password="x",
-        insecure=True, is_debug=False)
 
 
 @pytest.mark.parametrize(
@@ -89,44 +52,3 @@ def test_error_codes_raise(status_code, exception):
     """4xx/5xx codes raise (the branches the tautology used to skip)."""
     with pytest.raises(exception):
         RedfishManager.default_error_handler(_Resp(status_code))
-
-
-@pytest.mark.parametrize(
-    "status_code, exception",
-    [
-        (401, AuthenticationFailed),
-        (403, RedfishForbidden),
-        (404, ResourceNotFound),
-        (405, UnexpectedResponse),
-        (409, UnexpectedResponse),
-        (500, UnexpectedResponse),
-        (501, UnexpectedResponse),
-        (502, UnexpectedResponse),
-        (503, UnexpectedResponse),
-    ],
-)
-def test_base_handler_preserves_dmtf_envelope(status_code, exception):
-    """RedfishManagerBase.default_error_handler — the override every command uses —
-    raises the parsed RedfishError envelope (status, error.code, @Message.ExtendedInfo)
-    for every error code, not a generic string. Regression: the override previously
-    raised "Failed acquire result. Status code N" for 501/5xx, defeating the Redfish
-    error contract that the parent-only test could not see.
-    """
-    with pytest.raises(exception) as raised:
-        _base_manager().default_error_handler(_BodyResp(status_code, _DMTF_ERROR_BODY))
-    parsed = raised.value.args[0]
-    assert isinstance(parsed, RedfishError)
-    assert parsed.status_code == status_code
-    assert parsed.code == "Base.1.18.GeneralError"
-
-
-@pytest.mark.parametrize(
-    "status_code, expected",
-    [(200, "Ok"), (201, "Created"), (202, "AcceptedTaskGenerated"),
-     (204, "Success"), (206, "Success")],
-)
-def test_base_handler_maps_success_codes(status_code, expected):
-    """The base override maps 2xx codes; an unmapped 2xx returns Success (the
-    line-689 tautology that made this branch meaningless is fixed)."""
-    result = _base_manager().default_error_handler(_BodyResp(status_code, {}))
-    assert result.name == expected

--- a/tests/test_redfish_error_contract.py
+++ b/tests/test_redfish_error_contract.py
@@ -1,0 +1,589 @@
+"""Focused tests for generic DMTF Redfish error handling.
+
+See docs/external/redfish-error-contract.md for the binding protocol contract.
+"""
+
+import argparse
+import ast
+import json
+import tarfile
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from redfish_ctl.cmd_exceptions import (
+    AuthenticationFailed,
+    ResourceNotFound,
+    UnexpectedResponse,
+)
+from redfish_ctl.redfish_exceptions import RedfishForbidden
+from redfish_ctl.redfish_main import json_printer
+from redfish_ctl.redfish_manager import RedfishManager
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_respond_error import RedfishError
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_ROOT = REPO_ROOT / "redfish_ctl"
+CONTRACT_DOC = REPO_ROOT / "docs" / "external" / "redfish-error-contract.md"
+DMTF_2026_1_ROOT = REPO_ROOT / "spec" / "dmtf" / "redfish" / "2026.1"
+DMTF_2026_1_MANIFEST = DMTF_2026_1_ROOT / "manifest.yaml"
+DSP8010_2026_1_SCHEMA_BUNDLE = (
+    DMTF_2026_1_ROOT / "schemas" / "DSP8010_2026.1.zip"
+)
+DSP2043_2026_1_MOCKUPS_BUNDLE = (
+    DMTF_2026_1_ROOT / "mockups" / "DSP2043_2026.1.zip"
+)
+DELL_FULL_CORPUS = REPO_ROOT / "full_corpus" / "dell_xr8620t_full_corpus.tar.gz"
+GB300_FULL_CORPUS = REPO_ROOT / "full_corpus" / "supermicro_gb300_full_corpus.tar.gz"
+
+
+_EXTENDED_INFO = [
+    {
+        "MessageId": "Base.1.18.ResourceMissingAtURI",
+        "Message": "The resource at the URI /redfish/v1/Managers/1/VM1 was not found.",
+        "MessageArgs": ["/redfish/v1/Managers/1/VM1"],
+        "MessageSeverity": "Warning",
+        "Resolution": "Use a supported Redfish or OEM virtual-media endpoint.",
+    }
+]
+
+_DMTF_ERROR_BODY = {
+    "error": {
+        "code": "Base.1.18.GeneralError",
+        "message": "Standard VirtualMedia is not implemented on this BMC.",
+        "@Message.ExtendedInfo": _EXTENDED_INFO,
+    }
+}
+
+
+def _args(**kw):
+    base = dict(no_stdout=False, json_only=True, yaml=False)
+    base.update(kw)
+    return argparse.Namespace(**base)
+
+
+def _corpus_json(tarball, member):
+    with tarfile.open(tarball, "r:gz") as archive:
+        stream = archive.extractfile(member)
+        assert stream is not None, f"{member} missing from {tarball}"
+        return json.loads(stream.read().decode("utf-8"))
+
+
+def _zip_names(bundle):
+    with zipfile.ZipFile(bundle) as archive:
+        return set(archive.namelist())
+
+
+def _assert_location_points_to_dmtf(descriptor, expected_publication_uri, expected_uri):
+    locations = descriptor.get("Location")
+    assert isinstance(locations, list)
+    assert locations
+    location = locations[0]
+    assert location["PublicationUri"] == expected_publication_uri
+    assert location["Uri"] == expected_uri
+
+
+def _assert_redfish_schema_file(
+    descriptor,
+    *,
+    expected_odata_id,
+    expected_schema,
+    expected_publication_uri,
+    expected_uri,
+):
+    assert descriptor["@odata.id"] == expected_odata_id
+    assert descriptor["@odata.type"].startswith("#JsonSchemaFile.")
+    assert descriptor["Schema"] == expected_schema
+    _assert_location_points_to_dmtf(
+        descriptor,
+        expected_publication_uri,
+        expected_uri,
+    )
+
+
+class _Response:
+    """Minimal response double for offline Redfish error parsing."""
+
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.parametrize(
+    ("message_extended", "expected_fragment"),
+    [
+        (
+            [
+                {
+                    "Message": None,
+                    "MessageId": "Base.1.18.ActionNotSupported",
+                    "MessageArgs": ["VirtualMedia"],
+                }
+            ],
+            "ActionNotSupported",
+        ),
+        (
+            [
+                {
+                    "MessageId": "Base.1.18.ActionNotSupported",
+                    "MessageArgs": ["VirtualMedia"],
+                }
+            ],
+            "ActionNotSupported",
+        ),
+        (
+            [
+                SimpleNamespace(
+                    message=None,
+                    message_id="Base.1.18.ActionNotSupported",
+                    message_args=["VirtualMedia"],
+                )
+            ],
+            "ActionNotSupported",
+        ),
+        (
+            [SimpleNamespace(message={"raw": "dict message"}, message_id="", message_args=[])],
+            "dict message",
+        ),
+    ],
+)
+def test_redfish_error_str_never_raises_for_dmtf_extended_info_shapes(
+    message_extended,
+    expected_fragment,
+):
+    """Missing/null Message and raw dict/object ExtendedInfo entries stay printable."""
+    error = RedfishError(501, message=None)
+    error.message_extended = message_extended
+
+    rendered = str(error)
+
+    assert "HTTP 501" in rendered
+    assert expected_fragment in rendered
+
+
+def test_parse_error_preserves_dmtf_error_envelope_fields_and_status():
+    """DMTF error.code/message/ExtendedInfo stay attached to the RedfishError."""
+    parsed = RedfishManager.parse_error(_Response(501, _DMTF_ERROR_BODY))
+
+    assert parsed.status_code == 501
+    assert parsed.code == "Base.1.18.GeneralError"
+    assert parsed.message == "Standard VirtualMedia is not implemented on this BMC."
+    assert parsed.message_extended == _EXTENDED_INFO
+
+
+def test_dell_full_corpus_exposes_dmtf_error_schema_and_registry_contract():
+    """Dell iDRAC publishes DMTF resource/error schema and registry pointers."""
+    resource_schema = _corpus_json(
+        DELL_FULL_CORPUS,
+        "10.252.252.209/_redfish_v1_JsonSchemas_Resource.json",
+    )
+    error_schema = _corpus_json(
+        DELL_FULL_CORPUS,
+        "10.252.252.209/_redfish_v1_JsonSchemas_RedfishError.v1_0_1.json",
+    )
+    message_schema = _corpus_json(
+        DELL_FULL_CORPUS,
+        "10.252.252.209/_redfish_v1_JsonSchemas_Message.json",
+    )
+    base_messages = _corpus_json(
+        DELL_FULL_CORPUS,
+        "10.252.252.209/_redfish_v1_Registries_BaseMessages.json",
+    )
+
+    _assert_redfish_schema_file(
+        resource_schema,
+        expected_odata_id="/redfish/v1/JsonSchemas/Resource",
+        expected_schema="#Resource.Resource",
+        expected_publication_uri="http://redfish.dmtf.org/schemas/v1/Resource.json",
+        expected_uri="/redfish/v1/Schemas/Resource.json",
+    )
+    _assert_redfish_schema_file(
+        error_schema,
+        expected_odata_id="/redfish/v1/JsonSchemas/RedfishError.v1_0_1",
+        expected_schema="#RedfishError.v1_0_1.RedfishError",
+        expected_publication_uri=(
+            "http://redfish.dmtf.org/schemas/v1/RedfishError.v1_0_1.json"
+        ),
+        expected_uri="/redfish/v1/Schemas/RedfishError.v1_0_1.json",
+    )
+    _assert_redfish_schema_file(
+        message_schema,
+        expected_odata_id="/redfish/v1/JsonSchemas/Message",
+        expected_schema="#Message.Message",
+        expected_publication_uri="http://redfish.dmtf.org/schemas/v1/Message.json",
+        expected_uri="/redfish/v1/Schemas/Message.json",
+    )
+    assert base_messages["@odata.id"] == "/redfish/v1/Registries/BaseMessages"
+    assert base_messages["@odata.type"].startswith("#MessageRegistryFile.")
+    assert base_messages["Registry"] == "Base.1.12.1"
+    _assert_location_points_to_dmtf(
+        base_messages,
+        "https://redfish.dmtf.org/registries/v1/Base.1.12.1.json",
+        "/redfish/v1/Registries/BaseMessages/BaseRegistry.json",
+    )
+
+
+def test_gb300_full_corpus_exposes_dmtf_error_schema_and_registry_contract():
+    """GB300 publishes DMTF resource/error schema and registry pointers."""
+    resource_schema = _corpus_json(
+        GB300_FULL_CORPUS,
+        "172.25.230.37/_redfish_v1_JsonSchemas_Resource.json",
+    )
+    error_schema = _corpus_json(
+        GB300_FULL_CORPUS,
+        "172.25.230.37/_redfish_v1_JsonSchemas_redfish-error.json",
+    )
+    message_schema = _corpus_json(
+        GB300_FULL_CORPUS,
+        "172.25.230.37/_redfish_v1_JsonSchemas_Message.json",
+    )
+    base_registry = _corpus_json(
+        GB300_FULL_CORPUS,
+        "172.25.230.37/_redfish_v1_Registries_Base.json",
+    )
+
+    _assert_redfish_schema_file(
+        resource_schema,
+        expected_odata_id="/redfish/v1/JsonSchemas/Resource",
+        expected_schema="#Resource.Resource",
+        expected_publication_uri=(
+            "http://redfish.dmtf.org/schemas/v1/Resource.v1_19_0.json"
+        ),
+        expected_uri="/redfish/v1/JsonSchemas/Resource/Resource.v1_19_0.json",
+    )
+    _assert_redfish_schema_file(
+        error_schema,
+        expected_odata_id="/redfish/v1/JsonSchemas/redfish-error",
+        expected_schema="#redfish-error.redfish-error",
+        expected_publication_uri=(
+            "http://redfish.dmtf.org/schemas/v1/redfish-error.v1_0_2.json"
+        ),
+        expected_uri="/redfish/v1/JsonSchemas/redfish-error/redfish-error.v1_0_2.json",
+    )
+    _assert_redfish_schema_file(
+        message_schema,
+        expected_odata_id="/redfish/v1/JsonSchemas/Message",
+        expected_schema="#Message.Message",
+        expected_publication_uri=(
+            "http://redfish.dmtf.org/schemas/v1/Message.v1_2_1.json"
+        ),
+        expected_uri="/redfish/v1/JsonSchemas/Message/Message.v1_2_1.json",
+    )
+    assert base_registry["@odata.id"] == "/redfish/v1/Registries/Base"
+    assert base_registry["@odata.type"].startswith("#MessageRegistryFile.")
+    assert base_registry["Registry"] == "Base.1.18.1"
+    _assert_location_points_to_dmtf(
+        base_registry,
+        "https://redfish.dmtf.org/registries/Base.1.18.1.json",
+        "/redfish/v1/Registries/Base/Base",
+    )
+
+
+def test_dmtf_2026_1_release_manifest_names_required_contracts():
+    """The local DMTF release manifest binds docs, gates, and automation rules."""
+    manifest = yaml.safe_load(DMTF_2026_1_MANIFEST.read_text(encoding="utf-8"))
+
+    assert manifest["metadata"]["release"] == "2026.1"
+    assert manifest["metadata"]["publicationDate"] == "2026-05-17"
+    artifacts = {artifact["id"]: artifact for artifact in manifest["artifacts"]}
+    expected_artifacts = {
+        "DSP0266",
+        "DSP0268",
+        "DSP0272",
+        "DSP2043",
+        "DSP2046",
+        "DSP2053",
+        "DSP2065",
+        "DSP8010",
+        "DSP8011",
+        "DSP8013",
+    }
+    assert expected_artifacts.issubset(artifacts)
+
+    assert artifacts["DSP8010"]["localPath"] == "schemas/DSP8010_2026.1.zip"
+    assert artifacts["DSP8010"]["gitStorage"] == "git-lfs"
+    assert artifacts["DSP2043"]["localPath"] == "mockups/DSP2043_2026.1.zip"
+    assert artifacts["DSP2043"]["gitStorage"] == "normal-git"
+    assert artifacts["DSP8011"]["localRequiredWhen"]
+
+    contracts = {contract["id"]: contract for contract in manifest["contracts"]}
+    assert {
+        "error-envelope-normalization",
+        "schema-pointer-compatibility",
+        "simulator-corpus-baseline",
+    }.issubset(contracts)
+    assert "DSP8011" in contracts["error-envelope-normalization"]["authority"]
+
+    gates = {gate["id"]: gate for gate in manifest["gates"]}
+    assert {
+        "dmtf-release-manifest",
+        "dmtf-schema-bundle",
+        "dmtf-mockup-bundle",
+    }.issubset(gates)
+    assert any(
+        "Do not invent a Redfish error shape" in rule
+        for rule in manifest["automationRules"]
+    )
+
+    for artifact in artifacts.values():
+        local_path = artifact.get("localPath")
+        if artifact.get("localRequired"):
+            assert local_path
+            assert (DMTF_2026_1_ROOT / local_path).exists()
+
+
+def test_dsp8010_2026_1_schema_bundle_contains_required_error_artifacts():
+    """The pinned DSP8010 bundle carries schema files needed by the contract."""
+    names = _zip_names(DSP8010_2026_1_SCHEMA_BUNDLE)
+    expected_members = {
+        "DSP8010_2026.1/info.json",
+        "DSP8010_2026.1/DSP0268_2026.1.html",
+        "DSP8010_2026.1/DSP2046_2026.1.html",
+        "DSP8010_2026.1/DSP2053_2026.1.html",
+        "DSP8010_2026.1/DSP8010_2026.1.html",
+        "DSP8010_2026.1/json-schema/Resource.json",
+        "DSP8010_2026.1/json-schema/Resource.v1_19_0.json",
+        "DSP8010_2026.1/json-schema/Message.json",
+        "DSP8010_2026.1/json-schema/Message.v1_2_1.json",
+        "DSP8010_2026.1/json-schema/redfish-error.v1_0_2.json",
+        "DSP8010_2026.1/csdl/RedfishError_v1.xml",
+        "DSP8010_2026.1/csdl/AccelerationFunction_v1.xml",
+        "DSP8010_2026.1/openapi/AccelerationFunction.yaml",
+    }
+    assert expected_members.issubset(names)
+
+    with zipfile.ZipFile(DSP8010_2026_1_SCHEMA_BUNDLE) as archive:
+        info = json.loads(archive.read("DSP8010_2026.1/info.json"))
+    assert info == {"version": "2026.1", "date": "2026-04-02"}
+
+
+def test_dsp2043_2026_1_mockups_bundle_contains_simulator_seed_payloads():
+    """The pinned DSP2043 bundle carries DMTF mockups for simulator seeding."""
+    names = _zip_names(DSP2043_2026_1_MOCKUPS_BUNDLE)
+    expected_members = {
+        "DSP2043_2026.1/public-rackmount1/index.json",
+        "DSP2043_2026.1/public-rackmount1/Systems/index.json",
+        "DSP2043_2026.1/public-rackmount1/Managers/index.json",
+        "DSP2043_2026.1/public-applications/Systems/VM1/index.json",
+        "DSP2043_2026.1/public-applications/Managers/BMC/index.json",
+        "DSP2043_2026.1/public-applications/AccountService/index.json",
+        "DSP2043_2026.1/public-bladed/Chassis/index.json",
+        "DSP2043_2026.1/DSP2046-examples/ServiceRoot-v1-example.json",
+    }
+    assert expected_members.issubset(names)
+
+
+def test_contract_doc_names_dmtf_publication_surfaces():
+    """The written contract stays bound to DMTF schema and registry surfaces."""
+    text = CONTRACT_DOC.read_text(encoding="utf-8")
+
+    assert "DSP8010_2025.4.zip" in text
+    assert "DSP8010_2026.1.zip" in text
+    assert "DSP2043_2026.1.zip" in text
+    assert "DSP8011_2026.1.zip" in text
+    assert "https://redfish.dmtf.org/redfish/schema_index" in text
+    assert "https://redfish.dmtf.org/schemas/v1/" in text
+    assert "https://redfish.dmtf.org/schemas/v1/AccelerationFunction_v1.xml" in text
+    assert "https://redfish.dmtf.org/schemas/v1/AccelerationFunction.v1_0_5.json" in text
+    assert "https://redfish.dmtf.org/schemas/v1/AccelerationFunction.yaml" in text
+    assert "https://redfish.dmtf.org/registries/" in text
+
+
+def test_default_error_handler_raises_resource_not_found_with_parsed_dmtf_error():
+    """Default non-2xx handling surfaces the parsed RedfishError, not a generic string."""
+    with pytest.raises(ResourceNotFound) as raised:
+        RedfishManager.default_error_handler(_Response(501, _DMTF_ERROR_BODY))
+
+    parsed = raised.value.args[0]
+    assert isinstance(parsed, RedfishError)
+    assert parsed.status_code == 501
+    assert parsed.code == "Base.1.18.GeneralError"
+    assert parsed.message == "Standard VirtualMedia is not implemented on this BMC."
+    assert parsed.message_extended == _EXTENDED_INFO
+
+
+def _base_manager():
+    """Return a RedfishManagerBase instance — the class every command subclasses.
+
+    :return: an offline RedfishManagerBase (no BMC contact).
+    """
+    return RedfishManagerBase(
+        idrac_ip="mock", idrac_username="root", idrac_password="x",
+        insecure=True, is_debug=False)
+
+
+@pytest.mark.parametrize(
+    ("status_code", "exc_type"),
+    [
+        (401, AuthenticationFailed),
+        (403, RedfishForbidden),
+        (404, ResourceNotFound),
+        (405, UnexpectedResponse),
+        (409, UnexpectedResponse),
+        (500, UnexpectedResponse),
+        (501, UnexpectedResponse),
+        (502, UnexpectedResponse),
+        (503, UnexpectedResponse),
+    ],
+)
+def test_base_default_error_handler_preserves_dmtf_envelope(status_code, exc_type):
+    """Every command subclasses RedfishManagerBase, so ITS default_error_handler —
+    not the parent RedfishManager's — is the real command error path. For every
+    error code it must raise the parsed RedfishError envelope (status, error.code,
+    every @Message.ExtendedInfo), never a generic string, per the Redfish error
+    contract. Regression: the base override previously raised the generic
+    "Failed acquire result. Status code N" for 501/5xx, defeating the contract that
+    the parent-only test could not see.
+    """
+    manager = _base_manager()
+    with pytest.raises(exc_type) as raised:
+        manager.default_error_handler(_Response(status_code, _DMTF_ERROR_BODY))
+    parsed = raised.value.args[0]
+    assert isinstance(parsed, RedfishError)
+    assert parsed.status_code == status_code
+    assert parsed.code == "Base.1.18.GeneralError"
+    assert parsed.message_extended == _EXTENDED_INFO
+
+
+@pytest.mark.parametrize(
+    ("status_code", "expected"),
+    [(200, "Ok"), (201, "Created"), (202, "AcceptedTaskGenerated"), (204, "Success")],
+)
+def test_base_default_error_handler_maps_success_codes(status_code, expected):
+    """A 2xx code returns its mapped RedfishApiRespond — the line-689 tautology
+    (status_code >= 200 or < 300, always true) that made this branch meaningless
+    is fixed, so success codes resolve instead of falling through."""
+    manager = _base_manager()
+    result = manager.default_error_handler(_Response(status_code, {}))
+    assert result.name == expected
+
+
+def test_normalized_error_contract_round_trips_as_json_and_yaml(capsys):
+    """JSON and YAML output preserve the same structured DMTF error payload."""
+    parsed = RedfishManager.parse_error(_Response(501, _DMTF_ERROR_BODY))
+    schema = _corpus_json(
+        GB300_FULL_CORPUS,
+        "172.25.230.37/_redfish_v1_JsonSchemas_redfish-error.json",
+    )
+    registry = _corpus_json(
+        GB300_FULL_CORPUS,
+        "172.25.230.37/_redfish_v1_Registries_Base.json",
+    )
+    normalized = {
+        "status_code": parsed.status_code,
+        "schema": {
+            "@odata.id": schema["@odata.id"],
+            "@odata.type": schema["@odata.type"],
+            "Schema": schema["Schema"],
+            "PublicationUri": schema["Location"][0]["PublicationUri"],
+            "Uri": schema["Location"][0]["Uri"],
+        },
+        "registry": {
+            "@odata.id": registry["@odata.id"],
+            "Registry": registry["Registry"],
+            "PublicationUri": registry["Location"][0]["PublicationUri"],
+            "Uri": registry["Location"][0]["Uri"],
+        },
+        "error": {
+            "code": parsed.code,
+            "message": parsed.message,
+            "@Message.ExtendedInfo": parsed.message_extended,
+        },
+    }
+
+    json_printer(normalized, _args(yaml=False), colorized=False)
+    json_out = capsys.readouterr().out
+    assert json.loads(json_out) == normalized
+
+    json_printer(normalized, _args(yaml=True), colorized=False)
+    yaml_out = capsys.readouterr().out
+    assert yaml.safe_load(yaml_out) == normalized
+    assert "!!python" not in yaml_out
+    assert "RedfishError" not in json_out
+    assert "_message_extended" not in json_out
+
+
+def _call_name(node):
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return ""
+
+
+def _dict_string_keys(node):
+    if not isinstance(node, ast.Dict):
+        return set()
+    return {
+        key.value
+        for key in node.keys
+        if isinstance(key, ast.Constant) and isinstance(key.value, str)
+    }
+
+
+def _uses_response_status_code(node):
+    return any(
+        isinstance(candidate, ast.Attribute) and candidate.attr == "status_code"
+        for candidate in ast.walk(node)
+    )
+
+
+def _calls_redfish_error_parser(node):
+    parser_names = {"parse_error", "_error_text", "default_error_handler"}
+    return any(
+        isinstance(candidate, ast.Call) and _call_name(candidate.func) in parser_names
+        for candidate in ast.walk(node)
+    )
+
+
+def _is_handbuilt_error_command_result(node):
+    if not isinstance(node, ast.Return):
+        return False
+    call = node.value
+    if not isinstance(call, ast.Call):
+        return False
+    if _call_name(call.func) != "CommandResult":
+        return False
+    if not call.args:
+        return False
+    return {"error", "status_code"}.issubset(_dict_string_keys(call.args[0]))
+
+
+def test_http_error_command_results_are_parser_backed():
+    """Command HTTP errors must not bypass DMTF Redfish normalization."""
+    offenders = []
+    parser_modules = {
+        "redfish_manager.py",
+        "redfish_manager_base.py",
+        "redfish_respond.py",
+        "redfish_respond_error.py",
+    }
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        if path.name in parser_modules:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if not _uses_response_status_code(node):
+                continue
+            if _calls_redfish_error_parser(node):
+                continue
+            for child in ast.walk(node):
+                if _is_handbuilt_error_command_result(child):
+                    offenders.append(
+                        f"{path.relative_to(REPO_ROOT)}:{child.lineno} {node.name}"
+                    )
+
+    assert not offenders, (
+        "HTTP error CommandResult payloads must be built from parse_error, "
+        "_error_text, or default_error_handler so code/message/"
+        "@Message.ExtendedInfo/schema data is not flattened:\n"
+        + "\n".join(offenders)
+    )

--- a/tests/test_redfish_error_contract.py
+++ b/tests/test_redfish_error_contract.py
@@ -372,8 +372,16 @@ def test_dmtf_2026_1_release_manifest_names_required_contracts():
     assert any("output mode" in rule for rule in manifest["automationRules"])
 
     for artifact in artifacts.values():
-        local_path = artifact.get("localPath")
-        if artifact.get("localRequired"):
+        if not artifact.get("localRequired"):
+            continue
+        carried = artifact.get("carriedBy")
+        if carried:
+            # No standalone file: the artifact rides inside a carrier bundle
+            # (e.g. DSP2046/DSP2053 are members of the DSP8010 zip), so the
+            # carrier's presence is what "locally required" means here.
+            assert (DMTF_2026_1_ROOT / carried["path"]).exists()
+        else:
+            local_path = artifact.get("localPath")
             assert local_path
             assert (DMTF_2026_1_ROOT / local_path).exists()
 

--- a/tests/test_redfish_error_contract.py
+++ b/tests/test_redfish_error_contract.py
@@ -30,11 +30,27 @@ PACKAGE_ROOT = REPO_ROOT / "redfish_ctl"
 CONTRACT_DOC = REPO_ROOT / "docs" / "external" / "redfish-error-contract.md"
 DMTF_2026_1_ROOT = REPO_ROOT / "spec" / "dmtf" / "redfish" / "2026.1"
 DMTF_2026_1_MANIFEST = DMTF_2026_1_ROOT / "manifest.yaml"
+HTTP_STATUS_CONTRACT = DMTF_2026_1_ROOT / "reference" / (
+    "http-status-and-error-contract.md"
+)
+TELEMETRY_CONTRACT = DMTF_2026_1_ROOT / "reference" / "telemetry-contract.md"
+OUTPUT_ADAPTER_PLAN = DMTF_2026_1_ROOT / "reference" / "output-adapter-plan.md"
 DSP8010_2026_1_SCHEMA_BUNDLE = (
     DMTF_2026_1_ROOT / "schemas" / "DSP8010_2026.1.zip"
 )
+DSP8011_2026_1_REGISTRY_BUNDLE = (
+    DMTF_2026_1_ROOT / "registries" / "DSP8011_2026.1.zip"
+)
 DSP2043_2026_1_MOCKUPS_BUNDLE = (
     DMTF_2026_1_ROOT / "mockups" / "DSP2043_2026.1.zip"
+)
+TELEMETRY_WIP_BUNDLE = (
+    REPO_ROOT / "spec" / "dmtf" / "redfish" / "wip" / "telemetry-streaming" /
+    "DSP-IS0027_WIP80.zip"
+)
+ART_WIP_BUNDLE = (
+    REPO_ROOT / "spec" / "dmtf" / "redfish" / "wip" / "art" /
+    "DSP-IS0026_WIP80.zip"
 )
 DELL_FULL_CORPUS = REPO_ROOT / "full_corpus" / "dell_xr8620t_full_corpus.tar.gz"
 GB300_FULL_CORPUS = REPO_ROOT / "full_corpus" / "supermicro_gb300_full_corpus.tar.gz"
@@ -75,6 +91,19 @@ def _corpus_json(tarball, member):
 def _zip_names(bundle):
     with zipfile.ZipFile(bundle) as archive:
         return set(archive.namelist())
+
+
+def _repo_path(path):
+    return REPO_ROOT / path
+
+
+def _defined_test_names():
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    return {
+        node.name
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name.startswith("test_")
+    }
 
 
 def _assert_location_points_to_dmtf(descriptor, expected_publication_uri, expected_uri):
@@ -310,13 +339,19 @@ def test_dmtf_2026_1_release_manifest_names_required_contracts():
     assert artifacts["DSP8010"]["gitStorage"] == "git-lfs"
     assert artifacts["DSP2043"]["localPath"] == "mockups/DSP2043_2026.1.zip"
     assert artifacts["DSP2043"]["gitStorage"] == "normal-git"
-    assert artifacts["DSP8011"]["localRequiredWhen"]
+    assert artifacts["DSP8011"]["localPath"] == "registries/DSP8011_2026.1.zip"
+    assert artifacts["DSP8011"]["gitStorage"] == "git-lfs"
+    assert {"Base.1.12.1.json", "Base.1.18.1.json", "Telemetry.1.2.0.json"}.issubset(
+        set(artifacts["DSP8011"]["requiredMembers"])
+    )
 
     contracts = {contract["id"]: contract for contract in manifest["contracts"]}
     assert {
         "error-envelope-normalization",
         "schema-pointer-compatibility",
         "simulator-corpus-baseline",
+        "redfish-telemetry-resource-contract",
+        "output-rendering-adapter-contract",
     }.issubset(contracts)
     assert "DSP8011" in contracts["error-envelope-normalization"]["authority"]
 
@@ -325,17 +360,58 @@ def test_dmtf_2026_1_release_manifest_names_required_contracts():
         "dmtf-release-manifest",
         "dmtf-schema-bundle",
         "dmtf-mockup-bundle",
+        "dmtf-registry-bundle",
+        "dmtf-telemetry-contract",
+        "output-rendering-contract",
     }.issubset(gates)
     assert any(
         "Do not invent a Redfish error shape" in rule
         for rule in manifest["automationRules"]
     )
+    assert any("DSP8011 registries" in rule for rule in manifest["automationRules"])
+    assert any("output mode" in rule for rule in manifest["automationRules"])
 
     for artifact in artifacts.values():
         local_path = artifact.get("localPath")
         if artifact.get("localRequired"):
             assert local_path
             assert (DMTF_2026_1_ROOT / local_path).exists()
+
+    supplemental = {
+        artifact["id"]: artifact
+        for artifact in manifest.get("supplementalArtifacts", [])
+    }
+    assert {
+        "DSP-IS0027-WIP80",
+        "DSP-IS0026-WIP80",
+        "DSP0271-WIP",
+        "DSP0288",
+    }.issubset(supplemental)
+    assert supplemental["DSP-IS0027-WIP80"]["requiredMembers"]
+
+    for artifact in supplemental.values():
+        if artifact.get("localRequired"):
+            assert _repo_path(artifact["repoPath"]).exists()
+
+
+def test_dmtf_manifest_enforced_by_entries_resolve_to_defined_tests():
+    """Every manifest-enforced test reference must exist in this test module."""
+    manifest = yaml.safe_load(DMTF_2026_1_MANIFEST.read_text(encoding="utf-8"))
+    known_tests = _defined_test_names()
+    references = []
+
+    for contract in manifest["contracts"]:
+        references.extend(contract.get("enforcedBy", []))
+    for gate in manifest["gates"]:
+        references.extend(gate.get("checks", []))
+
+    assert references
+    missing = []
+    for reference in references:
+        module, _, test_name = reference.partition("::")
+        if module != "tests/test_redfish_error_contract.py" or test_name not in known_tests:
+            missing.append(reference)
+    assert not missing
 
 
 def test_dsp8010_2026_1_schema_bundle_contains_required_error_artifacts():
@@ -363,6 +439,85 @@ def test_dsp8010_2026_1_schema_bundle_contains_required_error_artifacts():
     assert info == {"version": "2026.1", "date": "2026-04-02"}
 
 
+def test_dsp8010_2026_1_schema_bundle_contains_telemetry_artifacts():
+    """DMTF telemetry schema files are local input for exporter and span tests."""
+    names = _zip_names(DSP8010_2026_1_SCHEMA_BUNDLE)
+    expected_members = {
+        "DSP8010_2026.1/json-schema/TelemetryService.json",
+        "DSP8010_2026.1/json-schema/TelemetryService.v1_4_1.json",
+        "DSP8010_2026.1/json-schema/MetricDefinition.json",
+        "DSP8010_2026.1/json-schema/MetricDefinition.v1_3_6.json",
+        "DSP8010_2026.1/json-schema/MetricReport.json",
+        "DSP8010_2026.1/json-schema/MetricReport.v1_5_2.json",
+        "DSP8010_2026.1/json-schema/MetricReportDefinition.json",
+        "DSP8010_2026.1/json-schema/MetricReportDefinition.v1_4_7.json",
+        "DSP8010_2026.1/json-schema/TelemetryData.json",
+        "DSP8010_2026.1/json-schema/TelemetryData.v1_0_0.json",
+        "DSP8010_2026.1/json-schema/EventService.json",
+        "DSP8010_2026.1/json-schema/EventDestination.json",
+        "DSP8010_2026.1/json-schema/Sensor.json",
+        "DSP8010_2026.1/json-schema/EnvironmentMetrics.json",
+        "DSP8010_2026.1/json-schema/ThermalMetrics.json",
+        "DSP8010_2026.1/json-schema/ProcessorMetrics.json",
+        "DSP8010_2026.1/json-schema/MemoryMetrics.json",
+        "DSP8010_2026.1/csdl/TelemetryService_v1.xml",
+        "DSP8010_2026.1/openapi/TelemetryService.v1_4_1.yaml",
+    }
+    assert expected_members.issubset(names)
+
+
+def test_dsp8011_2026_1_registry_bundle_contains_base_and_telemetry_messages():
+    """The pinned DSP8011 bundle carries live-corpus Base versions and telemetry."""
+    names = _zip_names(DSP8011_2026_1_REGISTRY_BUNDLE)
+    expected_members = {
+        "Base.1.12.1.json",
+        "Base.1.18.1.json",
+        "Base.1.23.0.json",
+        "Telemetry.1.0.0.json",
+        "Telemetry.1.0.1.json",
+        "Telemetry.1.1.0.json",
+        "Telemetry.1.1.1.json",
+        "Telemetry.1.2.0.json",
+        "DSP2065_2026.1.html",
+        "DSP2065_2026.1.pdf",
+    }
+    assert expected_members.issubset(names)
+
+    with zipfile.ZipFile(DSP8011_2026_1_REGISTRY_BUNDLE) as archive:
+        dell_base = json.loads(archive.read("Base.1.12.1.json"))
+        gb300_base = json.loads(archive.read("Base.1.18.1.json"))
+        telemetry = json.loads(archive.read("Telemetry.1.2.0.json"))
+
+    assert dell_base["RegistryPrefix"] == "Base"
+    assert dell_base["RegistryVersion"] == "1.12.1"
+    assert gb300_base["RegistryPrefix"] == "Base"
+    assert gb300_base["RegistryVersion"] == "1.18.1"
+    assert telemetry["RegistryPrefix"] == "Telemetry"
+    assert telemetry["RegistryVersion"] == "1.2.0"
+
+
+def test_dsp8011_registry_members_have_message_templates_and_severity_fields():
+    """Registry entries keep templates, severity, resolution, and arg metadata."""
+    cases = [
+        ("Base.1.18.1.json", "GeneralError", 0),
+        ("Base.1.18.1.json", "ResourceMissingAtURI", 1),
+        ("Base.1.23.0.json", "ActionParameterNotSupported", 2),
+        ("Telemetry.1.2.0.json", "TelemetryDataCreated", 2),
+        ("Telemetry.1.2.0.json", "TriggerNumericAboveUpperCritical", 4),
+    ]
+    with zipfile.ZipFile(DSP8011_2026_1_REGISTRY_BUNDLE) as archive:
+        for member, message_id, expected_args in cases:
+            registry = json.loads(archive.read(member))
+            message = registry["Messages"][message_id]
+            assert message["Message"]
+            assert message["Resolution"]
+            assert message["NumberOfArgs"] == expected_args
+            assert message.get("MessageSeverity") or message.get("Severity")
+            if expected_args:
+                assert len(message["ParamTypes"]) == expected_args
+                assert len(message["ArgDescriptions"]) == expected_args
+
+
 def test_dsp2043_2026_1_mockups_bundle_contains_simulator_seed_payloads():
     """The pinned DSP2043 bundle carries DMTF mockups for simulator seeding."""
     names = _zip_names(DSP2043_2026_1_MOCKUPS_BUNDLE)
@@ -375,6 +530,58 @@ def test_dsp2043_2026_1_mockups_bundle_contains_simulator_seed_payloads():
         "DSP2043_2026.1/public-applications/AccountService/index.json",
         "DSP2043_2026.1/public-bladed/Chassis/index.json",
         "DSP2043_2026.1/DSP2046-examples/ServiceRoot-v1-example.json",
+    }
+    assert expected_members.issubset(names)
+
+
+def test_dsp2043_2026_1_mockups_bundle_contains_telemetry_examples():
+    """The mockup bundle carries DMTF telemetry payloads for simulator seeding."""
+    names = _zip_names(DSP2043_2026_1_MOCKUPS_BUNDLE)
+    expected_members = {
+        "DSP2043_2026.1/public-telemetry/index.json",
+        "DSP2043_2026.1/public-telemetry/TelemetryService/index.json",
+        "DSP2043_2026.1/public-telemetry/TelemetryService/MetricReports/index.json",
+        "DSP2043_2026.1/public-telemetry/TelemetryService/MetricDefinitions/index.json",
+        "DSP2043_2026.1/public-telemetry/TelemetryService/TelemetryData/index.json",
+        "DSP2043_2026.1/public-telemetry/TelemetryService/MetricReportDefinitions/index.json",
+        "DSP2043_2026.1/DSP2046-examples/TelemetryService-v1-example.json",
+        "DSP2043_2026.1/DSP2046-examples/MetricReport-v1-example.json",
+        "DSP2043_2026.1/DSP2046-examples/MetricReportDefinition-v1-example.json",
+        "DSP2043_2026.1/DSP2046-examples/TelemetryData-v1-example.json",
+        "DSP2043_2026.1/DSP2046-examples/EventService-v1-example.json",
+        "DSP2043_2026.1/DSP2046-examples/TelemetryService-v1-CollectTelemetryData-request-example.json",
+        "DSP2043_2026.1/DSP2046-examples/TelemetryService-v1-SubmitTestMetricReport-request-example.json",
+    }
+    assert expected_members.issubset(names)
+
+
+def test_telemetry_wip_bundle_contains_streaming_schema_and_mockups():
+    """The WIP telemetry bundle carries feed schemas and public PDU mockups."""
+    names = _zip_names(TELEMETRY_WIP_BUNDLE)
+    expected_members = {
+        "metadata/TelemetryFeed_v1.xml",
+        "metadata/TelemetryService_v1.xml",
+        "metadata/EventService_v1.xml",
+        "metadata/EventDestination_v1.xml",
+        "mockups/public-pdu/TelemetryService/index.json",
+        "mockups/public-pdu/TelemetryService/TelemetryFeeds/index.json",
+        "mockups/public-pdu/TelemetryService/TelemetryFeeds/Circuits/index.json",
+        "mockups/public-pdu/TelemetryService/TelemetryFeeds/EnvironmentMetrics/index.json",
+        "mockups/public-pdu/TelemetryService/TelemetryFeeds/Outlets/index.json",
+        "Redfish Telemetry Streaming and Reporting WIP v0.8.pdf",
+    }
+    assert expected_members.issubset(names)
+
+
+def test_art_wip_bundle_contains_automatic_recovery_trigger_schema_and_mockups():
+    """The ART WIP bundle carries automatic recovery trigger schema/examples."""
+    names = _zip_names(ART_WIP_BUNDLE)
+    expected_members = {
+        "csdl/AutomaticRecoveryTrigger_v1.xml",
+        "mockups/AutomaticRecoveryTrigger-v1-example.json",
+        "mockups/AutomaticRecoveryTrigger-v1-SendTicket-request-example.json",
+        "DSPIS0026_WIP80.pdf",
+        "DSPIS0026_WIP80.html",
     }
     assert expected_members.issubset(names)
 
@@ -393,6 +600,53 @@ def test_contract_doc_names_dmtf_publication_surfaces():
     assert "https://redfish.dmtf.org/schemas/v1/AccelerationFunction.v1_0_5.json" in text
     assert "https://redfish.dmtf.org/schemas/v1/AccelerationFunction.yaml" in text
     assert "https://redfish.dmtf.org/registries/" in text
+    assert "output-adapter-plan.md" in text
+    assert "telemetry-contract.md" in text
+
+
+def test_reference_docs_lock_status_telemetry_and_output_contracts():
+    """Agent-readable references name the status, telemetry, and output rules."""
+    http_text = HTTP_STATUS_CONTRACT.read_text(encoding="utf-8")
+    telemetry_text = TELEMETRY_CONTRACT.read_text(encoding="utf-8")
+    output_text = OUTPUT_ADAPTER_PLAN.read_text(encoding="utf-8")
+
+    for status in ["200 OK", "201 Created", "202 Accepted", "204 No Content"]:
+        assert status in http_text
+    for status in ["400 Bad Request", "404 Not Found", "501 Not Implemented"]:
+        assert status in http_text
+    assert "@Message.ExtendedInfo" in http_text
+    assert "MessageId" in http_text
+    assert "MessageArgs" in http_text
+    assert "Redfish parser" in http_text
+
+    for resource in [
+        "TelemetryService",
+        "MetricDefinition",
+        "MetricReport",
+        "MetricReportDefinition",
+        "TelemetryData",
+        "TelemetryFeed",
+    ]:
+        assert resource in telemetry_text
+    assert "OTLP" in telemetry_text
+    assert "public-telemetry" in telemetry_text
+
+    assert "-o, --output human|json|yaml|name|wide" in output_text
+    assert "--machine" in output_text
+    assert "--raw" in output_text
+    assert "JSON and YAML never call `str(exception)`" in output_text
+
+
+def test_output_adapter_plan_is_documented():
+    """The planned renderer keeps human, JSON, and YAML on one object."""
+    plan = OUTPUT_ADAPTER_PLAN.read_text(encoding="utf-8")
+
+    assert "human|json|yaml|name|wide" in plan
+    assert "--output json --json_only --nocolor" in plan
+    assert "Telemetry exporter" in plan
+    assert "--log-file" in plan
+    assert "--no-stdout" in plan
+    assert "--insecure" in plan
 
 
 def test_default_error_handler_raises_resource_not_found_with_parsed_dmtf_error():
@@ -409,7 +663,7 @@ def test_default_error_handler_raises_resource_not_found_with_parsed_dmtf_error(
 
 
 def _base_manager():
-    """Return a RedfishManagerBase instance — the class every command subclasses.
+    """Return a RedfishManagerBase instance - the class every command subclasses.
 
     :return: an offline RedfishManagerBase (no BMC contact).
     """
@@ -433,8 +687,8 @@ def _base_manager():
     ],
 )
 def test_base_default_error_handler_preserves_dmtf_envelope(status_code, exc_type):
-    """Every command subclasses RedfishManagerBase, so ITS default_error_handler —
-    not the parent RedfishManager's — is the real command error path. For every
+    """Every command subclasses RedfishManagerBase, so ITS default_error_handler -
+    not the parent RedfishManager's - is the real command error path. For every
     error code it must raise the parsed RedfishError envelope (status, error.code,
     every @Message.ExtendedInfo), never a generic string, per the Redfish error
     contract. Regression: the base override previously raised the generic
@@ -456,7 +710,7 @@ def test_base_default_error_handler_preserves_dmtf_envelope(status_code, exc_typ
     [(200, "Ok"), (201, "Created"), (202, "AcceptedTaskGenerated"), (204, "Success")],
 )
 def test_base_default_error_handler_maps_success_codes(status_code, expected):
-    """A 2xx code returns its mapped RedfishApiRespond — the line-689 tautology
+    """A 2xx code returns its mapped RedfishApiRespond - the line-689 tautology
     (status_code >= 200 or < 300, always true) that made this branch meaningless
     is fixed, so success codes resolve instead of falling through."""
     manager = _base_manager()


### PR DESCRIPTION
## Summary

Adds a DMTF-backed Redfish contract baseline for error normalization, telemetry, simulator seed data, and output rendering.

- Adds public DMTF 2026.1 spec bundle layout under `spec/dmtf/redfish/`, including DSP8010 schemas, DSP8011 registries, DSP2043 mockups, protocol/data-model/profile docs, and telemetry WIP material.
- Adds a machine-readable release manifest with required artifacts, required bundle members, contracts, and gate references.
- Adds public reference docs for HTTP status/error handling, telemetry alignment, and the planned `-o/--output human|json|yaml|name|wide` adapter.
- Extends `tests/test_redfish_error_contract.py` to lock schema/registry/mockup/telemetry bundle contents, registry message fields, corpus schema pointers, JSON/YAML preservation, and parser-backed HTTP error handling.
- Adds a command-path regression for `RedfishManagerBase.default_error_handler` so the real command path must preserve parsed DMTF `RedfishError` envelopes for error status codes.

Refs #223 and #225.

## Status

Draft / no-go for merge until CI runs and the engine-side error handler changes required by these contract tests are included. This branch currently locks the contract and fixtures; it does not claim the full implementation is complete.

## Validation

Static local checks only:

- `python -m py_compile tests/test_redfish_error_contract.py`
- `yq e '.kind' spec/dmtf/redfish/2026.1/manifest.yaml`
- `git diff --check -- .gitattributes docs/external/redfish-error-contract.md spec/.gitignore spec/README.md spec/dmtf/redfish/2026.1/manifest.yaml spec/dmtf/redfish/2026.1/reference tests/test_redfish_error_contract.py`
- `git check-attr` confirmed DSP8010/DSP8011/PDF/WIP artifacts use LFS and DSP2043 remains normal Git.

Full pytest/gate execution is expected from the repository CI surface.