### PR TITLE
Accept Splunk Observability ingest host; readback by freshness + dimension (#363)

### DIFF
--- a/redfish_ctl/telemetry/cmd_exporter.py
+++ b/redfish_ctl/telemetry/cmd_exporter.py
@@ -502,13 +502,23 @@ class Exporter(RedfishManagerBase,
                         "SPLUNK_O11Y_REALM) and an API token (--signalfx-api-token-env "
                         "or SPLUNK_API_TOKEN)")
                 metric_names = sorted({sample.metric for sample in samples})
+                # Scope the readback to this host's MTS via its unique identity
+                # dimension, so a neighbor pushing the same metric is not mistaken
+                # for this host's series.
+                dimensions = {}
+                for sample in samples:
+                    host = sample.dimensions.get("host.name")
+                    if host:
+                        dimensions = {"host.name": host}
+                        break
                 readback_start = time.monotonic()
                 readback = exporter.verify_signalfx_readback(
-                    realm, api_token, metric_names)
+                    realm, api_token, metric_names, dimensions)
                 readback_ms = int((time.monotonic() - readback_start) * 1000)
                 summary, error = exporter.build_readback_result(
                     status, ingest_url, len(samples), metric_names, readback,
-                    {"scrape": scrape_ms, "push": push_ms, "readback": readback_ms})
+                    {"scrape": scrape_ms, "push": push_ms, "readback": readback_ms},
+                    int(time.time() * 1000))
                 return CommandResult(summary, None, summary, error)
             samples = collect_current_samples()
             data = (to_signalfx_body(samples) if exporter_output == "signalfx"

--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -1016,54 +1016,27 @@ def to_signalfx_body(samples: Iterable[MetricSample]) -> dict[str, list[dict]]:
     }
 
 
-# Splunk Observability ingest host: accepts a datapoint POST and returns 200/"OK"
-# but never records the metric time series. SignalFx datapoint ingest requires the
-# ingest.<realm>.signalfx.com host instead.
-_OBSERVABILITY_INGEST_HOST = re.compile(
-    r"ingest\.([a-z0-9-]+)\.observability\.splunkcloud\.com", re.IGNORECASE)
-
-
-def _normalize_signalfx_ingest_url(ingest_url: str) -> str:
-    """Rewrite a Splunk Observability ingest host to the SignalFx datapoint host.
-
-    ``ingest.<realm>.observability.splunkcloud.com`` is replaced with
-    ``ingest.<realm>.signalfx.com``; the realm, scheme, path, and port are kept.
-    Any other host is returned unchanged.
-
-    :param ingest_url: the ingest URL to normalize.
-    :return: the URL with the observability host rewritten, else unchanged.
-    """
-    return _OBSERVABILITY_INGEST_HOST.sub(r"ingest.\1.signalfx.com", ingest_url or "")
-
-
 def _require_datapoint_url(ingest_url: str) -> str:
     """Return ``ingest_url`` when it is a full SignalFx datapoint endpoint, else raise.
 
     ``push_signalfx`` POSTs the URL as-is (it does not append a path), so a bare
     host such as ``https://ingest.us1.observability.splunkcloud.com`` accepts the
     request context but silently drops every datapoint. Require the full
-    ``…/v2/datapoint`` endpoint, and reject the Observability ingest host outright,
-    so misconfiguration fails loudly instead.
+    ``…/v2/datapoint`` endpoint so misconfiguration fails loudly instead. The host
+    itself is not restricted: ``ingest.<realm>.observability.splunkcloud.com`` is
+    the current Splunk ingest host and ``ingest.<realm>.signalfx.com`` is the
+    legacy one — both are accepted.
 
     :param ingest_url: the SignalFx ingest URL to validate.
     :return: ``ingest_url`` unchanged when it is a full datapoint endpoint.
-    :raises ValueError: if the URL is not a full ``…/v2/datapoint`` endpoint, or it
-        targets the Observability ingest host that silently drops datapoints.
+    :raises ValueError: if the URL is not a full ``…/v2/datapoint`` endpoint.
     """
     if SIGNALFX_DATAPOINT_PATH not in (ingest_url or ""):
         raise ValueError(
             "SignalFx ingest URL must be the full datapoint endpoint ending in "
             f"{SIGNALFX_DATAPOINT_PATH} (e.g. "
-            "https://ingest.us1.signalfx.com/v2/datapoint), not a bare host like "
-            f"https://ingest.us1.observability.splunkcloud.com; got {ingest_url!r}"
-        )
-    if _OBSERVABILITY_INGEST_HOST.search(ingest_url):
-        raise ValueError(
-            "SignalFx ingest URL targets the Splunk Observability host "
-            "(ingest.<realm>.observability.splunkcloud.com), which returns 200/OK "
-            "but drops every datapoint; use ingest.<realm>.signalfx.com instead; "
-            f"got {ingest_url!r}"
-        )
+            "https://ingest.us1.observability.splunkcloud.com/v2/datapoint), not a "
+            f"bare host; got {ingest_url!r}")
     return ingest_url
 
 
@@ -1102,22 +1075,13 @@ def resolve_signalfx_ingest_url(ingest_url: Optional[str] = None) -> str:
     full ``…/v2/datapoint`` endpoint (see ``_require_datapoint_url``).
 
     :param ingest_url: explicit ingest URL; falls back to ``SPLUNK_INGEST_URL``.
-    :return: a validated full ``…/v2/datapoint`` ingest URL (Observability host
-        normalized to the SignalFx datapoint host).
+    :return: a validated full ``…/v2/datapoint`` ingest URL.
     :raises ValueError: if no URL is set or it is not a full datapoint endpoint.
     """
     url = ingest_url or os.environ.get("SPLUNK_INGEST_URL", "")
     if not url:
         raise ValueError("SPLUNK_INGEST_URL is not set")
-    normalized = _normalize_signalfx_ingest_url(url)
-    if normalized != url:
-        # Never silent: surface the rewrite so a deploy dry-run shows the real target.
-        print(
-            f"note: rewrote SignalFx ingest host to the datapoint host {normalized} "
-            "(the observability.splunkcloud.com host returns OK but drops datapoints)",
-            file=sys.stderr,
-        )
-    return _require_datapoint_url(normalized)
+    return _require_datapoint_url(url)
 
 
 def push_signalfx(body: Mapping, token: str, ingest_url: str, timeout: float = 20.0) -> int:
@@ -1146,24 +1110,45 @@ def push_signalfx(body: Mapping, token: str, ingest_url: str, timeout: float = 2
         return response.status
 
 
+def _mts_query(metric: str, dimensions: Optional[Mapping] = None) -> str:
+    """Build a metrictimeseries query for one metric, scoped by dimensions.
+
+    A metric time series is identified by the metric name AND its dimension set
+    (Splunk data model), so scoping by a unique dimension such as ``host.name``
+    reads back this host's series rather than every host that reports the metric.
+
+    :param metric: the SignalFx metric name.
+    :param dimensions: dimension key->value pairs to AND into the query.
+    :return: the SignalFx search query string.
+    """
+    terms = [f'sf_metric:"{metric}"']
+    for key, value in sorted((dimensions or {}).items()):
+        terms.append(f'{key}:"{value}"')
+    return " AND ".join(terms)
+
+
 def signalfx_metric_readback(
-        realm: str, api_token: str, metric: str, timeout: float = 20.0) -> dict:
+        realm: str, api_token: str, metric: str,
+        dimensions: Optional[Mapping] = None, timeout: float = 20.0) -> dict:
     """Return how many time series exist for a metric in Splunk MTS, and how fresh.
 
     A SignalFx datapoint POST returns HTTP 200/``OK`` even when the datapoints are
-    dropped (for example the Observability ingest host, see issue #363), so ingest
-    success must be confirmed by reading the metric time series back — not by
-    trusting the POST status.
+    not recorded, so ingest success must be confirmed by reading the metric time
+    series back — not by trusting the POST status (issue #363). Because Splunk
+    retains inactive series for 13 months, the caller must also check freshness
+    (``newest_ms``), not merely a nonzero count.
 
     :param realm: Splunk Observability realm (for example ``us1``).
     :param api_token: API (read) token, sent as the ``X-SF-Token`` header; never logged.
     :param metric: SignalFx metric name to look up.
+    :param dimensions: dimension key->value pairs to scope the query to one entity.
     :param timeout: HTTP timeout in seconds.
     :return: ``{"count": <matching series>, "newest_ms": <latest update ms, 0 if none>}``.
     :raises ValueError: when the API answers with a non-JSON body.
     """
     query = urllib.parse.urlencode(
-        {"query": f'sf_metric:"{metric}"', "limit": 50, "orderBy": "-sf_updatedOnMs"})
+        {"query": _mts_query(metric, dimensions), "limit": 50,
+         "orderBy": "-sf_updatedOnMs"})
     url = f"https://api.{realm}.signalfx.com/v2/metrictimeseries?{query}"
     request = urllib.request.Request(url, headers={"X-SF-Token": api_token})
     with urllib.request.urlopen(request, timeout=timeout) as response:
@@ -1184,52 +1169,61 @@ def signalfx_metric_readback(
 
 def verify_signalfx_readback(
         realm: str, api_token: str, metrics: Iterable[str],
-        timeout: float = 20.0) -> dict:
-    """Confirm each pushed metric is visible in Splunk MTS.
+        dimensions: Optional[Mapping] = None, timeout: float = 20.0) -> dict:
+    """Confirm each pushed metric is visible in Splunk MTS for one entity.
 
     :param realm: Splunk Observability realm.
     :param api_token: API (read) token; never logged.
     :param metrics: metric names to confirm (the names that were pushed).
+    :param dimensions: dimension key->value pairs scoping the query to this host.
     :param timeout: per-query HTTP timeout in seconds.
     :return: ``{metric: {"count": int, "newest_ms": int}}`` for each metric.
     """
-    return {metric: signalfx_metric_readback(realm, api_token, metric, timeout)
+    return {metric: signalfx_metric_readback(realm, api_token, metric, dimensions, timeout)
             for metric in sorted(set(metrics))}
 
 
 def build_readback_result(
-        push_status: int, ingest_url: str, sample_count: int,
-        metric_names: list, readback: dict, timing_ms: dict) -> tuple:
+        push_status: int, ingest_url: str, sample_count: int, metric_names: list,
+        readback: dict, timing_ms: dict, now_ms: int,
+        freshness_ms: int = 900000) -> tuple:
     """Build the compact canary summary and verdict from a readback.
 
-    A metric is visible when its readback ``count`` is greater than zero. When any
-    pushed metric is missing, the verdict is an error: the POST succeeded but the
-    datapoints were not ingested (issue #363), so a 200 is not proof.
+    A metric is confirmed only when its readback series is BOTH present
+    (``count`` > 0) AND fresh (``newest_ms`` within ``freshness_ms`` of ``now_ms``).
+    Splunk retains inactive series for 13 months, so a nonzero count alone can be a
+    stale series this push did not create; a missing or stale metric is an error:
+    the POST succeeded yet the datapoints were not ingested now (issue #363).
 
     :param push_status: the HTTP status the SignalFx POST returned.
-    :param ingest_url: the (normalized) ingest URL that was POSTed to.
+    :param ingest_url: the ingest URL that was POSTed to.
     :param sample_count: number of samples scraped and pushed.
     :param metric_names: the distinct metric names that were pushed.
     :param readback: ``{metric: {"count": int, "newest_ms": int}}`` from MTS.
     :param timing_ms: ``{"scrape": int, "push": int, "readback": int}`` durations.
-    :return: ``(summary_dict, error_or_None)`` — the compact result and verdict.
+    :param now_ms: current wall-clock time in ms, for the freshness window.
+    :param freshness_ms: how recent ``newest_ms`` must be to count as this push.
+    :return: ``(summary_dict, error_or_None)`` -- the compact result and verdict.
     """
-    visible = sorted(name for name, series in readback.items() if series["count"] > 0)
-    missing = sorted(set(metric_names) - set(visible))
+    fresh = sorted(
+        name for name, series in readback.items()
+        if series["count"] > 0 and series["newest_ms"] >= now_ms - freshness_ms)
+    missing = sorted(set(metric_names) - set(fresh))
     summary = {
         "push_status": push_status,
         "ingest_url": ingest_url,
         "sample_count": sample_count,
         "metrics_pushed": len(metric_names),
-        "metrics_visible": len(visible),
+        "metrics_fresh": len(fresh),
         "missing_metrics": missing,
         "readback": readback,
         "timing_ms": timing_ms,
+        "freshness_ms": freshness_ms,
     }
     error = None if not missing else (
         f"SignalFx POST returned {push_status} but {len(missing)} of "
-        f"{len(metric_names)} pushed metrics have no time series in Splunk MTS — "
-        "the POST succeeded yet datapoints were not ingested")
+        f"{len(metric_names)} pushed metrics have no fresh time series in Splunk "
+        "MTS -- the POST succeeded yet the datapoints were not ingested")
     return summary, error
 
 

--- a/tests/test_signalfx_readback.py
+++ b/tests/test_signalfx_readback.py
@@ -10,6 +10,7 @@ Author Mus spyroot@gmail.com
 import json
 from unittest import mock
 
+from redfish_ctl.telemetry import exporter
 from redfish_ctl.telemetry.exporter import (
     build_readback_result,
     signalfx_metric_readback,
@@ -58,27 +59,45 @@ def test_verify_readback_covers_each_metric():
     assert all(v["count"] == 1 for v in out.values())
 
 
-def test_verdict_ok_when_all_visible():
-    """All pushed metrics visible -> no error, compact summary populated."""
-    readback = {"hw.power": {"count": 1, "newest_ms": 9}, "hw.temp": {"count": 3, "newest_ms": 9}}
-    summary, error = build_readback_result(
-        200, "https://ingest.us1.signalfx.com/v2/datapoint", 5,
-        ["hw.power", "hw.temp"], readback, {"scrape": 10, "push": 20, "readback": 30})
-    assert error is None
-    assert summary["metrics_visible"] == 2 and summary["missing_metrics"] == []
-    assert "readback" not in summary["timing_ms"] or summary["timing_ms"]["readback"] == 30
+def test_readback_scopes_query_by_dimension():
+    """The MTS query is scoped by the entity dimension so only this host's series
+    is read back, not every host reporting the metric (Splunk MTS identity)."""
+    assert exporter._mts_query("hw.power", {"host.name": "slot1"}) == (
+        'sf_metric:"hw.power" AND host.name:"slot1"')
+    assert exporter._mts_query("hw.power") == 'sf_metric:"hw.power"'
 
 
-def test_verdict_errors_when_a_metric_is_missing():
-    """POST 200 but a metric has no series -> verdict is an error (issue #363).
+_NOW = 1_700_000_000_000
 
-    This is the false-success the gate exists to catch: a 200 is not proof.
-    """
-    readback = {"hw.power": {"count": 1, "newest_ms": 9}, "hw.temp": {"count": 0, "newest_ms": 0}}
+
+def test_verdict_ok_when_series_fresh():
+    """All pushed metrics have a fresh series -> no error."""
+    readback = {"hw.power": {"count": 1, "newest_ms": _NOW - 1000},
+                "hw.temp": {"count": 3, "newest_ms": _NOW - 2000}}
     summary, error = build_readback_result(
         200, "https://ingest.us1.observability.splunkcloud.com/v2/datapoint", 5,
-        ["hw.power", "hw.temp"], readback, {"scrape": 10, "push": 20, "readback": 30})
-    assert error is not None
-    assert "not ingested" in error
+        ["hw.power", "hw.temp"], readback, {"scrape": 10, "push": 20, "readback": 30}, _NOW)
+    assert error is None
+    assert summary["metrics_fresh"] == 2 and summary["missing_metrics"] == []
+
+
+def test_verdict_errors_when_a_metric_is_absent():
+    """POST 200 but a metric has no series -> error (issue #363): 200 is not proof."""
+    readback = {"hw.power": {"count": 1, "newest_ms": _NOW},
+                "hw.temp": {"count": 0, "newest_ms": 0}}
+    summary, error = build_readback_result(
+        200, "https://ingest.us1.observability.splunkcloud.com/v2/datapoint", 5,
+        ["hw.power", "hw.temp"], readback, {"scrape": 10, "push": 20, "readback": 30}, _NOW)
+    assert error is not None and "not ingested" in error
     assert summary["missing_metrics"] == ["hw.temp"]
-    assert summary["push_status"] == 200
+
+
+def test_verdict_errors_on_stale_series():
+    """A series with count>0 but a STALE newest_ms is not proof of this push —
+    Splunk retains inactive MTS for 13 months, so freshness is required."""
+    readback = {"hw.power": {"count": 1, "newest_ms": _NOW - 40 * 24 * 3600 * 1000}}
+    summary, error = build_readback_result(
+        200, "https://ingest.us1.observability.splunkcloud.com/v2/datapoint", 1,
+        ["hw.power"], readback, {"scrape": 10, "push": 20, "readback": 30}, _NOW)
+    assert error is not None
+    assert summary["metrics_fresh"] == 0 and summary["missing_metrics"] == ["hw.power"]

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -879,27 +879,28 @@ def test_resolve_signalfx_ingest_url_validates_full_datapoint_endpoint(monkeypat
         resolve_signalfx_ingest_url()
 
 
-def test_resolve_signalfx_normalizes_observability_ingest_host(monkeypatch, capsys):
-    """The Observability ingest host returns 200/OK but drops datapoints, so it is
-    rewritten to the SignalFx datapoint host, preserving realm and path (#363)."""
+def test_resolve_signalfx_accepts_observability_host(monkeypatch):
+    """ingest.<realm>.observability.splunkcloud.com/v2/datapoint is the current,
+    correct Splunk ingest host — it is accepted as-is, not rewritten (the zero-
+    visibility in #363 was not the host; see the readback gate)."""
     monkeypatch.delenv("SPLUNK_INGEST_URL", raising=False)
-    out = resolve_signalfx_ingest_url(
-        "https://ingest.us1.observability.splunkcloud.com/v2/datapoint")
-    assert out == "https://ingest.us1.signalfx.com/v2/datapoint"
-    # the rewrite is surfaced, not silent, so a deploy dry-run shows the real target
-    assert "rewrote SignalFx ingest host" in capsys.readouterr().err
+    url = "https://ingest.us1.observability.splunkcloud.com/v2/datapoint"
+    assert resolve_signalfx_ingest_url(url) == url
     monkeypatch.setenv("SPLUNK_INGEST_URL",
                        "https://ingest.eu0.observability.splunkcloud.com/v2/datapoint")
     assert (resolve_signalfx_ingest_url()
-            == "https://ingest.eu0.signalfx.com/v2/datapoint")
+            == "https://ingest.eu0.observability.splunkcloud.com/v2/datapoint")
 
 
-def test_require_datapoint_url_rejects_observability_host_directly():
-    """The validator rejects the Observability host even with the /v2/datapoint
-    path, so a direct push_signalfx call cannot bypass the normalization (#363)."""
-    with pytest.raises(ValueError, match="Observability"):
-        _require_datapoint_url(
-            "https://ingest.us1.observability.splunkcloud.com/v2/datapoint")
+def test_require_datapoint_url_accepts_both_hosts_needs_path():
+    """Both the observability and legacy signalfx hosts are accepted with the
+    /v2/datapoint path; only a bare host (no path) is rejected."""
+    for host in ("ingest.us1.observability.splunkcloud.com",
+                 "ingest.us1.signalfx.com"):
+        full = f"https://{host}/v2/datapoint"
+        assert _require_datapoint_url(full) == full
+    with pytest.raises(ValueError, match="v2/datapoint"):
+        _require_datapoint_url("https://ingest.us1.observability.splunkcloud.com")
 
 
 def _report_row(source_property, value, report="HGX_HealthMetrics_0"):

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -34,8 +34,8 @@ redfish_ctl/redfish_manager.py:302
 redfish_ctl/redfish_manager_base.py:412
 redfish_ctl/telemetry/cmd_exporter.py:496
 redfish_ctl/telemetry/cmd_exporter.py:497
-redfish_ctl/telemetry/exporter.py:1092
-redfish_ctl/telemetry/exporter.py:1109
+redfish_ctl/telemetry/exporter.py:1065
+redfish_ctl/telemetry/exporter.py:1081
 redfish_ctl/telemetry/exporter.py:281
 redfish_ctl/telemetry/exporter.py:386
 redfish_ctl/telemetry/exporter.py:387


### PR DESCRIPTION
Corrects two earlier missteps on #363, per the Splunk ingest data model:

1. **`ingest.<realm>.observability.splunkcloud.com/v2/datapoint` is the correct host** — not broken. My #365 rewrote it to `signalfx.com` and rejected it in the validator; that was based on the initial #363 diagnosis your own canary update refuted. This **reverts** the rewrite + rejection and keeps only the `/v2/datapoint` path check (a bare host with no path still drops data). `signalfx.com` (legacy) is also accepted.

2. **Readback verdict now requires freshness, not just presence.** Splunk retains inactive MTS for **13 months**, so `count>0` alone can be a stale series this push didn't create. The verdict now checks `newest_ms` within a window, and the MTS query is **scoped by the `host.name` dimension** so a neighbor reporting the same metric isn't mistaken for this host's series (MTS identity = metric + dimensions).

Tests: observability host accepted; both hosts need the path; readback errors on absent AND stale series; dimension-scoped query. 7 offline tests.