### PR TITLE
Normalize the base error handler per the Redfish error contract

### DIFF
--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -23,7 +23,6 @@ https://www.dell.com/support/manuals/en-us/idrac9-lifecycle-controller-v4.x-seri
 Author Mus spyroot@gmail.com
 """
 import argparse
-import asyncio
 import functools
 import json
 import logging
@@ -682,29 +681,34 @@ class RedfishManagerBase(RedfishManager):
 
     def default_error_handler(
             self, response: requests.models.Response) -> RedfishApiRespond:
-        """Default error handler.
-        :param response:
-        :return:
-        """
-        if response.status_code >= 200 or response.status_code < 300:
-            if response.status_code in self._http_code_mapping:
-                return self._http_code_mapping[response.status_code]
+        """Normalize a non-2xx Redfish response per the Redfish error contract.
 
-        if response.status_code == 401:
-            raise AuthenticationFailed("Authentication failed.")
-        elif response.status_code == 403:
-            raise RedfishForbidden("access forbidden")
-        elif response.status_code == 404:
-            error_msg = RedfishManager.parse_error(response)
-            raise ResourceNotFound(error_msg)
-        if 401 <= response.status_code < 500:
-            # we try to parse error.
-            self._redfish_error = RedfishManagerBase.parse_error(response)
-        if response.status_code != 200:
-            raise UnexpectedResponse(
-                f"Failed acquire result. Status code "
-                f"{response.status_code}"
-            )
+        A success code returns its mapped ``RedfishApiRespond``. Every error code
+        is normalized through :meth:`RedfishManager.parse_error`, so the raised
+        exception carries the parsed :class:`RedfishError` envelope (HTTP status,
+        ``error.code``/``error.message`` and every ``@Message.ExtendedInfo``
+        entry) as its primary value — never a generic string — including for an
+        unsupported-operation ``501``/``404``/``405``/``409``. See
+        docs/external/redfish-error-contract.md.
+
+        :param response: the Redfish HTTP response to classify.
+        :return: the mapped ``RedfishApiRespond`` for a 2xx success code.
+        :raises AuthenticationFailed: on HTTP 401, carrying the parsed error.
+        :raises RedfishForbidden: on HTTP 403, carrying the parsed error.
+        :raises ResourceNotFound: on HTTP 404, carrying the parsed error.
+        :raises UnexpectedResponse: on any other error code, carrying the parsed error.
+        """
+        code = response.status_code
+        if 200 <= code < 300:
+            return self._http_code_mapping.get(code, RedfishApiRespond.Success)
+        self._redfish_error = RedfishManager.parse_error(response)
+        if code == 401:
+            raise AuthenticationFailed(self._redfish_error)
+        if code == 403:
+            raise RedfishForbidden(self._redfish_error)
+        if code == 404:
+            raise ResourceNotFound(self._redfish_error)
+        raise UnexpectedResponse(self._redfish_error)
 
     def check_api_version(self):
         """Check Dell LLC Service API set

--- a/tests/test_cmd_boot_dualmode.py
+++ b/tests/test_cmd_boot_dualmode.py
@@ -456,11 +456,11 @@ def test_boot_one_shot_x10_reboot_501_returns_error_after_patch(
     patches = [request for request in service.requests if request.method == "PATCH"]
     posts = [request for request in service.requests if request.method == "POST"]
     assert isinstance(result, CommandResult)
-    assert result.error == (
-        "reboot post-step failed: Failed acquire result. Status code 501"
-    )
+    # The 501 is normalized to a Redfish error envelope (contract), not a generic
+    # "Failed acquire result" string; the reboot step still reports cleanly.
+    assert result.error == "reboot post-step failed: Redfish error (HTTP 501)"
     assert result.data["Status"] == "ok"
-    assert result.data["reboot_error"] == "Failed acquire result. Status code 501"
+    assert result.data["reboot_error"] == "Redfish error (HTTP 501)"
     assert len(patches) == 1
     assert patches[0].path.lower() == "/redfish/v1/systems/1"
     assert patches[0].json() == {

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -6,10 +6,26 @@ dead. These pin the success/raise mapping. No network.
 """
 import pytest
 
-from redfish_ctl.cmd_exceptions import ResourceNotFound
+from redfish_ctl.cmd_exceptions import (
+    AuthenticationFailed,
+    ResourceNotFound,
+    UnexpectedResponse,
+)
 from redfish_ctl.redfish_exceptions import RedfishForbidden, RedfishUnauthorized
 from redfish_ctl.redfish_manager import RedfishManager
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_respond_error import RedfishError
 from redfish_ctl.redfish_shared import RedfishApiRespond
+
+_DMTF_ERROR_BODY = {
+    "error": {
+        "code": "Base.1.18.GeneralError",
+        "message": "Standard VirtualMedia is not implemented on this BMC.",
+        "@Message.ExtendedInfo": [
+            {"MessageId": "Base.1.18.ActionNotSupported",
+             "Message": "The action is not supported.", "Severity": "Critical"}],
+    }
+}
 
 
 class _Resp:
@@ -20,6 +36,27 @@ class _Resp:
 
     def json(self):
         return {}
+
+
+class _BodyResp:
+    """Fake response carrying a status code and a JSON error body."""
+
+    def __init__(self, status_code: int, body):
+        self.status_code = status_code
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def _base_manager():
+    """Return an offline RedfishManagerBase — the class every command subclasses.
+
+    :return: a RedfishManagerBase instance that makes no BMC contact.
+    """
+    return RedfishManagerBase(
+        idrac_ip="mock", idrac_username="root", idrac_password="x",
+        insecure=True, is_debug=False)
 
 
 @pytest.mark.parametrize(
@@ -52,3 +89,44 @@ def test_error_codes_raise(status_code, exception):
     """4xx/5xx codes raise (the branches the tautology used to skip)."""
     with pytest.raises(exception):
         RedfishManager.default_error_handler(_Resp(status_code))
+
+
+@pytest.mark.parametrize(
+    "status_code, exception",
+    [
+        (401, AuthenticationFailed),
+        (403, RedfishForbidden),
+        (404, ResourceNotFound),
+        (405, UnexpectedResponse),
+        (409, UnexpectedResponse),
+        (500, UnexpectedResponse),
+        (501, UnexpectedResponse),
+        (502, UnexpectedResponse),
+        (503, UnexpectedResponse),
+    ],
+)
+def test_base_handler_preserves_dmtf_envelope(status_code, exception):
+    """RedfishManagerBase.default_error_handler — the override every command uses —
+    raises the parsed RedfishError envelope (status, error.code, @Message.ExtendedInfo)
+    for every error code, not a generic string. Regression: the override previously
+    raised "Failed acquire result. Status code N" for 501/5xx, defeating the Redfish
+    error contract that the parent-only test could not see.
+    """
+    with pytest.raises(exception) as raised:
+        _base_manager().default_error_handler(_BodyResp(status_code, _DMTF_ERROR_BODY))
+    parsed = raised.value.args[0]
+    assert isinstance(parsed, RedfishError)
+    assert parsed.status_code == status_code
+    assert parsed.code == "Base.1.18.GeneralError"
+
+
+@pytest.mark.parametrize(
+    "status_code, expected",
+    [(200, "Ok"), (201, "Created"), (202, "AcceptedTaskGenerated"),
+     (204, "Success"), (206, "Success")],
+)
+def test_base_handler_maps_success_codes(status_code, expected):
+    """The base override maps 2xx codes; an unmapped 2xx returns Success (the
+    line-689 tautology that made this branch meaningless is fixed)."""
+    result = _base_manager().default_error_handler(_BodyResp(status_code, {}))
+    assert result.name == expected

--- a/tests/test_network_adapter_reset_dualmode.py
+++ b/tests/test_network_adapter_reset_dualmode.py
@@ -93,7 +93,9 @@ def test_network_adapter_reset_reports_root_read_failures(gb300_corpus_mock):
     assert isinstance(result, CommandResult)
     assert result.data is None
     assert "failed to read /redfish/v1/Chassis" in result.error
-    assert "Authentication failed" in result.error
+    # 401 is normalized to the Redfish error envelope (HTTP status preserved),
+    # not the old hardcoded "Authentication failed." string.
+    assert "HTTP 401" in result.error
     assert _post_requests(service) == []
 
 

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -31,7 +31,7 @@ redfish_ctl/redfish_manager.py:271
 redfish_ctl/redfish_manager.py:273
 redfish_ctl/redfish_manager.py:275
 redfish_ctl/redfish_manager.py:302
-redfish_ctl/redfish_manager_base.py:412
+redfish_ctl/redfish_manager_base.py:411
 redfish_ctl/telemetry/cmd_exporter.py:496
 redfish_ctl/telemetry/cmd_exporter.py:497
 redfish_ctl/telemetry/exporter.py:1065

--- a/tools/span_root_baseline.txt
+++ b/tools/span_root_baseline.txt
@@ -6,5 +6,5 @@ redfish_ctl/discover/cli.py:220
 redfish_ctl/discovery/net_scan.py:61
 redfish_ctl/redfish_manager.py:237
 redfish_ctl/redfish_manager.py:245
-redfish_ctl/redfish_manager_base.py:370
-redfish_ctl/redfish_manager_base.py:378
+redfish_ctl/redfish_manager_base.py:369
+redfish_ctl/redfish_manager_base.py:377


### PR DESCRIPTION
The engine-side fix behind the DMTF error contract (PR #366's B1). Every command subclasses `RedfishManagerBase`, whose `default_error_handler` **overrides** the parent's normalized one and raised `UnexpectedResponse("Failed acquire result. Status code 501")` for 501/5xx — dropping the Redfish error envelope. Now it routes every error code through `RedfishManager.parse_error`, so the raised exception carries the parsed `RedfishError` (status, `error.code`, every `@Message.ExtendedInfo`). Also fixes the line-689 `>= 200 or < 300` tautology.

Self-contained regression tests in `test_error_handler.py` (no spec/ bundle dependency) exercise the base override across 401/403/404/405/409/500/501/502/503 (envelope preserved) and 2xx (mapped). 25 param-cases.

**Brain review** (`code_review` at `think_max`, task 128aea63): verdict CHANGES-NEEDED on one Major — exception arg changed `str`→`RedfishError`, could break `exc.args[0]` callers. **Refuted by local verification:** all 4 catch sites use `str(exc)` (renders via `RedfishError.__str__`); the only `.args[0]` is on an unrelated `NodeNotFound`. The 4 minors are intended (contract) or verified dead (asyncio import). Scope: GET path only — the mutation path (`read_api_respond`), error-object fields, and JSON/YAML error rendering are tracked follow-ups (M1-M4).

Decoupled from the DMTF spec bundle so #366 rebases on top.