### PR TITLE
Normalize the write/mutation error path per the DMTF contract (M1)

### DIFF
--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -1267,26 +1267,23 @@ class RedfishManagerBase(RedfishManager):
         if 200 <= response.status_code < 300:
             return self._http_code_mapping[response.status_code]
 
+        # Normalize the write-path error per the Redfish error contract: every
+        # raised exception carries the parsed RedfishError envelope (status,
+        # error.code, @Message.ExtendedInfo), never a flattened string. 405/409
+        # keep returning RedfishApiRespond.Error (the caller reads the envelope
+        # from self._redfish_error), so the return contract is unchanged.
         self._redfish_error = RedfishManagerBase.parse_error(response)
         if 300 <= response.status_code < 500:
             if response.status_code == 400:
                 raise RedfishException(self._redfish_error)
             if response.status_code == 401:
-                raise RedfishUnauthorized("Authorization failed.")
+                raise RedfishUnauthorized(self._redfish_error)
             if response.status_code == 403:
-                raise RedfishForbidden("Authorization failed.")
-            if response.status_code == 404:
                 raise RedfishForbidden(self._redfish_error)
+            if response.status_code == 404:
+                raise ResourceNotFound(self._redfish_error)
             return RedfishApiRespond.Error
-        elif response.status_code >= 500:
-            raise RedfishException(
-                f"{self._redfish_error.message} HTTP Status code: "
-                f"{response.status_code}")
-        else:
-            raise RedfishException(
-                f"{self._redfish_error}, HTTP Status code: "
-                f"{response.status_code}"
-            )
+        raise RedfishException(self._redfish_error)
 
     def default_patch_success(
             self,

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -7,9 +7,25 @@ dead. These pin the success/raise mapping. No network.
 import pytest
 
 from redfish_ctl.cmd_exceptions import ResourceNotFound
-from redfish_ctl.redfish_exceptions import RedfishForbidden, RedfishUnauthorized
+from redfish_ctl.redfish_exceptions import (
+    RedfishException,
+    RedfishForbidden,
+    RedfishUnauthorized,
+)
 from redfish_ctl.redfish_manager import RedfishManager
+from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_respond_error import RedfishError
 from redfish_ctl.redfish_shared import RedfishApiRespond
+
+_DMTF_ERROR_BODY = {
+    "error": {
+        "code": "Base.1.18.GeneralError",
+        "message": "The write failed.",
+        "@Message.ExtendedInfo": [
+            {"MessageId": "Base.1.18.ActionNotSupported",
+             "Message": "not supported", "Severity": "Critical"}],
+    }
+}
 
 
 class _Resp:
@@ -20,6 +36,28 @@ class _Resp:
 
     def json(self):
         return {}
+
+
+class _WriteResp:
+    """Fake write response: status code, headers, and a JSON error body."""
+
+    def __init__(self, status_code: int, body):
+        self.status_code = status_code
+        self.headers = {}
+        self._body = body
+
+    def json(self):
+        return self._body
+
+
+def _base_manager():
+    """Return an offline RedfishManagerBase (the mutation-path host).
+
+    :return: a RedfishManagerBase instance that makes no BMC contact.
+    """
+    return RedfishManagerBase(
+        idrac_ip="mock", idrac_username="root", idrac_password="x",
+        insecure=True, is_debug=False)
 
 
 @pytest.mark.parametrize(
@@ -52,3 +90,41 @@ def test_error_codes_raise(status_code, exception):
     """4xx/5xx codes raise (the branches the tautology used to skip)."""
     with pytest.raises(exception):
         RedfishManager.default_error_handler(_Resp(status_code))
+
+
+@pytest.mark.parametrize(
+    "status_code, exception",
+    [
+        (400, RedfishException),
+        (401, RedfishUnauthorized),
+        (403, RedfishForbidden),
+        (404, ResourceNotFound),
+        (500, RedfishException),
+        (502, RedfishException),
+        (503, RedfishException),
+    ],
+)
+def test_write_path_preserves_dmtf_envelope(status_code, exception):
+    """read_api_respond (the POST/PATCH/DELETE path) raises the parsed RedfishError
+    envelope for every error code, not a flattened string. Regression: 401/403 used
+    'Authorization failed.', 5xx used '<message> HTTP Status code: N' (dropping
+    error.code + @Message.ExtendedInfo), and 404 raised the wrong type."""
+    with pytest.raises(exception) as raised:
+        _base_manager().read_api_respond(_WriteResp(status_code, _DMTF_ERROR_BODY),
+                                         expected=204)
+    parsed = raised.value.args[0]
+    assert isinstance(parsed, RedfishError)
+    assert parsed.status_code == status_code
+    assert parsed.code == "Base.1.18.GeneralError"
+
+
+def test_write_path_405_returns_error_with_envelope():
+    """405/409 keep returning RedfishApiRespond.Error (callers read the envelope
+    from self._redfish_error), so the non-raising return contract is unchanged."""
+    manager = _base_manager()
+    result = manager.read_api_respond(_WriteResp(405, _DMTF_ERROR_BODY), expected=204)
+    # compare by member name: the base uses redfish_manager_shared.RedfishApiRespond,
+    # a distinct enum from redfish_shared's, so identity comparison would fail.
+    assert result.name == "Error"
+    assert isinstance(manager._redfish_error, RedfishError)
+    assert manager._redfish_error.status_code == 405


### PR DESCRIPTION
Fixes M1: `read_api_respond` (the POST/PATCH/DELETE path used by every destructive command) dropped the Redfish error envelope — 401/403 raised the string "Authorization failed.", 5xx flattened to `<message> HTTP Status code: N` (losing `error.code` + `@Message.ExtendedInfo`), and 404 raised the wrong type (`RedfishForbidden`). Now every raised error carries the parsed `RedfishError` envelope, 404 is `ResourceNotFound`, and 405/409 keep returning `RedfishApiRespond.Error` (the only consumer reads the envelope from `self._redfish_error`).

**Brain-reviewed** (`code_review` think_max, task fdc9ea70): SAFE TO MERGE; 3 minors all refuted by local verification (5xx str keeps "HTTP 503" via `RedfishError.__str__`; zero `except RedfishForbidden` callers; the exception classes accept objects). Commit 1 = tests (red on the current write path), commit 2 = fix (green). Found + queued a separate two-`RedfishApiRespond`-enums duplication (0017).