### PR TITLE
Report rejected action POSTs as failures

### DIFF
--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -1919,14 +1919,24 @@ class RedfishManagerBase(RedfishManager):
             "redfish.action.level": level.value,
         }
         with tracing.client_span_attributes(span_attributes):
-            result, _ = self.base_post(target, payload=body, do_async=do_async,
-                                       expected_status=expected_status)
+            result, api_resp = self.base_post(target, payload=body, do_async=do_async,
+                                              expected_status=expected_status)
         data = result.data if isinstance(result.data, dict) else {"result": result.data}
-        data.setdefault("executed", True)
         data.setdefault("action", full)
         data.setdefault("target", target)
         data.setdefault("level", level.value)
-        return CommandResult(data, actions, None, result.error)
+
+        error = result.error
+        if api_resp == RedfishApiRespond.Error or error is not None:
+            data["executed"] = False
+            if error is None:
+                error = getattr(self, "_redfish_error", None)
+            if error is None:
+                error = f"action {full} failed with {api_resp.name}"
+            return CommandResult(data, actions, None, error)
+
+        data.setdefault("executed", True)
+        return CommandResult(data, actions, None, None)
 
     def reboot(
             self,

--- a/redfish_ctl/redfish_manager_base.py
+++ b/redfish_ctl/redfish_manager_base.py
@@ -1460,6 +1460,7 @@ class RedfishManagerBase(RedfishManager):
         err = None
         response = None
         api_resp = RedfishApiRespond.Error
+        self._redfish_error = None
         try:
             r = f"{self._default_method}{self.redfish_ip}{resource}"
             if not do_async:
@@ -1549,6 +1550,10 @@ class RedfishManagerBase(RedfishManager):
         api_resp_msg = self.api_success_msg(api_resp)
         if redfish_resp is not None:
             api_resp_msg.update(api_resp_msg)
+        if api_resp == RedfishApiRespond.Error and err is None:
+            err = self._redfish_error
+            if err is None and response is not None:
+                err = self.parse_error(response)
 
         return CommandResult(api_resp_msg, None, None, err), api_resp
 
@@ -1930,9 +1935,8 @@ class RedfishManagerBase(RedfishManager):
         if api_resp == RedfishApiRespond.Error or error is not None:
             data["executed"] = False
             if error is None:
-                error = getattr(self, "_redfish_error", None)
-            if error is None:
-                error = f"action {full} failed with {api_resp.name}"
+                status_name = getattr(api_resp, "name", str(api_resp))
+                error = f"action {full} failed with {status_name}"
             return CommandResult(data, actions, None, error)
 
         data.setdefault("executed", True)

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -135,8 +135,10 @@ def test_invoke_action_rejected_post_reports_error(redfish_mock_factory, monkeyp
 
     def rejected_post(resource, payload=None, do_async=False, expected_status=202):
         calls.append((resource, payload, do_async, expected_status))
-        mgr._redfish_error = "429 Too Many Requests"
-        return CommandResult({"Status": "error"}, None, None, None), RedfishApiRespond.Error
+        return (
+            CommandResult({"Status": "error"}, None, None, "429 Too Many Requests"),
+            RedfishApiRespond.Error,
+        )
 
     monkeypatch.setattr(mgr, "base_post", rejected_post)
 
@@ -156,6 +158,65 @@ def test_invoke_action_rejected_post_reports_error(redfish_mock_factory, monkeyp
     assert result.data["action"] == "#EventService.SubmitTestEvent"
     assert result.data["target"] == "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent"
     assert _post_count(svc) == 0
+
+
+def test_invoke_action_rejected_post_without_error_uses_status_fallback(
+    redfish_mock_factory, monkeypatch
+):
+    """A rejected action POST still returns an actionable error without details."""
+    mgr, svc = redfish_mock_factory("supermicro")
+
+    def rejected_post(resource, payload=None, do_async=False, expected_status=202):
+        return CommandResult({"Status": "error"}, None, None, None), RedfishApiRespond.Error
+
+    monkeypatch.setattr(mgr, "base_post", rejected_post)
+
+    result = mgr.invoke_action(
+        "/redfish/v1/EventService",
+        "SubmitTestEvent",
+        payload={"MessageId": "Alert.1.0.TestEvent"},
+        full_action_type="#EventService.SubmitTestEvent",
+    )
+
+    assert result.error == "action #EventService.SubmitTestEvent failed with Error"
+    assert result.data["executed"] is False
+    assert _post_count(svc) == 0
+
+
+class _WriteErrorResponse:
+    status_code = 405
+    headers = {}
+
+    def json(self):
+        return {
+            "error": {
+                "code": "Base.1.18.GeneralError",
+                "message": "write rejected",
+            }
+        }
+
+
+def test_base_post_error_response_carries_parsed_error(
+    redfish_mock_factory, monkeypatch
+):
+    """A rejected write returns its parsed Redfish error with the result."""
+    mgr, _svc = redfish_mock_factory("supermicro")
+    monkeypatch.setattr(
+        mgr,
+        "api_post_call",
+        lambda *_args, **_kwargs: _WriteErrorResponse(),
+    )
+
+    result, api_resp = mgr.base_post(
+        "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent",
+        payload={"MessageId": "Alert.1.0.TestEvent"},
+        expected_status=202,
+    )
+
+    assert api_resp == RedfishApiRespond.Error
+    assert result.error is mgr._redfish_error
+    assert result.error.status_code == 405
+    assert result.error.code == "Base.1.18.GeneralError"
 
 
 def test_destructive_blocks_without_confirm(redfish_mock_factory):

--- a/tests/test_action_foundation.py
+++ b/tests/test_action_foundation.py
@@ -7,7 +7,9 @@ against tests/supermicro_fixtures/ through the real requests path; the mock
 records every POST so we can assert exactly what did (or did not) fire.
 """
 from redfish_ctl.actions.action_policy import Destructiveness, classify
+from redfish_ctl.redfish_manager import CommandResult
 from redfish_ctl.redfish_manager_base import RedfishManagerBase
+from redfish_ctl.redfish_manager_shared import RedfishApiRespond
 
 
 def _post_count(svc):
@@ -124,6 +126,36 @@ def test_invoke_resolves_target_from_actions_block(redfish_mock_factory):
     assert result.data.get("executed") is True
     assert result.data["target"] == "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent"
     assert _post_count(svc) == 1
+
+
+def test_invoke_action_rejected_post_reports_error(redfish_mock_factory, monkeypatch):
+    """A rejected action POST must not be reported as successful execution."""
+    mgr, svc = redfish_mock_factory("supermicro")
+    calls = []
+
+    def rejected_post(resource, payload=None, do_async=False, expected_status=202):
+        calls.append((resource, payload, do_async, expected_status))
+        mgr._redfish_error = "429 Too Many Requests"
+        return CommandResult({"Status": "error"}, None, None, None), RedfishApiRespond.Error
+
+    monkeypatch.setattr(mgr, "base_post", rejected_post)
+
+    result = mgr.invoke_action("/redfish/v1/EventService", "SubmitTestEvent",
+                               payload={"MessageId": "Alert.1.0.TestEvent"},
+                               full_action_type="#EventService.SubmitTestEvent")
+
+    assert calls == [(
+        "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent",
+        {"MessageId": "Alert.1.0.TestEvent"},
+        False,
+        202,
+    )]
+    assert result.error == "429 Too Many Requests"
+    assert result.data["Status"] == "error"
+    assert result.data["executed"] is False
+    assert result.data["action"] == "#EventService.SubmitTestEvent"
+    assert result.data["target"] == "/redfish/v1/EventService/Actions/EventService.SubmitTestEvent"
+    assert _post_count(svc) == 0
 
 
 def test_destructive_blocks_without_confirm(redfish_mock_factory):


### PR DESCRIPTION
## Summary
- propagate action POST rejection from the shared invoke_action primitive as a failed execution
- surface the parsed Redfish error when base_post returns RedfishApiRespond.Error without raising
- add regression coverage for rejected POSTs after action target discovery

## Validation
- git diff --check
- git diff --cached --check