### PR TITLE
Make metric type consistent across Prometheus, SignalFx, and OTLP

### DIFF
--- a/redfish_ctl/telemetry/exporter.py
+++ b/redfish_ctl/telemetry/exporter.py
@@ -815,6 +815,7 @@ def _gpu_metric_report_sample(
                 dims | {"property": GPU_THROTTLE_PROPERTIES[prop_name]},
                 "s",
                 row.get("Timestamp"),
+                metric_type="counter",  # cumulative throttle time, not a gauge
             )
 
     if source == "memory":
@@ -999,21 +1000,25 @@ def render_prometheus_text(samples: Iterable[MetricSample]) -> str:
 
 
 def to_signalfx_body(samples: Iterable[MetricSample]) -> dict[str, list[dict]]:
-    """Wrap samples in the SignalFx /v2/datapoint gauge envelope.
+    """Wrap samples in the SignalFx /v2/datapoint envelope, keyed by metric type.
+
+    A ``counter`` metric_type is a monotonic cumulative counter, so it goes under the
+    SignalFx ``cumulative_counter`` envelope (matching the Prometheus ``counter`` type
+    and the OTLP monotonic Sum); everything else is a ``gauge``. This keeps the stored
+    Splunk metric type consistent with the other backends.
 
     :param samples: metric samples to wrap.
-    :return: SignalFx ``/v2/datapoint`` body with a ``gauge`` list.
+    :return: SignalFx ``/v2/datapoint`` body with ``gauge`` and/or ``cumulative_counter`` lists.
     """
-    return {
-        "gauge": [
-            {
-                "metric": sample.metric,
-                "value": sample.value,
-                "dimensions": dict(sample.dimensions),
-            }
-            for sample in samples
-        ]
-    }
+    body: dict[str, list[dict]] = {}
+    for sample in samples:
+        envelope = "cumulative_counter" if sample.metric_type == "counter" else "gauge"
+        body.setdefault(envelope, []).append({
+            "metric": sample.metric,
+            "value": sample.value,
+            "dimensions": dict(sample.dimensions),
+        })
+    return body
 
 
 def _require_datapoint_url(ingest_url: str) -> str:
@@ -1423,20 +1428,28 @@ def _sample(metric: str,
             dims: Mapping[str, str],
             unit: Optional[str] = None,
             timestamp: Optional[str] = None,
-            metric_type: str = "gauge") -> MetricSample:
+            metric_type: Optional[str] = None) -> MetricSample:
     """Construct a MetricSample with stringified dimension values.
 
     :param metric: metric name.
     :param value: numeric sample value.
     :param dims: dimension mapping.
-    :param unit: optional unit annotation.
+    :param unit: optional unit annotation; coerced to str so a non-string BMC unit
+        cannot reach the OTLP mapper.
     :param timestamp: optional sample timestamp.
-    :param metric_type: Prometheus/OpenMetrics sample type.
+    :param metric_type: explicit sample type; when None it is derived from the metric
+        name (monotonic-counter names -> ``counter``, else ``gauge``) so Prometheus,
+        SignalFx, and OTLP all agree on the type. This is the single classifier point.
     :return: the assembled MetricSample.
     """
+    if metric_type is None:
+        from . import otlp
+        metric_type = "counter" if otlp.is_monotonic_counter(metric) else "gauge"
     return MetricSample(metric=metric, value=float(value),
                         dimensions={k: str(v) for k, v in dims.items()},
-                        metric_type=metric_type, unit=unit, timestamp=timestamp)
+                        metric_type=metric_type,
+                        unit=(str(unit) if unit is not None else None),
+                        timestamp=timestamp)
 
 
 def _with_dims(identity: Mapping[str, str], **extra) -> dict[str, str]:
@@ -1451,7 +1464,7 @@ def _with_dims(identity: Mapping[str, str], **extra) -> dict[str, str]:
         if value not in (None, "")
     }
     for key in REQUIRED_DIMENSIONS:
-        dims.setdefault(key, str(identity.get(key, "unknown")))
+        dims.setdefault(key, str(identity.get(key) or "unknown"))
     for key, value in extra.items():
         if value not in (None, ""):
             dims[key] = str(value)

--- a/redfish_ctl/telemetry/otlp.py
+++ b/redfish_ctl/telemetry/otlp.py
@@ -33,6 +33,7 @@ RESOURCE_DIM_KEYS = RESOURCE_DIMENSIONS
 # one of these suffixes, or is total energy. Everything else is a Gauge.
 _COUNTER_SUFFIXES = (
     "_bytes", "_frames", "_packets", "_errors", "_discards", "_count", "_wait",
+    "_total", "_dropped",
 )
 _COUNTER_EXACT = frozenset({"hw.energy_kwh"})
 
@@ -130,7 +131,9 @@ def metrics_data_from_samples(samples: Iterable, service_name: str = "redfish_ct
     grouped: dict[str, dict] = {}
     for sample in samples:
         dp_attrs = {k: v for k, v in sample.dimensions.items() if k not in RESOURCE_DIM_KEYS}
-        entry = grouped.setdefault(sample.metric, {"unit": sample.unit, "points": []})
+        entry = grouped.setdefault(
+            sample.metric,
+            {"unit": sample.unit, "metric_type": sample.metric_type, "points": []})
         entry["points"].append(NumberDataPoint(
             attributes=dp_attrs,
             start_time_unix_nano=ts,
@@ -140,7 +143,10 @@ def metrics_data_from_samples(samples: Iterable, service_name: str = "redfish_ct
 
     metrics = []
     for name, entry in grouped.items():
-        if is_monotonic_counter(name):
+        # Trust the sample's declared metric_type (the single classifier, set at
+        # _sample construction) so OTLP agrees with Prometheus/SignalFx instead of
+        # re-deriving from the name.
+        if entry["metric_type"] == "counter":
             data = Sum(
                 data_points=entry["points"],
                 aggregation_temporality=AggregationTemporality.CUMULATIVE,

--- a/tests/test_otlp_exporter.py
+++ b/tests/test_otlp_exporter.py
@@ -48,7 +48,8 @@ def _samples():
     return [
         MetricSample("hw.power", 512.0, dict(dims), unit="W"),
         MetricSample("hw.gpu.power", 700.0, {**dims, "gpu": "GPU_0"}, unit="W"),
-        MetricSample("hw.fabric.rx_bytes", 12345.0, {**dims, "port": "NVLink_0"}, unit="By"),
+        MetricSample("hw.fabric.rx_bytes", 12345.0, {**dims, "port": "NVLink_0"}, unit="By",
+                     metric_type="counter"),
     ]
 
 

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -819,7 +819,7 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
         "hw.gpu.throttle.duration_seconds",
         "hw.gpu.temperature",
     } <= metrics
-    leak_points = [point for point in gauges if point["metric"] == "hw.leak.state"]
+    leak_points = [point for point in points if point["metric"] == "hw.leak.state"]
     assert len(leak_points) == 4
     assert {point["value"] for point in leak_points} == {0.0}
     assert {point["dimensions"]["source"] for point in leak_points} == {"leak-detector"}
@@ -832,9 +832,9 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
         "Chassis_0_LeakDetector_1_ColdPlate",
         "Chassis_0_LeakDetector_1_Manifold",
     }
-    assert all(REQUIRED_DIMS <= set(point["dimensions"]) for point in gauges)
+    assert all(REQUIRED_DIMS <= set(point["dimensions"]) for point in points)
     thermal_points = [
-        point for point in gauges
+        point for point in points
         if point["metric"] == "hw.temperature"
         and point["dimensions"].get("source") == "thermal-subsystem"
     ]
@@ -1002,23 +1002,23 @@ def test_exporter_uses_environment_metrics_command_rollups(gb300_exporter_manage
         vendor="supermicro",
     )
 
-    gauges = result.data["gauge"]
+    points = [point for envelope in result.data.values() for point in envelope]
     processor_power = [
-        point for point in gauges
+        point for point in points
         if point["metric"] == "hw.gpu.power"
         and point["dimensions"].get("source") == "environment"
         and point["dimensions"].get("resource_type") == "Processor"
         and point["dimensions"].get("resource") == "GPU_0"
     ]
     memory_power = [
-        point for point in gauges
+        point for point in points
         if point["metric"] == "hw.power"
         and point["dimensions"].get("source") == "environment"
         and point["dimensions"].get("resource_type") == "Memory"
         and point["dimensions"].get("resource") == "GPU_0_DRAM_0"
     ]
     processor_energy = [
-        point for point in gauges
+        point for point in points
         if point["metric"] == "hw.energy_kwh"
         and point["dimensions"].get("source") == "environment"
         and point["dimensions"].get("resource_type") == "Processor"

--- a/tests/test_telemetry_exporter.py
+++ b/tests/test_telemetry_exporter.py
@@ -799,13 +799,13 @@ def test_exporter_command_collects_supermicro_fixture_metrics(redfish_mock_facto
         vendor="supermicro",
     )
 
-    gauges = result.data["gauge"]
-    metrics = {point["metric"] for point in gauges}
+    points = [point for envelope in result.data.values() for point in envelope]
+    metrics = {point["metric"] for point in points}
     assert {"hw.power", "hw.gpu.power", "hw.fabric.rx_bytes", "hw.leak.state"} <= metrics
     assert {"hw.scrape.ok", "hw.scrape.duration_seconds"} <= metrics
-    scrape_ok = next(point for point in gauges if point["metric"] == "hw.scrape.ok")
+    scrape_ok = next(point for point in points if point["metric"] == "hw.scrape.ok")
     scrape_duration = next(
-        point for point in gauges
+        point for point in points
         if point["metric"] == "hw.scrape.duration_seconds"
     )
     assert scrape_ok["value"] == 1
@@ -1066,7 +1066,7 @@ def test_once_push_signalfx_posts_body_exactly_once(redfish_mock_factory, monkey
     assert calls[0]["body"] is result.data
     assert result.data["gauge"]
     assert result.extra["push_status"] == 200
-    assert result.extra["sample_count"] == len(result.data["gauge"])
+    assert result.extra["sample_count"] == sum(len(pts) for pts in result.data.values())
 
 
 def test_once_push_signalfx_rejects_bare_ingest_url(redfish_mock_factory, monkeypatch):

--- a/tests/test_telemetry_metric_type_agreement.py
+++ b/tests/test_telemetry_metric_type_agreement.py
@@ -1,0 +1,96 @@
+"""GATE: metric type agrees across Prometheus, SignalFx, and OTLP for every metric.
+
+Regression guard: previously counters were gauges on Prometheus/SignalFx but monotonic Sums
+on OTLP (the same metric had two types depending on backend). This gate fails if a metric's
+gauge/counter classification ever diverges between the three backends again, or drifts from
+its expected type.
+
+Author Mus spyroot@gmail.com
+"""
+import pytest
+
+from redfish_ctl.telemetry import exporter, otlp
+
+# Curated metric -> expected type, including the tricky cases the data-type audit surfaced.
+_EXPECTED = {
+    # gauges (instantaneous)
+    "hw.power": "gauge",
+    "hw.temperature": "gauge",
+    "hw.voltage": "gauge",
+    "hw.gpu.power": "gauge",
+    "hw.gpu.temperature": "gauge",
+    "hw.scrape.duration_seconds": "gauge",
+    "redfish_exporter_scrape_duration_seconds": "gauge",
+    "redfish_exporter_last_success_timestamp_seconds": "gauge",
+    # counters (monotonic cumulative)
+    "hw.fabric.rx_bytes": "counter",
+    "hw.fabric.tx_bytes": "counter",
+    "hw.fabric.crc_errors": "counter",
+    "hw.fabric.link_down_count": "counter",
+    "hw.fabric.vl15_dropped": "counter",
+    "hw.energy_kwh": "counter",
+    "redfish_exporter_collection_errors_total": "counter",
+    "hw.gpu.throttle.duration_seconds": "counter",
+}
+
+_DIMS = {"host.name": "h", "node": "n", "server.address": "s", "bmc.ip": "b", "vendor": "v"}
+# hw.gpu.throttle.duration_seconds is cumulative but its name does not suffix-match, so its
+# mapper sets metric_type explicitly; everything else derives from the name.
+_EXPLICIT = {"hw.gpu.throttle.duration_seconds": "counter"}
+
+
+def _prometheus_type(name, sample):
+    """Return the Prometheus ``# TYPE`` for a metric, or None.
+
+    :param name: metric name.
+    :param sample: the sample to render.
+    :return: the type token from the ``# TYPE`` line.
+    """
+    for line in exporter.render_prometheus_text([sample]).splitlines():
+        if line.startswith(f"# TYPE {name} "):
+            return line.split()[-1]
+    return None
+
+
+def _signalfx_envelope(sample):
+    """Return the SignalFx envelope key a sample lands under.
+
+    :param sample: the sample to wrap.
+    :return: ``gauge`` or ``cumulative_counter``.
+    """
+    for envelope, points in exporter.to_signalfx_body([sample]).items():
+        if points:
+            return envelope
+    return None
+
+
+@pytest.mark.parametrize("name,expected", sorted(_EXPECTED.items()))
+def test_metric_type_agrees_across_backends(name, expected):
+    """GATE: Prometheus TYPE, SignalFx envelope, and OTLP Sum/Gauge all match the expected type."""
+    sample = exporter._sample(name, 1.0, _DIMS, metric_type=_EXPLICIT.get(name))
+    assert sample.metric_type == expected, f"{name} declared {sample.metric_type}, expected {expected}"
+
+    assert _prometheus_type(name, sample) == expected
+
+    assert _signalfx_envelope(sample) == (
+        "cumulative_counter" if expected == "counter" else "gauge")
+
+    pytest.importorskip("opentelemetry.sdk.metrics.export")
+    from opentelemetry.sdk.metrics.export import Gauge, Sum
+
+    from redfish_ctl.telemetry.otlp import metrics_data_from_samples
+    data = (metrics_data_from_samples([sample], service_name="redfish_ctl")
+            .resource_metrics[0].scope_metrics[0].metrics[0].data)
+    if expected == "counter":
+        assert isinstance(data, Sum) and data.is_monotonic
+    else:
+        assert isinstance(data, Gauge)
+
+
+def test_is_monotonic_counter_covers_audit_cases():
+    """The name classifier recognizes the counters the audit flagged (incl _total, _dropped)."""
+    assert otlp.is_monotonic_counter("redfish_exporter_collection_errors_total")
+    assert otlp.is_monotonic_counter("hw.fabric.vl15_dropped")
+    assert otlp.is_monotonic_counter("hw.fabric.rx_bytes")
+    assert not otlp.is_monotonic_counter("hw.scrape.duration_seconds")
+    assert not otlp.is_monotonic_counter("hw.power")

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -34,8 +34,8 @@ redfish_ctl/redfish_manager.py:302
 redfish_ctl/redfish_manager_base.py:411
 redfish_ctl/telemetry/cmd_exporter.py:771
 redfish_ctl/telemetry/cmd_exporter.py:772
-redfish_ctl/telemetry/exporter.py:1065
-redfish_ctl/telemetry/exporter.py:1081
+redfish_ctl/telemetry/exporter.py:1070
+redfish_ctl/telemetry/exporter.py:1086
 redfish_ctl/telemetry/exporter.py:228
 redfish_ctl/telemetry/exporter.py:346
 redfish_ctl/telemetry/exporter.py:347
@@ -48,10 +48,10 @@ redfish_ctl/telemetry/identity.py:292
 redfish_ctl/telemetry/identity.py:300
 redfish_ctl/telemetry/identity.py:307
 redfish_ctl/telemetry/identity.py:311
-redfish_ctl/telemetry/otlp.py:70
 redfish_ctl/telemetry/otlp.py:71
-redfish_ctl/telemetry/otlp.py:73
+redfish_ctl/telemetry/otlp.py:72
 redfish_ctl/telemetry/otlp.py:74
-redfish_ctl/telemetry/otlp.py:77
+redfish_ctl/telemetry/otlp.py:75
 redfish_ctl/telemetry/otlp.py:78
+redfish_ctl/telemetry/otlp.py:79
 redfish_ctl/webui/server.py:30


### PR DESCRIPTION
## Summary

Fixes the metric-type inconsistency the data-type audit surfaced: counters were emitted as **gauges** on Prometheus/SignalFx but as monotonic **Sums** on OTLP, so the same metric had a different type per backend and `rate()`/`increase()` diverged.

`metric_type` is now the single source of truth — derived once at `_sample` construction (or set explicitly) — and **every backend reads it**:
- Prometheus `# TYPE`
- SignalFx `cumulative_counter` envelope (was: everything under `gauge`)
- OTLP `Sum(monotonic, cumulative)` (was: independently re-derived from the metric name)

Also classifies the `_total` / `_dropped` counters and the cumulative GPU throttle duration correctly, and coerces a non-string `unit` and a present-`None` identity dimension.

## Gate — so a regression trips automatically

`tests/test_telemetry_metric_type_agreement.py` asserts, for every metric (gauges + the tricky counters), that the Prometheus TYPE, the SignalFx envelope, and the OTLP Sum/Gauge **all agree**. If a future change flips a type on one backend, this gate fails.

## Notes

- **Stacked on #378** (base = `neroshige/portable-identity-strategies`); GitHub retargets it to `main` when #378 merges.
- Contract change: Prometheus `# TYPE` flips gauge→counter for the counters (correct; matches OTLP), and SignalFx stores them as `cumulative_counter`. This is what makes the future live golden smoke (board `0140`) pass — source type == destination type.
