### PR TITLE
Wire redfish trace spans to Splunk under the shared redfish_ctl identity

### DIFF
--- a/redfish_ctl/redfish_main.py
+++ b/redfish_ctl/redfish_main.py
@@ -451,9 +451,13 @@ def main(cmd_args: argparse.Namespace, command_name_to_cmd: Dict) -> None:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     # Optional OTLP span pipeline for this run; no-op unless --otlp-traces is set.
+    # Endpoint/headers resolve from OTEL_EXPORTER_OTLP_* (point them at the Splunk O11y
+    # OTLP ingest with an X-SF-Token header); deployment.environment and other resource
+    # keys come from OTEL_RESOURCE_ATTRIBUTES. service.name defaults to the shared
+    # redfish_ctl identity so spans and hw.* metrics land on one APM service node.
     if getattr(cmd_args, "otlp_traces", False):
         from .telemetry import tracing
-        tracing.setup_otlp("redfish-ctl")
+        tracing.setup_otlp()
 
     # the manager is the main interface main uses to interact with the BMC.
     redfish_api = RedfishManagerBase(host=cmd_args.redfish_host,

--- a/redfish_ctl/telemetry/tracing.py
+++ b/redfish_ctl/telemetry/tracing.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import contextlib
 from contextvars import ContextVar
-from typing import Any, Callable, Iterator, Optional
+from typing import Any, Callable, Iterator, Mapping, Optional
 from urllib.parse import urlsplit
 
 # Set by enable_tracing(); None means tracing is off and every helper no-ops.
@@ -46,24 +46,52 @@ def enable_tracing(tracer: Any) -> None:
     _TRACER = tracer
 
 
-def setup_otlp(service_name: str = "redfish-ctl") -> None:
+def _trace_resource_attrs(service_name: str,
+                          resource_attrs: Optional[Mapping[str, str]] = None) -> dict:
+    """Build the OTLP trace Resource attributes for a redfish_ctl run.
+
+    The OpenTelemetry SDK additionally merges ``OTEL_RESOURCE_ATTRIBUTES`` from the
+    environment into the Resource, so ``deployment.environment`` and other identity
+    keys can be supplied at deploy time (no code change) and still correlate traces
+    with the exporter's ``hw.*`` metrics on the shared identity keys.
+
+    :param service_name: the ``service.name`` resource attribute (the APM service-map node).
+    :param resource_attrs: optional extra resource attributes to merge; ``None`` values are skipped.
+    :return: a resource-attribute dict carrying a non-empty ``service.name``.
+    """
+    attrs = {"service.name": str(service_name)}
+    for key, value in (resource_attrs or {}).items():
+        if value is None:
+            continue
+        attrs[str(key)] = str(value)
+    return attrs
+
+
+def setup_otlp(service_name: Optional[str] = None,
+               resource_attrs: Optional[Mapping[str, str]] = None) -> None:
     """Install an OTLP span pipeline and enable tracing.
 
     Builds a ``TracerProvider`` + ``BatchSpanProcessor`` + ``OTLPSpanExporter``
-    and turns tracing on. The exporter resolves its endpoint from the standard
-    ``OTEL_EXPORTER_OTLP_*`` environment itself, so the ``/v1/traces`` path is
-    appended correctly for a generic endpoint (do not pre-pass one here).
+    and turns tracing on. The exporter resolves its endpoint and headers from the
+    standard ``OTEL_EXPORTER_OTLP_*`` environment; point them at the Splunk O11y
+    OTLP ingest (``OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`` = the ingest trace URL,
+    ``OTEL_EXPORTER_OTLP_HEADERS`` = ``X-SF-Token=<access-token>``), so no endpoint
+    is hard-coded here.
 
     Requires the OpenTelemetry SDK + OTLP exporter (the ``[otlp]`` extra);
-    raises a clear error otherwise. ``service.name`` becomes the APM service
-    map node.
+    raises a clear error otherwise.
 
     :param service_name: value for the ``service.name`` resource attribute (the APM
-        service-map node name).
+        service-map node); defaults to the shared ``redfish_ctl`` identity so traces
+        and ``hw.*`` metrics land on one service node. An empty value falls back to it.
+    :param resource_attrs: optional extra resource attributes (e.g. deployment.environment)
+        merged into the trace Resource so traces carry the same identity keys as metrics.
     :raises RuntimeError: when the OpenTelemetry SDK or an OTLP exporter is not installed.
     """
+    from .identity import DEFAULT_SERVICE_NAME
+    resolved_service_name = str(service_name or "").strip() or DEFAULT_SERVICE_NAME
     global _OTLP_SETUP_SERVICE_NAME
-    if _TRACER is not None and _OTLP_SETUP_SERVICE_NAME == service_name:
+    if _TRACER is not None and _OTLP_SETUP_SERVICE_NAME == resolved_service_name:
         return
     try:
         from opentelemetry.sdk.resources import Resource
@@ -88,10 +116,12 @@ def setup_otlp(service_name: str = "redfish-ctl") -> None:
                 "Install redfish_ctl[otlp]."
             ) from exc
 
-    provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+    provider = TracerProvider(
+        resource=Resource.create(
+            _trace_resource_attrs(resolved_service_name, resource_attrs)))
     provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
     enable_tracing(provider.get_tracer("redfish_ctl"))
-    _OTLP_SETUP_SERVICE_NAME = service_name
+    _OTLP_SETUP_SERVICE_NAME = resolved_service_name
 
 
 def disable_tracing() -> None:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -288,3 +288,43 @@ def test_setup_otlp_is_idempotent_when_already_configured(monkeypatch):
         tracing.setup_otlp("redfish-controller")
     finally:
         tracing.disable_tracing()
+
+
+def test_trace_resource_attrs_carries_service_name_and_merges_identity():
+    """The trace Resource always carries service.name and merges caller identity keys,
+    so redfish spans and hw.* metrics correlate on deployment.environment in Splunk."""
+    attrs = tracing._trace_resource_attrs(
+        "redfish_ctl",
+        {"deployment.environment": "nv72-gb300",
+         "deployment.environment.name": "nv72-gb300"},
+    )
+    assert attrs["service.name"] == "redfish_ctl"
+    assert attrs["deployment.environment"] == "nv72-gb300"
+    assert attrs["deployment.environment.name"] == "nv72-gb300"
+
+
+def test_trace_resource_attrs_skips_none_and_stringifies():
+    """None extras are dropped and values are stringified for the OTLP Resource."""
+    attrs = tracing._trace_resource_attrs("redfish_ctl", {"absent": None, "port": 5})
+    assert "absent" not in attrs
+    assert attrs["port"] == "5"
+
+
+def test_setup_otlp_defaults_to_shared_redfish_ctl_service_name(monkeypatch):
+    """setup_otlp() with no argument resolves service.name to the shared redfish_ctl
+    identity (unified with metrics) — the old 'redfish-ctl' split-brain default is gone.
+
+    Proven offline via the idempotency early-return: pre-seeding the guard with
+    redfish_ctl makes a no-arg setup_otlp() return before any SDK import. If the default
+    were still 'redfish-ctl' the names would differ, the guard would miss, and it would
+    try to build the pipeline and raise without the [otlp] extra installed.
+    """
+    from redfish_ctl.telemetry.identity import DEFAULT_SERVICE_NAME
+
+    assert DEFAULT_SERVICE_NAME == "redfish_ctl"
+    tracing.enable_tracing(object())
+    monkeypatch.setattr(tracing, "_OTLP_SETUP_SERVICE_NAME", DEFAULT_SERVICE_NAME)
+    try:
+        tracing.setup_otlp()
+    finally:
+        tracing.disable_tracing()


### PR DESCRIPTION
Phase-0 enablement for live end-to-end span coverage: make redfish spans actually reach Splunk APM under one service node.

## What
- `setup_otlp` defaults `service.name` to the shared `redfish_ctl` identity (was the split-brain `redfish-ctl`); traces and `hw.*` metrics now land on one APM service node. Zero series churn — there are currently 0 redfish spans in Splunk.
- Trace Resource is built through a testable `_trace_resource_attrs` helper and accepts extra resource attributes (e.g. deployment.environment) so traces carry the same identity keys as metrics.
- Endpoint/headers/deployment come from standard OTEL env (`OTEL_EXPORTER_OTLP_*`, `OTEL_RESOURCE_ATTRIBUTES`) — no hardcoded endpoint, no new in-code env reads (config-loader gate unaffected).

## Deploy (Splunk O11y)
`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`=<ingest trace URL>, `OTEL_EXPORTER_OTLP_HEADERS`=`X-SF-Token=<access-token>`, `OTEL_RESOURCE_ATTRIBUTES`=`deployment.environment=<env>`, run with `--otlp-traces`.

## Tests
Offline: `_trace_resource_attrs` carries service.name + merges identity + skips None; `setup_otlp()` default resolves to `redfish_ctl` (proves the split-brain default is gone). Live span→Splunk proof runs on the fleet ([otlp] + Splunk creds).

Out of scope (follow-ups): full trace-Resource instance.id coherence (0050), async-GET span-root orphans (0013).