### PR TITLE
Add dns-set command (Manager EthernetInterface static DNS) with BMC-authoritative validation

### DIFF
--- a/redfish_ctl/__init__.py
+++ b/redfish_ctl/__init__.py
@@ -81,6 +81,7 @@ from .pci.cmd_pci import *
 from .manager.cmd_manager import *
 from .manager.cmd_manager_network import *
 from .manager.cmd_ntp_set import *
+from .manager.cmd_dns_set import *
 from .manager.cmd_manager_reset import *
 
 

--- a/redfish_ctl/manager/cmd_dns_set.py
+++ b/redfish_ctl/manager/cmd_dns_set.py
@@ -1,0 +1,172 @@
+"""Set Manager EthernetInterface static DNS name servers with a guarded PATCH.
+
+    redfish_ctl dns-set --interface eth0 --server 8.8.8.8 --confirm
+    redfish_ctl dns-set --clear --confirm
+
+Author Mus spyroot@gmail.com
+"""
+
+from abc import abstractmethod
+from typing import Optional
+
+from ..cmd_exceptions import InvalidArgument
+from ..redfish_manager import CommandResult
+from ..redfish_manager_base import RedfishManagerBase
+from ..redfish_manager_shared import ApiRequestType, Singleton
+
+_MAX_DNS_SERVERS = 4
+
+
+def _normalize_dns_servers(servers, clear: bool = False) -> list[str]:
+    """Normalize DNS server arguments into a clean list.
+
+    The values are deliberately NOT IP-validated on the client: the BMC is the
+    authority on address validity, so a bad address surfaces as a real BMC HTTP
+    error recorded on the operation span (an APM error trace) rather than being
+    masked by a client-side rejection.
+
+    :param servers: one server string, a comma-joined string, or a list of them.
+    :param clear: request an empty DNS list; rejects any provided ``servers``.
+    :return: the normalized list of DNS servers (empty when ``clear`` is set).
+    :raises InvalidArgument: when ``clear`` is combined with servers, no server is
+        given, or more than four are given.
+    """
+    if clear:
+        if servers:
+            raise InvalidArgument("--clear cannot be used with --server")
+        return []
+    if servers is None:
+        raise InvalidArgument("at least one DNS server is required")
+    raw_servers = [servers] if isinstance(servers, str) else list(servers)
+    normalized = []
+    for raw in raw_servers:
+        for value in str(raw).split(","):
+            server = value.strip()
+            if server:
+                normalized.append(server)
+    if not normalized:
+        raise InvalidArgument("at least one DNS server is required")
+    if len(normalized) > _MAX_DNS_SERVERS:
+        raise InvalidArgument(
+            f"StaticNameServers supports at most {_MAX_DNS_SERVERS} servers")
+    return normalized
+
+
+class DnsSet(RedfishManagerBase,
+             scm_type=ApiRequestType.DnsSet,
+             name='dns-set',
+             metaclass=Singleton):
+    """Set Manager EthernetInterface StaticNameServers after a dry-run preview."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize the dns-set command."""
+        super(DnsSet, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls):
+        """Register the guarded dns-set subcommand.
+
+        :param cls: the command class the base parser is built from.
+        :return: tuple of (ArgumentParser, command name, command help).
+        """
+        cmd_parser = cls.base_parser()
+        cmd_parser.add_argument(
+            '--server', action='append', dest='servers', metavar='IP',
+            help="DNS server IP; repeat for up to 4 servers")
+        cmd_parser.add_argument(
+            '--clear', action='store_true', dest='clear', default=False,
+            help="clear the static DNS server list")
+        cmd_parser.add_argument(
+            '--interface', type=str, dest='interface_id', default=None, metavar='ID',
+            help="optional Manager EthernetInterface id to patch; default patches all")
+        cmd_parser.add_argument(
+            '--confirm', action='store_true', dest='confirm', default=False,
+            help="apply the PATCH; without it the command only previews")
+        help_text = "set Manager EthernetInterface static DNS servers"
+        return cmd_parser, "dns-set", help_text
+
+    def _interface_uris(self, do_async: bool) -> list[str]:
+        """Discover the Manager EthernetInterface member URIs.
+
+        :param do_async: run the discovery queries asynchronously.
+        :return: list of EthernetInterface ``@odata.id`` URIs across managers.
+        """
+        uris: list[str] = []
+        for manager_uri in self.discover_manager_ids():
+            try:
+                manager = self.base_query(manager_uri, do_async=do_async).data or {}
+            except Exception:
+                continue
+            collection = (manager.get("EthernetInterfaces") or {}).get("@odata.id")
+            if not collection:
+                continue
+            try:
+                members = (self.base_query(
+                    collection, do_async=do_async).data or {}).get("Members", [])
+            except Exception:
+                continue
+            uris.extend(m["@odata.id"] for m in members if "@odata.id" in m)
+        return uris
+
+    def execute(self,
+                filename: Optional[str] = None,
+                data_type: Optional[str] = "json",
+                verbose: Optional[bool] = False,
+                do_async: Optional[bool] = False,
+                do_expanded: Optional[bool] = False,
+                servers=None,
+                interface_id: Optional[str] = None,
+                clear: Optional[bool] = False,
+                confirm: Optional[bool] = False,
+                **kwargs) -> CommandResult:
+        """Preview or apply static DNS servers on Manager EthernetInterfaces.
+
+        :param filename: accepted for CLI compatibility; not used by this command.
+        :param data_type: accepted for CLI compatibility; not used by this command.
+        :param verbose: accepted for CLI compatibility; not used by this command.
+        :param do_async: run the discovery and PATCH requests asynchronously.
+        :param do_expanded: accepted for CLI compatibility; not used by this command.
+        :param servers: the DNS server IPs to set (up to four).
+        :param interface_id: optional Manager EthernetInterface id to restrict the write to.
+        :param clear: clear the static DNS server list instead of setting servers.
+        :param confirm: apply the PATCH; without it the command only previews.
+        :return: CommandResult whose data is the dry-run preview (dry_run, servers,
+            targets) without ``--confirm``, or the applied results with it.
+        :raises InvalidArgument: when the servers are invalid or no Manager
+            EthernetInterface is found.
+        """
+        normalized = _normalize_dns_servers(servers, bool(clear))
+        payload = {"StaticNameServers": normalized}
+
+        targets = self._interface_uris(bool(do_async))
+        if interface_id:
+            targets = [
+                uri for uri in targets
+                if uri.rstrip("/").rsplit("/", 1)[-1] == interface_id
+            ]
+        if not targets:
+            raise InvalidArgument("no Manager EthernetInterface resources found")
+
+        if not confirm:
+            return CommandResult({
+                "dry_run": True,
+                "note": "preview only; re-run with --confirm to apply",
+                "servers": normalized,
+                "targets": targets,
+            }, None, None, None)
+
+        applied = []
+        for uri in targets:
+            result, status = self.base_patch(
+                uri, payload=payload, do_async=do_async, expected_status=200)
+            applied.append({
+                "target": uri,
+                "status": str(status),
+                "error": result.error,
+            })
+
+        return CommandResult({
+            "servers": normalized,
+            "applied": applied,
+        }, None, None, None)

--- a/redfish_ctl/redfish_manager_shared.py
+++ b/redfish_ctl/redfish_manager_shared.py
@@ -204,6 +204,7 @@ class ApiRequestType(Enum):
     ManagerQuery = auto()
     ManagerNetworkProtocol = auto()
     NtpSet = auto()
+    DnsSet = auto()
     IdentifyLed = auto()
     ManagerReset = auto()
 

--- a/tests/test_dns_set_dualmode.py
+++ b/tests/test_dns_set_dualmode.py
@@ -1,0 +1,113 @@
+"""Dual-mode tests for the dns-set command."""
+
+import pytest
+
+from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.redfish_manager import CommandResult
+from redfish_ctl.redfish_manager_shared import ApiRequestType
+
+
+def _patch_requests(service):
+    return [request for request in service.requests if request.method == "PATCH"]
+
+
+def _mutating_requests(service):
+    return [
+        request for request in service.requests
+        if request.method in {"POST", "PATCH", "DELETE"}
+    ]
+
+
+def _overlay_single_manager_with_eth0(service):
+    """Pin discovery to one Manager (BMC_0) with a single eth0 EthernetInterface."""
+    service._overlay["/redfish/v1/managers"] = {
+        "@odata.id": "/redfish/v1/Managers",
+        "Members": [{"@odata.id": "/redfish/v1/Managers/BMC_0"}],
+        "Members@odata.count": 1,
+    }
+    service._overlay["/redfish/v1/managers/bmc_0"] = {
+        "@odata.id": "/redfish/v1/Managers/BMC_0",
+        "Id": "BMC_0",
+        "EthernetInterfaces": {
+            "@odata.id": "/redfish/v1/Managers/BMC_0/EthernetInterfaces",
+        },
+    }
+    service._overlay["/redfish/v1/managers/bmc_0/ethernetinterfaces"] = {
+        "@odata.id": "/redfish/v1/Managers/BMC_0/EthernetInterfaces",
+        "Members": [
+            {"@odata.id": "/redfish/v1/Managers/BMC_0/EthernetInterfaces/eth0"},
+        ],
+        "Members@odata.count": 1,
+    }
+    service._overlay["/redfish/v1/managers/bmc_0/ethernetinterfaces/eth0"] = {
+        "@odata.id": "/redfish/v1/Managers/BMC_0/EthernetInterfaces/eth0",
+        "Id": "eth0",
+        "StaticNameServers": [],
+    }
+
+
+def test_dns_set_dry_run_previews_static_name_servers_without_writing(
+        redfish_mock_factory):
+    """dns-set previews the StaticNameServers PATCH target by default."""
+    manager, service = redfish_mock_factory("supermicro")
+    _overlay_single_manager_with_eth0(service)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DnsSet, "dns-set",
+        servers=["8.8.8.8"], interface_id="eth0")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    assert result.data["dry_run"] is True
+    assert result.data["servers"] == ["8.8.8.8"]
+    assert result.data["targets"] == [
+        "/redfish/v1/Managers/BMC_0/EthernetInterfaces/eth0"]
+    assert _mutating_requests(service) == []
+
+
+def test_dns_set_confirm_patches_static_name_servers(redfish_mock_factory):
+    """dns-set --confirm PATCHes StaticNameServers on the EthernetInterface."""
+    manager, service = redfish_mock_factory("supermicro")
+    _overlay_single_manager_with_eth0(service)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DnsSet, "dns-set",
+        servers=["8.8.8.8"], interface_id="eth0", confirm=True)
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].path == "/redfish/v1/managers/bmc_0/ethernetinterfaces/eth0"
+    assert patches[0].json() == {"StaticNameServers": ["8.8.8.8"]}
+    assert result.data["applied"] == [{
+        "target": "/redfish/v1/Managers/BMC_0/EthernetInterfaces/eth0",
+        "status": "RedfishApiRespond.Ok",
+        "error": None,
+    }]
+
+
+def test_dns_set_clear_patches_empty_static_name_servers(redfish_mock_factory):
+    """dns-set --clear PATCHes an empty StaticNameServers list."""
+    manager, service = redfish_mock_factory("supermicro")
+    _overlay_single_manager_with_eth0(service)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DnsSet, "dns-set",
+        clear=True, interface_id="eth0", confirm=True)
+
+    patches = _patch_requests(service)
+    assert len(patches) == 1
+    assert patches[0].json() == {"StaticNameServers": []}
+    assert result.data["servers"] == []
+
+
+def test_dns_set_clear_rejects_explicit_servers(redfish_mock_factory):
+    """dns-set --clear is mutually exclusive with explicit --server values."""
+    manager, service = redfish_mock_factory("supermicro")
+    _overlay_single_manager_with_eth0(service)
+
+    with pytest.raises(InvalidArgument):
+        manager.sync_invoke(
+            ApiRequestType.DnsSet, "dns-set",
+            servers=["8.8.8.8"], clear=True, interface_id="eth0", confirm=True)
+
+    assert _mutating_requests(service) == []


### PR DESCRIPTION
Fills a gap (no DNS command existed) and demonstrates the transport-seam error path.

## What
`dns-set` sets/clears `StaticNameServers` on Manager EthernetInterfaces via a guarded PATCH — dry-run preview by default, `--confirm` to apply, optional `--interface <id>`. Mirrors `ntp-set`. New `ApiRequestType.DnsSet` + registered in `__init__.py`.

## Why no client IP validation
The BMC is the authority on address validity, so a bad address surfaces as a **real BMC HTTP error recorded on the operation span** (an APM error trace) rather than being masked client-side. This is the point: every command's success AND failure is captured at the traced transport seam — an agent can't fake it.

## Verified live (GB300 BMC, capture→set→restore)
- set `8.8.8.8` → `RedfishApiRespond.Ok`, eth0 = ['8.8.8.8'].
- set `999.999.999.999` → **HTTP 400** ("value does not meet constraints"); bad value did not apply.
- `--clear` → eth0 = [].
- Splunk APM: `sf_operation:dns-set` = 8, `sf_error:true` = 4 (the bad-IP error traces).

Dual-mode test added (dry-run preview, confirm PATCHes StaticNameServers, clear, --clear/--server mutual exclusion).