### PR TITLE
Propagate per-target BMC errors to the operation span (Redfish reason on the APM trace)

### DIFF
--- a/redfish_ctl/manager/cmd_dns_set.py
+++ b/redfish_ctl/manager/cmd_dns_set.py
@@ -166,7 +166,11 @@ class DnsSet(RedfishManagerBase,
                 "error": result.error,
             })
 
+        # Surface any per-target BMC error as the CommandResult error so it marks
+        # the operation span failed (the Redfish reason lands on the APM trace,
+        # not just the HTTP status on the client span).
+        errors = [item["error"] for item in applied if item["error"]]
         return CommandResult({
             "servers": normalized,
             "applied": applied,
-        }, None, None, None)
+        }, None, None, "; ".join(str(error) for error in errors) or None)

--- a/redfish_ctl/manager/cmd_ntp_set.py
+++ b/redfish_ctl/manager/cmd_ntp_set.py
@@ -365,8 +365,12 @@ class NtpSet(RedfishManagerBase,
                 "error": result.error,
             })
 
+        # Surface any per-target BMC error as the CommandResult error so it marks
+        # the operation span failed (the Redfish reason lands on the APM trace,
+        # not just the HTTP status on the client span).
+        errors = [item["error"] for item in applied if item["error"]]
         return CommandResult({
             "servers": normalized_servers,
             "applied": applied,
             "skipped": skipped,
-        }, None, None, None)
+        }, None, None, "; ".join(str(error) for error in errors) or None)

--- a/tests/test_dns_set_dualmode.py
+++ b/tests/test_dns_set_dualmode.py
@@ -111,3 +111,32 @@ def test_dns_set_clear_rejects_explicit_servers(redfish_mock_factory):
             servers=["8.8.8.8"], clear=True, interface_id="eth0", confirm=True)
 
     assert _mutating_requests(service) == []
+
+
+def test_dns_set_propagates_bmc_error_to_command_result(
+        redfish_mock_factory, monkeypatch):
+    """A failing PATCH surfaces on CommandResult.error so the operation span (and
+    the APM trace) carries the Redfish reason, not just the client-span HTTP status.
+    """
+    manager, service = redfish_mock_factory("supermicro")
+    _overlay_single_manager_with_eth0(service)
+
+    reason = ("The property 'StaticNameServers' with the requested value could not "
+              "be written because the value does not meet the constraints of the "
+              "implementation. (HTTP 400)")
+
+    def _failing_patch(self, resource, payload=None, do_async=False,
+                       data_type="json", expected_status=204, ignore_error_code=0):
+        return CommandResult(None, None, None, reason), "RedfishApiRespond.Failed"
+
+    monkeypatch.setattr(
+        "redfish_ctl.redfish_manager_base.RedfishManagerBase.base_patch",
+        _failing_patch)
+
+    result = manager.sync_invoke(
+        ApiRequestType.DnsSet, "dns-set",
+        servers=["999.999.999.999"], interface_id="eth0", confirm=True)
+
+    assert result.error is not None
+    assert "does not meet the constraints" in result.error
+    assert result.data["applied"][0]["error"] == reason


### PR DESCRIPTION
Follow-up to a live trace check: the parser reads the GB300 Redfish error correctly (full `Message.ExtendedInfo` into `result.error`), but `dns-set`/`ntp-set` buried per-target PATCH errors in `data["applied"]` and returned top-level `CommandResult.error=None`. So `record_result` never marked the **root operation span** failed — the APM trace showed the client-span HTTP 400 but not the Redfish reason on the root, and the root read OK instead of root-cause.

## Fix
Surface any per-target error as the CommandResult error (joined). Now `record_result` stamps the operation span ERROR with the parsed Redfish reason, so the trace's root span shows **why**, not just the HTTP status. Success path is unchanged (no errors -> None). Regression test added.