### PR TITLE
Add OTLP dependencies to conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,5 +29,8 @@ dependencies:
   # Optional TUI ("tui" extra in setup.py): pretty tables for redfish-discover.
   - rich>=13
   - pip:
+      # Mirror the "otlp" extra so the GB300 conda image carries the exporter.
+      - opentelemetry-sdk>=1.20
+      - opentelemetry-exporter-otlp>=1.20
       # Install redfish_ctl itself (and anything not on conda-forge) via pip.
       - -e .

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -110,3 +110,5 @@ def test_conda_environment_includes_make_build_tools() -> None:
     environment_text = (REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
 
     assert "  - twine" in environment_text
+    assert "opentelemetry-sdk>=1.20" in environment_text
+    assert "opentelemetry-exporter-otlp>=1.20" in environment_text

--- a/tests/test_makefile_targets.py
+++ b/tests/test_makefile_targets.py
@@ -110,5 +110,11 @@ def test_conda_environment_includes_make_build_tools() -> None:
     environment_text = (REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
 
     assert "  - twine" in environment_text
+
+
+def test_conda_environment_includes_otlp_extra_dependencies() -> None:
+    """The GB300 conda image should carry the dependencies needed for OTLP export."""
+    environment_text = (REPO_ROOT / "environment.yml").read_text(encoding="utf-8")
+
     assert "opentelemetry-sdk>=1.20" in environment_text
     assert "opentelemetry-exporter-otlp>=1.20" in environment_text


### PR DESCRIPTION
## Summary
- add the OTLP SDK and exporter packages to the project conda environment
- keep a regression assertion so the GB300 dev image keeps those dependencies when rebuilt from environment.yml

## Validation
- git diff --cached --check before commit
- GitHub CI pending