### PR TITLE
Bake the OTLP exporter into the conda env so agent containers can emit traces

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -31,3 +31,8 @@ dependencies:
   - pip:
       # Install redfish_ctl itself (and anything not on conda-forge) via pip.
       - -e .
+      # OTLP span/metric exporter (mirrors setup.py extras_require["otlp"]) so the
+      # container image can emit traces to Splunk without a start-time install.
+      # The Dockerfile strips only the "- -e ." line, so this survives into the
+      # built conda env; agent containers then run redfish_ctl --otlp-traces.
+      - opentelemetry-exporter-otlp-proto-http>=1.20


### PR DESCRIPTION
Part of the fleet-runner enablement for the codex-span parallel queue (issue #387 umbrella / task 0070).

## Problem
The gb300 agent entrypoint runs `pip install -e .[dev]`, and `[dev]` pulls `opentelemetry-sdk` but **not** the OTLP exporter. So `redfish_ctl --otlp-traces` in a container fails with `ModuleNotFoundError: opentelemetry.exporter` (observed live during the span proof — I had to pip-install it ad hoc in the ephemeral container).

## Fix
Add `opentelemetry-exporter-otlp-proto-http>=1.20` to `environment.yml` (mirrors setup.py `extras_require["otlp"]`). The Dockerfile strips only the `- -e .` line, so this survives into the built conda env — the image carries the exporter, no start-time install.

## Rebuild + remaining operator step
After merge: `make gb300-image SLOT=<n>` (then `gb300-agent-image`/`gb300-provision`) rebuilds from HEAD. The entrypoint already exports **both** tokens from `/secrets` (SPLUNK_API_TOKEN from splunk_token, SPLUNK_ACCESS_TOKEN from splunk_ingest_token) — agents read env, never search. Operator still needs to re-bake the **valid** ingest token (id HHgPICOA4AM) + the API token into `/secrets` (0070); the stale baked one 401s.