### PR TITLE
Add telemetry docs freshness gate

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -35,6 +35,7 @@ mandatory_ids:
   - repo.config-loader
   - repo.span-root
   - repo.no-legacy-resurrection
+  - repo.telemetry-docs-current
   - scm.exact-commit
   - repo.no-agent-artifacts
   - repo.large-artifact-policy
@@ -85,6 +86,7 @@ gates:
   - {id: repo.config-loader, profile: merge, command: scripts/gates/repository/config-loader.sh, required: true, mutates: false}
   - {id: repo.span-root, profile: merge, command: scripts/gates/repository/span-root.sh, required: true, mutates: false}
   - {id: repo.no-legacy-resurrection, profile: merge, command: scripts/gates/repository/no-legacy-resurrection.sh, required: true, mutates: false}
+  - {id: repo.telemetry-docs-current, profile: merge, command: scripts/gates/repository/telemetry-docs-current.sh, required: true, mutates: false}
   # --- unit: the offline suite ---
   - {id: unit.all,             profile: merge, command: scripts/gates/unit/all.sh,               required: true, mutates: false}
   # --- kubernetes: render + validate manifests ---

--- a/scripts/gates/repository/telemetry-docs-current.sh
+++ b/scripts/gates/repository/telemetry-docs-current.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# repo.telemetry-docs-current (merge, mutates:false): the generated GB300
+# telemetry metrics reference must match the exporter mapper and fixture corpus.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python tools/generate_telemetry_metrics_doc.py --check

--- a/tools/generate_telemetry_metrics_doc.py
+++ b/tools/generate_telemetry_metrics_doc.py
@@ -27,7 +27,7 @@ if str(REPO_ROOT) not in sys.path:
 from redfish_ctl.telemetry import exporter  # noqa: E402
 
 DEFAULT_CORPUS = REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz"
-DEFAULT_OUTPUT = REPO_ROOT / "docs" / "telemetry-metrics.md"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "external" / "telemetry-metrics.md"
 DEFAULT_LEAF = "172.25.230.37"
 IDENTITY = exporter.build_identity_dimensions(DEFAULT_LEAF, vendor="supermicro")
 


### PR DESCRIPTION
## Summary
- fix the telemetry metrics doc generator default output path to the current docs/external location
- add a required repository gate that runs the generator in --check mode
- register the gate in the merge profile so stale generated docs fail CI

## Verification
- conda run -n idrac_ctl bash scripts/gates/repository/telemetry-docs-current.sh
- conda run -n idrac_ctl python tools/gate_meta.py
- conda run -n idrac_ctl ruff check tools/generate_telemetry_metrics_doc.py
- /opt/homebrew/bin/shellcheck -x -S style scripts/gates/repository/telemetry-docs-current.sh
- git diff --check
- git diff --cached --check
- conda run -n idrac_ctl python -m pytest -q