### PR TITLE
Fix internal toolbox pipeline: numpy dep, schema gate, kube-linter policy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,11 @@ dependencies:
   - ruff
   - mypy
   - twine
+  # numpy powers the discovery crawl's rest_api_map.npy output (setup.py "discovery"
+  # and "dev" extras; imported by discovery/cmd_discovery.py). Optional at runtime but
+  # REQUIRED to collect the discovery/corpus tests, so this conda toolbox env matches
+  # GitHub CI's `pip install -e .[dev]` instead of the bare `-e .` below.
+  - numpy
   # Schema validation (tools/redfish_validate.py)
   - jsonschema>=4.18
   - referencing

--- a/k8s/ci/test-job.yaml
+++ b/k8s/ci/test-job.yaml
@@ -11,6 +11,13 @@ kind: Job
 metadata:
   name: __JOB_NAME__
   namespace: __NAMESPACE__
+  annotations:
+    # Ephemeral single-run CI gate Job (backoffLimit 0, TTL 1800s): clones into an emptyDir and
+    # runs the offline suite as root -- apt/pip/clone/pytest all need a writable root fs and the
+    # image entrypoint is root. Not a long-lived service, so kube-linter's prod-hardening checks
+    # are intentionally exempted here (kubernetes.policy).
+    ignore-check.kube-linter.io/run-as-non-root: "ephemeral CI gate job installs deps and runs as root"
+    ignore-check.kube-linter.io/no-read-only-root-fs: "ephemeral CI gate job needs a writable root fs (apt/pip/clone/pytest)"
   labels:
     app.kubernetes.io/name: redfish-ctl-ci
     redfish-ctl.io/ref: __REF_LABEL__

--- a/k8s/sandbox/gb300-fleet.yaml
+++ b/k8s/sandbox/gb300-fleet.yaml
@@ -30,6 +30,11 @@ kind: StatefulSet
 metadata:
   name: gb300-bmc
   namespace: redfish-sandbox
+  annotations:
+    # Sandbox fleet simulator: 36 replicas modelling BMCs on one cluster. Density is intentional --
+    # pod anti-affinity (one-per-node) would prevent scheduling 36 pods on the limited sandbox
+    # nodes, so exempt this check for the sim (kubernetes.policy).
+    ignore-check.kube-linter.io/no-anti-affinity: "sandbox fleet sim; density intentional, anti-affinity blocks scheduling 36 pods"
   labels:
     app.kubernetes.io/name: gb300-bmc
     app.kubernetes.io/component: fleet-sim

--- a/k8s/sandbox/ilo-sim.yaml
+++ b/k8s/sandbox/ilo-sim.yaml
@@ -4,6 +4,11 @@ kind: Deployment
 metadata:
   name: ilo-sim
   namespace: redfish-sandbox
+  annotations:
+    # Sandbox Redfish simulator (ephemeral test workload) that writes to its working fs, so a
+    # read-only root fs would break it; the pod already runs as non-root (uid 10001). Exempt this
+    # one check for the sandbox (kubernetes.policy).
+    ignore-check.kube-linter.io/no-read-only-root-fs: "sandbox sim writes to fs; ephemeral test workload"
   labels:
     app.kubernetes.io/name: ilo-sim
     app.kubernetes.io/component: redfish-sandbox

--- a/scripts/gates/kubernetes/schema.sh
+++ b/scripts/gates/kubernetes/schema.sh
@@ -7,10 +7,12 @@ if ! command -v kubeconform >/dev/null 2>&1; then
   echo "kubernetes.schema: kubeconform not installed in this gate environment" >&2
   exit 1
 fi
-# Validate concrete manifests only: skip Helm templates ({{ ... }}) and manifests carrying __PLACEHOLDER__
-# substitutions, both of which are not valid YAML/k8s until rendered. Both markers live in file CONTENT,
-# so they are matched against the file, never against its name.
+# Validate concrete manifests only. Skip by CONTENT: Helm templates ({{ ... }}) and manifests carrying
+# __PLACEHOLDER__ substitutions (not valid YAML/k8s until rendered). Skip by NAME: a Helm chart's
+# Chart.yaml / values.yaml -- plain YAML but chart metadata, not k8s resources (no 'kind'), so
+# kubeconform rejects them ("missing 'kind' key"). templates/ (rendered elsewhere) and crds/ still flow through.
 files="$(git ls-files 'k8s/**/*.yaml' 'charts/**/*.yaml' | while read -r f; do
+  case "$(basename "$f")" in Chart.yaml | values.yaml) continue ;; esac
   grep -qE '\{\{|__[A-Z0-9_]+__' "$f" || echo "$f"
 done)"
 if [ -z "$files" ]; then


### PR DESCRIPTION
## What

Three fixes so the internal GitLab toolbox pipeline passes the same offline suite
GitHub CI already passes. The toolbox builds its env from `environment.yml` (conda)
and runs the k8s gates with `kubeconform`/`kube-linter` present; GitHub CI installs
`.[dev]` and lacks those tools — so each surface stayed green on what the other
couldn't see.

- **`environment.yml`: add `numpy`.** It lived only in `setup.py`'s `discovery`/`dev`
  extras, so the toolbox's `pip install -e .` never pulled it and 4 discovery/corpus
  test modules failed to import — `unit.all` aborted during collection.
- **`kubernetes.schema` (`schema.sh`): skip `Chart.yaml`/`values.yaml`.** They're Helm
  chart metadata (no `kind`), so kubeconform rejected them ("missing 'kind' key").
  Skipped by name alongside the existing `{{ }}` template skip; `templates/` and
  `crds/` still flow through.
- **`kubernetes.policy`: scoped `kube-linter` ignore annotations.** For the ephemeral CI
  gate Job and the two sandbox sims, where the prod-hardening checks don't apply
  (run-as-non-root / read-only-root-fs on ephemeral workloads; anti-affinity on a
  36-replica density sim). Each annotation carries its reason.

## Verified

- **numpy** — full suite in the toolbox: **2074 passed** (the 4 collection errors gone).
- **schema.sh** — `kubernetes.schema` gate now exits 0 (47 resources, 0 errors).
- **kube-linter** — `kube-linter lint k8s/ charts/redfish-controller/` → *No lint errors found*.

## Not included

The toolbox image also needs `make` (3 `test_makefile_targets` tests shell out to it;
GitHub CI's runner has it, the harbor toolbox doesn't) — that's a builder/toolbox-image
change, tracked separately.
