### PR TITLE
Trace rejected NTP sets and fix the X10 empty-secondary 400

### DIFF
--- a/redfish_ctl/manager/cmd_ntp_set.py
+++ b/redfish_ctl/manager/cmd_ntp_set.py
@@ -151,11 +151,18 @@ class NtpSet(IDracManager,
         """
         if len(servers) > _MAX_LEGACY_NTP_SERVERS:
             raise InvalidArgument(_LEGACY_NTP_SERVER_LIMIT_REASON)
-        return {
-            "NTPEnable": bool(servers),
-            "PrimaryNTPServer": servers[0] if servers else "",
-            "SecondaryNTPServer": servers[1] if len(servers) > 1 else "",
-        }
+        # Some legacy BMCs (Supermicro X10) reject an empty-string server field
+        # ("value '' ... is of a different type than the property can accept",
+        # HTTP 400), so only include Primary/Secondary when it has a real value.
+        # For a clear (empty ``servers``) this disables NTP (``NTPEnable`` False)
+        # but leaves any stored server addresses untouched, since the empty-string
+        # write that would blank them is exactly what the BMC rejects.
+        payload = {"NTPEnable": bool(servers)}
+        if servers:
+            payload["PrimaryNTPServer"] = servers[0]
+        if len(servers) > 1:
+            payload["SecondaryNTPServer"] = servers[1]
+        return payload
 
     @staticmethod
     def _legacy_ntp_skip_reason(servers):
@@ -365,8 +372,28 @@ class NtpSet(IDracManager,
                 "error": result.error,
             })
 
+        # Surface any per-target PATCH failure on the CommandResult's top-level
+        # error, so the CLI exits non-zero and the operation span is recorded as
+        # ERROR. A rejected (but valid-format) NTP value is the negative path;
+        # previously the top-level error was hard-coded None, so a failed PATCH
+        # looked green in the trace.
+        failures = [item for item in applied if item.get("error") is not None]
+        overall_error = None
+        if failures:
+            overall_error = "NTP PATCH failed on {}/{} target(s): {}".format(
+                len(failures), len(applied),
+                "; ".join(
+                    "{} ({}): {}".format(
+                        item.get("Manager", "?"),
+                        item.get("status", "?"),
+                        item.get("error"),
+                    )
+                    for item in failures
+                ),
+            )
+
         return CommandResult({
             "servers": normalized_servers,
             "applied": applied,
             "skipped": skipped,
-        }, None, None, None)
+        }, None, None, overall_error)

--- a/tests/manager/test_ntp_set_dualmode.py
+++ b/tests/manager/test_ntp_set_dualmode.py
@@ -1,5 +1,7 @@
 """Dual-mode tests for the ntp-set command."""
 
+import re
+
 import pytest
 
 from redfish_ctl.cmd_exceptions import InvalidArgument
@@ -124,7 +126,6 @@ def test_ntp_set_confirm_patches_x10_legacy_ntp_resource(redfish_mock_factory):
     assert patches[0].json() == {
         "NTPEnable": True,
         "PrimaryNTPServer": "0.pool.ntp.org",
-        "SecondaryNTPServer": "",
     }
     assert result.data["applied"] == [{
         "Manager": "1",
@@ -132,6 +133,49 @@ def test_ntp_set_confirm_patches_x10_legacy_ntp_resource(redfish_mock_factory):
         "status": "RedfishApiRespond.Ok",
         "error": None,
     }]
+    assert result.error is None
+
+
+def test_ntp_set_surfaces_error_when_x10_legacy_patch_fails(redfish_mock_factory):
+    """A soft-failed legacy NTP PATCH is surfaced on the top-level result error.
+
+    A non-raising write failure (e.g. HTTP 409 conflict, which ``base_patch``
+    reports as ``RedfishApiRespond.Error`` with a set ``result.error`` rather than
+    raising) must not look green: the per-target failure is aggregated into the
+    command's top-level ``result.error`` so the CLI exits non-zero and the
+    operation span is recorded as ERROR. Regression for the previously hard-coded
+    ``None`` top-level error. (A hard 400/401/403/404 already raises and fails
+    loudly on its own; the aggregation covers the soft-error band.)
+    """
+    manager, service = redfish_mock_factory("supermicro_x10")
+    service.mocker.patch(
+        re.compile(r"/redfish/v1/managers/1/ntp$", re.IGNORECASE),
+        status_code=409,
+        json={
+            "error": {
+                "@Message.ExtendedInfo": [{
+                    "MessageId": "Base.1.12.ResourceInStandby",
+                    "Message": "The NTP resource is busy and rejected the update.",
+                    "Severity": "Critical",
+                }],
+            },
+        },
+    )
+
+    result = manager.sync_invoke(
+        ApiRequestType.NtpSet,
+        "ntp-set",
+        servers=["0.pool.ntp.org"],
+        confirm=True,
+    )
+
+    assert isinstance(result, CommandResult)
+    assert result.error is not None
+    assert "1/1 target(s)" in result.error
+    applied = result.data["applied"]
+    assert len(applied) == 1
+    assert applied[0]["Manager"] == "1"
+    assert applied[0]["error"] is not None
 
 
 def test_ntp_set_clear_patches_x10_legacy_ntp_resource(redfish_mock_factory):
@@ -150,8 +194,6 @@ def test_ntp_set_clear_patches_x10_legacy_ntp_resource(redfish_mock_factory):
     assert patches[0].path == "/redfish/v1/managers/1/ntp"
     assert patches[0].json() == {
         "NTPEnable": False,
-        "PrimaryNTPServer": "",
-        "SecondaryNTPServer": "",
     }
     assert result.data["servers"] == []
     assert result.data["applied"] == [{


### PR DESCRIPTION
Two `ntp-set` fixes found + validated by a live multi-vendor smoke (Supermicro X10 + NVIDIA GB300), OTLP traces confirmed in Splunk.

- **Rejected NTP sets no longer swallowed.** `execute()` recorded each PATCH error in `applied[].error` but returned `CommandResult(..., error=None)`, so a BMC rejection left the operation-root span `OK` — a red PATCH looked green. Now per-target failures aggregate into the top-level error → CLI exits non-zero and the span records ERROR. Live: the X10's HTTP 400 now surfaces as an operation-root ERROR span.
- **Legacy single-server NTP set no longer 400s.** `_legacy_ntp_payload` sent `SecondaryNTPServer=""` for one server; the X10 rejects an empty-string server (`value '' … different type`, HTTP 400). Now a server field is only sent when it has a value. Live: single-server `ntp-set` succeeds on the X10.

Existing offline tests updated to the corrected payload shape (omit empty server fields). Success path unchanged (error stays None).