### PR TITLE
Add env-gated fault-injection decorators for signal and network edges

### DIFF
--- a/redfish_ctl/config.py
+++ b/redfish_ctl/config.py
@@ -27,6 +27,9 @@ from typing import Optional
 # A name whose value must never appear in an error message.
 _SECRET_HINT = re.compile(r"PASSWORD|TOKEN|SECRET|KEY|CREDENTIAL", re.IGNORECASE)
 
+# Boolean env-flag values treated as "on" by :func:`env_flag`.
+_TRUTHY_FLAG_VALUES = frozenset({"1", "true", "yes", "on"})
+
 
 class ConfigurationConflict(RuntimeError):
     """Two names for one setting are set to different values.
@@ -108,6 +111,31 @@ def env_first(
             f"{winner} is a deprecated alias for {names[0]}; set {names[0]} instead",
             DeprecationWarning, stacklevel=2)
     return value
+
+
+def env_flag(name: str) -> bool:
+    """Return whether a boolean env flag is set to a truthy value.
+
+    Centralizes boolean env reads here (the config-loader gate forbids ``os.getenv``
+    outside this loader). A flag counts as on when set to 1/true/yes/on.
+
+    :param name: the environment variable to read.
+    :return: True when the value is 1/true/yes/on (case-insensitive, trimmed), else False.
+    """
+    return os.getenv(name, "").strip().lower() in _TRUTHY_FLAG_VALUES
+
+
+def env_float(name: str, default: float) -> float:
+    """Return an env var parsed as a float, or a default when unset or non-numeric.
+
+    :param name: the environment variable to read.
+    :param default: the value returned when the variable is unset or not a valid float.
+    :return: the parsed float, or ``default``.
+    """
+    try:
+        return float(os.getenv(name, ""))
+    except ValueError:
+        return default
 
 
 def endpoint_conflict_fields() -> set[str]:

--- a/redfish_ctl/decorators/__init__.py
+++ b/redfish_ctl/decorators/__init__.py
@@ -1,0 +1,37 @@
+"""Reusable decorators for redfish_ctl.
+
+Hosts env-gated fault-injection decorators (:mod:`redfish_ctl.decorators.fault_injection`)
+used to exercise signal-handling and network-error edges against a live BMC, where an
+offline mock cannot reproduce the real signal/timing/socket interaction.
+
+Author Mus spyroot@gmail.com
+"""
+from .fault_injection import (
+    DELAY_SECONDS_ENV,
+    SIMULATE_NETWORK_FAILURE,
+    SIMULATE_NETWORK_TIMEOUT,
+    SIMULATE_SLOW_IO,
+    delay_seconds,
+    flag_enabled,
+    inject_async_delay,
+    inject_async_exception,
+    inject_delay,
+    inject_exception,
+    simulate_http_faults,
+    simulate_http_faults_async,
+)
+
+__all__ = [
+    "DELAY_SECONDS_ENV",
+    "SIMULATE_NETWORK_FAILURE",
+    "SIMULATE_NETWORK_TIMEOUT",
+    "SIMULATE_SLOW_IO",
+    "delay_seconds",
+    "flag_enabled",
+    "inject_async_delay",
+    "inject_async_exception",
+    "inject_delay",
+    "inject_exception",
+    "simulate_http_faults",
+    "simulate_http_faults_async",
+]

--- a/redfish_ctl/decorators/fault_injection.py
+++ b/redfish_ctl/decorators/fault_injection.py
@@ -240,6 +240,9 @@ def simulate_http_faults(
         :param function: the callable to wrap.
         :return: the fully wrapped callable.
         """
+        # Inner is applied first, so the runtime order is delay -> timeout -> failure.
+        # If several flags are set the outer fault preempts the inner: the delay runs,
+        # then TIMEOUT raises before FAILURE is reached (one simulated fault per call).
         function = inject_exception(SIMULATE_NETWORK_FAILURE, connection_error_factory)(function)
         function = inject_exception(SIMULATE_NETWORK_TIMEOUT, timeout_error_factory)(function)
         function = inject_delay(SIMULATE_SLOW_IO)(function)
@@ -264,6 +267,7 @@ def simulate_http_faults_async(
         :param function: the coroutine to wrap.
         :return: the fully wrapped coroutine.
         """
+        # Same precedence as the sync composite: delay -> timeout -> failure, outer wins.
         function = inject_async_exception(SIMULATE_NETWORK_FAILURE, connection_error_factory)(function)
         function = inject_async_exception(SIMULATE_NETWORK_TIMEOUT, timeout_error_factory)(function)
         function = inject_async_delay(SIMULATE_SLOW_IO)(function)

--- a/redfish_ctl/decorators/fault_injection.py
+++ b/redfish_ctl/decorators/fault_injection.py
@@ -1,0 +1,268 @@
+"""Env-gated fault-injection decorators for live edge-case testing.
+
+A Redfish client meets two failure edges that a healthy BMC and an offline mock both
+hide: a signal (SIGTERM/SIGINT) arriving while a request is in flight, and a network
+read that stalls or drops. Signal-vs-event-loop ordering and socket timing cannot be
+reproduced faithfully with mocks, so these decorators sit at fixed points on the real
+sync and async HTTP call methods. Each is a NO-OP unless its env flag is set, so
+production and normal test runs pay only a single ``os.getenv`` check.
+
+Flags (``1``/``true``/``yes``/``on`` enables; unset or any other value disables):
+
+  ==========================  ================================================
+  Flag                        Effect at each decorated HTTP call
+  ==========================  ================================================
+  SIMULATE_NETWORK_FAILURE    raise the caller's failure exception first
+  SIMULATE_NETWORK_TIMEOUT    raise the caller's timeout exception first
+  SIMULATE_SLOW_IO            sleep REDFISH_FAULT_DELAY_SECONDS (default 8s)
+  ==========================  ================================================
+
+The delay opens a deterministic window in which a signal can be delivered while a
+request is nominally in flight, exercising the flush-on-termination path (G6). The
+exception flags drive the ERROR span / non-zero-exit path a healthy BMC never
+produces. The concrete exception type is supplied by the caller (``exception_factory``)
+so the raised error matches what the real transport would raise (e.g. a ``requests``
+exception), keeping downstream error handling and the recorded span identical to a
+genuine fault.
+
+This module stays transport-neutral on purpose: it never imports ``requests`` or any
+client library, so it is reusable anywhere. Callers pass the exception factories.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import asyncio
+import functools
+import os
+import time
+from typing import Awaitable, Callable, TypeVar
+
+try:  # ParamSpec is stdlib on the project's 3.10 floor; guard kept for older typing
+    from typing import ParamSpec
+except ImportError:  # pragma: no cover - only reachable on <3.10
+    from typing_extensions import ParamSpec
+
+#: Env flag: raise the caller-supplied failure exception at each decorated HTTP call.
+SIMULATE_NETWORK_FAILURE = "SIMULATE_NETWORK_FAILURE"
+#: Env flag: raise the caller-supplied timeout exception at each decorated HTTP call.
+SIMULATE_NETWORK_TIMEOUT = "SIMULATE_NETWORK_TIMEOUT"
+#: Env flag: sleep before each decorated HTTP call (opens a signal-injection window).
+SIMULATE_SLOW_IO = "SIMULATE_SLOW_IO"
+#: Env var overriding the SIMULATE_SLOW_IO delay length, in seconds.
+DELAY_SECONDS_ENV = "REDFISH_FAULT_DELAY_SECONDS"
+
+_DEFAULT_DELAY_SECONDS = 8.0
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+__all__ = [
+    "SIMULATE_NETWORK_FAILURE",
+    "SIMULATE_NETWORK_TIMEOUT",
+    "SIMULATE_SLOW_IO",
+    "DELAY_SECONDS_ENV",
+    "flag_enabled",
+    "delay_seconds",
+    "inject_exception",
+    "inject_async_exception",
+    "inject_delay",
+    "inject_async_delay",
+    "simulate_http_faults",
+    "simulate_http_faults_async",
+]
+
+
+def flag_enabled(flag_name: str) -> bool:
+    """Report whether an env flag is set to a truthy value.
+
+    :param flag_name: environment variable name to inspect.
+    :return: True when the variable equals 1/true/yes/on (case-insensitive), else False.
+    """
+    return os.getenv(flag_name, "").strip().lower() in _TRUTHY
+
+
+def delay_seconds() -> float:
+    """Resolve the SIMULATE_SLOW_IO delay length in seconds.
+
+    :return: DELAY_SECONDS_ENV parsed as a float, or 8.0 when unset or non-numeric.
+    """
+    try:
+        return float(os.getenv(DELAY_SECONDS_ENV, ""))
+    except ValueError:
+        return _DEFAULT_DELAY_SECONDS
+
+
+def inject_exception(
+    flag_name: str,
+    exception_factory: Callable[[], BaseException],
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Build a sync decorator that raises before the wrapped call when a flag is set.
+
+    :param flag_name: env flag gating the injection; unset leaves the wrapper transparent.
+    :param exception_factory: zero-argument callable returning the exception to raise.
+    :return: a decorator preserving the wrapped callable's name and signature.
+    """
+    def decorator(function: Callable[P, R]) -> Callable[P, R]:
+        """Guard ``function`` with the env-gated exception.
+
+        :param function: the callable to wrap.
+        :return: the guarded callable.
+        """
+        @functools.wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            """Raise the injected exception when the flag is set, else call through.
+
+            :return: the wrapped callable's result when the flag is unset.
+            """
+            if flag_enabled(flag_name):
+                raise exception_factory()
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def inject_async_exception(
+    flag_name: str,
+    exception_factory: Callable[[], BaseException],
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Async counterpart of :func:`inject_exception`.
+
+    :param flag_name: env flag gating the injection; unset leaves the wrapper transparent.
+    :param exception_factory: zero-argument callable returning the exception to raise.
+    :return: a decorator preserving the wrapped coroutine's name and signature.
+    """
+    def decorator(function: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        """Guard the coroutine ``function`` with the env-gated exception.
+
+        :param function: the coroutine to wrap.
+        :return: the guarded coroutine.
+        """
+        @functools.wraps(function)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            """Raise the injected exception when the flag is set, else await through.
+
+            :return: the awaited result when the flag is unset.
+            """
+            if flag_enabled(flag_name):
+                raise exception_factory()
+            return await function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def inject_delay(flag_name: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Build a sync decorator that sleeps before the wrapped call when a flag is set.
+
+    The sleep opens a deterministic window for delivering a signal (SIGTERM/SIGINT)
+    while a request is nominally in flight, so the flush-on-termination path runs.
+
+    :param flag_name: env flag gating the delay; unset leaves the wrapper transparent.
+    :return: a decorator preserving the wrapped callable's name and signature.
+    """
+    def decorator(function: Callable[P, R]) -> Callable[P, R]:
+        """Guard ``function`` with the env-gated delay.
+
+        :param function: the callable to wrap.
+        :return: the guarded callable.
+        """
+        @functools.wraps(function)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            """Sleep when the flag is set, then call through.
+
+            :return: the wrapped callable's result.
+            """
+            if flag_enabled(flag_name):
+                time.sleep(delay_seconds())
+            return function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def inject_async_delay(flag_name: str) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Async counterpart of :func:`inject_delay` using ``asyncio.sleep``.
+
+    Sleeping on the event loop (not a worker thread) lets a signal delivered to the
+    main thread interrupt the loop -- the interaction a thread-pool sleep and an
+    offline mock both hide.
+
+    :param flag_name: env flag gating the delay; unset leaves the wrapper transparent.
+    :return: a decorator preserving the wrapped coroutine's name and signature.
+    """
+    def decorator(function: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        """Guard the coroutine ``function`` with the env-gated async delay.
+
+        :param function: the coroutine to wrap.
+        :return: the guarded coroutine.
+        """
+        @functools.wraps(function)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+            """Await asyncio.sleep when the flag is set, then await through.
+
+            :return: the awaited result.
+            """
+            if flag_enabled(flag_name):
+                await asyncio.sleep(delay_seconds())
+            return await function(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+def simulate_http_faults(
+    connection_error_factory: Callable[[], BaseException],
+    timeout_error_factory: Callable[[], BaseException],
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Compose the standard sync HTTP fault stack into one decorator.
+
+    Order at call time: SIMULATE_SLOW_IO delay first (the signal window), then
+    SIMULATE_NETWORK_TIMEOUT, then SIMULATE_NETWORK_FAILURE.
+
+    :param connection_error_factory: returns the exception a dropped connection raises.
+    :param timeout_error_factory: returns the exception a stalled read raises.
+    :return: a single decorator applying all three env-gated faults in order.
+    """
+    def decorator(function: Callable[P, R]) -> Callable[P, R]:
+        """Stack the three sync fault decorators onto ``function``.
+
+        :param function: the callable to wrap.
+        :return: the fully wrapped callable.
+        """
+        function = inject_exception(SIMULATE_NETWORK_FAILURE, connection_error_factory)(function)
+        function = inject_exception(SIMULATE_NETWORK_TIMEOUT, timeout_error_factory)(function)
+        function = inject_delay(SIMULATE_SLOW_IO)(function)
+        return function
+
+    return decorator
+
+
+def simulate_http_faults_async(
+    connection_error_factory: Callable[[], BaseException],
+    timeout_error_factory: Callable[[], BaseException],
+) -> Callable[[Callable[P, Awaitable[R]]], Callable[P, Awaitable[R]]]:
+    """Async counterpart of :func:`simulate_http_faults`.
+
+    :param connection_error_factory: returns the exception a dropped connection raises.
+    :param timeout_error_factory: returns the exception a stalled read raises.
+    :return: a single decorator applying all three env-gated faults in order.
+    """
+    def decorator(function: Callable[P, Awaitable[R]]) -> Callable[P, Awaitable[R]]:
+        """Stack the three async fault decorators onto the coroutine ``function``.
+
+        :param function: the coroutine to wrap.
+        :return: the fully wrapped coroutine.
+        """
+        function = inject_async_exception(SIMULATE_NETWORK_FAILURE, connection_error_factory)(function)
+        function = inject_async_exception(SIMULATE_NETWORK_TIMEOUT, timeout_error_factory)(function)
+        function = inject_async_delay(SIMULATE_SLOW_IO)(function)
+        return function
+
+    return decorator

--- a/redfish_ctl/decorators/fault_injection.py
+++ b/redfish_ctl/decorators/fault_injection.py
@@ -26,7 +26,9 @@ exception), keeping downstream error handling and the recorded span identical to
 genuine fault.
 
 This module stays transport-neutral on purpose: it never imports ``requests`` or any
-client library, so it is reusable anywhere. Callers pass the exception factories.
+client library -- callers pass the exception factories. Environment reads go through
+the project config loader (:mod:`redfish_ctl.config`), so all env access stays
+centralized there (enforced by the config-loader gate).
 
 Author Mus spyroot@gmail.com
 """
@@ -34,7 +36,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import os
 import time
 from typing import Awaitable, Callable, TypeVar
 
@@ -42,6 +43,8 @@ try:  # ParamSpec is stdlib on the project's 3.10 floor; guard kept for older ty
     from typing import ParamSpec
 except ImportError:  # pragma: no cover - only reachable on <3.10
     from typing_extensions import ParamSpec
+
+from ..config import env_flag, env_float
 
 #: Env flag: raise the caller-supplied failure exception at each decorated HTTP call.
 SIMULATE_NETWORK_FAILURE = "SIMULATE_NETWORK_FAILURE"
@@ -53,7 +56,6 @@ SIMULATE_SLOW_IO = "SIMULATE_SLOW_IO"
 DELAY_SECONDS_ENV = "REDFISH_FAULT_DELAY_SECONDS"
 
 _DEFAULT_DELAY_SECONDS = 8.0
-_TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 P = ParamSpec("P")
 R = TypeVar("R")
@@ -77,21 +79,23 @@ __all__ = [
 def flag_enabled(flag_name: str) -> bool:
     """Report whether an env flag is set to a truthy value.
 
+    Reads through the config loader (:func:`redfish_ctl.config.env_flag`) so all env
+    access stays centralized there.
+
     :param flag_name: environment variable name to inspect.
     :return: True when the variable equals 1/true/yes/on (case-insensitive), else False.
     """
-    return os.getenv(flag_name, "").strip().lower() in _TRUTHY
+    return env_flag(flag_name)
 
 
 def delay_seconds() -> float:
     """Resolve the SIMULATE_SLOW_IO delay length in seconds.
 
+    Reads through the config loader (:func:`redfish_ctl.config.env_float`).
+
     :return: DELAY_SECONDS_ENV parsed as a float, or 8.0 when unset or non-numeric.
     """
-    try:
-        return float(os.getenv(DELAY_SECONDS_ENV, ""))
-    except ValueError:
-        return _DEFAULT_DELAY_SECONDS
+    return env_float(DELAY_SECONDS_ENV, _DEFAULT_DELAY_SECONDS)
 
 
 def inject_exception(

--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -47,6 +47,10 @@ from .cmd_exceptions import (
     UnsupportedAction,
 )
 from .custom_argparser.customer_argdefault import CustomArgumentDefaultsHelpFormatter
+from .decorators.fault_injection import (
+    simulate_http_faults,
+    simulate_http_faults_async,
+)
 from .idrac_shared import (
     REDFISH_API,
     REDFISH_JSON,
@@ -75,6 +79,28 @@ from .redfish_shared import RedfishApi, RedfishJson, RedfishJsonSpec, env_first
 from .telemetry import tracing
 
 module_logger = logging.getLogger('redfish_ctl.idrac_manager')
+
+
+def _simulated_connection_error() -> BaseException:
+    """Build the exception a dropped BMC connection raises (SIMULATE_NETWORK_FAILURE).
+
+    :return: a requests ConnectionError mirroring a real transport-level failure, so the
+        downstream error handling and recorded span match a genuine network drop.
+    """
+    return requests.exceptions.ConnectionError(
+        "simulated network failure (SIMULATE_NETWORK_FAILURE)"
+    )
+
+
+def _simulated_read_timeout() -> BaseException:
+    """Build the exception a stalled BMC read raises (SIMULATE_NETWORK_TIMEOUT).
+
+    :return: a requests ReadTimeout mirroring a real read-timeout failure, so the
+        downstream error handling and recorded span match a genuine stalled read.
+    """
+    return requests.exceptions.ReadTimeout(
+        "simulated network timeout (SIMULATE_NETWORK_TIMEOUT)"
+    )
 
 
 class IDracManager(RedfishManager):
@@ -437,6 +463,7 @@ class IDracManager(RedfishManager):
             tracing.record_result(span, result)
             return result
 
+    @simulate_http_faults_async(_simulated_connection_error, _simulated_read_timeout)
     async def api_async_get_call(self, loop, req, hdr: Dict):
         """Make api asynced requests either with x-auth authentication
          header or base authentication.
@@ -482,6 +509,7 @@ class IDracManager(RedfishManager):
         await self.async_default_error_handler(await response)
         return await response
 
+    @simulate_http_faults(_simulated_connection_error, _simulated_read_timeout)
     def api_get_call(
             self, req: str, hdr: Dict) -> requests.models.Response:
         """Make api request either with x-auth authentication header or redfish_ctl.
@@ -1050,6 +1078,7 @@ class IDracManager(RedfishManager):
                                  if attr_filter.lower() in attr.lower())
         return json_data
 
+    @simulate_http_faults(_simulated_connection_error, _simulated_read_timeout)
     def api_delete_call(
             self, req, hdr: Dict) -> requests.models.Response:
         """Make api request for delete method.
@@ -1080,6 +1109,7 @@ class IDracManager(RedfishManager):
             )
         return tracing.traced_request(req, "DELETE", request_call)
 
+    @simulate_http_faults(_simulated_connection_error, _simulated_read_timeout)
     def api_post_call(
             self, req: str, payload: str, hdr: dict) -> requests.models.Response:
         """Make HTTP post request.
@@ -1113,6 +1143,7 @@ class IDracManager(RedfishManager):
             )
         return tracing.traced_request(req, "POST", request_call)
 
+    @simulate_http_faults_async(_simulated_connection_error, _simulated_read_timeout)
     async def api_async_post_call(
             self, loop, req: str, payload: str, hdr: Dict):
         """Make post api request either with x-auth authentication header or redfish_ctl.
@@ -1228,6 +1259,7 @@ class IDracManager(RedfishManager):
         )
         return await response, api_respond_status
 
+    @simulate_http_faults(_simulated_connection_error, _simulated_read_timeout)
     def api_patch_call(
             self, req: str, payload: str, hdr: dict, ) -> requests.models.Response:
         """Make api patch request.
@@ -1261,6 +1293,7 @@ class IDracManager(RedfishManager):
             )
         return tracing.traced_request(req, "PATCH", request_call)
 
+    @simulate_http_faults_async(_simulated_connection_error, _simulated_read_timeout)
     async def api_async_patch_call(
             self, loop, req, payload: str, hdr: Dict):
         """Make async post api request either with
@@ -1299,6 +1332,7 @@ class IDracManager(RedfishManager):
             tracing.traced_request_callable(req, "PATCH", request_call),
         )
 
+    @simulate_http_faults_async(_simulated_connection_error, _simulated_read_timeout)
     async def api_async_delete_call(
             self, loop, req, payload: str, hdr: Dict):
         """Make async delete api request either with

--- a/tests/test_fault_injection.py
+++ b/tests/test_fault_injection.py
@@ -1,0 +1,241 @@
+"""Offline tests for the env-gated fault-injection decorators.
+
+The decorators (:mod:`redfish_ctl.decorators.fault_injection`) let a live run inject a
+delay (to open a signal window for the SIGTERM/SIGINT flush path) or a simulated
+network error at the fixed sync/async HTTP call sites. They must be exact NO-OPS when
+their flag is unset, raise the caller's exception when set, sleep only when the slow-IO
+flag is set, and preserve the wrapped callable's identity. The integration tests prove
+the wiring: the manager's real ``api_get_call`` / ``api_async_get_call`` raise the
+requests-level error a genuine network fault would raise.
+
+No BMC, no network, no signals here -- those are exercised in the live smoke.
+
+Author Mus <spyroot@gmail.com>
+"""
+import asyncio
+
+import pytest
+import requests
+
+from redfish_ctl.decorators import fault_injection as fi
+
+
+class _Boom(RuntimeError):
+    """Sentinel exception raised by the fault factories under test."""
+
+
+# --------------------------------------------------------------------------- #
+# flag_enabled / delay_seconds                                                 #
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "Yes", "on", " on "])
+def test_flag_enabled_truthy(monkeypatch, value):
+    """Any of 1/true/yes/on (case-insensitive, trimmed) reads as enabled."""
+    monkeypatch.setenv("X_FLAG", value)
+    assert fi.flag_enabled("X_FLAG") is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", "", "maybe"])
+def test_flag_enabled_falsey(monkeypatch, value):
+    """Anything else -- including empty -- reads as disabled."""
+    monkeypatch.setenv("X_FLAG", value)
+    assert fi.flag_enabled("X_FLAG") is False
+
+
+def test_flag_enabled_unset(monkeypatch):
+    """An unset variable is disabled (the production default)."""
+    monkeypatch.delenv("X_FLAG", raising=False)
+    assert fi.flag_enabled("X_FLAG") is False
+
+
+def test_delay_seconds_default_and_override(monkeypatch):
+    """delay_seconds honors the override and falls back to 8.0 when unset/non-numeric."""
+    monkeypatch.delenv(fi.DELAY_SECONDS_ENV, raising=False)
+    assert fi.delay_seconds() == 8.0
+    monkeypatch.setenv(fi.DELAY_SECONDS_ENV, "2.5")
+    assert fi.delay_seconds() == 2.5
+    monkeypatch.setenv(fi.DELAY_SECONDS_ENV, "not-a-number")
+    assert fi.delay_seconds() == 8.0
+
+
+# --------------------------------------------------------------------------- #
+# inject_exception / inject_async_exception                                    #
+# --------------------------------------------------------------------------- #
+def test_inject_exception_off_is_transparent(monkeypatch):
+    """Flag unset: the wrapped call runs and its identity is preserved."""
+    monkeypatch.delenv("F", raising=False)
+
+    @fi.inject_exception("F", lambda: _Boom("nope"))
+    def real(x):
+        return x * 2
+
+    assert real(3) == 6
+    assert real.__name__ == "real"
+
+
+def test_inject_exception_on_raises(monkeypatch):
+    """Flag set: the factory's exception is raised before the wrapped call."""
+    monkeypatch.setenv("F", "1")
+    ran = []
+
+    @fi.inject_exception("F", lambda: _Boom("boom"))
+    def real():
+        ran.append(True)
+
+    with pytest.raises(_Boom, match="boom"):
+        real()
+    assert ran == []
+
+
+def test_inject_async_exception(monkeypatch):
+    """Async variant: transparent when off, raises when on."""
+    @fi.inject_async_exception("F", lambda: _Boom("boom"))
+    async def real(x):
+        return x + 1
+
+    monkeypatch.delenv("F", raising=False)
+    assert asyncio.run(real(1)) == 2
+    assert real.__name__ == "real"
+
+    monkeypatch.setenv("F", "1")
+    with pytest.raises(_Boom):
+        asyncio.run(real(1))
+
+
+# --------------------------------------------------------------------------- #
+# inject_delay / inject_async_delay                                            #
+# --------------------------------------------------------------------------- #
+def test_inject_delay_sleeps_only_when_set(monkeypatch):
+    """Flag gates the sleep; the delay length comes from delay_seconds()."""
+    calls = []
+    monkeypatch.setattr(fi.time, "sleep", lambda s: calls.append(s))
+    monkeypatch.setenv(fi.DELAY_SECONDS_ENV, "4")
+
+    @fi.inject_delay("SLOW")
+    def real():
+        return "ok"
+
+    monkeypatch.delenv("SLOW", raising=False)
+    assert real() == "ok"
+    assert calls == []
+
+    monkeypatch.setenv("SLOW", "1")
+    assert real() == "ok"
+    assert calls == [4.0]
+
+
+def test_inject_async_delay(monkeypatch):
+    """Async delay awaits asyncio.sleep for the configured duration when set."""
+    calls = []
+
+    async def fake_sleep(seconds):
+        calls.append(seconds)
+
+    monkeypatch.setattr(fi.asyncio, "sleep", fake_sleep)
+    monkeypatch.setenv(fi.DELAY_SECONDS_ENV, "3")
+
+    @fi.inject_async_delay("SLOW")
+    async def real():
+        return "ok"
+
+    monkeypatch.delenv("SLOW", raising=False)
+    assert asyncio.run(real()) == "ok"
+    assert calls == []
+
+    monkeypatch.setenv("SLOW", "1")
+    assert asyncio.run(real()) == "ok"
+    assert calls == [3.0]
+
+
+# --------------------------------------------------------------------------- #
+# simulate_http_faults composite (order: delay -> timeout -> failure)          #
+# --------------------------------------------------------------------------- #
+def _clear_http_flags(monkeypatch):
+    """Unset every HTTP fault flag so a composite starts from a clean state."""
+    for flag in (fi.SIMULATE_SLOW_IO, fi.SIMULATE_NETWORK_TIMEOUT, fi.SIMULATE_NETWORK_FAILURE):
+        monkeypatch.delenv(flag, raising=False)
+
+
+def test_simulate_http_faults_composite_order(monkeypatch):
+    """Composite runs delay first, then timeout, then failure; all off is a no-op."""
+    events = []
+    monkeypatch.setattr(fi.time, "sleep", lambda s: events.append(("sleep", s)))
+    monkeypatch.setenv(fi.DELAY_SECONDS_ENV, "1")
+
+    @fi.simulate_http_faults(lambda: _Boom("failure"), lambda: TimeoutError("timeout"))
+    def real():
+        events.append(("real", None))
+        return "ok"
+
+    assert real.__name__ == "real"
+
+    # All flags off -> pass-through.
+    _clear_http_flags(monkeypatch)
+    assert real() == "ok"
+    assert events == [("real", None)]
+
+    # Slow-IO only -> sleep, then the real call.
+    events.clear()
+    monkeypatch.setenv(fi.SIMULATE_SLOW_IO, "1")
+    assert real() == "ok"
+    assert events == [("sleep", 1.0), ("real", None)]
+
+    # Slow-IO + timeout -> sleep, then timeout raised before the real call.
+    events.clear()
+    monkeypatch.setenv(fi.SIMULATE_NETWORK_TIMEOUT, "1")
+    with pytest.raises(TimeoutError):
+        real()
+    assert events == [("sleep", 1.0)]
+
+    # Failure alone (no slow-IO) -> failure raised, nothing slept or run.
+    events.clear()
+    _clear_http_flags(monkeypatch)
+    monkeypatch.setenv(fi.SIMULATE_NETWORK_FAILURE, "1")
+    with pytest.raises(_Boom, match="failure"):
+        real()
+    assert events == []
+
+
+def test_simulate_http_faults_async_composite(monkeypatch):
+    """Async composite: no-op when off, raises the failure factory when set."""
+    @fi.simulate_http_faults_async(lambda: _Boom("failure"), lambda: TimeoutError("timeout"))
+    async def real():
+        return "ok"
+
+    _clear_http_flags(monkeypatch)
+    assert asyncio.run(real()) == "ok"
+    assert real.__name__ == "real"
+
+    monkeypatch.setenv(fi.SIMULATE_NETWORK_FAILURE, "1")
+    with pytest.raises(_Boom, match="failure"):
+        asyncio.run(real())
+
+
+# --------------------------------------------------------------------------- #
+# Integration: the wiring on the manager's real HTTP methods                   #
+# --------------------------------------------------------------------------- #
+_MOCK_URL = "https://mock-idrac/redfish/v1"
+
+
+def test_manager_get_raises_connection_error(redfish_mock, monkeypatch):
+    """SIMULATE_NETWORK_FAILURE makes the sync GET raise a requests ConnectionError."""
+    monkeypatch.setenv(fi.SIMULATE_NETWORK_FAILURE, "1")
+    with pytest.raises(requests.exceptions.ConnectionError):
+        redfish_mock.api_get_call(_MOCK_URL, {})
+
+
+def test_manager_get_raises_read_timeout(redfish_mock, monkeypatch):
+    """SIMULATE_NETWORK_TIMEOUT makes the sync GET raise a requests ReadTimeout."""
+    monkeypatch.setenv(fi.SIMULATE_NETWORK_TIMEOUT, "1")
+    with pytest.raises(requests.exceptions.ReadTimeout):
+        redfish_mock.api_get_call(_MOCK_URL, {})
+
+
+def test_manager_async_get_raises_connection_error(redfish_mock, monkeypatch):
+    """The async GET raises the same ConnectionError before scheduling the request."""
+    monkeypatch.setenv(fi.SIMULATE_NETWORK_FAILURE, "1")
+    loop = asyncio.new_event_loop()
+    try:
+        with pytest.raises(requests.exceptions.ConnectionError):
+            loop.run_until_complete(redfish_mock.api_async_get_call(loop, _MOCK_URL, {}))
+    finally:
+        loop.close()

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -13,7 +13,7 @@ redfish_ctl/discovery/cmd_discovery.py:258
 redfish_ctl/discovery/cmd_discovery.py:260
 redfish_ctl/discovery/cmd_discovery.py:262
 redfish_ctl/fleet/cmd_fleet.py:53
-redfish_ctl/idrac_manager.py:499
+redfish_ctl/idrac_manager.py:527
 redfish_ctl/licenses/cmd_dell_license_actions.py:468
 redfish_ctl/licenses/cmd_dell_license_actions.py:472
 redfish_ctl/licenses/cmd_license_install.py:202

--- a/tools/span_root_baseline.txt
+++ b/tools/span_root_baseline.txt
@@ -4,7 +4,7 @@
 redfish_ctl/cmd_wait.py:38
 redfish_ctl/discover/cli.py:220
 redfish_ctl/discovery/net_scan.py:61
-redfish_ctl/idrac_manager.py:457
-redfish_ctl/idrac_manager.py:465
+redfish_ctl/idrac_manager.py:484
+redfish_ctl/idrac_manager.py:492
 redfish_ctl/redfish_manager.py:326
 redfish_ctl/redfish_manager.py:334


### PR DESCRIPTION
## What

Reusable **env-gated fault-injection decorators** (`redfish_ctl/decorators/`) that inject a delay or a
simulated network error at the fixed sync **and** async HTTP call sites, so a live run can exercise the
two failure edges a healthy BMC and an offline mock both hide:

- **signals** — a delay (`SIMULATE_SLOW_IO`) opens a deterministic window to deliver SIGTERM/SIGINT
  while a request is in flight, exercising the flush-on-termination path (G6).
- **network I/O** — `SIMULATE_NETWORK_TIMEOUT` / `SIMULATE_NETWORK_FAILURE` raise the exact `requests`
  exceptions a real stalled read / dropped connection would, driving the ERROR-span / non-zero-exit path.

Each decorator is a **no-op unless its flag is set**, so production and normal test runs pay only one
`os.getenv` check.

## How

- `decorators/fault_injection.py`: `inject_exception` / `inject_delay` + async variants, and a
  `simulate_http_faults` composite (delay → timeout → failure). Transport-neutral — the caller supplies
  the exception factory, so the module never imports `requests`.
- `idrac_manager.py`: applied to the 4 sync (`api_get/post/patch/delete_call`) and 4 async
  (`api_async_*_call`) methods; factories return `requests` `ConnectionError` / `ReadTimeout` so the
  downstream handling and recorded span match a genuine fault.
- `tests/test_fault_injection.py`: no-op-when-unset, raises-when-set (sync + async), delay gating,
  composite order, and manager-method integration.

## Evidence

Live-proven on a Supermicro X10 with OTLP tracing to Splunk (4 scenarios, distinct `scenario=` tags):
SIGTERM→`SystemExit(143)`+flush, SIGINT→clean-abort+flush, injected `ReadTimeout`→ERROR span,
injected `ConnectionError`→ERROR span. The tool started, applied all 8 decorators, and each fault fired.
