### PR TITLE
Remove duplicate _reset_command_singletons fixture in tests/conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,22 +236,6 @@ def _make_idrac(idrac_ip, username, password):
     )
 
 
-@pytest.fixture(autouse=True)
-def _reset_command_singletons():
-    """Give every test fresh command singletons so no cached state leaks.
-
-    Commands use ``metaclass=Singleton`` and cache per-host state
-    (``idrac_manage_servers`` and friends) on the instance. Without a reset, the
-    first vendor a command sees wins for the whole session — which only bites
-    cross-vendor tests (e.g. Supermicro then HPE resolve different host ids).
-    Clearing the instance registry before each test isolates them.
-    """
-    from redfish_ctl.idrac_shared import Singleton
-    Singleton._instances.clear()
-    yield
-    Singleton._instances.clear()
-
-
 @pytest.fixture
 def redfish_service():
     """The bare MockRedfishService mounted on a ``requests-mock`` transport.


### PR DESCRIPTION
The autouse fixture `_reset_command_singletons` was defined twice at module scope in `tests/conftest.py` (lines 71 and 239); the second definition silently shadowed the first. Both bodies were identical (`Singleton._instances.clear()` around a `yield`), so this keeps the first copy — it has the fuller docstring, including the note that the command dispatch `_registry` is untouched — and deletes the second. 16 pure deletions, no behavior change.

Offline static verification (no local pytest per repo policy):
- AST check: exactly one definition remains, decorated `pytest.fixture(autouse=True)`, body identical to the removed (previously active) copy
- `py_compile` OK, `ruff check` clean
- Import target confirmed: `Singleton._instances` in `redfish_ctl/idrac_shared.py`

CI on this PR is the authoritative validation.