### PR TITLE
CI: single Python version (3.10) + resync config-loader baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # main's branch protection requires test (3.10/3.11/3.12), so the matrix
-        # must run at least those three or the PR stays blocked. Dropped 3.13/3.14
-        # for speed. To go to a single version, first trim the required-checks
-        # list in main's branch protection.
-        python-version: ["3.10", "3.11", "3.12"]
+        # Single Python version: the floor (setup.py python_requires>=3.10), which
+        # catches use of newer-than-3.10 syntax. main's branch protection must
+        # require ONLY `test (3.10)`; if it still requires test (3.11)/test (3.12),
+        # a PR hangs on checks that no longer run.
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -33,8 +33,8 @@ redfish_ctl/redfish_manager.py:364
 redfish_ctl/redfish_manager.py:391
 redfish_ctl/telemetry/cmd_exporter.py:812
 redfish_ctl/telemetry/cmd_exporter.py:813
-redfish_ctl/telemetry/exporter.py:1143
-redfish_ctl/telemetry/exporter.py:1159
+redfish_ctl/telemetry/exporter.py:1157
+redfish_ctl/telemetry/exporter.py:1173
 redfish_ctl/telemetry/exporter.py:280
 redfish_ctl/telemetry/exporter.py:398
 redfish_ctl/telemetry/exporter.py:399


### PR DESCRIPTION
Two CI-hygiene changes:

1. **Single Python version** — collapse the `3.10/3.11/3.12` matrix to the floor `3.10` (`python_requires>=3.10`), so the ~2000-test offline suite runs once per PR instead of 3x. **Requires** trimming main's branch protection to require only `test (3.10)` (drop `test (3.11)`/`test (3.12)`), or PRs hang on checks that no longer run.
2. **Resync config-loader baseline** — the #402/#403 change added 14 lines to `exporter.py`, shifting two baselined env-read lines (1143->1157, 1159->1173) and reddening `config_loader_gate` on main. Baseline-only fix, no behavior change.

Merge order: trim branch protection to `test (3.10)` first, then this merges and main is green + single-version.