### PR TITLE
Hoist command registry and dispatch from IDracManager to RedfishManager

### DIFF
--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -44,7 +44,6 @@ from .cmd_exceptions import (
     PostRequestFailed,
     ResourceNotFound,
     UnexpectedResponse,
-    UnsupportedAction,
 )
 from .custom_argparser.customer_argdefault import CustomArgumentDefaultsHelpFormatter
 from .decorators.fault_injection import (
@@ -72,8 +71,6 @@ from .redfish_exceptions import RedfishException, RedfishForbidden, RedfishUnaut
 from .redfish_manager import (
     CommandResult,
     RedfishManager,
-    active_redfish_response_cache,
-    redfish_response_cache_scope,
 )
 from .redfish_shared import RedfishApi, RedfishJson, RedfishJsonSpec, env_first
 from .telemetry import tracing
@@ -107,8 +104,6 @@ class IDracManager(RedfishManager):
     """
     IDracManager Class, interact with a Redfish endpoint via REST API interface
     """
-
-    _registry = {t: {} for t in ApiRequestType}
 
     def __init__(self,
                  idrac_ip: Optional[str] = "",
@@ -293,176 +288,6 @@ class IDracManager(RedfishManager):
         """
         return self._x_auth
 
-    def __init_subclass__(cls, scm_type=None, name=None, **kwargs):
-        """Initialize and register all sub-commands.
-        :param scm_type:
-        :param name: sub-command name to differentiate each subcommand
-        :param kwargs:
-        :return:
-        """
-        super().__init_subclass__(**kwargs)
-        if scm_type is not None:
-            cls._registry[scm_type][name] = cls
-
-    @abstractmethod
-    def execute(self, **kwargs) -> CommandResult:
-        """Each sub-command must implement this method.  A dispatch automatically will
-        dispatch to each command, each command discovered during initial phase."""
-        pass
-
-    @staticmethod
-    @abstractmethod
-    def register_subcommand(cls) -> Tuple[argparse.ArgumentParser, str, str]:
-        """Each sub-command registers itself. Each command has its
-        own set of arguments and optional arguments.
-        :return: a Tuple that hold ArgumentParser, command name str, command help str
-        """
-        pass
-
-    @classmethod
-    def get_registry(cls):
-        """Return current command registry.
-        :return:
-        """
-        return dict(cls._registry)
-
-    @staticmethod
-    def _pop_connection_value(
-            kwargs: dict, primary: str, legacy: str, internal: str):
-        """Pop a dispatch connection argument, accepting deprecated aliases.
-
-        :param kwargs: dispatch keyword arguments.
-        :param primary: canonical keyword name.
-        :param legacy: deprecated alias keyword name.
-        :param internal: private keyword used by sync dispatch to avoid
-            colliding with subcommand-local ``host`` or ``port`` arguments.
-        :return: the popped value.
-        :raises KeyError: when no connection key exists.
-        """
-        if internal in kwargs:
-            value = kwargs.pop(internal)
-            kwargs.pop(legacy, None)
-            if kwargs.get(primary) in (value, None):
-                kwargs.pop(primary, None)
-            return value
-
-        if primary in kwargs:
-            value = kwargs.pop(primary)
-            legacy_value = kwargs.pop(legacy, None)
-            if value is not None:
-                return value
-            if legacy_value is not None:
-                return legacy_value
-            return value
-
-        return kwargs.pop(legacy)
-
-    @classmethod
-    def invoke(cls,
-               api_call: ApiRequestType,
-               name: str, **kwargs) -> CommandResult:
-        """Main interface uses to invoke a command.
-
-        :param api_call: api request type is enum for each cmd.
-        :param name: a name is key for a given api request type.
-                      So we can register under same type sub-commands.
-        :param kwargs: command arguments plus connection arguments. Connection
-            arguments accept canonical ``host``/``username``/``password``/``port``
-            names, legacy ``idrac_*`` aliases, or private ``_redfish_*`` keys
-            used by internal dispatch.
-        :return: command result returned by the registered command.
-        """
-        z = cls._registry[api_call]
-        if name not in z:
-            raise UnsupportedAction(f"Unknown {name} command.")
-        disp = z[name]
-        _host = cls._pop_connection_value(
-            kwargs, "host", "idrac_ip", "_redfish_host")
-        _username = cls._pop_connection_value(
-            kwargs, "username", "idrac_username", "_redfish_username")
-        _password = cls._pop_connection_value(
-            kwargs, "password", "idrac_password", "_redfish_password")
-        _port = cls._pop_connection_value(
-            kwargs, "port", "idrac_port", "_redfish_port")
-        _insecure = kwargs.pop("insecure")
-        _is_http = kwargs.pop("is_http")
-        _redfish_query = kwargs.pop("redfish_query", None)
-        _redfish_query_one_param_per_uri = kwargs.pop(
-            "redfish_query_one_param_per_uri", False
-        )
-        _redfish_cache = kwargs.pop("redfish_cache", None)
-
-        inst = disp(
-            idrac_ip=_host,
-            idrac_username=_username,
-            idrac_password=_password,
-            idrac_port=_port,
-            insecure=_insecure,
-            is_http=_is_http
-        )
-        inst._redfish_query = _redfish_query
-        inst._redfish_query_one_param_per_uri = _redfish_query_one_param_per_uri
-
-        if _redfish_cache is None:
-            return inst.execute(**kwargs)
-        with redfish_response_cache_scope(_redfish_cache):
-            return inst.execute(**kwargs)
-
-    async def async_invoke(
-            cls, api_call: ApiRequestType, name: str, **kwargs) -> CommandResult:
-        """Main interface uses to invoke a command.
-
-        :param api_call: api request type is enum for each cmd.
-        :param name: a name.
-        :param kwargs: command arguments plus connection arguments. Connection
-            arguments accept canonical ``host``/``username``/``password``/``port``
-            names, legacy ``idrac_*`` aliases, or private ``_redfish_*`` keys
-            used by internal dispatch.
-        :return: CommandResult.
-        """
-        z = cls._registry[api_call]
-        disp = z[name]
-        if name not in z:
-            raise UnsupportedAction(f"Unknown {name} command.")
-        _host = cls._pop_connection_value(
-            kwargs, "host", "idrac_ip", "_redfish_host")
-        _username = cls._pop_connection_value(
-            kwargs, "username", "idrac_username", "_redfish_username")
-        _password = cls._pop_connection_value(
-            kwargs, "password", "idrac_password", "_redfish_password")
-        _port = cls._pop_connection_value(
-            kwargs, "port", "idrac_port", "_redfish_port")
-        _insecure = kwargs.pop("insecure")
-        _is_http = kwargs.pop("is_http")
-        _redfish_query = kwargs.pop("redfish_query", None)
-        _redfish_query_one_param_per_uri = kwargs.pop(
-            "redfish_query_one_param_per_uri", False
-        )
-        _redfish_cache = kwargs.pop("redfish_cache", None)
-        module_logger.debug(f"dispatching {name} to Redfish port {_port}")
-
-        inst = disp(
-            idrac_ip=_host,
-            idrac_username=_username,
-            idrac_password=_password,
-            idrac_port=_port,
-            insecure=_insecure,
-            is_http=_is_http
-        )
-        inst._redfish_query = _redfish_query
-        inst._redfish_query_one_param_per_uri = _redfish_query_one_param_per_uri
-        # Operation root span named by the command (matches sync_invoke) so an
-        # async command's BMC client spans nest into ONE trace instead of
-        # surfacing as orphan "redfish.bmc.request" root traces in APM.
-        with tracing.operation_span(name) as span:
-            if _redfish_cache is None:
-                result = inst.execute(**kwargs)
-            else:
-                with redfish_response_cache_scope(_redfish_cache):
-                    result = inst.execute(**kwargs)
-            tracing.record_result(span, result)
-            return result
-
     @simulate_http_faults_async(_simulated_connection_error, _simulated_read_timeout)
     async def api_async_get_call(self, loop, req, hdr: Dict):
         """Make api asynced requests either with x-auth authentication
@@ -546,52 +371,6 @@ class IDracManager(RedfishManager):
                 raise
             tracing.record_response(span, response.status_code)
             return response
-
-    def sync_invoke(self, api_call: ApiRequestType, name: str, **kwargs) -> CommandResult:
-        """Synchronous invocation of target command
-
-        :param name: a name for command to differentiate sub-commands
-        :param api_call: enum i.e. a type command that we need invoke
-        :param kwargs: command-specific arguments. The manager injects private
-            ``_redfish_*`` connection keys before dispatching to the registered
-            command constructor.
-        :return: Return result depends on actual command,
-                 encapsulated in generic CommandResult
-        """
-        if len(self._username) == 0:
-            raise ValueError("Username is empty string.")
-        if len(self._password) == 0:
-            raise ValueError("Password is empty string.")
-        if len(self.redfish_ip) == 0:
-            raise ValueError("Redfish host is empty string.")
-
-        kwargs.update(
-            {
-                "_redfish_host": self.redfish_ip,
-                "_redfish_username": self._username,
-                "_redfish_password": self._password,
-                "_redfish_port": self._port,
-                # forward the original "skip verification" intent; _is_verify_cert
-                # is the inverse (requests' verify flag), so flip it back here.
-                "insecure": not self._is_verify_cert,
-                "is_http": self._is_http,
-            }
-        )
-        if "redfish_cache" not in kwargs:
-            redfish_cache = active_redfish_response_cache()
-            if redfish_cache is not None:
-                kwargs["redfish_cache"] = redfish_cache
-        # Operation root span named by the command (no-op unless tracing is on).
-        # When main already opened the operation root, nest under it instead of
-        # opening a second same-named root (the call stack IS the span tree); main
-        # records the result on that root. Only root here for direct/standalone
-        # callers (tests, nested tooling) where no operation span is active yet.
-        if tracing.current_span() is not None:
-            return self.invoke(api_call, name, **kwargs)
-        with tracing.operation_span(name) as span:
-            result = self.invoke(api_call, name, **kwargs)
-            tracing.record_result(span, result)
-            return result
 
     def get_job(self,
                 job_id: str,

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -6,6 +6,7 @@ https://www.dmtf.org/standards/REDFISH
 Author Mus spyroot@gmail.com
 """
 
+import argparse
 import asyncio
 import collections
 import contextvars
@@ -24,7 +25,12 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from .cmd_exceptions import AuthenticationFailed, ResourceNotFound, TaskIdUnavailable
+from .cmd_exceptions import (
+    AuthenticationFailed,
+    ResourceNotFound,
+    TaskIdUnavailable,
+    UnsupportedAction,
+)
 from .cmd_utils import save_if_needed
 from .redfish_exceptions import (
     RedfishForbidden,
@@ -45,6 +51,8 @@ from .redfish_shared import (
 )
 from .redfish_task_state import TERMINAL_TASK_STATES, TaskState, TaskStatus
 from .telemetry import tracing
+
+module_logger = logging.getLogger(__name__)
 
 """Each command encapsulate result in named tuple"""
 CommandResult = collections.namedtuple("cmd_result",
@@ -214,6 +222,224 @@ class RedfishManager:
         # run time
         self.action_targets = None
         self.api_endpoints = None
+
+    _registry = collections.defaultdict(dict)
+
+    def __init_subclass__(cls, scm_type=None, name=None, **kwargs):
+        """Initialize and register all sub-commands.
+        :param scm_type:
+        :param name: sub-command name to differentiate each subcommand
+        :param kwargs:
+        :return:
+        """
+        super().__init_subclass__(**kwargs)
+        if scm_type is not None:
+            cls._registry[scm_type][name] = cls
+
+    @abstractmethod
+    def execute(self, **kwargs) -> CommandResult:
+        """Each sub-command must implement this method.  A dispatch automatically will
+        dispatch to each command, each command discovered during initial phase."""
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def register_subcommand(cls) -> Tuple[argparse.ArgumentParser, str, str]:
+        """Each sub-command registers itself. Each command has its
+        own set of arguments and optional arguments.
+        :return: a Tuple that hold ArgumentParser, command name str, command help str
+        """
+        pass
+
+    @classmethod
+    def get_registry(cls):
+        """Return current command registry.
+        :return:
+        """
+        return dict(cls._registry)
+
+    @staticmethod
+    def _pop_connection_value(
+            kwargs: dict, primary: str, legacy: str, internal: str):
+        """Pop a dispatch connection argument, accepting deprecated aliases.
+
+        :param kwargs: dispatch keyword arguments.
+        :param primary: canonical keyword name.
+        :param legacy: deprecated alias keyword name.
+        :param internal: private keyword used by sync dispatch to avoid
+            colliding with subcommand-local ``host`` or ``port`` arguments.
+        :return: the popped value.
+        :raises KeyError: when no connection key exists.
+        """
+        if internal in kwargs:
+            value = kwargs.pop(internal)
+            kwargs.pop(legacy, None)
+            if kwargs.get(primary) in (value, None):
+                kwargs.pop(primary, None)
+            return value
+
+        if primary in kwargs:
+            value = kwargs.pop(primary)
+            legacy_value = kwargs.pop(legacy, None)
+            if value is not None:
+                return value
+            if legacy_value is not None:
+                return legacy_value
+            return value
+
+        return kwargs.pop(legacy)
+
+    @classmethod
+    def invoke(cls,
+               api_call: Hashable,
+               name: str, **kwargs) -> CommandResult:
+        """Main interface uses to invoke a command.
+
+        :param api_call: api request type is enum for each cmd.
+        :param name: a name is key for a given api request type.
+                      So we can register under same type sub-commands.
+        :param kwargs: command arguments plus connection arguments. Connection
+            arguments accept canonical ``host``/``username``/``password``/``port``
+            names, legacy ``idrac_*`` aliases, or private ``_redfish_*`` keys
+            used by internal dispatch.
+        :return: command result returned by the registered command.
+        """
+        z = cls._registry[api_call]
+        if name not in z:
+            raise UnsupportedAction(f"Unknown {name} command.")
+        disp = z[name]
+        _host = cls._pop_connection_value(
+            kwargs, "host", "idrac_ip", "_redfish_host")
+        _username = cls._pop_connection_value(
+            kwargs, "username", "idrac_username", "_redfish_username")
+        _password = cls._pop_connection_value(
+            kwargs, "password", "idrac_password", "_redfish_password")
+        _port = cls._pop_connection_value(
+            kwargs, "port", "idrac_port", "_redfish_port")
+        _insecure = kwargs.pop("insecure")
+        _is_http = kwargs.pop("is_http")
+        _redfish_query = kwargs.pop("redfish_query", None)
+        _redfish_query_one_param_per_uri = kwargs.pop(
+            "redfish_query_one_param_per_uri", False
+        )
+        _redfish_cache = kwargs.pop("redfish_cache", None)
+
+        inst = disp(
+            idrac_ip=_host,
+            idrac_username=_username,
+            idrac_password=_password,
+            idrac_port=_port,
+            insecure=_insecure,
+            is_http=_is_http
+        )
+        inst._redfish_query = _redfish_query
+        inst._redfish_query_one_param_per_uri = _redfish_query_one_param_per_uri
+
+        if _redfish_cache is None:
+            return inst.execute(**kwargs)
+        with redfish_response_cache_scope(_redfish_cache):
+            return inst.execute(**kwargs)
+
+    async def async_invoke(
+            cls, api_call: Hashable, name: str, **kwargs) -> CommandResult:
+        """Main interface uses to invoke a command.
+
+        :param api_call: api request type is enum for each cmd.
+        :param name: a name.
+        :param kwargs: command arguments plus connection arguments. Connection
+            arguments accept canonical ``host``/``username``/``password``/``port``
+            names, legacy ``idrac_*`` aliases, or private ``_redfish_*`` keys
+            used by internal dispatch.
+        :return: CommandResult.
+        """
+        z = cls._registry[api_call]
+        disp = z[name]
+        if name not in z:
+            raise UnsupportedAction(f"Unknown {name} command.")
+        _host = cls._pop_connection_value(
+            kwargs, "host", "idrac_ip", "_redfish_host")
+        _username = cls._pop_connection_value(
+            kwargs, "username", "idrac_username", "_redfish_username")
+        _password = cls._pop_connection_value(
+            kwargs, "password", "idrac_password", "_redfish_password")
+        _port = cls._pop_connection_value(
+            kwargs, "port", "idrac_port", "_redfish_port")
+        _insecure = kwargs.pop("insecure")
+        _is_http = kwargs.pop("is_http")
+        _redfish_query = kwargs.pop("redfish_query", None)
+        _redfish_query_one_param_per_uri = kwargs.pop(
+            "redfish_query_one_param_per_uri", False
+        )
+        _redfish_cache = kwargs.pop("redfish_cache", None)
+        module_logger.debug(f"dispatching {name} to Redfish port {_port}")
+
+        inst = disp(
+            idrac_ip=_host,
+            idrac_username=_username,
+            idrac_password=_password,
+            idrac_port=_port,
+            insecure=_insecure,
+            is_http=_is_http
+        )
+        inst._redfish_query = _redfish_query
+        inst._redfish_query_one_param_per_uri = _redfish_query_one_param_per_uri
+        # Operation root span named by the command (matches sync_invoke) so an
+        # async command's BMC client spans nest into ONE trace instead of
+        # surfacing as orphan "redfish.bmc.request" root traces in APM.
+        with tracing.operation_span(name) as span:
+            if _redfish_cache is None:
+                result = inst.execute(**kwargs)
+            else:
+                with redfish_response_cache_scope(_redfish_cache):
+                    result = inst.execute(**kwargs)
+            tracing.record_result(span, result)
+            return result
+
+    def sync_invoke(self, api_call: Hashable, name: str, **kwargs) -> CommandResult:
+        """Synchronous invocation of target command
+
+        :param name: a name for command to differentiate sub-commands
+        :param api_call: enum i.e. a type command that we need invoke
+        :param kwargs: command-specific arguments. The manager injects private
+            ``_redfish_*`` connection keys before dispatching to the registered
+            command constructor.
+        :return: Return result depends on actual command,
+                 encapsulated in generic CommandResult
+        """
+        if len(self._username) == 0:
+            raise ValueError("Username is empty string.")
+        if len(self._password) == 0:
+            raise ValueError("Password is empty string.")
+        if len(self.redfish_ip) == 0:
+            raise ValueError("Redfish host is empty string.")
+
+        kwargs.update(
+            {
+                "_redfish_host": self.redfish_ip,
+                "_redfish_username": self._username,
+                "_redfish_password": self._password,
+                "_redfish_port": self._port,
+                # forward the original "skip verification" intent; _is_verify_cert
+                # is the inverse (requests' verify flag), so flip it back here.
+                "insecure": not self._is_verify_cert,
+                "is_http": self._is_http,
+            }
+        )
+        if "redfish_cache" not in kwargs:
+            redfish_cache = active_redfish_response_cache()
+            if redfish_cache is not None:
+                kwargs["redfish_cache"] = redfish_cache
+        # Operation root span named by the command (no-op unless tracing is on).
+        # When main already opened the operation root, nest under it instead of
+        # opening a second same-named root (the call stack IS the span tree); main
+        # records the result on that root. Only root here for direct/standalone
+        # callers (tests, nested tooling) where no operation span is active yet.
+        if tracing.current_span() is not None:
+            return self.invoke(api_call, name, **kwargs)
+        with tracing.operation_span(name) as span:
+            result = self.invoke(api_call, name, **kwargs)
+            tracing.record_result(span, result)
+            return result
 
     @property
     def redfish_ip(self) -> str:

--- a/tests/test_registry_hoist.py
+++ b/tests/test_registry_hoist.py
@@ -1,0 +1,58 @@
+"""Offline tests for the hoisted command registry and dispatch machinery.
+
+The command ``_registry`` plus the ``invoke``/``sync_invoke``/``async_invoke``
+dispatch used to live on the Dell child ``IDracManager``. They now live on the
+product-neutral parent ``RedfishManager``; command classes inherit them one MRO
+hop higher and behave exactly as before. These tests pin that: the registry is a
+single shared object, dispatch still routes a known command, and an unknown
+``api_call`` now raises ``UnsupportedAction`` (the ``defaultdict`` delta) instead
+of a ``KeyError``. No BMC or network is involved.
+
+Author Mus <spyroot@gmail.com>
+"""
+import pytest
+
+from redfish_ctl.cmd_exceptions import UnsupportedAction
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import CommandResult, RedfishManager
+
+# Importing the command module registers SystemQuery/system_query via
+# __init_subclass__, so the registry is populated regardless of collection order.
+from redfish_ctl.system.cmd_system import SystemQuery  # noqa: F401
+
+
+def test_registry_is_a_single_shared_object():
+    """Child and parent expose the very same registry object, not two copies."""
+    assert IDracManager._registry is RedfishManager._registry
+
+
+def test_registry_is_populated_with_known_commands():
+    """The inherited registry holds real commands (system_query is registered)."""
+    registry = IDracManager().get_registry()
+    assert registry, "command registry is unexpectedly empty"
+    assert ApiRequestType.SystemQuery in registry
+    assert registry[ApiRequestType.SystemQuery].get("system_query") is SystemQuery
+
+
+def test_known_command_dispatches_through_inherited_sync_invoke(redfish_mock):
+    """A known command still routes through the inherited machinery to a result."""
+    result = redfish_mock.sync_invoke(ApiRequestType.SystemQuery, "system_query")
+    assert isinstance(result, CommandResult)
+
+
+def test_unknown_api_call_raises_unsupported_action_not_keyerror():
+    """An unregistered api_call key hits the defaultdict path and raises cleanly.
+
+    With the old ``{t: {} for t in ApiRequestType}`` registry this key was absent
+    and produced a ``KeyError``; the ``defaultdict(dict)`` yields an empty map so
+    the missing-name guard raises ``UnsupportedAction`` instead.
+    """
+    with pytest.raises(UnsupportedAction):
+        IDracManager.invoke("no-such-api-kind", "system_query")
+
+
+def test_unknown_name_under_known_api_call_raises_unsupported_action():
+    """A valid api_call with an unregistered name raises ``UnsupportedAction``."""
+    with pytest.raises(UnsupportedAction):
+        IDracManager.invoke(ApiRequestType.SystemQuery, "not_a_registered_name")

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -13,7 +13,7 @@ redfish_ctl/discovery/cmd_discovery.py:258
 redfish_ctl/discovery/cmd_discovery.py:260
 redfish_ctl/discovery/cmd_discovery.py:262
 redfish_ctl/fleet/cmd_fleet.py:53
-redfish_ctl/idrac_manager.py:527
+redfish_ctl/idrac_manager.py:352
 redfish_ctl/licenses/cmd_dell_license_actions.py:468
 redfish_ctl/licenses/cmd_dell_license_actions.py:472
 redfish_ctl/licenses/cmd_license_install.py:202
@@ -27,10 +27,10 @@ redfish_ctl/oem/cmd_nvidia_debug_token.py:317
 redfish_ctl/oem/cmd_nvidia_debug_token.py:319
 redfish_ctl/redfish_csdl.py:70
 redfish_ctl/redfish_main.py:177
-redfish_ctl/redfish_manager.py:360
-redfish_ctl/redfish_manager.py:362
-redfish_ctl/redfish_manager.py:364
-redfish_ctl/redfish_manager.py:391
+redfish_ctl/redfish_manager.py:586
+redfish_ctl/redfish_manager.py:588
+redfish_ctl/redfish_manager.py:590
+redfish_ctl/redfish_manager.py:617
 redfish_ctl/telemetry/cmd_exporter.py:812
 redfish_ctl/telemetry/cmd_exporter.py:813
 redfish_ctl/telemetry/exporter.py:1157

--- a/tools/span_root_baseline.txt
+++ b/tools/span_root_baseline.txt
@@ -4,7 +4,7 @@
 redfish_ctl/cmd_wait.py:38
 redfish_ctl/discover/cli.py:220
 redfish_ctl/discovery/net_scan.py:61
-redfish_ctl/idrac_manager.py:484
-redfish_ctl/idrac_manager.py:492
-redfish_ctl/redfish_manager.py:326
-redfish_ctl/redfish_manager.py:334
+redfish_ctl/idrac_manager.py:309
+redfish_ctl/idrac_manager.py:317
+redfish_ctl/redfish_manager.py:552
+redfish_ctl/redfish_manager.py:560


### PR DESCRIPTION
First step of the DMTF base consolidation: move the command registry (`_registry`, `__init_subclass__`), `get_registry`, and the dispatch surface (`invoke`/`async_invoke`/`sync_invoke`) from the Dell child `IDracManager` up to the neutral base `RedfishManager`.

Commands keep working unchanged via inheritance (`IDracManager(RedfishManager)`), so this is behavior-preserving. `tests/test_registry_hoist.py` asserts the registry lives on the base and dispatch still resolves. Enables generic (`RedfishManager`-rooted) commands to register/dispatch without the Dell child.