### PR TITLE
Dedup: inherit five shared accessor/helper methods from RedfishManager

### DIFF
--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -264,30 +264,6 @@ class IDracManager(RedfishManager):
         """
         return self.redfish_ip
 
-    @property
-    def username(self) -> str:
-        """BMC account username.
-
-        :return: the configured username.
-        """
-        return self._username
-
-    @property
-    def password(self) -> str:
-        """BMC account password.
-
-        :return: the configured password.
-        """
-        return self._password
-
-    @property
-    def x_auth(self) -> str:
-        """X-Auth token used in place of basic authentication.
-
-        :return: the X-Auth token, or None when basic auth is used.
-        """
-        return self._x_auth
-
     @simulate_http_faults_async(_simulated_connection_error, _simulated_read_timeout)
     async def api_async_get_call(self, loop, req, hdr: Dict):
         """Make api asynced requests either with x-auth authentication
@@ -319,20 +295,6 @@ class IDracManager(RedfishManager):
                     auth=(self._username, self._password)
                 )
             )
-
-    async def api_async_get_until_complete(
-            self, req, hdr: Dict, loop=None) -> requests.models.Response:
-        """Make asyncio request,
-        :param req: request
-        :param hdr: HTTP headers
-        :param loop: a default loop, if loop is None method will create
-        :return:
-        """
-        if loop is None:
-            loop = self._event_loop()
-        response = await self.api_async_get_call(loop, req, hdr)
-        await self.async_default_error_handler(await response)
-        return await response
 
     @simulate_http_faults(_simulated_connection_error, _simulated_read_timeout)
     def api_get_call(
@@ -1302,14 +1264,6 @@ class IDracManager(RedfishManager):
         return self.read_api_respond(
             response, expected=expected, ignore_error_code=ignore_error_code
         )
-
-    @staticmethod
-    def expanded(level=1):
-        """Return prefix to use for expanded respond.
-        :param level:
-        :return:
-        """
-        return f"?$expand=*($levels={level})"
 
     @staticmethod
     def _redact_sensitive_payload(payload):

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -13,7 +13,7 @@ redfish_ctl/discovery/cmd_discovery.py:258
 redfish_ctl/discovery/cmd_discovery.py:260
 redfish_ctl/discovery/cmd_discovery.py:262
 redfish_ctl/fleet/cmd_fleet.py:53
-redfish_ctl/idrac_manager.py:352
+redfish_ctl/idrac_manager.py:314
 redfish_ctl/licenses/cmd_dell_license_actions.py:468
 redfish_ctl/licenses/cmd_dell_license_actions.py:472
 redfish_ctl/licenses/cmd_license_install.py:202

--- a/tools/span_root_baseline.txt
+++ b/tools/span_root_baseline.txt
@@ -4,7 +4,7 @@
 redfish_ctl/cmd_wait.py:38
 redfish_ctl/discover/cli.py:220
 redfish_ctl/discovery/net_scan.py:61
-redfish_ctl/idrac_manager.py:309
-redfish_ctl/idrac_manager.py:317
+redfish_ctl/idrac_manager.py:285
+redfish_ctl/idrac_manager.py:293
 redfish_ctl/redfish_manager.py:552
 redfish_ctl/redfish_manager.py:560


### PR DESCRIPTION
Consolidation slice. `IDracManager` re-declared five methods identical to the `RedfishManager` base — the `username`/`password`/`x_auth` properties, the `expanded` static helper, and `api_async_get_until_complete`. Delete the copies so they inherit from the base; bump the config-loader/span-root baselines for the kept env-read/spans that shifted up.

The decorated HTTP methods `api_get_call`/`api_async_get_call` **stay** — they carry the `@simulate_http_faults` wiring the base lacks (moving that to the base is a separate slice). The genuine Dell overrides (`__init__`, `default_error_handler`, `fetch_task`, `get_task_state`, `api_success_msg`) are untouched. Behavior-preserving.