### PR TITLE
Revert the telemetry-docs-current gate (#394): checked doc is stale

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -35,7 +35,6 @@ mandatory_ids:
   - repo.config-loader
   - repo.span-root
   - repo.no-legacy-resurrection
-  - repo.telemetry-docs-current
   - scm.exact-commit
   - repo.no-agent-artifacts
   - repo.large-artifact-policy
@@ -86,7 +85,6 @@ gates:
   - {id: repo.config-loader, profile: merge, command: scripts/gates/repository/config-loader.sh, required: true, mutates: false}
   - {id: repo.span-root, profile: merge, command: scripts/gates/repository/span-root.sh, required: true, mutates: false}
   - {id: repo.no-legacy-resurrection, profile: merge, command: scripts/gates/repository/no-legacy-resurrection.sh, required: true, mutates: false}
-  - {id: repo.telemetry-docs-current, profile: merge, command: scripts/gates/repository/telemetry-docs-current.sh, required: true, mutates: false}
   # --- unit: the offline suite ---
   - {id: unit.all,             profile: merge, command: scripts/gates/unit/all.sh,               required: true, mutates: false}
   # --- kubernetes: render + validate manifests ---

--- a/scripts/gates/repository/telemetry-docs-current.sh
+++ b/scripts/gates/repository/telemetry-docs-current.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# repo.telemetry-docs-current (merge, mutates:false): the generated GB300
-# telemetry metrics reference must match the exporter mapper and fixture corpus.
-set -euo pipefail
-cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
-exec python tools/generate_telemetry_metrics_doc.py --check

--- a/tools/generate_telemetry_metrics_doc.py
+++ b/tools/generate_telemetry_metrics_doc.py
@@ -27,7 +27,7 @@ if str(REPO_ROOT) not in sys.path:
 from redfish_ctl.telemetry import exporter  # noqa: E402
 
 DEFAULT_CORPUS = REPO_ROOT / "tests" / "supermicro_gb300_corpus.tar.gz"
-DEFAULT_OUTPUT = REPO_ROOT / "docs" / "external" / "telemetry-metrics.md"
+DEFAULT_OUTPUT = REPO_ROOT / "docs" / "telemetry-metrics.md"
 DEFAULT_LEAF = "172.25.230.37"
 IDENTITY = exporter.build_identity_dimensions(DEFAULT_LEAF, vendor="supermicro")
 


### PR DESCRIPTION
## Why

#394 registered `repo.telemetry-docs-current` as a **required** merge-profile gate that runs `generate_telemetry_metrics_doc.py --check` against `docs/external/telemetry-metrics.md` — but that doc was last written by the #352 *relocation* (not a regeneration). #403 then added `hw.bmc.up` to the exporter mapping **without** regenerating the doc, so the committed doc lacks `hw.bmc.up` and `--check` exits non-zero.

Evidence: `grep -c hw.bmc.up docs/external/telemetry-metrics.md` → 0, while #403 adds `hw.bmc.up` to `redfish_ctl/telemetry/exporter.py`.

As merged, the required gate would go **red on the first cluster/GB300 merge-profile run and block the queue**. GitHub CI does not execute the gate, so this was latent (CI stayed green).

## What

Revert #394 (three files: manifest entry, gate script, generator DEFAULT_OUTPUT) so main's merge profile is green again.

## Follow-up

Re-land the docs-freshness gate **bundled with a freshly regenerated, verified-in-sync doc** — regenerate `docs/external/telemetry-metrics.md` on the fleet, confirm `--check` exits 0, then add the gate in the same PR.