### PR TITLE
Add the exception-interface gate: exceptions defined in one place

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -33,6 +33,7 @@ mandatory_ids:
   - repo.no-ghost-env
   - repo.arg-consistency
   - repo.config-loader
+  - repo.exception-interface
   - repo.span-root
   - repo.no-legacy-resurrection
   - scm.exact-commit
@@ -83,6 +84,7 @@ gates:
   - {id: repo.no-ghost-env, profile: merge, command: scripts/gates/repository/no-ghost-env.sh, required: true, mutates: false}
   - {id: repo.arg-consistency, profile: merge, command: scripts/gates/repository/arg-consistency.sh, required: true, mutates: false}
   - {id: repo.config-loader, profile: merge, command: scripts/gates/repository/config-loader.sh, required: true, mutates: false}
+  - {id: repo.exception-interface, profile: merge, command: scripts/gates/repository/exception-interface.sh, required: true, mutates: false}
   - {id: repo.span-root, profile: merge, command: scripts/gates/repository/span-root.sh, required: true, mutates: false}
   - {id: repo.no-legacy-resurrection, profile: merge, command: scripts/gates/repository/no-legacy-resurrection.sh, required: true, mutates: false}
   # --- unit: the offline suite ---

--- a/scripts/gates/repository/exception-interface.sh
+++ b/scripts/gates/repository/exception-interface.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# repo.exception-interface (merge, mutates:false): exception TYPES are defined in
+# ONE place — the exception interface (redfish_ctl/cmd_exceptions.py and
+# redfish_ctl/redfish_exceptions.py). A new exception class defined anywhere else
+# fails; a migrated one must leave the baseline (ratchet to zero). This keeps the
+# error contract the single top-level exit handler maps to exit codes from being
+# fragmented by ad-hoc call-site exception classes.
+# Implementation: tools/exception_interface_gate.py.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python3 tools/exception_interface_gate.py

--- a/tests/test_exception_interface_gate.py
+++ b/tests/test_exception_interface_gate.py
@@ -1,0 +1,74 @@
+"""Unit tests for the exception-interface gate's detection logic.
+
+The gate keeps exception types defined only in the exception interface
+(``redfish_ctl/cmd_exceptions.py``, ``redfish_ctl/redfish_exceptions.py``). These
+tests pin the transitive detection so a future edit cannot silently reopen the
+subclass bypass or start flagging non-exception classes.
+
+Author Mus spyroot@gmail.com
+"""
+import importlib.util
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_spec = importlib.util.spec_from_file_location(
+    "exception_interface_gate", REPO_ROOT / "tools" / "exception_interface_gate.py")
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+def test_suffix_names_are_exceptions():
+    """A base ending in Error/Exception marks its class as an exception type."""
+    assert gate._suffix_exc("RuntimeError")
+    assert gate._suffix_exc("HTTPException")
+    assert not gate._suffix_exc("Mapping")
+    assert not gate._suffix_exc("ConfigurationConflict")
+
+
+def test_direct_builtin_subclass_is_detected():
+    """A class subclassing a builtin exception is an exception type."""
+    classes = [("a.py", 1, "MyError", ["RuntimeError"])]
+    assert gate._exception_class_names(classes) == {"MyError"}
+
+
+def test_transitive_subclass_bypass_is_closed():
+    """Subclassing a project exception whose own name is not suffixed is still caught.
+
+    ``ConfigurationConflict(RuntimeError)`` is an exception; a class deriving from it
+    (``SneakyErr(ConfigurationConflict)``) must also be detected even though its base
+    name does not end in Error/Exception — otherwise the gate is trivially bypassable.
+    """
+    classes = [
+        ("config.py", 34, "ConfigurationConflict", ["RuntimeError"]),
+        ("sneaky.py", 9, "SneakyState", ["ConfigurationConflict"]),
+    ]
+    names = gate._exception_class_names(classes)
+    assert {"ConfigurationConflict", "SneakyState"} <= names
+
+
+def test_non_exception_class_is_not_flagged():
+    """A plain class (no exception base) is never treated as an exception type."""
+    classes = [("plain.py", 3, "PlainData", ["object"]),
+               ("plain.py", 20, "Mapping", [])]
+    assert gate._exception_class_names(classes) == set()
+
+
+def test_interface_modules_are_not_reported():
+    """An exception defined IN the interface is allowed; one outside it is a violation."""
+    classes = [
+        ("redfish_ctl/cmd_exceptions.py", 5, "InvalidArgument", ["RuntimeError"]),
+        ("redfish_ctl/network/cmd_x.py", 7, "LocalError", ["RuntimeError"]),
+    ]
+    names = gate._exception_class_names(classes)
+    reported = sorted(
+        f"{f}:{line}" for f, line, name, _bases in classes
+        if f not in gate._INTERFACE and name in names)
+    assert reported == ["redfish_ctl/network/cmd_x.py:7"]
+
+
+def test_baseline_skips_comments_and_blank_lines():
+    """The committed baseline parses to the five grandfathered locations only."""
+    base = gate._baseline()
+    assert "redfish_ctl/network/cmd_network_adapter_reset.py:25" in base
+    assert all(not entry.startswith("#") for entry in base)
+    assert len(base) == 5

--- a/tools/exception_interface_baseline.txt
+++ b/tools/exception_interface_baseline.txt
@@ -1,0 +1,9 @@
+# Exception classes defined OUTSIDE the interface (redfish_ctl/cmd_exceptions.py and
+# redfish_ctl/redfish_exceptions.py), grandfathered. Move each into the interface, then
+# delete its line. A NEW exception class outside the interface fails the gate.
+# Goal: empty baseline — every exception type in the interface, none anywhere else.
+redfish_ctl/api.py:27
+redfish_ctl/config.py:34
+redfish_ctl/fixtures_catalog.py:14
+redfish_ctl/network/cmd_network_adapter_reset.py:25
+redfish_ctl/proxy/core.py:53

--- a/tools/exception_interface_gate.py
+++ b/tools/exception_interface_gate.py
@@ -1,0 +1,150 @@
+"""Gate: exception types are defined in ONE place — the exception interface.
+
+Application code must raise the exceptions defined in ``redfish_ctl/cmd_exceptions.py``
+and ``redfish_ctl/redfish_exceptions.py`` — the API exception interface — not invent an
+ad-hoc exception class at a call site. A new exception class anywhere else fragments the
+error contract that the single top-level handler maps to exit codes, and it is invisible
+to callers who import the interface. This is the same disease as a scattered env read or
+a duplicate connection name: a cross-cutting concern smeared across files instead of
+owned in one spot.
+
+    python3 tools/exception_interface_gate.py
+
+Ratchet: existing out-of-interface exception classes are grandfathered in
+tools/exception_interface_baseline.txt; a NEW exception class outside the interface
+fails the gate, and a migrated one must leave the baseline. The goal is an empty
+baseline — every exception type in the interface, none anywhere else.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import subprocess
+import sys
+
+# The exception interface — the only modules allowed to define exception types.
+_INTERFACE = {
+    "redfish_ctl/cmd_exceptions.py",
+    "redfish_ctl/redfish_exceptions.py",
+}
+_BASELINE = pathlib.Path(__file__).parent / "exception_interface_baseline.txt"
+
+
+def _base_name(base: ast.expr) -> str:
+    """Return a class base's simple name (``requests.HTTPError`` -> ``HTTPError``).
+
+    :param base: a base-class expression from a ``ClassDef``.
+    :return: the base's final name component, or "" when it is not a plain name.
+    """
+    return base.attr if isinstance(base, ast.Attribute) else getattr(base, "id", "")
+
+
+def _suffix_exc(name: str) -> bool:
+    """Return whether a name looks like an exception type by suffix.
+
+    Covers builtin and third-party exceptions (``RuntimeError``, ``requests.HTTPError``).
+
+    :param name: a class or base name.
+    :return: True when it ends in ``Error`` or ``Exception``.
+    """
+    return name.endswith("Error") or name.endswith("Exception")
+
+
+def _all_classes() -> list[tuple[str, int, str, list[str]]]:
+    """Return every ``ClassDef`` in ``redfish_ctl/`` as (path, line, name, base names).
+
+    Includes the interface modules (their exception names seed the detection) and
+    tolerates an unparseable file: a syntax error is a different gate's job, so it must
+    not crash this required gate.
+
+    :return: one tuple per class definition across the package.
+    """
+    out: list[tuple[str, int, str, list[str]]] = []
+    files = subprocess.check_output(
+        ["git", "ls-files", "redfish_ctl/*.py", "redfish_ctl/**/*.py"]).decode().split()
+    for f in files:
+        try:
+            tree = ast.parse(pathlib.Path(f).read_text(encoding="utf-8"))
+        except (SyntaxError, ValueError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef):
+                out.append((f, node.lineno, node.name,
+                            [_base_name(b) for b in node.bases]))
+    return out
+
+
+def _exception_class_names(classes: list[tuple[str, int, str, list[str]]]) -> set[str]:
+    """Return, transitively, the name of every class that is an exception type.
+
+    A class is an exception when a base is suffixed ``Error``/``Exception`` OR inherits
+    from an already-known exception class. The fixpoint closes the bypass of subclassing
+    a project exception whose own name is not suffixed (e.g. ``ConfigurationConflict``).
+
+    :param classes: all class definitions in the package.
+    :return: the set of exception class names.
+    """
+    known: set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for _f, _line, name, bases in classes:
+            if name in known:
+                continue
+            if any(_suffix_exc(b) or b in known for b in bases):
+                known.add(name)
+                changed = True
+    return known
+
+
+def _violations() -> list[str]:
+    """Return ``path:line`` for every exception class defined outside the interface.
+
+    :return: sorted ``"path:line"`` strings, one per offending class definition.
+    """
+    classes = _all_classes()
+    exception_names = _exception_class_names(classes)
+    return sorted(
+        f"{f}:{line}"
+        for f, line, name, _bases in classes
+        if f not in _INTERFACE and name in exception_names
+    )
+
+
+def _baseline() -> set[str]:
+    """Return grandfathered ``path:line`` exception-class locations.
+
+    :return: the allowed pre-existing offending locations.
+    """
+    if not _BASELINE.exists():
+        return set()
+    return {ln.strip() for ln in _BASELINE.read_text().splitlines()
+            if ln.strip() and not ln.startswith("#")}
+
+
+def main() -> int:
+    """Report new out-of-interface exception classes and stale baseline entries.
+
+    :return: 0 when clean, 1 on a new exception class or a stale baseline entry.
+    """
+    base = _baseline()
+    viol = set(_violations())
+    new = sorted(viol - base)
+    stale = sorted(base - viol)
+    for v in new:
+        print(f"exception-interface: {v} — exception class defined outside the interface; "
+              "define it in redfish_ctl/cmd_exceptions.py or redfish_ctl/redfish_exceptions.py")
+    for v in stale:
+        print(f"exception-interface: {v} baselined but no longer an exception class — "
+              "remove it from the baseline (ratchet tightens)")
+    if new or stale:
+        print(f"exception-interface: {len(new)} new, {len(stale)} stale")
+        return 1
+    print(f"exception-interface: clean ({len(base)} classes baselined for migration)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Registers `repo.exception-interface` — a ratcheting source gate that keeps exception **types** defined in one place: the exception interface (`redfish_ctl/cmd_exceptions.py` and `redfish_ctl/redfish_exceptions.py`). An exception class defined anywhere else in `redfish_ctl/` fails the gate.

## Why

An ad-hoc exception class at a call site is invisible to consumers who import the interface and fragments the error contract that the single top-level handler maps to exit codes — the same cross-cutting disease as a scattered env read (`repo.config-loader`). This gate is the exception dimension of that family.

## Ratchet

Five existing out-of-interface classes are grandfathered in `tools/exception_interface_baseline.txt`:
- `redfish_ctl/api.py:27` `RedfishApiError` (the consumer API surface itself)
- `redfish_ctl/config.py:34` `ConfigurationConflict`
- `redfish_ctl/fixtures_catalog.py:14` `CatalogError`
- `redfish_ctl/network/cmd_network_adapter_reset.py:25` `_DiscoveryError`
- `redfish_ctl/proxy/core.py:53` `NodeNotFound`

A **new** class outside the interface fails; a **migrated** one must leave the baseline. Goal: empty baseline. Follow-up PRs migrate each down (starting with `_DiscoveryError` and `RedfishApiError`).

## Validation

- `tools/exception_interface_gate.py` clean (5 baselined); AST-based, mirrors `config_loader_gate.py`.
- Wrapper `scripts/gates/repository/exception-interface.sh` runs clean; shellcheck clean.
- `meta.gate-registry` accepts the registration (command exists, executable, in `mandatory_ids`).