### PR TITLE
Add corpus live-diff and self-check to the corpus CLI

### DIFF
--- a/docs/external/corpus-library.md
+++ b/docs/external/corpus-library.md
@@ -72,6 +72,36 @@ python tools/corpus.py pull --vendor supermicro --model gb300
 python tools/corpus.py extract-all --vendor dell --dest /tmp/dell_corpus
 ```
 
+## Diff a corpus against a live BMC
+
+`live-diff` compares one corpus against a live Redfish endpoint, read-only
+(GET requests only, routed through the project client). Only STABLE
+identity/config fields are compared — Manufacturer, Model, firmware versions,
+boot allowable values, and the BIOS attribute key set — so volatile state
+(power, sensor readings) never reports as drift. Resources are discovered from
+the ServiceRoot collection links and their `Members` lists, so the same walk
+covers every vendor's member naming:
+
+```bash
+python tools/corpus.py live-diff --vendor supermicro --model gb300 --ip <bmc-ip>
+python tools/corpus.py live-diff --vendor dell --model xr8620t --ip <bmc-ip> --dry-run
+```
+
+`--dry-run` prints the fetch plan (the discovered resource paths) without
+touching the network. The JSON report goes to stdout and diagnostics to stderr; the exit
+code is 0 on match (gaps included), 1 on drift, 2 on a usage or environment
+error. Credentials resolve from the gitignored inventory file or the
+`REDFISH_USERNAME`/`REDFISH_PASSWORD` environment variables — never from argv.
+
+`self-check` runs the same comparison engine with the corpus on BOTH sides —
+no network, no credentials — which validates a newly added corpus walks
+cleanly through the generic discovery:
+
+```bash
+python tools/corpus.py self-check                     # every pulled corpus
+python tools/corpus.py self-check --vendor hpe        # one vendor
+```
+
 ## Use a corpus from a test
 
 Tests do not unpack tarballs by hand — they call the shared extractor

--- a/tests/test_corpus_diff.py
+++ b/tests/test_corpus_diff.py
@@ -1,0 +1,410 @@
+"""Offline tests for the vendor-generic corpus diff engine (tools/corpus_diff.py).
+
+Covers the discovery walk on a synthetic Dell-shaped tree (member ids the old
+hardcoded tool could NOT handle), drift and gap classification, the dry-run
+plan, bounded output, and — when the LFS tarballs are pulled — a self-check of
+every committed vendor corpus, which proves the walk is vendor-generic across
+the real Dell/HPE/Supermicro/NVIDIA layouts. No network, no credentials.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+
+import pytest
+from vendor_corpus import corpus_dir as extract_corpus
+
+from tools import corpus, corpus_diff
+
+
+def _write(directory, path, payload):
+    """Write one flattened corpus fixture for ``path`` into ``directory``.
+
+    :param directory: corpus directory under construction.
+    :param path: Redfish resource path the fixture serves.
+    :param payload: JSON-serializable resource body.
+    """
+    (directory / corpus_diff.fixture_name(path)).write_text(json.dumps(payload))
+
+
+def _dell_shaped_corpus(directory):
+    """Build a minimal Dell-shaped corpus tree (System.Embedded.1 member ids).
+
+    The member ids deliberately differ from the Supermicro ``System_0``/``BMC_0``
+    shape so a hardcoded-path walker would find nothing — passing this tree
+    proves the discovery is generic.
+
+    :param directory: empty directory to fill with flattened fixtures.
+    """
+    _write(directory, "/redfish/v1", {
+        "Vendor": "Dell", "Product": "iDRAC", "RedfishVersion": "1.15.1",
+        "Systems": {"@odata.id": "/redfish/v1/Systems"},
+        "Managers": {"@odata.id": "/redfish/v1/Managers"},
+    })
+    _write(directory, "/redfish/v1/Systems", {
+        "Members": [{"@odata.id": "/redfish/v1/Systems/System.Embedded.1"}]})
+    _write(directory, "/redfish/v1/Systems/System.Embedded.1", {
+        "Manufacturer": "Dell Inc.", "Model": "XR8620t", "BiosVersion": "2.3.4",
+        "Boot": {"BootSourceOverrideTarget@Redfish.AllowableValues": ["None", "Pxe"]},
+        "Bios": {"@odata.id": "/redfish/v1/Systems/System.Embedded.1/Bios"},
+    })
+    _write(directory, "/redfish/v1/Systems/System.Embedded.1/Bios", {
+        "Attributes": {"BootMode": "Uefi", "ProcTurboMode": "Enabled"}})
+    _write(directory, "/redfish/v1/Managers", {
+        "Members": [{"@odata.id": "/redfish/v1/Managers/iDRAC.Embedded.1"}]})
+    _write(directory, "/redfish/v1/Managers/iDRAC.Embedded.1", {
+        "Manufacturer": "Dell Inc.", "Model": "iDRAC9",
+        "FirmwareVersion": "7.10.30.00", "ManagerType": "BMC"})
+
+
+def test_self_diff_of_dell_shaped_tree_is_all_match(tmp_path):
+    """A Dell-shaped tree self-diffs 100% match — discovery is not hardcoded.
+
+    The old tool hardcoded Supermicro ``System_0``/``BMC_0`` paths; this tree
+    only answers Dell ids, so full coverage here is the genericity proof.
+    """
+    _dell_shaped_corpus(tmp_path)
+    fetch = corpus_diff.corpus_fetcher(tmp_path)
+    report = corpus_diff.compare(fetch, fetch)
+    summary = report["summary"]
+    assert summary["ok"] and summary["drift"] == 0 and summary["gaps"] == 0
+    checked_paths = {row["path"] for row in report["rows"]}
+    assert "/redfish/v1/Systems/System.Embedded.1" in checked_paths
+    assert "/redfish/v1/Systems/System.Embedded.1/Bios" in checked_paths
+    assert "/redfish/v1/Managers/iDRAC.Embedded.1" in checked_paths
+
+
+def test_drift_in_stable_fields_and_member_set_is_detected(tmp_path):
+    """A changed BiosVersion, BIOS key set, and member set all report drift.
+
+    These are the config changes the tool exists to catch: reference corpus on
+    one side, a re-flashed / re-configured box on the other.
+    """
+    ref, live = tmp_path / "ref", tmp_path / "live"
+    ref.mkdir(), live.mkdir()
+    _dell_shaped_corpus(ref)
+    _dell_shaped_corpus(live)
+    system_path = "/redfish/v1/Systems/System.Embedded.1"
+    _write(live, system_path, {
+        "Manufacturer": "Dell Inc.", "Model": "XR8620t", "BiosVersion": "9.9.9",
+        "Boot": {"BootSourceOverrideTarget@Redfish.AllowableValues": ["None", "Pxe"]},
+        "Bios": {"@odata.id": f"{system_path}/Bios"},
+    })
+    _write(live, f"{system_path}/Bios", {"Attributes": {"BootMode": "Uefi"}})
+    _write(live, "/redfish/v1/Managers", {"Members": []})
+    report = corpus_diff.compare(corpus_diff.corpus_fetcher(live),
+                                 corpus_diff.corpus_fetcher(ref))
+    drifted = {(r["path"], r["field"]) for r in report["rows"]
+               if r["status"] == "drift"}
+    assert (system_path, "BiosVersion") in drifted
+    assert (f"{system_path}/Bios", "Attributes#keys") in drifted
+    assert ("/redfish/v1/Managers", "Members#ids") in drifted
+    assert not report["summary"]["ok"]
+
+
+def test_gaps_are_reported_but_do_not_fail(tmp_path):
+    """A resource missing on one side is a gap row, never drift.
+
+    A live box that does not serve the Bios resource (or is unreachable for
+    one GET) must not fail the whole comparison — unreachable is not "changed".
+    """
+    ref = tmp_path / "ref"
+    ref.mkdir()
+    _dell_shaped_corpus(ref)
+    ref_fetch = corpus_diff.corpus_fetcher(ref)
+    bios = "/redfish/v1/Systems/System.Embedded.1/Bios"
+
+    def live_fetch(path):
+        """Serve the reference tree except the Bios resource.
+
+        :param path: Redfish resource path.
+        :return: the reference fixture, or None for the Bios resource.
+        """
+        return None if path == bios else ref_fetch(path)
+
+    report = corpus_diff.compare(live_fetch, ref_fetch)
+    gap_rows = [r for r in report["rows"] if r["status"] == "live_gap"]
+    assert [r["path"] for r in gap_rows] == [bios]
+    assert report["summary"]["ok"] and report["summary"]["gaps"] == 1
+
+
+def test_plan_is_corpus_side_only(tmp_path):
+    """The dry-run plan discovers every path without any live-side fetch."""
+    _dell_shaped_corpus(tmp_path)
+    paths = corpus_diff.plan(corpus_diff.corpus_fetcher(tmp_path))
+    assert paths[0] == "/redfish/v1"
+    assert "/redfish/v1/Systems/System.Embedded.1/Bios" in paths
+    assert "/redfish/v1/Managers/iDRAC.Embedded.1" in paths
+
+
+def test_detail_output_is_bounded(tmp_path):
+    """A huge BIOS key-set diff stays within the bounded-output budget.
+
+    Agents pay per token: one drift row must never dump a 1000-key registry.
+    """
+    ref, live = tmp_path / "ref", tmp_path / "live"
+    ref.mkdir(), live.mkdir()
+    _dell_shaped_corpus(ref)
+    _dell_shaped_corpus(live)
+    bios = "/redfish/v1/Systems/System.Embedded.1/Bios"
+    _write(live, bios, {"Attributes": {f"Key{i}": i for i in range(1000)}})
+    report = corpus_diff.compare(corpus_diff.corpus_fetcher(live),
+                                 corpus_diff.corpus_fetcher(ref))
+    row = next(r for r in report["rows"]
+               if r["path"] == bios and r["status"] == "drift")
+    assert len(row["detail"]) < 500
+
+
+def test_corpus_fetcher_is_case_insensitive_and_json_safe(tmp_path):
+    """Odd fixture-name casing still resolves; a corrupt fixture yields None."""
+    (tmp_path / "_REDFISH_v1.json").write_text(json.dumps({"Vendor": "X"}))
+    (tmp_path / "_redfish_v1_Managers.json").write_text("{not json")
+    fetch = corpus_diff.corpus_fetcher(tmp_path)
+    assert fetch("/redfish/v1") == {"Vendor": "X"}
+    assert fetch("/redfish/v1/Managers") is None
+    assert fetch("/redfish/v1/Systems") is None
+
+
+def test_boot_allowable_values_drift_is_detected(tmp_path):
+    """A changed boot AllowableValues list reports drift, not a silent pass.
+
+    Regression: the field path contains a DOT inside one property name
+    (``BootSourceOverrideTarget@Redfish.AllowableValues``); a dot-split walker
+    dug past the wrong keys, saw absent-on-both-sides, and counted it as a
+    match — the comparison was silently dead for exactly this field.
+    """
+    ref, live = tmp_path / "ref", tmp_path / "live"
+    ref.mkdir(), live.mkdir()
+    _dell_shaped_corpus(ref)
+    _dell_shaped_corpus(live)
+    system_path = "/redfish/v1/Systems/System.Embedded.1"
+    _write(live, system_path, {
+        "Manufacturer": "Dell Inc.", "Model": "XR8620t", "BiosVersion": "2.3.4",
+        "Boot": {"BootSourceOverrideTarget@Redfish.AllowableValues": ["None"]},
+        "Bios": {"@odata.id": f"{system_path}/Bios"},
+    })
+    report = corpus_diff.compare(corpus_diff.corpus_fetcher(live),
+                                 corpus_diff.corpus_fetcher(ref))
+    boot_field = "Boot/BootSourceOverrideTarget@Redfish.AllowableValues"
+    boot_rows = [r for r in report["rows"]
+                 if r["path"] == system_path and r["field"] == boot_field]
+    assert boot_rows and boot_rows[0]["status"] == "drift"
+    # And in the untouched self-diff the SAME field must be actively verified:
+    self_report = corpus_diff.compare(corpus_diff.corpus_fetcher(ref),
+                                      corpus_diff.corpus_fetcher(ref))
+    self_row = next(r for r in self_report["rows"]
+                    if r["path"] == system_path and r["field"] == boot_field)
+    assert self_row["status"] == "match"
+
+
+def test_field_absent_on_both_sides_is_not_a_match(tmp_path):
+    """A field neither side has counts as ``not_present``, never verified.
+
+    Counting absent-vs-absent as a match inflates the verified-field count and
+    hides a dead comparison — the exact failure mode of the dot-split bug.
+    """
+    ref = tmp_path / "ref"
+    ref.mkdir()
+    _dell_shaped_corpus(ref)
+    manager = "/redfish/v1/Managers/iDRAC.Embedded.1"
+    body = json.loads((ref / corpus_diff.fixture_name(manager)).read_text())
+    del body["ManagerType"]
+    _write(ref, manager, body)
+    fetch = corpus_diff.corpus_fetcher(ref)
+    report = corpus_diff.compare(fetch, fetch)
+    row = next(r for r in report["rows"]
+               if r["path"] == manager and r["field"] == "ManagerType")
+    assert row["status"] == "not_present"
+    assert report["summary"]["not_present"] == 1
+    assert report["summary"]["ok"]
+
+
+def test_paginated_collection_refuses_a_green_result(tmp_path):
+    """A collection carrying ``Members@odata.nextLink`` cannot report ok.
+
+    Page one is not the full member set: comparing it silently would
+    misrepresent drift status, so the row is flagged and ``ok`` goes False
+    (the CLI maps it to the usage/environment exit, not to drift).
+    """
+    ref = tmp_path / "ref"
+    ref.mkdir()
+    _dell_shaped_corpus(ref)
+    body = json.loads((ref / corpus_diff.fixture_name("/redfish/v1/Systems")).read_text())
+    body["Members@odata.nextLink"] = "/redfish/v1/Systems?$skip=1"
+    _write(ref, "/redfish/v1/Systems", body)
+    fetch = corpus_diff.corpus_fetcher(ref)
+    report = corpus_diff.compare(fetch, fetch)
+    paginated = [r for r in report["rows"] if r["status"] == "paginated"]
+    assert paginated and paginated[0]["path"] == "/redfish/v1/Systems"
+    assert report["summary"]["paginated"] == 2  # flagged on both sides
+    assert not report["summary"]["ok"]
+
+
+def test_plan_is_empty_without_a_service_root(tmp_path):
+    """An empty corpus dir yields an EMPTY plan, not fallback paths.
+
+    The fallback collection paths must not fabricate a plan out of nothing —
+    the CLI keys its 'discovered nothing' exit-2 guard on plan emptiness.
+    """
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert corpus_diff.plan(corpus_diff.corpus_fetcher(empty)) == []
+
+
+def test_case_colliding_fixtures_are_refused(tmp_path):
+    """Two fixtures differing only by name case raise instead of shadowing.
+
+    The index is case-insensitive; letting glob order pick a silent winner
+    would make the comparison nondeterministic across filesystems.
+    """
+    (tmp_path / "_redfish_v1.json").write_text(json.dumps({"Vendor": "A"}))
+    (tmp_path / "_REDFISH_V1.json").write_text(json.dumps({"Vendor": "B"}))
+    with pytest.raises(ValueError, match="case-colliding"):
+        corpus_diff.corpus_fetcher(tmp_path)
+
+
+def _tar_corpus(tmp_path, arcname, builder):
+    """Pack a synthetic corpus into a ``.tar.gz`` shaped like the real ones.
+
+    :param tmp_path: test temp root.
+    :param arcname: internal root directory name (the manifest ``arcname``).
+    :param builder: callable filling a directory with flattened fixtures.
+    :return: path to the created tarball.
+    """
+    import tarfile
+    tree = tmp_path / "tree" / arcname
+    tree.mkdir(parents=True)
+    builder(tree)
+    tarball = tmp_path / "corpus.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(tree, arcname=arcname)
+    return tarball
+
+
+def test_cli_self_check_emits_one_json_document(tmp_path, monkeypatch, capsys):
+    """`self-check` stdout is exactly ONE parseable JSON document (exit 0).
+
+    Concatenated per-corpus documents broke every JSON consumer of the
+    documented default invocation.
+    """
+    tarball = _tar_corpus(tmp_path, "10.0.0.1", _dell_shaped_corpus)
+    row = {"vendor": "dell", "model": "fake", "tarball": tarball.name,
+           "arcname": "10.0.0.1", "json_count": 6}
+    monkeypatch.setattr(corpus, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(corpus, "load_manifest", lambda *a, **k: [row, row])
+    code = corpus.main(["self-check"])
+    out = capsys.readouterr()
+    document = json.loads(out.out)  # would raise on concatenated documents
+    assert code == 0
+    assert document["mode"] == "self-check"
+    assert document["summary"]["corpora_checked"] == 2
+    assert document["summary"]["ok"]
+
+
+def test_cli_self_check_all_skipped_is_exit_2_with_json(tmp_path, monkeypatch, capsys):
+    """Every corpus skipped (pointer/missing) = exit 2 and an explicit document.
+
+    A fresh clone without ``git lfs pull`` must not get a green self-check
+    that verified nothing.
+    """
+    pointer = tmp_path / "p.tar.gz"
+    pointer.write_bytes(b"version https://git-lfs.github.com/spec/v1\n")
+    rows = [
+        {"vendor": "a", "model": "ptr", "tarball": "p.tar.gz", "arcname": "x"},
+        {"vendor": "b", "model": "gone", "tarball": "missing.tar.gz", "arcname": "x"},
+    ]
+    monkeypatch.setattr(corpus, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(corpus, "load_manifest", lambda *a, **k: rows)
+    code = corpus.main(["self-check"])
+    out = capsys.readouterr()
+    document = json.loads(out.out)
+    assert code == 2
+    assert document["summary"]["corpora_checked"] == 0
+    assert len(document["skipped"]) == 2
+    assert not document["summary"]["ok"]
+
+
+def test_cli_live_diff_missing_tarball_is_exit_2(tmp_path, monkeypatch, capsys):
+    """A manifest row whose tarball file is missing exits 2, not a traceback.
+
+    ``FileNotFoundError`` escaping as exit 1 would collide with the drift
+    exit code and hide an environment problem as a finding.
+    """
+    rows = [{"vendor": "a", "model": "gone", "tarball": "no.tar.gz", "arcname": "x"}]
+    monkeypatch.setattr(corpus, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(corpus, "load_manifest", lambda *a, **k: rows)
+    code = corpus.main(["live-diff", "--vendor", "a", "--model", "gone",
+                        "--ip", "203.0.113.5"])
+    assert code == 2
+    assert "missing" in capsys.readouterr().err
+
+
+def test_cli_live_diff_dry_run_document_shape_is_stable(tmp_path, monkeypatch, capsys):
+    """Dry-run and real runs share one top-level key set (dry_run flags which).
+
+    A consumer must be able to key on the same fields in both modes instead of
+    guessing which keys exist.
+    """
+    corpus_dir = tmp_path / "extracted"
+    corpus_dir.mkdir()
+    _dell_shaped_corpus(corpus_dir)
+    code = corpus.main(["live-diff", "--corpus-dir", str(corpus_dir),
+                        "--ip", "203.0.113.5", "--dry-run"])
+    document = json.loads(capsys.readouterr().out)
+    assert code == 0
+    assert set(document) == {"mode", "dry_run", "corpus", "target",
+                             "plan", "summary", "rows"}
+    assert document["dry_run"] is True and document["plan"]
+    assert document["summary"] is None and document["rows"] == []
+
+
+def test_cli_live_diff_empty_corpus_dir_is_exit_2(tmp_path, capsys):
+    """An existing-but-empty --corpus-dir fails loudly instead of passing.
+
+    A typo'd directory produced ``checked=0, ok=True`` before the guard —
+    silent false success on a tool whose one job is verification.
+    """
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    code = corpus.main(["live-diff", "--corpus-dir", str(empty),
+                        "--ip", "203.0.113.5", "--dry-run"])
+    assert code == 2
+    assert "discovered nothing" in capsys.readouterr().err
+
+
+def test_cli_credentials_half_filled_inventory_falls_back(tmp_path, monkeypatch):
+    """An inventory node without user/password falls through to env, never "None".
+
+    ``str(None)`` credentials would attempt real BMC logins as user "None"
+    and risk an account lockout.
+    """
+    inventory = tmp_path / "inv.yaml"
+    inventory.write_text("nodes:\n  - bmc:\n      ip: 10.0.0.9\n")
+    monkeypatch.setenv("REDFISH_USERNAME", "opuser")
+    monkeypatch.setenv("REDFISH_PASSWORD", "opsecret")
+    assert corpus._bmc_credentials("10.0.0.9", inventory) == ("opuser", "opsecret")
+    for var in ("REDFISH_USERNAME", "REDFISH_PASSWORD",
+                "IDRAC_USERNAME", "IDRAC_PASSWORD"):
+        monkeypatch.delenv(var, raising=False)
+    with pytest.raises(SystemExit) as excinfo:
+        corpus._bmc_credentials("10.0.0.9", inventory)
+    assert excinfo.value.code == 2
+
+
+@pytest.mark.parametrize("row", corpus.load_manifest(),
+                         ids=lambda r: f"{r['vendor']}-{r['model']}")
+def test_every_committed_corpus_self_checks_clean(row):
+    """Each real vendor corpus self-diffs with zero drift through the engine.
+
+    One test per manifest row: Dell, HPE, Supermicro X10/GB300, and NVIDIA all
+    walk through the SAME discovery code — the vendor-genericity contract for
+    the corpus-as-sim surface. Skipped per-corpus when the LFS tarball is not
+    pulled (CI without ``git lfs pull`` stays green).
+    """
+    tarball = corpus._tarball_path(row)
+    if not tarball.exists() or corpus._is_lfs_pointer(tarball):
+        pytest.skip(f"{row['tarball']} not pulled (bare LFS pointer)")
+    fetch = corpus_diff.corpus_fetcher(extract_corpus(tarball, row["arcname"]))
+    report = corpus_diff.compare(fetch, fetch)
+    summary = report["summary"]
+    assert summary["ok"], [r for r in report["rows"] if r["status"] == "drift"]
+    assert summary["checked"] > 0, "self-check walked nothing — discovery broke"

--- a/tools/corpus.py
+++ b/tools/corpus.py
@@ -15,6 +15,23 @@ extract-all   Extract every corpus into ``<dest>/<vendor>_<model>/`` (full JSON
 verify        Assert every tarball exists, is LFS-tracked, and its ``.json``
               count matches the manifest (bare LFS pointers are skipped, not
               failed, so the check works before ``git lfs pull``).
+self-check    Offline: diff each corpus against ITSELF through the generic
+              discovery engine (``tools/corpus_diff.py``) — proves the walk is
+              vendor-generic and the corpus is self-consistent. No network.
+live-diff     Read-only (GET-only) diff of one corpus against a live BMC via
+              the ``redfish_ctl`` client: stable identity/config fields only,
+              volatile state ignored. ``--dry-run`` prints the fetch plan
+              without touching the network.
+
+    python tools/corpus.py self-check
+    python tools/corpus.py live-diff --vendor supermicro --model gb300 --ip <bmc-ip>
+    python tools/corpus.py live-diff --vendor dell --model xr8620t --ip <bmc-ip> --dry-run
+
+Audience: agent | human. The two diff subcommands emit a JSON report on stdout
+(diagnostics on stderr) and exit 0 on match/gaps-only, 1 on drift, 2 on a
+usage/environment error. BMC credentials come from the gitignored inventory
+(``.internal/inventory/env-inventory.yaml``) or the ``REDFISH_USERNAME`` /
+``REDFISH_PASSWORD`` environment variables — never from argv, never printed.
 
 The module is also importable: :func:`load_manifest` returns the parsed rows and
 :func:`resolve` maps ``(vendor, model)`` to a row, so callers can locate a corpus
@@ -23,15 +40,26 @@ by vendor/model instead of the raw capture-IP ``arcname``.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import os
+import shutil
 import subprocess
 import sys
 import tarfile
+import tempfile
 from pathlib import Path
 from typing import Optional
 
+try:  # imported as tools.corpus (tests) or run as a script from tools/
+    from tools import corpus_diff
+except ImportError:  # pragma: no cover - script-run path (sys.path[0] = tools/)
+    import corpus_diff
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MANIFEST_PATH = REPO_ROOT / "tests" / "corpus" / "manifest.json"
+# Repo-anchored (not cwd-relative) so the tool works from any working directory.
+DEFAULT_INVENTORY = REPO_ROOT / ".internal" / "inventory" / "env-inventory.yaml"
 
 
 def load_manifest(path: Path = MANIFEST_PATH) -> list[dict]:
@@ -156,6 +184,253 @@ def cmd_verify(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+@contextlib.contextmanager
+def _extracted(row: dict):
+    """Extract one corpus tarball to a temp dir, yield its leaf, always clean up.
+
+    ``try/finally`` (not ``atexit``) removes the tree, so even an exception
+    mid-comparison cannot leave a ~1600-file extraction behind, and disk use is
+    bounded to one corpus at a time.
+
+    :param row: manifest row (``tarball`` + ``arcname``).
+    :return: context manager yielding the flattened-fixture directory.
+    """
+    tmp = Path(tempfile.mkdtemp(prefix="corpus_diff_"))
+    try:
+        with tarfile.open(_tarball_path(row)) as tar:
+            try:
+                tar.extractall(tmp, filter="data")  # py3.12+ path-safe filter
+            except TypeError:  # pragma: no cover - py<3.12 lacks the kwarg
+                tar.extractall(tmp)
+        yield tmp / row["arcname"]
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+def _corpus_ready(row: dict) -> Optional[str]:
+    """Return why a corpus tarball is unusable, or None when it is ready.
+
+    A missing file and a bare LFS pointer are both environment states (exit 2
+    territory), never allowed to surface as a traceback or a drift exit.
+
+    :param row: manifest row to check.
+    :return: a human-readable reason with the next step, or None when usable.
+    """
+    path = _tarball_path(row)
+    if not path.exists():
+        return (f"{row['tarball']} is missing — check tests/corpus/manifest.json "
+                "or run `git lfs pull`")
+    if _is_lfs_pointer(path):
+        return (f"{row['tarball']} is a bare LFS pointer — run "
+                f"`python tools/corpus.py pull --vendor {row['vendor']} "
+                f"--model {row['model']}`")
+    return None
+
+
+def _bmc_credentials(ip: str, inventory: Path) -> tuple[str, str]:
+    """Resolve BMC credentials for ``ip`` — inventory first, then environment.
+
+    Values are used in memory only and never printed. Passwords are NEVER
+    accepted on argv (argv leaks into process listings and shell history).
+
+    :param ip: BMC IP whose credentials to resolve.
+    :param inventory: gitignored inventory YAML (``nodes[].bmc{ip,user,password}``).
+    :return: ``(username, password)``.
+    :raises SystemExit: exit code 2 (message on stderr) when nothing resolves.
+        A bare string ``SystemExit`` would exit 1 and collide with the drift
+        code, so the message is printed and the code raised explicitly.
+    """
+    if inventory.exists():
+        import yaml
+        inv = yaml.safe_load(inventory.read_text())
+        for node in (inv or {}).get("nodes", []):
+            bmc = node.get("bmc") or {}
+            if str(bmc.get("ip")) == ip:
+                user, password = bmc.get("user"), bmc.get("password")
+                if user and password:  # a half-filled node must not become "None"
+                    return str(user), str(password)
+                break  # fall through to the env pair / the loud error
+    user = os.environ.get("REDFISH_USERNAME") or os.environ.get("IDRAC_USERNAME")
+    password = os.environ.get("REDFISH_PASSWORD") or os.environ.get("IDRAC_PASSWORD")
+    if user and password:
+        return user, password
+    print(f"error: no credentials for BMC {ip}: not in {inventory} and "
+          "REDFISH_USERNAME/REDFISH_PASSWORD are unset\n"
+          "next step: add the node to the inventory or export the env pair",
+          file=sys.stderr)
+    raise SystemExit(2)
+
+
+def _live_fetcher(ip: str, username: str, password: str) -> "corpus_diff.Fetcher":
+    """Build the live-side fetcher, routed through the ``redfish_ctl`` client.
+
+    All Redfish I/O goes through the project client (raw HTTP is forbidden by
+    the team contract); every call is a plain GET. A transport or protocol
+    failure is reported on stderr and surfaces as a ``live_gap`` row — one
+    unreachable resource must not abort the whole diff.
+
+    :param ip: BMC host or IP.
+    :param username: BMC account username.
+    :param password: BMC account password (in memory only).
+    :return: fetcher mapping a resource path to its parsed dict or None.
+    """
+    from redfish_ctl.idrac_manager import IDracManager
+    manager = IDracManager(host=ip, username=username,
+                           password=password, insecure=True)
+
+    def fetch(path: str) -> Optional[dict]:
+        """GET one live resource; None on any failure (reported to stderr).
+
+        A rejected credential aborts the whole run (exit 2) instead of turning
+        every resource into a gap: retrying a bad login per-resource reports a
+        useless all-gap result and risks locking the BMC account.
+
+        :param path: Redfish resource path.
+        :return: parsed resource dict, or None when the GET fails.
+        :raises SystemExit: exit code 2 on an authentication/authorization
+            failure.
+        """
+        try:
+            result = manager.base_query(path)
+        except Exception as exc:  # any one failed GET is a gap, not an abort
+            name = exc.__class__.__name__
+            if any(word in name for word in
+                   ("Authentication", "Unauthorized", "Forbidden")):
+                print(f"error: BMC rejected the credentials on {path} ({name})\n"
+                      "next step: fix the inventory entry or the "
+                      "REDFISH_USERNAME/REDFISH_PASSWORD pair", file=sys.stderr)
+                raise SystemExit(2)
+            # Class name ONLY — an exception's message can embed transport
+            # details and must never risk echoing credential material.
+            print(f"live {path}: {name}", file=sys.stderr)
+            return None
+        data = getattr(result, "data", None)
+        return data if isinstance(data, dict) else None
+
+    return fetch
+
+
+def _summary_exit(summary: dict) -> int:
+    """Map one comparison summary to the exit-code contract.
+
+    :param summary: :func:`corpus_diff.compare` summary.
+    :return: 2 when NOTHING was checked (an empty/wrong corpus must never
+        pass) or when a collection was paginated (page one is not the full
+        member set — the comparison is incomplete), 1 on drift, else 0.
+    """
+    if summary["checked"] == 0 or summary.get("paginated"):
+        return 2
+    return 0 if summary["ok"] else 1
+
+
+def _stderr_line(mode: str, label: str, summary: dict) -> None:
+    """Print the one-line human summary for a comparison to stderr.
+
+    :param mode: ``self-check`` or ``live-diff``.
+    :param label: ``vendor/model`` label of the compared corpus.
+    :param summary: :func:`corpus_diff.compare` summary.
+    """
+    print(f"{mode} {label}: {summary['matched']}/{summary['checked']} "
+          f"stable fields match, drift={summary['drift']} gaps={summary['gaps']}",
+          file=sys.stderr)
+
+
+def cmd_self_check(args: argparse.Namespace) -> int:
+    """Diff each selected corpus against itself (offline genericity check)."""
+    rows = _select(load_manifest(), args.vendor, args.model)
+    if not rows:
+        print("no corpora match the filter\n"
+              "next step: `python tools/corpus.py list`", file=sys.stderr)
+        return 2
+    reports, skipped, worst = [], [], 0
+    for row in rows:
+        label = f"{row['vendor']}/{row['model']}"
+        reason = _corpus_ready(row)
+        if reason:
+            skipped.append({"corpus": label, "reason": reason})
+            print(f"self-check {label}: skipped — {reason}", file=sys.stderr)
+            continue
+        with _extracted(row) as corpus_dir:
+            fetch = corpus_diff.corpus_fetcher(corpus_dir)
+            report = corpus_diff.compare(fetch, fetch)
+        reports.append({"corpus": label, "summary": report["summary"],
+                        "rows": report["rows"]})
+        _stderr_line("self-check", label, report["summary"])
+        worst = max(worst, _summary_exit(report["summary"]))
+    if not reports:
+        worst = 2
+        print("error: self-check verified NOTHING (every corpus was skipped)\n"
+              "next step: `python tools/corpus.py pull`", file=sys.stderr)
+    # Exactly ONE JSON document per process, whatever was selected or skipped.
+    print(json.dumps({
+        "mode": "self-check",
+        "summary": {"corpora_checked": len(reports), "corpora_skipped": len(skipped),
+                    "drift": sum(r["summary"]["drift"] for r in reports),
+                    "ok": worst == 0},
+        "reports": reports, "skipped": skipped,
+    }, indent=1))
+    return worst
+
+
+def cmd_live_diff(args: argparse.Namespace) -> int:
+    """Diff one corpus against a live BMC (GET-only; ``--dry-run`` = no I/O)."""
+    if args.corpus_dir:
+        corpus_source, label = Path(args.corpus_dir), str(args.corpus_dir)
+        if not corpus_source.is_dir():
+            print(f"error: --corpus-dir {corpus_source} is not a directory\n"
+                  "next step: extract a corpus first "
+                  "(`python tools/corpus.py extract-all`)", file=sys.stderr)
+            return 2
+        extracted = contextlib.nullcontext(corpus_source)
+    else:
+        if not (args.vendor and args.model):
+            print("error: pass --vendor AND --model (or --corpus-dir)\n"
+                  "next step: `python tools/corpus.py list` shows the choices",
+                  file=sys.stderr)
+            return 2
+        row = resolve(args.vendor, args.model)
+        if row is None:
+            print(f"error: no corpus for {args.vendor}/{args.model}\n"
+                  "next step: `python tools/corpus.py list`", file=sys.stderr)
+            return 2
+        reason = _corpus_ready(row)
+        if reason:
+            print(f"error: {reason}", file=sys.stderr)
+            return 2
+        extracted, label = _extracted(row), f"{row['vendor']}/{row['model']}"
+    with extracted as corpus_dir:
+        corpus_fetch = corpus_diff.corpus_fetcher(corpus_dir)
+        # One stable document shape for BOTH dry and real runs, so a consumer
+        # can always key on the same fields (plan is null on a real run;
+        # summary/rows are null/empty on a dry run).
+        document = {"mode": "live-diff", "dry_run": bool(args.dry_run),
+                    "corpus": label, "target": args.ip,
+                    "plan": None, "summary": None, "rows": []}
+        if args.dry_run:
+            document["plan"] = corpus_diff.plan(corpus_fetch)
+            print(json.dumps(document, indent=1))
+            print("dry-run: no network round-trips performed", file=sys.stderr)
+            if not document["plan"]:
+                print("error: the plan discovered nothing — corpus dir is empty "
+                      "or lacks the ServiceRoot fixture\nnext step: "
+                      "`python tools/corpus.py verify`", file=sys.stderr)
+                return 2
+            return 0
+        username, password = _bmc_credentials(args.ip, Path(args.inventory))
+        live_fetch = _live_fetcher(args.ip, username, password)
+        report = corpus_diff.compare(live_fetch, corpus_fetch)
+    document["summary"], document["rows"] = report["summary"], report["rows"]
+    print(json.dumps(document, indent=1))
+    _stderr_line("live-diff", label, report["summary"])
+    code = _summary_exit(report["summary"])
+    if code == 2:
+        print("error: live-diff checked nothing — wrong corpus dir, empty "
+              "corpus, or every live GET failed\nnext step: verify the corpus "
+              "(`python tools/corpus.py verify`) and the BMC route/credentials",
+              file=sys.stderr)
+    return code
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Construct the argparse CLI."""
     parser = argparse.ArgumentParser(description="Manage the Redfish corpus library.")
@@ -165,6 +440,7 @@ def build_parser() -> argparse.ArgumentParser:
         ("pull", cmd_pull, False),
         ("extract-all", cmd_extract_all, True),
         ("verify", cmd_verify, False),
+        ("self-check", cmd_self_check, False),
     ):
         p = sub.add_parser(name, help=func.__doc__.splitlines()[0])
         p.add_argument("--vendor", help="filter to one vendor (e.g. dell)")
@@ -172,6 +448,19 @@ def build_parser() -> argparse.ArgumentParser:
         if needs_dest:
             p.add_argument("--dest", required=True, help="destination directory")
         p.set_defaults(func=func)
+    live = sub.add_parser(
+        "live-diff", help=cmd_live_diff.__doc__.splitlines()[0])
+    live.add_argument("--vendor", help="corpus vendor (e.g. supermicro)")
+    live.add_argument("--model", help="corpus model (e.g. gb300)")
+    live.add_argument("--corpus-dir", help="extracted corpus dir (overrides "
+                                           "--vendor/--model resolution)")
+    live.add_argument("--ip", required=True, help="live BMC host or IP (GET-only)")
+    live.add_argument("--inventory", default=str(DEFAULT_INVENTORY),
+                      help="credentials inventory YAML (never printed); env "
+                           "REDFISH_USERNAME/REDFISH_PASSWORD is the fallback")
+    live.add_argument("--dry-run", action="store_true",
+                      help="print the fetch plan as JSON; no network I/O")
+    live.set_defaults(func=cmd_live_diff)
     return parser
 
 

--- a/tools/corpus_diff.py
+++ b/tools/corpus_diff.py
@@ -1,0 +1,333 @@
+"""Vendor-generic comparison engine: a Redfish corpus vs a live BMC (or itself).
+
+Compares STABLE identity/config fields (Manufacturer, Model, firmware versions,
+boot allowable values, the BIOS attribute KEY SET) between two Redfish trees and
+ignores volatile state (power, sensor readings, timestamps). Resources are
+DISCOVERED, never hardcoded: the ServiceRoot links name the Systems/Managers
+collections and their ``Members`` lists name the per-vendor member ids, so the
+same engine walks a Dell tree (``System.Embedded.1``), an HPE tree
+(``Systems/1``), or a Supermicro tree (``System_0``) without per-vendor code.
+
+Both sides of the comparison are plain fetchers (``path -> dict | None``): the
+corpus side reads flattened ``_redfish_v1_*.json`` fixtures from an extracted
+corpus directory, and the live side is injected by the caller (see
+``tools/corpus.py live-diff``, which routes through the ``redfish_ctl`` client).
+Feeding the SAME corpus fetcher to both sides is the offline self-check that
+proves the discovery is vendor-generic.
+
+Row statuses: ``match`` / ``drift`` (a stable field differs — the failure
+signal) / ``live_gap`` (live side unreachable or lacks the resource) /
+``corpus_gap`` (the capture never included the resource) / ``not_present`` (a
+field absent on BOTH sides — never observed, so it counts as neither verified
+nor drifted). Gaps are reported but do not fail the comparison; only drift
+does. A comparison that verified NOTHING (``checked == 0``) is an error the
+CLI maps to its usage/environment exit code, never a pass.
+
+Consumed by ``tools/corpus.py`` (subcommands ``live-diff`` and ``self-check``)
+and ``tests/test_corpus_diff.py``.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Callable, Optional
+
+SERVICE_ROOT = "/redfish/v1"
+
+# Stable fields compared per resource kind. The nesting separator is "/" — a
+# character that cannot appear in a Redfish property name — because property
+# names themselves may contain dots (``...@Redfish.AllowableValues``). A
+# trailing "#keys" compares the KEY SET of a dict (the BIOS attribute names)
+# instead of its volatile values.
+SERVICE_ROOT_FIELDS = ("Vendor", "Product", "RedfishVersion")
+SYSTEM_FIELDS = ("Manufacturer", "Model", "BiosVersion",
+                 "Boot/BootSourceOverrideTarget@Redfish.AllowableValues")
+BIOS_FIELDS = ("Attributes#keys",)
+MANAGER_FIELDS = ("Manufacturer", "Model", "FirmwareVersion", "ManagerType")
+
+# Unique absence sentinel: a real Redfish value can never be identical to this
+# object, so "field missing" can never collide with (or match) a string value.
+_ABSENT = object()
+
+# Bounded output: cap list diffs and value reprs so a huge BIOS registry can
+# never turn one drift row into a multi-kilobyte dump.
+_DETAIL_ITEMS = 5
+_DETAIL_CHARS = 120
+
+Fetcher = Callable[[str], Optional[dict]]
+
+
+def fixture_name(path: str) -> str:
+    """Return the flattened corpus filename for a Redfish resource path.
+
+    Mirrors the crawl layout served by the mock BMC server: every ``/`` becomes
+    ``_`` and the file carries a ``.json`` suffix.
+
+    :param path: Redfish resource path (e.g. ``/redfish/v1/Systems``).
+    :return: flattened fixture filename (e.g. ``_redfish_v1_Systems.json``).
+    """
+    return "_" + path.strip("/").replace("/", "_") + ".json"
+
+
+def corpus_fetcher(corpus_dir: Path) -> Fetcher:
+    """Return a fetcher reading flattened fixtures from an extracted corpus.
+
+    The directory is indexed ONCE, case-insensitively, so repeated lookups are
+    dict hits and a vendor's odd path casing cannot miss its own fixture.
+
+    :param corpus_dir: directory of flattened ``_redfish_v1_*.json`` files.
+    :return: fetcher mapping a resource path to its parsed fixture dict or None.
+    """
+    files = sorted(Path(corpus_dir).glob("*.json"))
+    index: dict[str, Path] = {}
+    collisions = []
+    for p in files:
+        key = p.name.lower()
+        if key in index:
+            collisions.append(f"{index[key].name} <-> {p.name}")
+        index[key] = p
+    if collisions:
+        # Two fixtures differing only by case would shadow each other in a
+        # filesystem-order-dependent way — refuse loudly instead of guessing.
+        raise ValueError(
+            f"corpus {corpus_dir} has case-colliding fixtures: "
+            + "; ".join(collisions[:_DETAIL_ITEMS]))
+
+    def fetch(path: str) -> Optional[dict]:
+        """Read one flattened fixture for ``path``, or None when not captured.
+
+        :param path: Redfish resource path.
+        :return: parsed fixture dict, or None when the corpus lacks the file.
+        """
+        hit = index.get(fixture_name(path).lower())
+        if hit is None:
+            return None
+        try:
+            data = json.loads(hit.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    return fetch
+
+
+def _dig(obj, field_path: str):
+    """Follow a ``/``-separated key path through nested dicts.
+
+    The separator is ``/`` because Redfish property names may themselves
+    contain dots (``BootSourceOverrideTarget@Redfish.AllowableValues``).
+
+    :param obj: root object (typically a parsed Redfish resource).
+    :param field_path: ``/``-separated key path (e.g. ``Boot/BootSource...``).
+    :return: the value at the path, or the unique :data:`_ABSENT` sentinel.
+    """
+    cur = obj
+    for part in field_path.split("/"):
+        if not isinstance(cur, dict) or part not in cur:
+            return _ABSENT
+        cur = cur[part]
+    return cur
+
+
+def _clip(value) -> str:
+    """Render a value for a report row within the bounded-output budget.
+
+    :param value: any comparison value (:data:`_ABSENT` renders as ``<absent>``).
+    :return: ``repr`` of the value, truncated to the detail budget.
+    """
+    text = "<absent>" if value is _ABSENT else repr(value)
+    return text if len(text) <= _DETAIL_CHARS else text[:_DETAIL_CHARS] + "..."
+
+
+def _row(path: str, field: str, status: str, detail: str) -> dict:
+    """Build one report row.
+
+    :param path: Redfish resource path the row describes.
+    :param field: compared field name (or a pseudo-field like ``Members#ids``).
+    :param status: ``match`` | ``drift`` | ``live_gap`` | ``corpus_gap``.
+    :param detail: bounded human-readable detail line.
+    :return: the row dict.
+    """
+    return {"path": path, "field": field, "status": status, "detail": detail}
+
+
+def _compare_field(path: str, field: str, live: dict, corpus: dict) -> dict:
+    """Compare one stable field between the live and corpus resources.
+
+    :param path: resource path (for the report row).
+    :param field: dotted field name; a ``#keys`` suffix compares a dict's key set.
+    :param live: live-side resource dict.
+    :param corpus: corpus-side resource dict.
+    :return: a ``match``/``drift`` report row.
+    """
+    if field.endswith("#keys"):
+        base = field[: -len("#keys")]
+        lv, cv = _dig(live, base), _dig(corpus, base)
+        lk = set(lv.keys()) if isinstance(lv, dict) else set()
+        ck = set(cv.keys()) if isinstance(cv, dict) else set()
+        if lk == ck:
+            return _row(path, field, "match", f"{base}: {len(lk)} keys match")
+        return _row(path, field, "drift",
+                    f"{base}: live_only={sorted(lk - ck)[:_DETAIL_ITEMS]} "
+                    f"corpus_only={sorted(ck - lk)[:_DETAIL_ITEMS]}")
+    lv, cv = _dig(live, field), _dig(corpus, field)
+    if lv is _ABSENT and cv is _ABSENT:
+        # Never observed on either side: not verified, so it must not count as
+        # a match (that would inflate the verified-field count).
+        return _row(path, field, "not_present", "absent on both sides")
+    status = "match" if lv == cv else "drift"
+    return _row(path, field, status, f"live={_clip(lv)} corpus={_clip(cv)}")
+
+
+def _members(resource: Optional[dict]) -> list[str]:
+    """Return the sorted ``Members`` ``@odata.id`` list of a collection.
+
+    :param resource: a Redfish collection resource, or None.
+    :return: sorted member resource paths (empty when absent/malformed).
+    """
+    if not isinstance(resource, dict):
+        return []
+    out = []
+    for member in resource.get("Members", []):
+        if isinstance(member, dict) and isinstance(member.get("@odata.id"), str):
+            out.append(member["@odata.id"].rstrip("/"))
+    return sorted(out)
+
+
+def _link(resource: Optional[dict], key: str) -> Optional[str]:
+    """Return a linked resource path (``resource[key]["@odata.id"]``).
+
+    :param resource: a Redfish resource dict, or None.
+    :param key: linked property name (e.g. ``Systems``, ``Bios``).
+    :return: the linked path, or None when the link is absent.
+    """
+    if not isinstance(resource, dict):
+        return None
+    link = resource.get(key)
+    if isinstance(link, dict) and isinstance(link.get("@odata.id"), str):
+        return link["@odata.id"].rstrip("/")
+    return None
+
+
+def _compare_resource(path: str, fields: tuple[str, ...],
+                      live_fetch: Fetcher, corpus_fetch: Fetcher,
+                      rows: list[dict]) -> Optional[dict]:
+    """Fetch one resource on both sides and compare its stable fields.
+
+    Appends result rows in place; a missing side yields a single gap row.
+
+    :param path: resource path to fetch on both sides.
+    :param fields: stable fields to compare when both sides are present.
+    :param live_fetch: live-side fetcher.
+    :param corpus_fetch: corpus-side fetcher.
+    :param rows: report row list, appended in place.
+    :return: the corpus-side resource (for follow-up link discovery), or None.
+    """
+    corpus = corpus_fetch(path)
+    if corpus is None:
+        rows.append(_row(path, "-", "corpus_gap", "not captured in the corpus"))
+        return None
+    live = live_fetch(path)
+    if live is None:
+        rows.append(_row(path, "-", "live_gap", "unreachable / not served live"))
+        return corpus
+    for field in fields:
+        rows.append(_compare_field(path, field, live, corpus))
+    return corpus
+
+
+def plan(corpus_fetch: Fetcher) -> list[str]:
+    """Return the resource paths a comparison WOULD fetch (the dry-run plan).
+
+    Discovery runs on the corpus side only — no live I/O happens.
+
+    :param corpus_fetch: corpus-side fetcher.
+    :return: ordered resource paths the comparison would touch.
+    """
+    root = corpus_fetch(SERVICE_ROOT)
+    if root is None:
+        # No ServiceRoot => nothing is discoverable; an empty plan is the
+        # loud signal (the CLI maps it to its usage/environment exit).
+        return []
+    paths = [SERVICE_ROOT]
+    for coll_key in ("Systems", "Managers"):
+        coll_path = _link(root, coll_key) or f"{SERVICE_ROOT}/{coll_key}"
+        paths.append(coll_path)
+        coll = corpus_fetch(coll_path)
+        for member_path in _members(coll):
+            paths.append(member_path)
+            if coll_key == "Systems":
+                bios = _link(corpus_fetch(member_path), "Bios")
+                if bios:
+                    paths.append(bios)
+    return paths
+
+
+def compare(live_fetch: Fetcher, corpus_fetch: Fetcher) -> dict:
+    """Walk the discovered tree and compare every stable field.
+
+    The corpus is the reference: discovery (collection links, member ids, the
+    Bios link) is driven from the corpus side, and the live side is fetched for
+    the same paths. Differing member-id SETS are drift (hardware/config
+    changed); a resource missing on one side is a gap, not drift.
+
+    :param live_fetch: live-side fetcher (a real BMC via ``redfish_ctl``, the
+        mock server, or the corpus itself for a self-check).
+    :param corpus_fetch: corpus-side fetcher (see :func:`corpus_fetcher`).
+    :return: report dict with ``rows`` and a ``summary`` (``ok`` = no drift).
+    """
+    rows: list[dict] = []
+    root = _compare_resource(SERVICE_ROOT, SERVICE_ROOT_FIELDS,
+                             live_fetch, corpus_fetch, rows)
+    member_fields = {"Systems": SYSTEM_FIELDS, "Managers": MANAGER_FIELDS}
+    for coll_key, fields in member_fields.items():
+        coll_path = _link(root, coll_key) or f"{SERVICE_ROOT}/{coll_key}"
+        corpus_coll = corpus_fetch(coll_path)
+        if corpus_coll is None:
+            rows.append(_row(coll_path, "-", "corpus_gap",
+                             "collection not captured in the corpus"))
+            continue
+        live_coll = live_fetch(coll_path)
+        if live_coll is None:
+            rows.append(_row(coll_path, "-", "live_gap",
+                             "collection unreachable / not served live"))
+            continue
+        for side, coll in (("live", live_coll), ("corpus", corpus_coll)):
+            if isinstance(coll, dict) and "Members@odata.nextLink" in coll:
+                # A paginated collection means page one is NOT the full member
+                # set — the comparison would be silently incomplete, so flag it
+                # loudly (the CLI refuses a green exit on any paginated row).
+                rows.append(_row(coll_path, "Members@odata.nextLink", "paginated",
+                                 f"{side} collection is paginated; only page one "
+                                 "was compared"))
+        live_ids, corpus_ids = set(_members(live_coll)), set(_members(corpus_coll))
+        if live_ids == corpus_ids:
+            rows.append(_row(coll_path, "Members#ids", "match",
+                             f"{len(corpus_ids)} members match"))
+        else:
+            rows.append(_row(
+                coll_path, "Members#ids", "drift",
+                f"live_only={sorted(live_ids - corpus_ids)[:_DETAIL_ITEMS]} "
+                f"corpus_only={sorted(corpus_ids - live_ids)[:_DETAIL_ITEMS]}"))
+        for member_path in sorted(corpus_ids & live_ids):
+            member = _compare_resource(member_path, fields,
+                                       live_fetch, corpus_fetch, rows)
+            if coll_key == "Systems":
+                bios_path = _link(member, "Bios")
+                if bios_path:
+                    _compare_resource(bios_path, BIOS_FIELDS,
+                                      live_fetch, corpus_fetch, rows)
+    drift = sum(r["status"] == "drift" for r in rows)
+    gaps = sum(r["status"] in ("live_gap", "corpus_gap") for r in rows)
+    matched = sum(r["status"] == "match" for r in rows)
+    not_present = sum(r["status"] == "not_present" for r in rows)
+    paginated = sum(r["status"] == "paginated" for r in rows)
+    return {
+        "rows": rows,
+        "summary": {"checked": matched + drift, "matched": matched,
+                    "drift": drift, "gaps": gaps,
+                    "not_present": not_present, "paginated": paginated,
+                    "ok": drift == 0 and paginated == 0},
+    }


### PR DESCRIPTION
## What

Two subcommands on the single corpus entry point (`tools/corpus.py`), backed by one new engine module (`tools/corpus_diff.py`):

- **`live-diff`** — read-only (GET-only, via the `redfish_ctl` client) diff of a committed corpus against a live BMC. Compares STABLE identity/config fields only: Manufacturer, Model, BiosVersion/FirmwareVersion, boot allowable values, the BIOS attribute key set. Volatile state (power, sensors) is never compared. `--dry-run` prints the fetch plan with zero network round-trips.
- **`self-check`** — the same engine with the corpus on BOTH sides: proves a corpus walks cleanly through the generic discovery, offline, no credentials.

## Why generic

Resources are **discovered** — ServiceRoot links → collection `Members` → resource links — so one walk covers `System.Embedded.1` (Dell), `Systems/1` (HPE), and `System_0` (Supermicro) with no per-vendor code and no hardcoded fixture paths. Verified against all five committed corpora: every one self-checks clean through the same code path. The corpus is the evidence the pre-code classification pass consumes; `live-diff` is the freshness gate proving that evidence still matches the hardware, and `self-check` validates a new capture before anyone reasons from it.

## Contract (agent-grade)

One JSON document per process on stdout, diagnostics on stderr; exit 0 match / 1 drift / 2 usage-or-environment. Fails loudly with the next step: an empty corpus dir, an un-pulled LFS pointer, a missing tarball, rejected credentials, or a run that verified nothing all exit 2 — never a green pass. Credentials resolve from the gitignored inventory or `REDFISH_USERNAME`/`REDFISH_PASSWORD`, never argv, never printed. A rejected credential aborts immediately (no per-resource retry against a BMC account).

## Review hardening applied

An adversarial review pass surfaced and this PR fixes: a dead comparison (the boot-AllowableValues field path contains a dot inside the property name, so a dot-split walker never reached it and absent-vs-absent counted as match — now a `/` separator plus a `not_present` status that is never counted as verified), multi-corpus stdout that was not one parseable JSON document, checked-nothing runs passing green, missing-tarball tracebacks colliding with the drift exit code, half-filled inventory nodes authenticating as the literal string "None", case-colliding fixtures shadowing nondeterministically, and cwd-relative inventory resolution.

## Validation

- `self-check` across all 5 committed corpora: one parseable document, 5/5 clean, boot-values actively compared (7 rows match/not_present split), 13 previously fake-matched fields now correctly `not_present`.
- 16 offline tests: engine (discovery, drift, gaps, not_present, bounded output, case-collision) + CLI surface (single-document stdout, exit 0/1/2 mapping, pointer/missing-tarball/empty-dir paths, credential fallback), plus a per-vendor parametrized self-check over the real LFS corpora (pointer-safe skip).
- ruff + py_compile clean; docs section added to `docs/external/corpus-library.md`.