### PR TITLE
Fix Dell-lens tests asserting DMTF-generic task ids

### DIFF
--- a/tests/delloem/test_dell_software_update_schedule_dualmode.py
+++ b/tests/delloem/test_dell_software_update_schedule_dualmode.py
@@ -1,9 +1,10 @@
 """Dual-mode-style coverage for Dell software update schedule actions."""
 
-import json
+import copy
 from pathlib import Path
 
 import pytest
+from conftest import MockRedfishService, _build_fixture_index
 from vendor_corpus import corpus_dir
 
 from redfish_ctl.cmd_exceptions import InvalidArgument
@@ -18,7 +19,6 @@ DELL_CORPUS = corpus_dir(
     Path(__file__).parent.parent / "dell_xr8620t_corpus.tar.gz",
     "10.252.252.209",
 )
-DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
 SERVICE = (
     "/redfish/v1/Systems/System.Embedded.1/Oem/Dell/"
     "DellSoftwareInstallationService"
@@ -27,82 +27,60 @@ SET_TARGET = f"{SERVICE}/Actions/DellSoftwareInstallationService.SetUpdateSchedu
 CLEAR_TARGET = f"{SERVICE}/Actions/DellSoftwareInstallationService.ClearUpdateSchedule"
 
 
-def _fixture_for_path(path):
-    """Return the extracted Dell fixture matching a Redfish path.
-
-    :param path: request path from requests-mock.
-    :return: fixture path, or None when the corpus lacks the resource.
-    """
-    name = "_" + path.strip("/").replace("/", "_") + ".json"
-    return DELL_INDEX.get(name.lower())
-
-
-def _service_body():
-    """Return the DellSoftwareInstallationService fixture body.
-
-    :return: parsed DellSoftwareInstallationService JSON.
-    """
-    return json.loads(_fixture_for_path(SERVICE).read_text())
-
-
 @pytest.fixture
-def dell_software_manager():
-    """Serve the committed Dell corpus over requests-mock.
+def dell_software_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus.
 
-    :return: tuple of IDracManager, recorded requests, and GET overrides.
+    The vendor-faithful service realizes an Action POST the Dell way: 202 plus
+    a ``JID_`` OEM job id in the Location header, never a DMTF-generic token.
+
+    :return: tuple of IDracManager and the recording MockRedfishService.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    requests = []
-    overrides = {}
-
-    def get_cb(request, context):
-        requests.append(request)
-        override = overrides.get(request.path.lower())
-        if override is not None:
-            context.status_code = 200
-            return json.dumps(override)
-        fixture = _fixture_for_path(request.path)
-        if fixture is None:
-            context.status_code = 404
-            return json.dumps({"error": f"no fixture for {request.path}"})
-        context.status_code = 200
-        return fixture.read_text()
-
-    def post_cb(request, context):
-        requests.append(request)
-        context.status_code = 202
-        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/software-schedule-1"
-        return json.dumps({
-            "Task": {
-                "@odata.id": "/redfish/v1/TaskService/Tasks/software-schedule-1"
-            }
-        })
-
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
     with requests_mock.Mocker() as mocker:
-        mocker.get(requests_mock.ANY, text=get_cb)
-        mocker.post(requests_mock.ANY, text=post_cb)
-        manager = IDracManager(
-            idrac_ip="mock-dell-software",
-            idrac_username="root",
-            idrac_password="mock",
-            insecure=True,
-            is_debug=False,
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            IDracManager(
+                idrac_ip="mock-dell-software",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
         )
-        yield manager, requests, overrides
 
 
-def _post_requests(requests):
-    """Return POST requests recorded by the mock Redfish transport.
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
 
-    :param requests: recorded requests-mock request objects.
+    :param service: the recording MockRedfishService.
     :return: list of POST requests.
     """
-    return [request for request in requests if request.method == "POST"]
+    return [request for request in service.requests if request.method == "POST"]
 
 
-def test_dell_software_update_schedule_lists_targets(dell_software_manager):
+def _overlay_installation_service(service, body):
+    """Overlay DellSoftwareInstallationService under both common request casings.
+
+    :param service: the recording MockRedfishService.
+    :param body: replacement installation-service body.
+    """
+    service._overlay[SERVICE] = body
+    service._overlay[SERVICE.lower()] = body
+
+
+def test_dell_software_update_schedule_lists_targets(dell_software_mock):
     """Omitting --action lists set/clear targets without POSTing."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -126,12 +104,12 @@ def test_dell_software_update_schedule_lists_targets(dell_software_manager):
         "HTTPS",
         "NFS",
     ]
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
-def test_dell_software_update_schedule_set_previews_payload(dell_software_manager):
+def test_dell_software_update_schedule_set_previews_payload(dell_software_mock):
     """SetUpdateSchedule resolves and previews payloads by default."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -155,12 +133,12 @@ def test_dell_software_update_schedule_set_previews_payload(dell_software_manage
         "ShareType": "HTTP",
         "ApplyReboot": "NoReboot",
     }
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
-def test_dell_software_update_schedule_set_confirm_posts(dell_software_manager):
-    """--confirm POSTs a SetUpdateSchedule payload to the discovered target."""
-    manager, requests, _ = dell_software_manager
+def test_dell_software_update_schedule_set_confirm_posts(dell_software_mock):
+    """--confirm POSTs SetUpdateSchedule; the Dell lens realizes a ``JID_`` job id."""
+    manager, service = dell_software_mock
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -172,13 +150,14 @@ def test_dell_software_update_schedule_set_confirm_posts(dell_software_manager):
         confirm=True,
     )
 
-    posts = _post_requests(requests)
+    posts = _post_requests(service)
     assert isinstance(result, CommandResult)
     assert result.error is None
     assert result.data["executed"] is True
     assert result.data["action"] == "#DellSoftwareInstallationService.SetUpdateSchedule"
     assert result.data["target"] == SET_TARGET
-    assert result.data["task_id"] == "software-schedule-1"
+    assert result.data["task_id"] == service.JOB_ID
+    assert service.JOB_ID.startswith("JID_")
     assert len(posts) == 1
     assert posts[0].path.lower() == SET_TARGET.lower()
     assert posts[0].json() == {
@@ -189,10 +168,10 @@ def test_dell_software_update_schedule_set_confirm_posts(dell_software_manager):
 
 
 def test_dell_software_update_schedule_set_dry_run_overrides_confirm(
-    dell_software_manager,
+    dell_software_mock,
 ):
     """--dry_run keeps SetUpdateSchedule from POSTing even with --confirm."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -208,14 +187,14 @@ def test_dell_software_update_schedule_set_dry_run_overrides_confirm(
     assert result.data["dry_run"] is True
     assert result.data["blocked"] is None
     assert result.data["target"] == SET_TARGET
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
 def test_dell_software_update_schedule_rejects_invalid_allowable(
-    dell_software_manager,
+    dell_software_mock,
 ):
     """Inline allowable values reject invalid SetUpdateSchedule enum values."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -237,12 +216,12 @@ def test_dell_software_update_schedule_rejects_invalid_allowable(
             "allowed": ["CIFS", "FTP", "HTTP", "HTTPS", "NFS"],
         }
     ]
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
-def test_dell_software_update_schedule_clear_previews(dell_software_manager):
+def test_dell_software_update_schedule_clear_previews(dell_software_mock):
     """ClearUpdateSchedule previews by default without POSTing."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -257,14 +236,14 @@ def test_dell_software_update_schedule_clear_previews(dell_software_manager):
     assert result.data["target"] == CLEAR_TARGET
     assert result.data["payload"] == {}
     assert result.data["blocked"] == "destructive action requires --confirm"
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
 def test_dell_software_update_schedule_clear_confirm_posts_empty_payload(
-    dell_software_manager,
+    dell_software_mock,
 ):
     """--confirm POSTs an empty ClearUpdateSchedule body."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -273,7 +252,7 @@ def test_dell_software_update_schedule_clear_confirm_posts_empty_payload(
         confirm=True,
     )
 
-    posts = _post_requests(requests)
+    posts = _post_requests(service)
     assert isinstance(result, CommandResult)
     assert result.error is None
     assert result.data["executed"] is True
@@ -285,13 +264,13 @@ def test_dell_software_update_schedule_clear_confirm_posts_empty_payload(
 
 
 def test_dell_software_update_schedule_reports_missing_action(
-    dell_software_manager,
+    dell_software_mock,
 ):
     """A service without SetUpdateSchedule reports the available schedule action."""
-    manager, requests, overrides = dell_software_manager
-    body = _service_body()
+    manager, service = dell_software_mock
+    body = copy.deepcopy(service._state(SERVICE))
     body["Actions"].pop("#DellSoftwareInstallationService.SetUpdateSchedule")
-    overrides[SERVICE.lower()] = body
+    _overlay_installation_service(service, body)
 
     result = manager.sync_invoke(
         ApiRequestType.DellSoftwareUpdateSchedule,
@@ -303,14 +282,14 @@ def test_dell_software_update_schedule_reports_missing_action(
     assert isinstance(result, CommandResult)
     assert result.error == "Dell software update schedule action not found: set"
     assert [row["Action"] for row in result.data["available"]] == ["clear"]
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
 def test_dell_software_update_schedule_rejects_empty_set_payload(
-    dell_software_manager,
+    dell_software_mock,
 ):
     """SetUpdateSchedule requires at least one payload field."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     with pytest.raises(InvalidArgument, match="--action set requires"):
         manager.sync_invoke(
@@ -319,14 +298,14 @@ def test_dell_software_update_schedule_rejects_empty_set_payload(
             action="set",
         )
 
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
 def test_dell_software_update_schedule_rejects_non_object_json(
-    dell_software_manager,
+    dell_software_mock,
 ):
     """The payload JSON must be an object."""
-    manager, requests, _ = dell_software_manager
+    manager, service = dell_software_mock
 
     with pytest.raises(InvalidArgument, match="JSON object"):
         manager.sync_invoke(
@@ -336,7 +315,7 @@ def test_dell_software_update_schedule_rejects_non_object_json(
             payload_json='["not-object"]',
         )
 
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
 def test_dell_software_update_schedule_is_registered():

--- a/tests/logs/test_log_clear_dualmode.py
+++ b/tests/logs/test_log_clear_dualmode.py
@@ -2,18 +2,63 @@
 
 Uses the HPE overlay because it exposes several clearable log services across
 both the Systems and Managers roots (IML/SL/Event on Systems/1, IEL on
-Managers/1), which exercises the cross-vendor multi-root discovery. ClearLog is
-DESTRUCTIVE, so the guard/confirm behavior is the core of these tests. Offline,
-no live BMC.
+Managers/1), which exercises the cross-vendor multi-root discovery. The Dell
+lens runs against the XR8620t corpus, whose only clearable service is the SEL
+at Managers/iDRAC.Embedded.1 (Lclog and FaultList expose no ClearLog); a Dell
+ClearLog realizes with a ``JID_`` OEM job id. ClearLog is DESTRUCTIVE, so the
+guard/confirm behavior is the core of these tests. Offline, no live BMC.
 """
+import copy
+from pathlib import Path
+
 import pytest
+from conftest import MockRedfishService, _build_fixture_index
+from vendor_corpus import corpus_dir
 
 from redfish_ctl.cmd_exceptions import InvalidArgument
+from redfish_ctl.idrac_manager import IDracManager
 from redfish_ctl.idrac_shared import ApiRequestType
 from redfish_ctl.logs.cmd_log_clear import LogClear
 from redfish_ctl.redfish_manager import CommandResult
 
+DELL_CORPUS = corpus_dir(
+    Path(__file__).parent.parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
+)
 _IML_CLEAR_TARGET = "/redfish/v1/Systems/1/LogServices/IML/Actions/LogService.ClearLog"
+_DELL_SEL = "/redfish/v1/Managers/iDRAC.Embedded.1/LogServices/Sel"
+_DELL_SEL_CLEAR_TARGET = f"{_DELL_SEL}/Actions/LogService.ClearLog"
+
+
+@pytest.fixture
+def dell_log_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus.
+
+    The vendor-faithful service realizes an Action POST the Dell way: 202 plus
+    a ``JID_`` OEM job id in the Location header, never a DMTF-generic token.
+
+    :return: tuple of IDracManager and the recording MockRedfishService.
+    """
+    requests_mock = pytest.importorskip("requests_mock")
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
+    with requests_mock.Mocker() as mocker:
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            IDracManager(
+                idrac_ip="mock-dell-logs",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
+        )
 
 
 def _post_requests(redfish_service):
@@ -106,11 +151,58 @@ def test_log_clear_unknown_service_raises(redfish_mock_factory):
     assert _post_requests(svc) == []
 
 
-def test_log_clear_no_clearable_services_raises(redfish_mock):
-    """A box exposing no ClearLog action (the Dell mock) fails with a clear message."""
+def test_log_clear_dell_lens_discovers_sel_only(dell_log_mock):
+    """Dell-lens discovery lists exactly the corpus-proven clearable SEL.
+
+    The XR8620t corpus carries three Manager log services (Sel, Lclog,
+    FaultList); only the SEL exposes #LogService.ClearLog.
+    """
+    mgr, svc = dell_log_mock
+
+    result = mgr.sync_invoke(ApiRequestType.LogClear, "log-clear")
+
+    assert isinstance(result, CommandResult)
+    assert result.error is None
+    services = result.data["clearable_log_services"]
+    assert [(s["Id"], s["uri"]) for s in services] == [("Sel", _DELL_SEL)]
+    assert _post_requests(svc) == []
+
+
+def test_log_clear_dell_lens_confirm_clears_sel(dell_log_mock):
+    """--confirm clears the Dell SEL; the realization carries a ``JID_`` job id."""
+    mgr, svc = dell_log_mock
+
+    result = mgr.sync_invoke(
+        ApiRequestType.LogClear, "log-clear", log_service="Sel", confirm=True)
+
+    assert result.error is None
+    assert result.data["executed"] is True
+    assert result.data["target"] == _DELL_SEL_CLEAR_TARGET
+    assert result.data["task_id"] == svc.JOB_ID
+    assert svc.JOB_ID.startswith("JID_")
+
+    posts = _post_requests(svc)
+    assert len(posts) == 1
+    assert posts[0].path.lower() == _DELL_SEL_CLEAR_TARGET.lower()
+
+
+def test_log_clear_no_clearable_services_raises(dell_log_mock):
+    """A tree with the SEL's ClearLog stripped fails with a clear message.
+
+    The Dell corpus proves the SEL IS clearable, so the no-clearable edge is
+    constructed here by removing the action, never asserted as Dell semantics.
+    A box can genuinely lack ClearLog everywhere, which is why the command
+    fails closed with this message rather than a lookup error.
+    """
+    mgr, svc = dell_log_mock
+    body = copy.deepcopy(svc._state(_DELL_SEL))
+    body["Actions"].pop("#LogService.ClearLog")
+    svc._overlay[_DELL_SEL] = body
+    svc._overlay[_DELL_SEL.lower()] = body
+
     with pytest.raises(
             InvalidArgument, match="no clearable log services found"):
-        redfish_mock.sync_invoke(
+        mgr.sync_invoke(
             ApiRequestType.LogClear, "log-clear", log_service="Sel")
 
 

--- a/tests/oem/test_dell_vflash_state_dualmode.py
+++ b/tests/oem/test_dell_vflash_state_dualmode.py
@@ -1,10 +1,10 @@
 """Dual-mode-style coverage for Dell vFlash state changes."""
 
-import json
-from contextlib import contextmanager
+import copy
 from pathlib import Path
 
 import pytest
+from conftest import MockRedfishService, _build_fixture_index
 from vendor_corpus import corpus_dir
 
 from redfish_ctl.actions.action_policy import Destructiveness, classify
@@ -17,7 +17,6 @@ from redfish_ctl.redfish_manager import CommandResult
 DELL_CORPUS = corpus_dir(
     Path(__file__).parent.parent / "dell_xr8620t_corpus.tar.gz", "10.252.252.209"
 )
-DELL_INDEX = {path.name.lower(): path for path in DELL_CORPUS.glob("*.json")}
 PERSISTENT_STORAGE_SERVICE = (
     "/redfish/v1/Managers/iDRAC.Embedded.1/Oem/Dell/"
     "DellPersistentStorageService"
@@ -29,78 +28,65 @@ VFLASH_TARGET = (
 )
 
 
-def _fixture_for_path(path):
-    """Return the extracted Dell fixture matching a Redfish path.
+@pytest.fixture
+def dell_vflash_mock():
+    """Return a manager and mock service backed by the Dell XR8620t corpus.
 
-    :param path: request path from requests-mock.
-    :return: fixture path, or None when the corpus lacks the resource.
-    """
-    name = "_" + path.strip("/").replace("/", "_") + ".json"
-    return DELL_INDEX.get(name.lower())
+    The vendor-faithful service realizes an Action POST the Dell way: 202 plus
+    a ``JID_`` OEM job id in the Location header, never a DMTF-generic token.
 
-
-@contextmanager
-def _mock_dell_vflash(persistent_storage_transform=None):
-    """Serve the committed Dell corpus over requests-mock.
-
-    :param persistent_storage_transform: optional mutator for the service fixture.
-    :return: context yielding IDracManager and recorded requests.
+    :return: tuple of IDracManager and the recording MockRedfishService.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    requests = []
-
-    def get_cb(request, context):
-        requests.append(request)
-        fixture = _fixture_for_path(request.path)
-        if fixture is None:
-            context.status_code = 404
-            return json.dumps({"error": f"no fixture for {request.path}"})
-        data = json.loads(fixture.read_text())
-        is_service = request.path.rstrip("/").lower() == (
-            PERSISTENT_STORAGE_SERVICE.lower()
-        )
-        if is_service and persistent_storage_transform:
-            data = persistent_storage_transform(data)
-        context.status_code = 200
-        return json.dumps(data)
-
-    def post_cb(request, context):
-        requests.append(request)
-        context.status_code = 202
-        context.headers["Location"] = "/redfish/v1/TaskService/Tasks/vflash-1"
-        return json.dumps({
-            "Task": {"@odata.id": "/redfish/v1/TaskService/Tasks/vflash-1"}
-        })
-
+    service = MockRedfishService(
+        DELL_CORPUS,
+        index=_build_fixture_index(DELL_CORPUS),
+    )
     with requests_mock.Mocker() as mocker:
-        mocker.get(requests_mock.ANY, text=get_cb)
-        mocker.post(requests_mock.ANY, text=post_cb)
-        manager = IDracManager(
-            idrac_ip="mock-dell-vflash",
-            idrac_username="root",
-            idrac_password="mock",
-            insecure=True,
-            is_debug=False,
+        mocker.get(requests_mock.ANY, text=service.get_cb)
+        mocker.patch(requests_mock.ANY, text=service.patch_cb)
+        mocker.post(requests_mock.ANY, text=service.post_cb)
+        mocker.delete(requests_mock.ANY, text=service.delete_cb)
+        service.mocker = mocker
+        yield (
+            IDracManager(
+                idrac_ip="mock-dell-vflash",
+                idrac_username="root",
+                idrac_password="mock",
+                insecure=True,
+                is_debug=False,
+            ),
+            service,
         )
-        yield manager, requests
 
 
-def _post_requests(requests):
-    """Return POST requests recorded by the mock Redfish transport.
+def _post_requests(service):
+    """Return POST requests recorded by the mock Redfish service.
 
-    :param requests: recorded requests-mock request objects.
+    :param service: the recording MockRedfishService.
     :return: list of POST requests.
     """
-    return [request for request in requests if request.method == "POST"]
+    return [request for request in service.requests if request.method == "POST"]
 
 
-def test_dell_vflash_state_lists_target_without_posting():
+def _overlay_persistent_service(service, body):
+    """Overlay DellPersistentStorageService under both common request casings.
+
+    :param service: the recording MockRedfishService.
+    :param body: replacement persistent-storage service body.
+    """
+    service._overlay[PERSISTENT_STORAGE_SERVICE] = body
+    service._overlay[PERSISTENT_STORAGE_SERVICE.lower()] = body
+
+
+def test_dell_vflash_state_lists_target_without_posting(dell_vflash_mock):
     """With no requested state, the command lists the VFlash target only."""
-    with _mock_dell_vflash() as (manager, requests):
-        result = manager.sync_invoke(
-            ApiRequestType.DellVFlashStateChange,
-            "dell-vflash-state",
-        )
+    manager, service = dell_vflash_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellVFlashStateChange,
+        "dell-vflash-state",
+    )
 
     assert isinstance(result, CommandResult)
     assert result.error is None
@@ -110,17 +96,18 @@ def test_dell_vflash_state_lists_target_without_posting():
         "target": VFLASH_TARGET,
         "requested_states": ["Disable", "Enable"],
     }
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
-def test_dell_vflash_state_without_confirm_is_preview_only():
+def test_dell_vflash_state_without_confirm_is_preview_only(dell_vflash_mock):
     """VFlashStateChange resolves the target but does not POST without confirm."""
-    with _mock_dell_vflash() as (manager, requests):
-        result = manager.sync_invoke(
-            ApiRequestType.DellVFlashStateChange,
-            "dell-vflash-state",
-            requested_state="Enable",
-        )
+    manager, service = dell_vflash_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellVFlashStateChange,
+        "dell-vflash-state",
+        requested_state="Enable",
+    )
 
     assert isinstance(result, CommandResult)
     assert result.error is None
@@ -130,41 +117,44 @@ def test_dell_vflash_state_without_confirm_is_preview_only():
     assert result.data["level"] == "destructive"
     assert result.data["blocked"] == "destructive action requires --confirm"
     assert result.data["payload"] == {"RequestedState": "Enable"}
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
-def test_dell_vflash_state_confirm_posts_requested_state():
-    """--confirm POSTs the requested state to the discovered action target."""
-    with _mock_dell_vflash() as (manager, requests):
-        result = manager.sync_invoke(
-            ApiRequestType.DellVFlashStateChange,
-            "dell-vflash-state",
-            requested_state="Disable",
-            confirm=True,
-        )
+def test_dell_vflash_state_confirm_posts_requested_state(dell_vflash_mock):
+    """--confirm POSTs the state; the Dell lens realizes a ``JID_`` job id."""
+    manager, service = dell_vflash_mock
 
-    posts = _post_requests(requests)
+    result = manager.sync_invoke(
+        ApiRequestType.DellVFlashStateChange,
+        "dell-vflash-state",
+        requested_state="Disable",
+        confirm=True,
+    )
+
+    posts = _post_requests(service)
     assert isinstance(result, CommandResult)
     assert result.error is None
     assert result.data["executed"] is True
     assert result.data["action"] == VFLASH_ACTION
     assert result.data["target"] == VFLASH_TARGET
     assert result.data["level"] == "destructive"
-    assert result.data["task_id"] == "vflash-1"
+    assert result.data["task_id"] == service.JOB_ID
+    assert service.JOB_ID.startswith("JID_")
     assert len(posts) == 1
     assert posts[0].path.lower() == VFLASH_TARGET.lower()
     assert posts[0].json() == {"RequestedState": "Disable"}
 
 
-def test_dell_vflash_state_rejects_invalid_requested_state():
+def test_dell_vflash_state_rejects_invalid_requested_state(dell_vflash_mock):
     """Inline allowable values reject an unsupported RequestedState before POST."""
-    with _mock_dell_vflash() as (manager, requests):
-        result = manager.sync_invoke(
-            ApiRequestType.DellVFlashStateChange,
-            "dell-vflash-state",
-            requested_state="Suspend",
-            confirm=True,
-        )
+    manager, service = dell_vflash_mock
+
+    result = manager.sync_invoke(
+        ApiRequestType.DellVFlashStateChange,
+        "dell-vflash-state",
+        requested_state="Suspend",
+        confirm=True,
+    )
 
     assert isinstance(result, CommandResult)
     assert result.error == (
@@ -178,23 +168,22 @@ def test_dell_vflash_state_rejects_invalid_requested_state():
             "allowed": ["Disable", "Enable"],
         }
     ]
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
-def test_dell_vflash_state_reports_missing_action_without_posting():
+def test_dell_vflash_state_reports_missing_action_without_posting(dell_vflash_mock):
     """A persistent-storage resource without VFlashStateChange fails closed."""
+    manager, service = dell_vflash_mock
+    body = copy.deepcopy(service._state(PERSISTENT_STORAGE_SERVICE))
+    body.get("Actions", {}).pop(VFLASH_ACTION, None)
+    _overlay_persistent_service(service, body)
 
-    def without_vflash_action(data):
-        data.get("Actions", {}).pop(VFLASH_ACTION, None)
-        return data
-
-    with _mock_dell_vflash(without_vflash_action) as (manager, requests):
-        result = manager.sync_invoke(
-            ApiRequestType.DellVFlashStateChange,
-            "dell-vflash-state",
-            requested_state="Enable",
-            confirm=True,
-        )
+    result = manager.sync_invoke(
+        ApiRequestType.DellVFlashStateChange,
+        "dell-vflash-state",
+        requested_state="Enable",
+        confirm=True,
+    )
 
     assert isinstance(result, CommandResult)
     assert result.error == (
@@ -202,7 +191,7 @@ def test_dell_vflash_state_reports_missing_action_without_posting():
     )
     assert VFLASH_ACTION not in result.data["available"]
     assert "AttachPartition" in result.data["available"]
-    assert _post_requests(requests) == []
+    assert _post_requests(service) == []
 
 
 def test_dell_vflash_state_exposes_cli_entrypoint_and_policy():


### PR DESCRIPTION
Three tests asserted one vendor's wire semantics under another vendor's mock lens (the bug class the tests/<domain> mirroring exists to surface). Dell realizes an Action POST as a JID_ OEM job; only non-Dell lenses return a DMTF TaskService token (see tests/conftest.py _vendor_task_id).

- tests/oem/test_dell_vflash_state_dualmode.py: a hand-rolled post_cb returned a DMTF Task Location (`vflash-1`) against the Dell XR8620t corpus. The mock is now the vendor-faithful MockRedfishService over the corpus (the test_dell_persistent_partition_dualmode pattern), and the confirm test asserts `task_id == service.JOB_ID` with the JID_ shape check.
- tests/delloem/test_dell_software_update_schedule_dualmode.py: same pattern, same fix (`software-schedule-1` replaced by the JID_ realization).
- tests/logs/test_log_clear_dualmode.py: test_log_clear_no_clearable_services_raises asserted the Dell mock has no clearable log services, but the XR8620t corpus proves the Managers SEL exposes #LogService.ClearLog (Lclog/FaultList do not); the old test only passed because the Dell overlay never authored LogServices fixtures. The Dell lens now asserts corpus truth (Sel discovered as the only clearable service; --confirm clears it with a JID_ realization), and the no-clearable edge is constructed explicitly by stripping the SEL's ClearLog action, so it no longer encodes fixture incompleteness as vendor semantics.

Offline throughout; no live BMC.