### PR TITLE
Vendor profiles: per-connection chokepoint strategy (slice 1)

### DIFF
--- a/redfish_ctl/dell_profile.py
+++ b/redfish_ctl/dell_profile.py
@@ -7,16 +7,31 @@ body-scrape, and the OEM job-queue polling semantics. Non-Dell connections
 never see these — :class:`~redfish_ctl.vendor_profile.DmtfProfile` and its
 siblings carry the DMTF forms only.
 
-Method bodies marked CHIP are relocated verbatim-in-semantics from
-``idrac_manager.py``/``redfish_manager.py`` by the implementation pass; each
-seam names its exact source anchor. Dell capability is NEVER reduced here
-(architecture.yaml ``no_capability_ceiling``): this module is where all of it
-lives, unleaked.
+Method bodies are relocated verbatim-in-semantics from
+``idrac_manager.py``/``redfish_manager.py``; each method names its source.
+Dell capability is NEVER reduced here (architecture.yaml
+``no_capability_ceiling``): this module is where all of it lives, unleaked.
 
 Author Mus spyroot@gmail.com
 """
 from __future__ import annotations
 
+import logging
+import re
+import time
+from typing import Optional, Tuple
+
+import requests
+from tqdm import tqdm
+
+from .cmd_exceptions import (
+    AuthenticationFailed,
+    ResourceNotFound,
+    UnexpectedResponse,
+)
+from .idrac_shared import REDFISH_API, REDFISH_JSON, JobState, RedfishApiRespond
+from .idrac_task_state import IdracTaskState, IdracTaskStatus
+from .redfish_exceptions import RedfishForbidden
 from .vendor_profile import DmtfProfile, register_profile
 
 
@@ -25,91 +40,352 @@ class DellProfile(DmtfProfile):
 
     vendor = "dell"
 
-    def decode_status(self, status_code: int):
+    # The Dell status rows relocated from ``IDracManager._http_code_mapping``:
+    # the full four-row map including 201 -> Created — the row only Dell adds
+    # (the neutral RedfishApiRespond enum has no Created member).
+    _status_map = {
+        200: RedfishApiRespond.Ok,
+        201: RedfishApiRespond.Created,
+        202: RedfishApiRespond.AcceptedTaskGenerated,
+        204: RedfishApiRespond.Success,
+    }
+
+    # Wire JobState string -> enum, relocated from ``IDracManager.__init__``
+    # (``_job_state_mapping``), so commands check a state without string
+    # branching.
+    _job_state_mapping = {
+        "Scheduled": JobState.Scheduled,
+        "Running": JobState.Running,
+        "Completed": JobState.Completed,
+        "Downloaded": JobState.Downloaded,
+        "Downloading": JobState.Downloading,
+        "Scheduling": JobState.Scheduling,
+        "Waiting": JobState.Waiting,
+        "Failed": JobState.Failed,
+        "CompletedWithErrors": JobState.CompletedWithErrors,
+        "RebootFailed": JobState.RebootFailed,
+        "RebootCompleted": JobState.RebootCompleted,
+        "RebootPending": JobState.RebootPending,
+        "PendingActivation": JobState.PendingActivation,
+        "Unknown": JobState.Unknown,
+    }
+
+    # Wire TaskState string -> enum, relocated from ``IDracManager.__init__``
+    # (``_task_state_mapping``). Note the Dell model spells the transient
+    # cancel state ``Canceling`` (one l), unlike DMTF's ``Cancelling``.
+    _task_state_mapping = {
+        "New": IdracTaskState.New,
+        "Running": IdracTaskState.Starting,
+        "Starting": IdracTaskState.Starting,
+        "Suspended": IdracTaskState.Suspended,
+        "Interrupted": IdracTaskState.Interrupted,
+        "Pending": IdracTaskState.Pending,
+        "Stopping": IdracTaskState.Stopping,
+        "Completed": IdracTaskState.Completed,
+        "Killed": IdracTaskState.Killed,
+        "Exception": IdracTaskState.Exception,
+        "Service": IdracTaskState.Service,
+        "Canceling": IdracTaskState.Canceling,
+        "Cancelled": IdracTaskState.Cancelled,
+    }
+
+    # Wire TaskStatus string -> enum, relocated from ``IDracManager.__init__``
+    # (``_task_status_mapping``).
+    _task_status_mapping = {
+        "ok": IdracTaskStatus.Ok,
+        "warning": IdracTaskStatus.Warning,
+        "critical": IdracTaskStatus.Critical,
+    }
+
+    def decode_status(self, status_code: int) -> RedfishApiRespond:
         """Fold an HTTP status into the signal, WITH Dell's 201=Created row.
 
-        CHIP: relocate ``_http_code_mapping`` from ``idrac_manager.py:186-191``
-        (the full four-row map including 201 -> RedfishApiRespond.Created; the
-        generic enum has no Created — see architecture.yaml state_decode).
+        Relocated from ``IDracManager._http_code_mapping`` plus the 2xx fold
+        of the Dell ``default_error_handler`` (unmapped 2xx -> Success).
 
         :param status_code: HTTP status from a Dell BMC response.
-        :return: the ``RedfishApiRespond`` signal (Created possible here only).
-        :raises NotImplementedError: until the implementation pass lands.
+        :return: the Dell ``RedfishApiRespond`` signal (Created possible here
+            only); ``Error`` for any non-2xx (the raising path is
+            :meth:`error_handler`).
         """
-        raise NotImplementedError("CHIP: relocate _http_code_mapping "
-                                  "(idrac_manager.py:186-191, incl. 201)")
+        if 200 <= status_code < 300:
+            return self._status_map.get(status_code, RedfishApiRespond.Success)
+        return RedfishApiRespond.Error
 
-    def error_handler(self, response, expected=None):
+    def error_handler(self, response, manager=None, expected=None):
         """Decode a response per Dell semantics (iDRAC error envelope).
 
-        CHIP: relocate the Dell ``default_error_handler`` override —
-        source: ``idrac_manager.py:555-584`` (parse_error + typed raises with
-        the IDRAC.2.x registry envelope).
+        Body relocated from the Dell ``IDracManager.default_error_handler``:
+        a 2xx folds via :meth:`decode_status`; every error code is normalized
+        through ``RedfishManager.parse_error`` so the raised exception carries
+        the parsed :class:`RedfishError` envelope — never a generic string.
+        When ``manager`` is passed, the parsed envelope is also recorded as
+        ``manager._redfish_error`` (the attribute callers read after a
+        non-raising write path), preserving the manager-side contract.
 
         :param response: the ``requests.Response`` to decode.
-        :param expected: optional expected-status override(s).
-        :return: the decoded signal (matching the current chokepoint contract).
-        :raises NotImplementedError: until the implementation pass lands.
+        :param manager: the connection's manager; receives ``_redfish_error``.
+        :param expected: reserved expected-status override; unused today.
+        :return: the folded ``RedfishApiRespond`` for a 2xx status.
+        :raises AuthenticationFailed: on HTTP 401, carrying the parsed error.
+        :raises RedfishForbidden: on HTTP 403, carrying the parsed error.
+        :raises ResourceNotFound: on HTTP 404, carrying the parsed error.
+        :raises UnexpectedResponse: on any other error code, carrying the parsed error.
         """
-        raise NotImplementedError("CHIP: relocate Dell default_error_handler "
-                                  "(idrac_manager.py:555-584)")
+        code = response.status_code
+        if 200 <= code < 300:
+            return self.decode_status(code)
+        from .redfish_manager import RedfishManager
+        redfish_error = RedfishManager.parse_error(response)
+        if manager is not None:
+            manager._redfish_error = redfish_error
+        if code == 401:
+            raise AuthenticationFailed(redfish_error)
+        if code == 403:
+            raise RedfishForbidden(redfish_error)
+        if code == 404:
+            raise ResourceNotFound(redfish_error)
+        raise UnexpectedResponse(redfish_error)
 
-    def parse_task_id(self, response):
+    @staticmethod
+    def _scrape_job_id(response) -> Optional[str]:
+        """Scrape a Dell ``JID_`` job id out of a response object's text.
+
+        The regex body relocated verbatim from the neutral
+        ``RedfishManager.job_id_from_respond`` — moving it here is what makes
+        the neutral layer Dell-literal-free (pays the known_debt row in
+        architecture.yaml state_decode).
+
+        :param response: requests.models.Response (or any object with a dict).
+        :return: the matched ``JID_...`` token, ``None`` when the pattern is
+            searched but absent, or an empty string when nothing was searchable.
+        """
+        try:
+            if response is not None and hasattr(response, "__dict__"):
+                response_dict = str(response.__dict__)
+                if response_dict is not None and len(response_dict) > 0:
+                    job_id = re.search("JID_.+?,", response_dict)
+                    if job_id is not None:
+                        job_id = job_id.group(0)
+                    return job_id
+        except AttributeError as attr_err:
+            logging.debug(f"could not read job id from respond object: {attr_err}")
+
+        return ""
+
+    def parse_task_id(self, response) -> Optional[str]:
         """Extract a job id: Location header first, then the JID_ body-scrape.
 
-        CHIP: relocate the ``JID_`` regex from ``redfish_manager.py:1072``
-        (moving it OUT of the neutral layer pays the known_debt row) and
-        compose it as: try the DMTF Location form via ``super()``, fall back
-        to the Dell body scrape.
+        The DMTF Location form (via ``super()``) is the primary path — Dell
+        normally does set the header; the ``JID_`` scrape is the Dell-only
+        fallback for responses that omit it.
 
         :param response: the response carrying Location header and/or body.
-        :return: the job id (``JID_...``) or task id, or None.
-        :raises NotImplementedError: until the implementation pass lands.
+        :return: the job id (``JID_...``) or task id, empty/None when neither
+            source names one.
         """
-        raise NotImplementedError("CHIP: relocate JID_ scrape "
-                                  "(redfish_manager.py:1072) behind super()")
+        job_id = super().parse_task_id(response)
+        if job_id:
+            return job_id
+        return self._scrape_job_id(response)
 
-    def fetch_task(self, manager, task_id: str, **kwargs):
+    def get_task_state(
+            self, manager, resp: requests.models.Response
+    ) -> Tuple[IdracTaskState, IdracTaskStatus]:
+        """Parse response and return task state and status, Dell vocabulary.
+
+        Body relocated from ``IDracManager.get_task_state``: if resp has no
+        json payload and JSONDecodeError raised, return Unknown state; if the
+        TaskStatus or TaskState key is absent from the response,
+        UnexpectedResponse is raised.
+
+        :param manager: the connection's manager (logging provider).
+        :param resp: a requests.models.Response object.
+        :return: redfish_ctl.IdracTaskState and redfish_ctl.IdracTaskStatus
+        :raise redfish_ctl.UnexpectedResponse: If the response body does not
+            contain a task state.
+        """
+        try:
+            resp_data = resp.json()
+        except requests.exceptions.JSONDecodeError as json_err:
+            manager.logger.error(
+                f"failed parse response to get a task state. {str(json_err)}"
+            )
+            return IdracTaskState.Unknown, IdracTaskStatus.Warning
+
+        # dodge case
+        if REDFISH_JSON.TaskStatus not in resp_data or REDFISH_JSON.TaskState not in resp_data:
+            raise UnexpectedResponse(f"IDRAC returned a {resp_data}, neither task state nor status is present..")
+
+        resp_state = resp_data[REDFISH_JSON.TaskState]
+        resp_status = resp_data[REDFISH_JSON.TaskStatus]
+
+        # update state and status.
+        task_state = self._task_state_mapping[resp_state]
+        task_status = self._task_status_mapping[resp_status.lower()]
+        return task_state, task_status
+
+    def fetch_task(self, manager, task_id: str, sleep_time: int = 10,
+                   wait_for: int = 0,
+                   wait_for_state: Optional[IdracTaskState] = None,
+                   timeout: Optional[float] = None, **kwargs) -> IdracTaskState:
         """Poll a Dell job/task to terminal state (OEM job queue semantics).
 
-        CHIP: relocate the Dell polling body from ``idrac_manager.py:407-553``
-        (tqdm progress via DMTF PercentComplete, Retry-After handling, the
-        ``_task_state_mapping``/``_job_state_mapping`` dicts from
-        ``idrac_manager.py:195-228``). Transport stays on ``manager``.
+        Body relocated from ``IDracManager.fetch_task``: consult the OEM
+        ``/Oem/Dell/Jobs`` job first (a finished job bounces off without
+        polling), then poll ``/redfish/v1/TaskService/Tasks/{id}`` with tqdm
+        progress via PercentComplete and ``Retry-After`` handling. Transport
+        stays on ``manager``.
 
         :param manager: the connection's manager (transport provider).
         :param task_id: the ``JID_``/task id to poll.
-        :return: the terminal task payload (matching the current contract).
-        :raises NotImplementedError: until the implementation pass lands.
+        :param sleep_time: default sleep between polls; a server ``Retry-After``
+            takes precedence when larger.
+        :param wait_for: wait for a specific status code instead of 200.
+        :param wait_for_state: wait for a specific state (defaults to the
+            Unknown sentinel, i.e. wait for completion).
+        :param timeout: accepted for cross-vendor signature parity; the Dell
+            poll is bounded by the job state, not a wall clock, and does not
+            consult it (matching the pre-relocation behavior).
+        :return: the last observed state (``IdracTaskState`` or ``JobState``
+            for an already-finished job), matching the pre-relocation contract.
+        :raise AuthenticationFailed: if the task service returns HTTP 401.
+        :raise UnexpectedResponse: on an unknown Dell job state string.
         """
-        raise NotImplementedError("CHIP: relocate Dell fetch_task "
-                                  "(idrac_manager.py:407-553 + state maps :195-228)")
+        if wait_for_state is None:
+            wait_for_state = IdracTaskState.Unknown
 
-    def get_task_state(self, manager, task_id: str, **kwargs):
-        """Read a Dell job/task state (IdracTaskState vocabulary).
+        last_update = 0
+        percent_done = 0
 
-        CHIP: relocate from ``idrac_manager.py:374`` (the Dell override).
+        # job might be already done.
+        jb = self.get_job(manager, task_id)
+
+        # if job scheduler or scheduling it make sense to wait otherwise we
+        # return state; we expect a JobState
+        if REDFISH_JSON.JobState in jb:
+
+            current_state = jb[REDFISH_JSON.JobState]
+            if current_state not in self._job_state_mapping:
+                raise UnexpectedResponse(f"IDRAC returned a {current_state} job type that we don't know.")
+            _ = self._job_state_mapping[current_state]
+            if current_state == JobState.Scheduled.value or current_state == JobState.Scheduling.value \
+                    or current_state == JobState.Running.value:
+                manager.logger.info(f"Job {task_id} is {current_state}.. waiting for completion.")
+            else:
+                manager.logger.info(f"Job {task_id} is {current_state}..bouncing off.")
+                return self._job_state_mapping[current_state]
+
+        # in case server will ask to wait.
+        retry_after = 0
+        # initial state we don't know
+        task_state = IdracTaskState.Unknown
+        with tqdm(total=100) as pbar:
+            while True:
+                # /redfish/v1/TaskService/Tasks/{TaskId}
+                resp = manager.api_get_call(f"{manager._default_method}{manager.idrac_ip}"
+                                            f"{REDFISH_API.Tasks}{task_id}", hdr={})
+
+                if 'Retry-After' in resp.headers:
+                    retry_after = int(resp.headers["Retry-After"])
+                    manager.logger.info(
+                        f"Remote server responded "
+                        f"with Retry-After {retry_after}"
+                    )
+                if resp.status_code == 401:
+                    manager.logger.error("task service returned 401")
+                    raise AuthenticationFailed("Authentication failed.")
+                # if server failed, meanwhile HTTP exception propagate
+                # up on the stack.
+                if resp.status_code > 499:
+                    manager.logger.critical(
+                        f"task service return http error code "
+                        f"{resp.status_code}"
+                    )
+                    break
+                # Cancellation: A subsequent GET request on the task monitor URI
+                # returns either the HTTP 410 Gone or 404 Not Found status code.
+                elif resp.status_code == 404 or resp.status_code == 410:
+                    manager.logger.info(f"task service returned {resp.status_code}")
+                    # at the end we check a state and return it might fail, exception etc.
+                    break
+                # if client expect something else than 200 or something else, we return result.
+                elif 0 < wait_for == resp.status_code:
+                    task_state, task_status = self.get_task_state(manager, resp)
+                    return task_state
+                # As long as the operation is in process, the service shall return the HTTP 202 Accepted status code
+                # when the client performs a GET request on the task monitor URI.
+                elif resp.status_code == 202:
+                    manager.logger.info("task service returned 202")
+                    # state acquisition and update state
+                    resp_data = resp.json()
+                    task_state, task_status = self.get_task_state(manager, resp)
+                    manager.logger.info(f"Updating state, new state "
+                                        f"{task_state.value}, status {task_status.value}")
+
+                    # update description so caller see.
+                    pbar.set_description(task_state.value)
+                    if (task_status == IdracTaskStatus.Critical
+                            or task_status == IdracTaskStatus.Warning):
+                        # we bounce, if status not ok
+                        break
+
+                    percent_done = manager.update_progress(resp_data, percent_done)
+                    if percent_done > last_update:
+                        last_update = percent_done
+                        inc = percent_done - pbar.n
+                        pbar.update(n=inc)
+
+                    # update retry time, we've been asked
+                    if retry_after > sleep_time:
+                        sleep_time = retry_after
+                    time.sleep(sleep_time)
+
+                # The appropriate HTTP status code, such as but not limited to 200 OK
+                # for most operations or 201 Created for POST to create a resource.
+                # if client passed wait_for for example 204 we need have handle for 200
+                elif resp.status_code == 200:
+                    task_state, task_status = self.get_task_state(manager, resp)
+                    manager.logger.info(
+                        f"Server return status code 200, Task state "
+                        f"{task_state.value}, {task_status.value}"
+                    )
+                    return task_state
+                # client wait for specific state
+                elif task_state == wait_for_state:
+                    manager.logger.info(f"caller asked for wait for a state {wait_for_state.value}")
+                    task_state, task_status = self.get_task_state(manager, resp)
+                    return task_state
+                else:
+                    # in all other cases update state and go back sleep.
+                    task_state, task_status = self.get_task_state(manager, resp)
+                    manager.logger.error("unexpected status code", resp.status_code)
+                    if retry_after > sleep_time:
+                        sleep_time = retry_after
+                    time.sleep(sleep_time)
+
+        return task_state
+
+    def get_job(self, manager, job_id: str, data_type: str = "json",
+                do_async: bool = False) -> dict:
+        """Query information for particular job from dell oem.
+
+        Body relocated from ``IDracManager.get_job``: respond is information
+        about a specific configuration Job scheduled by or being executed by a
+        Redfish service's Job Service, read from the Dell OEM job queue.
 
         :param manager: the connection's manager (transport provider).
-        :param task_id: the id to read.
-        :return: the task state (matching the current contract).
-        :raises NotImplementedError: until the implementation pass lands.
+        :param job_id: iDRAC job_id JID_744718373591
+        :param data_type: json or xml
+        :param do_async: note async will subscribe to an event loop.
+        :return: the job payload dict.
         """
-        raise NotImplementedError("CHIP: relocate Dell get_task_state "
-                                  "(idrac_manager.py:374)")
+        headers = {}
+        if data_type == "json":
+            headers.update(manager.json_content_type)
 
-    def get_job(self, manager, job_id: str, **kwargs):
-        """Read one Dell job from the OEM job queue.
-
-        CHIP: relocate from ``idrac_manager.py:337`` (Dell ``/Oem/Dell/Jobs``).
-
-        :param manager: the connection's manager (transport provider).
-        :param job_id: the ``JID_`` id to read.
-        :return: the job payload (matching the current contract).
-        :raises NotImplementedError: until the implementation pass lands.
-        """
-        raise NotImplementedError("CHIP: relocate Dell get_job "
-                                  "(idrac_manager.py:337)")
+        r = f"{manager.idrac_members}/Oem/Dell/Jobs/{job_id}"
+        return manager.base_query(r, do_expanded=True, do_async=do_async).data
 
 
 register_profile("dell", DellProfile)

--- a/redfish_ctl/dell_profile.py
+++ b/redfish_ctl/dell_profile.py
@@ -1,0 +1,115 @@
+"""Dell (iDRAC) vendor profile: the chokepoints that are genuinely Dell.
+
+Everything relocated here is Dell-evidenced by the three mechanical signals
+(v1.1.0 git era; the ``Dell*``/``Idrac*`` enum naming; the Dell crawl map):
+the 201=Created status row, the Dell error envelope, the ``JID_`` job-id
+body-scrape, and the OEM job-queue polling semantics. Non-Dell connections
+never see these — :class:`~redfish_ctl.vendor_profile.DmtfProfile` and its
+siblings carry the DMTF forms only.
+
+Method bodies marked CHIP are relocated verbatim-in-semantics from
+``idrac_manager.py``/``redfish_manager.py`` by the implementation pass; each
+seam names its exact source anchor. Dell capability is NEVER reduced here
+(architecture.yaml ``no_capability_ceiling``): this module is where all of it
+lives, unleaked.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+from .vendor_profile import DmtfProfile, register_profile
+
+
+class DellProfile(DmtfProfile):
+    """Dell chokepoint overrides on the shared DMTF base."""
+
+    vendor = "dell"
+
+    def decode_status(self, status_code: int):
+        """Fold an HTTP status into the signal, WITH Dell's 201=Created row.
+
+        CHIP: relocate ``_http_code_mapping`` from ``idrac_manager.py:186-191``
+        (the full four-row map including 201 -> RedfishApiRespond.Created; the
+        generic enum has no Created — see architecture.yaml state_decode).
+
+        :param status_code: HTTP status from a Dell BMC response.
+        :return: the ``RedfishApiRespond`` signal (Created possible here only).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate _http_code_mapping "
+                                  "(idrac_manager.py:186-191, incl. 201)")
+
+    def error_handler(self, response, expected=None):
+        """Decode a response per Dell semantics (iDRAC error envelope).
+
+        CHIP: relocate the Dell ``default_error_handler`` override —
+        source: ``idrac_manager.py:555-584`` (parse_error + typed raises with
+        the IDRAC.2.x registry envelope).
+
+        :param response: the ``requests.Response`` to decode.
+        :param expected: optional expected-status override(s).
+        :return: the decoded signal (matching the current chokepoint contract).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate Dell default_error_handler "
+                                  "(idrac_manager.py:555-584)")
+
+    def parse_task_id(self, response):
+        """Extract a job id: Location header first, then the JID_ body-scrape.
+
+        CHIP: relocate the ``JID_`` regex from ``redfish_manager.py:1072``
+        (moving it OUT of the neutral layer pays the known_debt row) and
+        compose it as: try the DMTF Location form via ``super()``, fall back
+        to the Dell body scrape.
+
+        :param response: the response carrying Location header and/or body.
+        :return: the job id (``JID_...``) or task id, or None.
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate JID_ scrape "
+                                  "(redfish_manager.py:1072) behind super()")
+
+    def fetch_task(self, manager, task_id: str, **kwargs):
+        """Poll a Dell job/task to terminal state (OEM job queue semantics).
+
+        CHIP: relocate the Dell polling body from ``idrac_manager.py:407-553``
+        (tqdm progress via DMTF PercentComplete, Retry-After handling, the
+        ``_task_state_mapping``/``_job_state_mapping`` dicts from
+        ``idrac_manager.py:195-228``). Transport stays on ``manager``.
+
+        :param manager: the connection's manager (transport provider).
+        :param task_id: the ``JID_``/task id to poll.
+        :return: the terminal task payload (matching the current contract).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate Dell fetch_task "
+                                  "(idrac_manager.py:407-553 + state maps :195-228)")
+
+    def get_task_state(self, manager, task_id: str, **kwargs):
+        """Read a Dell job/task state (IdracTaskState vocabulary).
+
+        CHIP: relocate from ``idrac_manager.py:374`` (the Dell override).
+
+        :param manager: the connection's manager (transport provider).
+        :param task_id: the id to read.
+        :return: the task state (matching the current contract).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate Dell get_task_state "
+                                  "(idrac_manager.py:374)")
+
+    def get_job(self, manager, job_id: str, **kwargs):
+        """Read one Dell job from the OEM job queue.
+
+        CHIP: relocate from ``idrac_manager.py:337`` (Dell ``/Oem/Dell/Jobs``).
+
+        :param manager: the connection's manager (transport provider).
+        :param job_id: the ``JID_`` id to read.
+        :return: the job payload (matching the current contract).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate Dell get_job "
+                                  "(idrac_manager.py:337)")
+
+
+register_profile("dell", DellProfile)

--- a/redfish_ctl/dell_profile.py
+++ b/redfish_ctl/dell_profile.py
@@ -258,8 +258,10 @@ class DellProfile(DmtfProfile):
         last_update = 0
         percent_done = 0
 
-        # job might be already done.
-        jb = self.get_job(manager, task_id)
+        # job might be already done. Read through the MANAGER seam (not this
+        # profile's own get_job) so class-level overrides and test monkeypatches
+        # on IDracManager.get_job keep intercepting, exactly as before the move.
+        jb = manager.get_job(task_id)
 
         # if job scheduler or scheduling it make sense to wait otherwise we
         # return state; we expect a JobState
@@ -311,7 +313,7 @@ class DellProfile(DmtfProfile):
                     break
                 # if client expect something else than 200 or something else, we return result.
                 elif 0 < wait_for == resp.status_code:
-                    task_state, task_status = self.get_task_state(manager, resp)
+                    task_state, task_status = manager.get_task_state(resp)
                     return task_state
                 # As long as the operation is in process, the service shall return the HTTP 202 Accepted status code
                 # when the client performs a GET request on the task monitor URI.
@@ -319,7 +321,7 @@ class DellProfile(DmtfProfile):
                     manager.logger.info("task service returned 202")
                     # state acquisition and update state
                     resp_data = resp.json()
-                    task_state, task_status = self.get_task_state(manager, resp)
+                    task_state, task_status = manager.get_task_state(resp)
                     manager.logger.info(f"Updating state, new state "
                                         f"{task_state.value}, status {task_status.value}")
 
@@ -345,7 +347,7 @@ class DellProfile(DmtfProfile):
                 # for most operations or 201 Created for POST to create a resource.
                 # if client passed wait_for for example 204 we need have handle for 200
                 elif resp.status_code == 200:
-                    task_state, task_status = self.get_task_state(manager, resp)
+                    task_state, task_status = manager.get_task_state(resp)
                     manager.logger.info(
                         f"Server return status code 200, Task state "
                         f"{task_state.value}, {task_status.value}"
@@ -354,11 +356,11 @@ class DellProfile(DmtfProfile):
                 # client wait for specific state
                 elif task_state == wait_for_state:
                     manager.logger.info(f"caller asked for wait for a state {wait_for_state.value}")
-                    task_state, task_status = self.get_task_state(manager, resp)
+                    task_state, task_status = manager.get_task_state(resp)
                     return task_state
                 else:
                     # in all other cases update state and go back sleep.
-                    task_state, task_status = self.get_task_state(manager, resp)
+                    task_state, task_status = manager.get_task_state(resp)
                     manager.logger.error("unexpected status code", resp.status_code)
                     if retry_after > sleep_time:
                         sleep_time = retry_after

--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -26,17 +26,14 @@ import argparse
 import functools
 import json
 import logging
-import time
 from abc import abstractmethod
 from datetime import datetime
 from functools import cached_property
 from typing import Dict, Optional, Tuple
 
 import requests
-from tqdm import tqdm
 
 from .cmd_exceptions import (
-    AuthenticationFailed,
     DeleteRequestFailed,
     InvalidArgumentFormat,
     MissingMandatoryArguments,
@@ -59,14 +56,12 @@ from .idrac_shared import (
     HTTPMethod,
     IDRACJobType,
     JobApplyTypes,
-    JobState,
     PowerState,
     RedfishAction,
     RedfishApiRespond,
     ScheduleJobType,
 )
 from .idrac_shared import ResetType as ResetType
-from .idrac_task_state import IdracTaskState, IdracTaskStatus
 from .redfish_exceptions import RedfishException, RedfishForbidden, RedfishUnauthorized
 from .redfish_manager import (
     CommandResult,
@@ -105,28 +100,36 @@ class IDracManager(RedfishManager):
     IDracManager Class, interact with a Redfish endpoint via REST API interface
     """
 
+    #: A connection nothing has classified yet presumes Dell — exactly the
+    #: pre-profile behavior of the Dell-based command family. Evidence (a
+    #: cached ServiceRoot classification) always outranks this presumption.
+    _default_profile_vendor = "dell"
+
     def __init__(self,
-                 idrac_ip: Optional[str] = "",
-                 idrac_username: Optional[str] = "root",
-                 idrac_password: Optional[str] = "",
-                 idrac_port: Optional[int] = 443,
+                 host: Optional[str] = "",
+                 username: Optional[str] = "root",
+                 password: Optional[str] = "",
+                 port: Optional[int] = 443,
                  insecure: Optional[bool] = True,
                  x_auth: Optional[str] = None,
                  is_http: Optional[bool] = False,
                  is_debug: Optional[bool] = False,
                  log_level=logging.NOTSET,
-                 host: Optional[str] = None,
-                 username: Optional[str] = None,
-                 password: Optional[str] = None,
-                 port: Optional[int] = None):
+                 **kwargs):
         """Default constructor requires credentials.
            By default, the manager uses json to serialize a data to callee
            and uses json content type.
 
-        :param idrac_ip: deprecated alias for ``host``.
-        :param idrac_username: deprecated alias for ``username``.
-        :param idrac_password: deprecated alias for ``password``.
-        :param idrac_port: deprecated alias for ``port``.
+        One credential parameter set exists: ``host``/``username``/``password``/
+        ``port``. The legacy ``idrac_*`` spellings are no longer parameters;
+        they arrive via ``**kwargs`` and coalesce in the base constructor for
+        one wave, after which they live only at the CLI/env edge (config.py,
+        argparse).
+
+        :param host: BMC host or IP address.
+        :param username: BMC account username; defaults to root.
+        :param password: BMC account password.
+        :param port: BMC TCP port (default 443); accepts an int or str.
         :param insecure: when True (the default) TLS certificate verification is
             skipped. BMC controllers present self-signed certificates, so
             verification is opt-in: pass ``insecure=False`` to verify the cert.
@@ -134,36 +137,22 @@ class IDracManager(RedfishManager):
         :param is_http: use plain HTTP instead of HTTPS for requests when True.
         :param is_debug: when True, include exception tracebacks in error logs.
         :param log_level: logging level applied to this manager's logger.
-        :param host: BMC host or IP address.
-        :param username: BMC account username; defaults to root.
-        :param password: BMC account password.
-        :param port: BMC TCP port (default 443); accepts an int or str.
+        :param kwargs: forwarded to the base constructor (legacy connection
+            aliases coalesce there).
         """
-        host = idrac_ip if host is None else host
-        username = idrac_username if username is None else username
-        password = idrac_password if password is None else password
-        port = idrac_port if port is None else port
-
-        super().__init__(redfish_ip=host,
-                         redfish_username=username,
-                         redfish_password=password,
-                         redfish_port=port,
+        super().__init__(host=host,
+                         username=username,
+                         password=password,
+                         port=port,
                          insecure=insecure,
                          is_http=is_http,
                          x_auth=x_auth,
-                         is_debug=is_debug)
+                         is_debug=is_debug,
+                         **kwargs)
 
         self.logger = logging.getLogger(__name__)
         self._logger_level = log_level
         self.logger.setLevel(self._logger_level)
-
-        self.content_type = {'Content-Type': 'application/json; charset=utf-8'}
-        self.json_content_type = {'Content-Type': 'application/json; charset=utf-8'}
-
-        self._manage_servers_obs = []
-        self._manage_chassis_obs = []
-        # mainly to track query sent , for unit test
-        self.query_counter = 0
 
         # mapping between rest API respond to respected
         # string that we report to apper layer.
@@ -175,58 +164,6 @@ class IDracManager(RedfishManager):
 
         }
 
-        # a mapping from http status code to result of request.
-        # the BMC is not consistent with the return code, so it is not very clear
-        # case when 200 is ok and 201 is something else. So it API per API
-        # Thus default success has extra field, so we can always
-        # pass what we expect for particular cmd.
-
-        #  Redfish spec 202 Request has been accepted for processing
-        #  but the processing has not been completed
-        self._http_code_mapping = {
-            200: RedfishApiRespond.Ok,
-            201: RedfishApiRespond.Created,
-            202: RedfishApiRespond.AcceptedTaskGenerated,
-            204: RedfishApiRespond.Success,
-        }
-
-        # mapping a string state to enum, so each cmd can just check a state
-        # without doing any string if else branches.
-        self._job_state_mapping = {
-            "Scheduled": JobState.Scheduled,
-            "Running": JobState.Running,
-            "Completed": JobState.Completed,
-            "Downloaded": JobState.Downloaded,
-            "Downloading": JobState.Downloading,
-            "Scheduling": JobState.Scheduling,
-            "Waiting": JobState.Waiting,
-            "Failed": JobState.Failed,
-            "CompletedWithErrors": JobState.CompletedWithErrors,
-            "RebootFailed": JobState.RebootFailed,
-            "RebootCompleted": JobState.RebootCompleted,
-            "RebootPending": JobState.RebootPending,
-            "PendingActivation": JobState.PendingActivation,
-            "Unknown": JobState.Unknown,
-        }
-
-        # mapping a task state string to enum
-        # without doing any string if else branches.
-        self._task_state_mapping = {
-            "New": IdracTaskState.New,
-            "Running": IdracTaskState.Starting,
-            "Starting": IdracTaskState.Starting,
-            "Suspended": IdracTaskState.Suspended,
-            "Interrupted": IdracTaskState.Interrupted,
-            "Pending": IdracTaskState.Pending,
-            "Stopping": IdracTaskState.Stopping,
-            "Completed": IdracTaskState.Completed,
-            "Killed": IdracTaskState.Killed,
-            "Exception": IdracTaskState.Exception,
-            "Service": IdracTaskState.Service,
-            "Canceling": IdracTaskState.Canceling,
-            "Cancelled": IdracTaskState.Cancelled
-        }
-
         # mapping from cli to job types
         self._cli_job_type_mapping = {
             CliJobTypes.Bios_Config.value: IDRACJobType.BIOSConfiguration.value,
@@ -235,18 +172,22 @@ class IDracManager(RedfishManager):
             CliJobTypes.RebootNoForce.value: IDRACJobType.RebootNoForce.value
         }
 
-        # mapping from string to task status enum
-        self._task_status_mapping = {
-            "ok": IdracTaskStatus.Ok,
-            "warning": IdracTaskStatus.Warning,
-            "critical": IdracTaskStatus.Critical
-        }
-
         self._redfish_error = None
 
-        # run time
-        self.action_targets = None
-        self.api_endpoints = None
+    @property
+    def _http_code_mapping(self):
+        """Transitional view of the Dell status rows, now owned by DellProfile.
+
+        The map (200/201/202/204 rows, including the Dell-only 201=Created)
+        moved to ``DellProfile._status_map`` — the single source. Non-chokepoint
+        consumers (``read_api_respond``, the subscription lifecycle helper)
+        still read ``self._http_code_mapping``; this property serves them until
+        those paths route through the profile. Read-only by contract.
+
+        :return: the Dell status-code map.
+        """
+        from .dell_profile import DellProfile
+        return DellProfile._status_map
 
     @property
     def idrac_ip(self) -> str:
@@ -338,20 +279,35 @@ class IDracManager(RedfishManager):
                 job_id: str,
                 data_type: Optional[str] = "json",
                 do_async: Optional[bool] = False) -> dict:
-        """Query information for particular job from dell oem.
-        Respond is information about a specific configuration Job scheduled
-        by or being executed by a Redfish service's Job Service.
+        """Query information for particular job, per the connection's profile.
+
+        Same-signature delegate: the Dell profile reads the OEM
+        ``/Oem/Dell/Jobs`` queue (the body that used to live here); a non-Dell
+        connection reads the DMTF ``TaskService`` task instead, so the OEM URL
+        never fires at a foreign BMC.
+
         :param job_id: iDRAC job_id JID_744718373591
         :param do_async: note async will subscribe to an event loop.
         :param data_type: json or xml
-        :return: CommandResult.
+        :return: the job payload dict.
         """
-        headers = {}
-        if data_type == "json":
-            headers.update(self.json_content_type)
+        return self.vendor_profile.get_job(
+            self, job_id, data_type=data_type, do_async=do_async)
 
-        r = f"{self.idrac_members}/Oem/Dell/Jobs/{job_id}"
-        return self.base_query(r, do_expanded=True, do_async=do_async).data
+    @staticmethod
+    def job_id_from_respond(response) -> str:
+        """Try to parse a Dell ``JID_`` job id from an HTTP respond body.
+
+        The scrape body moved out of the neutral ``RedfishManager`` into
+        ``DellProfile._scrape_job_id`` (it is a Dell literal); this Dell-side
+        delegate keeps the existing ``self.job_id_from_respond`` call sites
+        working unchanged.
+
+        :param response: requests.models.Response
+        :return: str: a job id or empty string
+        """
+        from .dell_profile import DellProfile
+        return DellProfile._scrape_job_id(response)
 
     @staticmethod
     def update_progress(resp_data, old_value):
@@ -371,198 +327,16 @@ class IDracManager(RedfishManager):
 
         return old_value
 
-    def get_task_state(
-            self, resp: requests.models.Response
-    ) -> Tuple[IdracTaskState, IdracTaskStatus]:
-        """Parse response and return task state and status,
-        if resp has no json payload and JSONDecodeError raised , return Unknown state.
-
-        if the TaskStatus or TaskState key is absent from the response, UnexpectedResponse is raised.
-
-        :param resp: a requests.models.Response object.
-        :return:  redfish_ctl.IdracTaskState and redfish_ctl.IdracTaskStatus
-        :raise  redfish_ctl.UnexpectedResponse: If the response body does not
-            contain a task state.
-        """
-        try:
-            resp_data = resp.json()
-        except requests.exceptions.JSONDecodeError as json_err:
-            self.logger.error(
-                f"failed parse response to get a task state. {str(json_err)}"
-            )
-            return IdracTaskState.Unknown, IdracTaskStatus.Warning
-
-        # dodge case
-        if REDFISH_JSON.TaskStatus not in resp_data or REDFISH_JSON.TaskState not in resp_data:
-            raise UnexpectedResponse(f"IDRAC returned a {resp_data}, neither task state nor status is present..")
-
-        resp_state = resp_data[REDFISH_JSON.TaskState]
-        resp_status = resp_data[REDFISH_JSON.TaskStatus]
-
-        # update state and status.
-        task_state = self._task_state_mapping[resp_state]
-        task_status = self._task_status_mapping[resp_status.lower()]
-        return task_state, task_status
-
-    def fetch_task(self,
-                   task_id: str,
-                   sleep_time: Optional[int] = 10,
-                   wait_for: Optional[int] = 0,
-                   wait_for_state: Optional[IdracTaskState] = IdracTaskState.Unknown,
-                   ) -> IdracTaskState:
-
-        """Synchronous fetch a job from the BMC and wait for job completion.
-
-        A job on the BMC is the Task and contains information about a task
-        that the Redfish Task Service schedules or executes.
-
-        Tasks represent operations that we want to wait.
-        Example we applied a change that create a task, and we need wait for completion.
-
-        Note: that caller can provide wait_for_state that will unblock waiting loop,
-        for example if we don't want wait for completion or error.  i.e.
-        Running or Scheduled is sufficient criterion.
-        (It useful for async io type of request)
-
-        if server return  404 or  410:
-        - if a state was update caller will get last known state.
-        - if a state never updated caller will get Unknown.
-
-        THus, for a caller it amke sense to re-check task services.
-
-        :param wait_for: by default, we wait status code 200 based on spec.
-                         in case API return something else. 204 for example.
-        :param task_id: task id as it returned from a task by task services.
-        :param sleep_time: a default sleep and wait, if server ask for retry_after, it takes precedence
-                           only if retry_after > sleep_time.
-        :param wait_for_state: wait a specific state. Example caller only care
-                               it Running and will resume later to monitor progress
-
-        :return: Nothing
-        :raise AuthenticationFailed MissingResource
-        """
-        last_update = 0
-        percent_done = 0
-
-        # job might be already done.
-        jb = self.get_job(task_id)
-
-        # if job scheduler or scheduling it make sense to wait otherwise we return state
-        # we expect a JobState
-        if REDFISH_JSON.JobState in jb:
-
-            current_state = jb[REDFISH_JSON.JobState]
-            if current_state not in self._job_state_mapping:
-                raise UnexpectedResponse(f"IDRAC returned a {current_state} job type that we don't know.")
-            _ = self._job_state_mapping[current_state]
-            if current_state == JobState.Scheduled.value or current_state == JobState.Scheduling.value \
-                    or current_state == JobState.Running.value:
-                self.logger.info(f"Job {task_id} is {current_state}.. waiting for completion.")
-            else:
-                self.logger.info(f"Job {task_id} is {current_state}..bouncing off.")
-                return self._job_state_mapping[current_state]
-
-        # in case server will ask to wait.
-        retry_after = 0
-        # initial state we don't know
-        task_state = IdracTaskState.Unknown
-        with tqdm(total=100) as pbar:
-            while True:
-                # /redfish/v1/TaskService/Tasks/{TaskId}
-                resp = self.api_get_call(f"{self._default_method}{self.idrac_ip}"
-                                         f"{REDFISH_API.Tasks}{task_id}", hdr={})
-
-                if 'Retry-After' in resp.headers:
-                    retry_after = int(resp.headers["Retry-After"])
-                    self.logger.info(
-                        f"Remote server responded "
-                        f"with Retry-After {retry_after}"
-                    )
-                if resp.status_code == 401:
-                    self.logger.error("task service returned 401")
-                    raise AuthenticationFailed("Authentication failed.")
-                # if server failed, meanwhile HTTP exception propagate
-                # up on the stack.
-                if resp.status_code > 499:
-                    self.logger.critical(
-                        f"task service return http error code "
-                        f"{resp.status_code}"
-                    )
-                    break
-                # Cancellation: A subsequent GET request on the task monitor URI
-                # returns either the HTTP 410 Gone or 404 Not Found status code.
-                elif resp.status_code == 404 or resp.status_code == 410:
-                    self.logger.info(f"task service returned {resp.status_code}")
-                    # at the end we check a state and return it might fail, exception etc.
-                    break
-                # if client expect something else than 200 or something else, we return result.
-                elif 0 < wait_for == resp.status_code:
-                    task_state, task_status = self.get_task_state(resp)
-                    return task_state
-                # As long as the operation is in process, the service shall return the HTTP 202 Accepted status code
-                # when the client performs a GET request on the task monitor URI.
-                elif resp.status_code == 202:
-                    self.logger.info("task service returned 202")
-                    # state acquisition and update state
-                    resp_data = resp.json()
-                    task_state, task_status = self.get_task_state(resp)
-                    self.logger.info(f"Updating state, new state "
-                                     f"{task_state.value}, status {task_status.value}")
-
-                    # update description so caller see.
-                    pbar.set_description(task_state.value)
-                    if (task_status == IdracTaskStatus.Critical
-                            or task_status == IdracTaskStatus.Warning):
-                        # we bounce, if status not ok
-                        break
-
-                    percent_done = self.update_progress(resp_data, percent_done)
-                    if percent_done > last_update:
-                        last_update = percent_done
-                        inc = percent_done - pbar.n
-                        pbar.update(n=inc)
-
-                    # update retry time, we've been asked
-                    if retry_after > sleep_time:
-                        sleep_time = retry_after
-                    time.sleep(sleep_time)
-
-                # The appropriate HTTP status code, such as but not limited to 200 OK
-                # for most operations or 201 Created for POST to create a resource.
-                # if client passed wait_for for example 204 we need have handle for 200
-                elif resp.status_code == 200:
-                    task_state, task_status = self.get_task_state(resp)
-                    self.logger.info(
-                        f"Server return status code 200, Task state "
-                        f"{task_state.value}, {task_status.value}"
-                    )
-                    return task_state
-                # client wait for specific state
-                elif task_state == wait_for_state:
-                    self.logger.info(f"caller asked for wait for a state {wait_for_state.value}")
-                    task_state, task_status = self.get_task_state(resp)
-                    return task_state
-                else:
-                    # in all other cases update state and go back sleep.
-                    task_state, task_status = self.get_task_state(resp)
-                    self.logger.error("unexpected status code", resp.status_code)
-                    if retry_after > sleep_time:
-                        sleep_time = retry_after
-                    time.sleep(sleep_time)
-
-        return task_state
-
     def default_error_handler(
             self, response: requests.models.Response) -> RedfishApiRespond:
-        """Normalize a non-2xx Redfish response per the Redfish error contract.
+        """Normalize a Redfish response per the connection's vendor profile.
 
-        A success code returns its mapped ``RedfishApiRespond``. Every error code
-        is normalized through :meth:`RedfishManager.parse_error`, so the raised
-        exception carries the parsed :class:`RedfishError` envelope (HTTP status,
-        ``error.code``/``error.message`` and every ``@Message.ExtendedInfo``
-        entry) as its primary value — never a generic string — including for an
-        unsupported-operation ``501``/``404``/``405``/``409``. See
-        docs/external/redfish-error-contract.md.
+        Same-signature delegate — the Dell decode body (the 201=Created row and
+        the typed raises carrying the parsed :class:`RedfishError` envelope,
+        see docs/external/redfish-error-contract.md) moved to
+        ``DellProfile.error_handler``; a non-Dell connection resolves the DMTF
+        decode instead. The profile records the parsed envelope on this
+        manager (``self._redfish_error``) before raising, as before.
 
         :param response: the Redfish HTTP response to classify.
         :return: the mapped ``RedfishApiRespond`` for a 2xx success code.
@@ -571,17 +345,7 @@ class IDracManager(RedfishManager):
         :raises ResourceNotFound: on HTTP 404, carrying the parsed error.
         :raises UnexpectedResponse: on any other error code, carrying the parsed error.
         """
-        code = response.status_code
-        if 200 <= code < 300:
-            return self._http_code_mapping.get(code, RedfishApiRespond.Success)
-        self._redfish_error = RedfishManager.parse_error(response)
-        if code == 401:
-            raise AuthenticationFailed(self._redfish_error)
-        if code == 403:
-            raise RedfishForbidden(self._redfish_error)
-        if code == 404:
-            raise ResourceNotFound(self._redfish_error)
-        raise UnexpectedResponse(self._redfish_error)
+        return self.vendor_profile.error_handler(response, manager=self)
 
     def check_api_version(self):
         """Check Dell LLC Service API set

--- a/redfish_ctl/idrac_manager.py
+++ b/redfish_ctl/idrac_manager.py
@@ -106,10 +106,10 @@ class IDracManager(RedfishManager):
     _default_profile_vendor = "dell"
 
     def __init__(self,
-                 host: Optional[str] = "",
-                 username: Optional[str] = "root",
-                 password: Optional[str] = "",
-                 port: Optional[int] = 443,
+                 host: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
+                 port: Optional[int] = None,
                  insecure: Optional[bool] = True,
                  x_auth: Optional[str] = None,
                  is_http: Optional[bool] = False,
@@ -126,10 +126,10 @@ class IDracManager(RedfishManager):
         one wave, after which they live only at the CLI/env edge (config.py,
         argparse).
 
-        :param host: BMC host or IP address.
-        :param username: BMC account username; defaults to root.
-        :param password: BMC account password.
-        :param port: BMC TCP port (default 443); accepts an int or str.
+        :param host: BMC host or IP address; effective default is empty.
+        :param username: BMC account username; effective default is ``root``.
+        :param password: BMC account password; effective default is empty.
+        :param port: BMC TCP port; effective default 443; accepts int or str.
         :param insecure: when True (the default) TLS certificate verification is
             skipped. BMC controllers present self-signed certificates, so
             verification is opt-in: pass ``insecure=False`` to verify the cert.

--- a/redfish_ctl/redfish_exceptions.py
+++ b/redfish_ctl/redfish_exceptions.py
@@ -50,3 +50,12 @@ class RedfishGone(RedfishException):
     """HTTP status code 410
     """
     pass
+
+
+class ProfileRegistrationCollision(RedfishException):
+    """Two vendor profiles registered under the same vendor key.
+
+    Raised at import time so a duplicate registration fails loudly during
+    startup instead of silently last-write-winning at dispatch time.
+    """
+    pass

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -701,6 +701,26 @@ class RedfishManager:
         api_resp = self.base_query("/redfish/v1/")
         return api_resp.data if api_resp is not None else None
 
+    @property
+    def vendor_profile(self):
+        """The connection's vendor chokepoint profile, resolved once and cached.
+
+        Vendor binds per CONNECTION, not per class: the profile is resolved
+        from the (already cached) ``_service_root`` via the discovery
+        classifier, so resolution costs ZERO extra BMC round trips when the
+        root was fetched anyway. Plumbing seam — the chokepoint call sites
+        delegate here in the implementation pass; nothing calls this yet.
+
+        :return: the connection's ``DmtfProfile`` (or vendor subclass) instance.
+        """
+        # Imports live here so the module graph is unchanged until first use;
+        # importing dell_profile guarantees the Dell registration is present.
+        from . import dell_profile  # noqa: F401  (registration side effect)
+        from .vendor_profile import profile_for_connection
+        return profile_for_connection(
+            self._host if hasattr(self, "_host") else self._redfish_ip,
+            self._port, lambda: self._service_root)
+
     @cached_property
     def redfish_version(self) -> str:
         """Return version remote endpoint implemented

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -13,7 +13,6 @@ import contextvars
 import copy
 import functools
 import logging
-import re
 import threading
 import time
 from abc import abstractmethod
@@ -27,7 +26,6 @@ from urllib3.util.retry import Retry
 
 from .cmd_exceptions import (
     AuthenticationFailed,
-    ResourceNotFound,
     TaskIdUnavailable,
     UnsupportedAction,
 )
@@ -36,7 +34,6 @@ from .redfish_exceptions import (
     RedfishForbidden,
     RedfishMethodNotAllowed,
     RedfishNotAcceptable,
-    RedfishUnauthorized,
 )
 from .redfish_query import RedfishQuery
 from .redfish_respond import RedfishRespondMessage
@@ -163,39 +160,77 @@ class RedfishManager:
             asyncio.set_event_loop(loop)
             return loop
 
+    @staticmethod
+    def _coalesce_ctor_alias(kwargs: dict, value, default, *aliases):
+        """Resolve one connection value from a canonical param and legacy aliases.
+
+        Transitional (one wave): direct constructions still pass
+        ``redfish_ip``/``idrac_ip``-style keywords; they arrive via ``**kwargs``
+        and are popped here so exactly ONE canonical value is stored. The
+        canonical parameter wins whenever it differs from its default.
+
+        :param kwargs: the constructor's ``**kwargs`` (aliases are popped).
+        :param value: the canonical parameter value as passed.
+        :param default: the canonical parameter's default.
+        :param aliases: legacy keyword names, highest precedence first.
+        :return: the resolved value.
+        """
+        alias_value = None
+        for name in aliases:
+            popped = kwargs.pop(name, None)
+            if alias_value is None:
+                alias_value = popped
+        if value == default and alias_value is not None:
+            return alias_value
+        return value
+
     def __init__(self,
-                 redfish_ip: Optional[str] = "",
-                 redfish_username: Optional[str] = "root",
-                 redfish_password: Optional[str] = "",
-                 redfish_port: Optional[int] = 443,
+                 host: Optional[str] = "",
+                 username: Optional[str] = "root",
+                 password: Optional[str] = "",
+                 port: Optional[int] = 443,
                  insecure: Optional[bool] = True,
                  is_http: Optional[bool] = False,
                  x_auth: Optional[str] = None,
-                 is_debug: Optional[bool] = False):
+                 is_debug: Optional[bool] = False,
+                 **kwargs):
         """Default constructor for Redfish Manager.
            it requires a credentials to interact with redfish endpoint.
            By default, Redfish Manager uses json to serialize a data to callee
            and uses json content type.
 
-        :param redfish_ip: redfish IP or hostname
-        :param redfish_username: redfish username default is root
-        :param redfish_password: redfish password.
-        :param redfish_port: redfish TCP port (default 443); accepts an int or str.
+        :param host: BMC IP or hostname.
+        :param username: BMC account username; default is root.
+        :param password: BMC account password.
+        :param port: BMC TCP port (default 443); accepts an int or str.
         :param insecure: when True (the default) TLS certificate verification is
             skipped. BMCs ship self-signed certificates, so verification is
             opt-in: pass ``insecure=False`` to verify the server certificate.
         :param is_http: use plain HTTP instead of HTTPS for requests when True.
         :param x_auth: X-Authentication header.
         :param is_debug: when True, include exception tracebacks in error logs.
+        :param kwargs: extensibility per the constructor contract; legacy
+            ``redfish_*``/``idrac_*`` connection aliases are still accepted
+            here for one wave (the canonical spelling wins on conflict), then
+            they live only at the CLI/env edge (config.py, argparse).
         """
-        self._redfish_ip = redfish_ip
-        self._username = redfish_username
-        self._password = redfish_password
+        host = self._coalesce_ctor_alias(
+            kwargs, host, "", "redfish_ip", "idrac_ip")
+        username = self._coalesce_ctor_alias(
+            kwargs, username, "root", "redfish_username", "idrac_username")
+        password = self._coalesce_ctor_alias(
+            kwargs, password, "", "redfish_password", "idrac_password")
+        port = self._coalesce_ctor_alias(
+            kwargs, port, 443, "redfish_port", "idrac_port")
 
-        if isinstance(redfish_port, str):
-            redfish_port = int(redfish_port)
+        self._host = host
+        self._username = username
+        self._password = password
 
-        self._port = redfish_port
+        if isinstance(port, str):
+            port = int(port)
+
+        self._port = port
         # ``insecure`` means "skip TLS verification"; requests' ``verify`` is the
         # inverse, so verification is enabled only when insecure is explicitly off.
         self._is_verify_cert = not insecure
@@ -325,10 +360,10 @@ class RedfishManager:
         _redfish_cache = kwargs.pop("redfish_cache", None)
 
         inst = disp(
-            idrac_ip=_host,
-            idrac_username=_username,
-            idrac_password=_password,
-            idrac_port=_port,
+            host=_host,
+            username=_username,
+            password=_password,
+            port=_port,
             insecure=_insecure,
             is_http=_is_http
         )
@@ -374,10 +409,10 @@ class RedfishManager:
         module_logger.debug(f"dispatching {name} to Redfish port {_port}")
 
         inst = disp(
-            idrac_ip=_host,
-            idrac_username=_username,
-            idrac_password=_password,
-            idrac_port=_port,
+            host=_host,
+            username=_username,
+            password=_password,
+            port=_port,
             insecure=_insecure,
             is_http=_is_http
         )
@@ -447,13 +482,33 @@ class RedfishManager:
 
         :return: the IP or hostname, suffixed with ``:port`` for non-443 ports.
         """
-        if ":" in self._redfish_ip:
-            return self._redfish_ip
+        if ":" in self._host:
+            return self._host
         else:
             if self._port != 443:
-                return f"{self._redfish_ip}:{self._port}"
+                return f"{self._host}:{self._port}"
             else:
-                return self._redfish_ip
+                return self._host
+
+    @property
+    def _redfish_ip(self) -> str:
+        """Transitional view of the canonical ``_host`` storage.
+
+        The connection host is stored once, as ``_host`` (the constructor
+        cleanup). This shim keeps pre-rename readers and writers of the old
+        private name working for one wave; delete with the alias retirement.
+
+        :return: the stored host value.
+        """
+        return self._host
+
+    @_redfish_ip.setter
+    def _redfish_ip(self, value: str) -> None:
+        """Write through to the canonical ``_host`` storage.
+
+        :param value: the host value to store.
+        """
+        self._host = value
 
     @property
     def username(self) -> str:
@@ -701,25 +756,47 @@ class RedfishManager:
         api_resp = self.base_query("/redfish/v1/")
         return api_resp.data if api_resp is not None else None
 
+    #: Vendor a connection resolves to when there is no better evidence — no
+    #: cached classification and no already-fetched ServiceRoot. The neutral
+    #: base presumes generic (DMTF); the Dell manager overrides with "dell",
+    #: which is exactly the pre-profile behavior of the Dell-based commands.
+    _default_profile_vendor = "generic"
+
     @property
     def vendor_profile(self):
         """The connection's vendor chokepoint profile, resolved once and cached.
 
-        Vendor binds per CONNECTION, not per class: the profile is resolved
-        from the (already cached) ``_service_root`` via the discovery
-        classifier, so resolution costs ZERO extra BMC round trips when the
-        root was fetched anyway. Plumbing seam — the chokepoint call sites
-        delegate here in the implementation pass; nothing calls this yet.
+        Vendor binds per CONNECTION, not per class. Resolution never performs
+        I/O of its own (a probe here would spend a BMC round trip — and consume
+        stubbed transports in offline suites); it consults, in order:
+
+        1. the connection cache — a prior classification on this (host, port),
+           shared by every command singleton on the connection;
+        2. the ``_service_root`` document, ONLY when some earlier call already
+           fetched and cached it (zero extra GETs), classified via the
+           discovery classifier and then cached for the connection;
+        3. the class-declared ``_default_profile_vendor`` — today's behavior
+           for a connection nothing has probed (not cached: a presumption is
+           not evidence, so a later real classification can still win).
 
         :return: the connection's ``DmtfProfile`` (or vendor subclass) instance.
         """
-        # Imports live here so the module graph is unchanged until first use;
-        # importing dell_profile guarantees the Dell registration is present.
+        # Imports live here so the module graph stays acyclic (vendor_profile
+        # imports this module); importing dell_profile guarantees the Dell
+        # registration is present.
         from . import dell_profile  # noqa: F401  (registration side effect)
-        from .vendor_profile import profile_for_connection
-        return profile_for_connection(
-            self._host if hasattr(self, "_host") else self._redfish_ip,
-            self._port, lambda: self._service_root)
+        from .vendor_profile import (
+            cached_profile,
+            profile_for_connection,
+            resolve_profile,
+        )
+        cached = cached_profile(self._host, self._port)
+        if cached is not None:
+            return cached
+        if "_service_root" in self.__dict__:
+            return profile_for_connection(
+                self._host, self._port, lambda: self._service_root)
+        return resolve_profile(type(self)._default_profile_vendor)
 
     @cached_property
     def redfish_version(self) -> str:
@@ -979,28 +1056,23 @@ class RedfishManager:
 
     @staticmethod
     def default_error_handler(response) -> RedfishApiRespond:
-        """Default error handler.
-        :param response:
-        :return:
+        """Default error handler, the DMTF (vendor-neutral) decode.
+
+        The body moved to ``DmtfProfile.error_handler`` (the vendor-profile
+        chokepoint set); this stays a @staticmethod because callers invoke it
+        unbound as ``RedfishManager.default_error_handler(resp)``, and always
+        decodes with DMTF semantics. Per-connection vendor dispatch happens in
+        ``IDracManager.default_error_handler``, which routes through
+        ``self.vendor_profile`` — the layer every registered command inherits.
+
+        :param response: the HTTP response to classify.
+        :return: the folded ``RedfishApiRespond`` for a 2xx status.
+        :raises RedfishUnauthorized: on HTTP 401.
+        :raises RedfishForbidden: on HTTP 403.
+        :raises ResourceNotFound: on any other non-2xx, with the parsed error.
         """
-        if response.status_code == 200:
-            return RedfishApiRespond.Ok
-        if response.status_code == 202:
-            return RedfishApiRespond.AcceptedTaskGenerated
-        if response.status_code == 204:
-            return RedfishApiRespond.Success
-        if 200 <= response.status_code < 300:
-            return RedfishApiRespond.Success
-        if response.status_code == 401:
-            raise RedfishUnauthorized("Unauthorized access")
-        elif response.status_code == 403:
-            raise RedfishForbidden("access forbidden")
-        elif response.status_code == 404:
-            error_msg = RedfishManager.parse_error(response)
-            raise ResourceNotFound(error_msg)
-        else:
-            error_msg = RedfishManager.parse_error(response)
-            raise ResourceNotFound(error_msg)
+        from .vendor_profile import DmtfProfile
+        return DmtfProfile.instance().error_handler(response)
 
     @staticmethod
     def value_from_json_list(json_obj, k: str):
@@ -1078,32 +1150,19 @@ class RedfishManager:
 
         return job_id
 
-    @staticmethod
-    def job_id_from_respond(
-            response: requests.models.Response) -> str:
-        """Try to parse job id from HTTP respond, otherwise empty string
-        :param response: requests.models.Response
-        :return: str: a job id or empty string
-        """
-        try:
-            if response is not None and hasattr(response, "__dict__"):
-                response_dict = str(response.__dict__)
-                if response_dict is not None and len(response_dict) > 0:
-                    job_id = re.search("JID_.+?,", response_dict)
-                    if job_id is not None:
-                        job_id = job_id.group(0)
-                    return job_id
-        except AttributeError as attr_err:
-            logging.debug(f"could not read job id from respond object: {attr_err}")
-
-        return ""
-
     def parse_task_id(self, data) -> str:
         """Parses input data and try to get a
         job id from the http header or http response.
 
+        Unwraps a ``CommandResult``'s ``extra`` or a raw response, then
+        delegates the extraction to the connection's vendor profile: the DMTF
+        form reads the ``Location`` header only; the Dell profile adds the
+        ``JID_`` body-scrape fallback (the regex that used to live here — the
+        neutral layer now holds no Dell literal).
+
         :param data:  http response or CommandResult
         :return: job_id or empty string.
+        :raises ValueError: when ``data`` is neither of the accepted shapes.
         """
         # get response from extra
         if data is None:
@@ -1120,66 +1179,26 @@ class RedfishManager:
         if resp is None:
             return ""
 
-        # this based on spec
-        try:
-            job_id = self.job_id_from_header(resp)
-            logging.debug(f"idrac api returned job_id: {job_id} in the response header.")
-            return job_id
-        # optional lookup, fall through to the response body below.
-        except TaskIdUnavailable as header_err:
-            logging.debug(f"no job id in the response header: {header_err}")
-
-        # this from response
-        try:
-            # try to get from the response, it an optional check.
-            job_id = self.job_id_from_respond(resp)
-            logging.debug(f"idrac api returned job_id: {job_id} in the response header.")
-        except TaskIdUnavailable as respond_err:
-            logging.debug(f"no job id in the response body: {respond_err}")
-
-        return ""
+        return self.vendor_profile.parse_task_id(resp)
 
     def get_task_state(
             self, resp: requests.models.Response
     ) -> Tuple[Optional[TaskState], Optional[TaskStatus]]:
-        """Parse a DMTF ``#Task`` response into its state and status.
+        """Parse a task response into its state and status, per vendor profile.
 
-        Reads the generic ``TaskState``/``TaskStatus`` properties a Redfish
-        ``TaskService`` serves on ``/redfish/v1/TaskService/Tasks/{id}``. Unlike
-        the Dell ``IDracManager.get_task_state``, it never consults the
-        ``/Oem/Dell/Jobs`` ``JobState`` and raises nothing on a missing key: an
-        absent, non-JSON, or non-spec value maps to ``None`` so the caller keeps
-        its last observed state.
+        Delegates to the connection's vendor profile: the DMTF form reads the
+        generic ``TaskState``/``TaskStatus`` properties and raises nothing on a
+        missing key (an absent, non-JSON, or non-spec value maps to ``None``);
+        the Dell profile parses the iDRAC vocabulary and raises
+        ``UnexpectedResponse`` when neither state nor status is present.
 
         :param resp: a requests.models.Response holding a ``#Task`` body.
         :return: a ``(TaskState, TaskStatus)`` tuple; either element is ``None``
             when the body is not a JSON object, the key is absent, or the value
-            is not a DMTF-defined enum member.
+            is not a DMTF-defined enum member. The Dell profile returns the
+            ``(IdracTaskState, IdracTaskStatus)`` vocabulary instead.
         """
-        try:
-            data = resp.json()
-        except requests.exceptions.JSONDecodeError as json_err:
-            self.logger.debug(f"task response carried no json body: {json_err}")
-            return None, None
-        if not isinstance(data, dict):
-            return None, None
-
-        def _coerce(enum_cls, value):
-            """Return the enum member for a wire value, or None if not a member.
-
-            :param enum_cls: the enum class to coerce into (TaskState / TaskStatus).
-            :param value: the raw wire value read from the #Task body.
-            :return: the matching enum member, or None when value is not a member.
-            """
-            try:
-                return enum_cls(value)
-            except ValueError:
-                return None
-
-        return (
-            _coerce(TaskState, data.get(RedfishJson.TaskState)),
-            _coerce(TaskStatus, data.get(RedfishJson.TaskStatus)),
-        )
+        return self.vendor_profile.get_task_state(self, resp)
 
     def fetch_task(
             self,
@@ -1188,16 +1207,14 @@ class RedfishManager:
             wait_for_state: Optional[TaskState] = None,
             timeout: Optional[float] = None,
     ) -> Optional[TaskState]:
-        """Poll the generic DMTF ``TaskService`` until a task finishes.
+        """Poll one task until it finishes, per the connection's vendor profile.
 
-        Blocks on ``GET /redfish/v1/TaskService/Tasks/{task_id}``, following the
-        Redfish task-monitor semantics: ``202 Accepted`` while the task runs,
-        ``200 OK`` once it carries a state, ``404``/``410`` when a cancelled task
-        is reaped. Returns as soon as the task reaches a terminal state
-        (Completed/Killed/Cancelled/Exception) or the optional ``wait_for_state``.
-        This is the vendor-neutral counterpart to ``IDracManager.fetch_task``,
-        which additionally consults the Dell OEM ``/Oem/Dell/Jobs`` job model;
-        here only the specification's ``TaskService`` is polled.
+        Delegates to the vendor profile resolved for this connection: the DMTF
+        form blocks on ``GET /redfish/v1/TaskService/Tasks/{task_id}`` following
+        the Redfish task-monitor semantics (``202`` while running, ``200`` once
+        a state is carried, ``404``/``410`` when a cancelled task is reaped);
+        the Dell profile additionally consults the OEM ``/Oem/Dell/Jobs`` job
+        model first. Same-signature delegate — existing callers are unchanged.
 
         :param task_id: the ``Id`` of the task, as returned when it was created.
         :param sleep_time: seconds to wait between polls; a server ``Retry-After``
@@ -1207,59 +1224,12 @@ class RedfishManager:
         :param timeout: optional wall-clock budget in seconds; ``None`` waits
             until a terminal state or the task is reaped.
         :return: the last observed :class:`TaskState`, or ``None`` if the task
-            never reported a recognised state.
+            never reported a recognised state (Dell returns its own vocabulary).
         :raise AuthenticationFailed: if the service returns HTTP 401.
         """
-        url = f"{self._default_method}{self.redfish_ip}{RedfishApi.Tasks}{task_id}"
-        started = time.monotonic()
-        task_state: Optional[TaskState] = None
-        poll_count = 0
-
-        # One INTERNAL span for the whole poll; each api_get_call below nests as a
-        # CLIENT child automatically because the OTel context is the call stack.
-        with tracing.poll_task_span() as poll_span:
-            try:
-                while True:
-                    resp = self.api_get_call(url, {})
-                    poll_count += 1
-                    code = resp.status_code
-
-                    if code == 401:
-                        raise AuthenticationFailed("task service returned 401.")
-                    # A reaped/cancelled task monitor returns 410 Gone or 404 Not
-                    # Found; a 5xx ends the wait. Keep the last state seen.
-                    if code in (404, 410) or code >= 500:
-                        self.logger.info(
-                            f"task {task_id} monitor returned {code}; stopping poll."
-                        )
-                        break
-
-                    state, _status = self.get_task_state(resp)
-                    if state is not None:
-                        task_state = state
-                    if wait_for_state is not None and task_state == wait_for_state:
-                        break
-                    if task_state in TERMINAL_TASK_STATES:
-                        break
-
-                    try:
-                        retry_after = int(resp.headers.get("Retry-After", 0) or 0)
-                    except (TypeError, ValueError):
-                        retry_after = 0
-                    delay = max(int(sleep_time or 0), retry_after)
-
-                    if timeout is not None and (time.monotonic() - started) >= timeout:
-                        self.logger.info(
-                            f"task {task_id} poll timed out after {timeout}s."
-                        )
-                        break
-                    time.sleep(delay)
-            finally:
-                self._set_poll_span_attributes(
-                    poll_span, poll_count, sleep_time, started, task_state
-                )
-
-        return task_state
+        return self.vendor_profile.fetch_task(
+            self, task_id, sleep_time=sleep_time,
+            wait_for_state=wait_for_state, timeout=timeout)
 
     @staticmethod
     def _set_poll_span_attributes(span, poll_count, sleep_time, started, task_state):

--- a/redfish_ctl/redfish_manager.py
+++ b/redfish_ctl/redfish_manager.py
@@ -167,11 +167,13 @@ class RedfishManager:
         Transitional (one wave): direct constructions still pass
         ``redfish_ip``/``idrac_ip``-style keywords; they arrive via ``**kwargs``
         and are popped here so exactly ONE canonical value is stored. The
-        canonical parameter wins whenever it differs from its default.
+        canonical parameter wins whenever it was passed (is not None) — the
+        precedence the pre-cleanup Dell constructor pinned; an alias fills in
+        only when the canonical was omitted, and the default applies last.
 
         :param kwargs: the constructor's ``**kwargs`` (aliases are popped).
-        :param value: the canonical parameter value as passed.
-        :param default: the canonical parameter's default.
+        :param value: the canonical parameter value as passed, or None.
+        :param default: the value used when neither spelling was passed.
         :param aliases: legacy keyword names, highest precedence first.
         :return: the resolved value.
         """
@@ -180,15 +182,17 @@ class RedfishManager:
             popped = kwargs.pop(name, None)
             if alias_value is None:
                 alias_value = popped
-        if value == default and alias_value is not None:
+        if value is not None:
+            return value
+        if alias_value is not None:
             return alias_value
-        return value
+        return default
 
     def __init__(self,
-                 host: Optional[str] = "",
-                 username: Optional[str] = "root",
-                 password: Optional[str] = "",
-                 port: Optional[int] = 443,
+                 host: Optional[str] = None,
+                 username: Optional[str] = None,
+                 password: Optional[str] = None,
+                 port: Optional[int] = None,
                  insecure: Optional[bool] = True,
                  is_http: Optional[bool] = False,
                  x_auth: Optional[str] = None,
@@ -199,10 +203,10 @@ class RedfishManager:
            By default, Redfish Manager uses json to serialize a data to callee
            and uses json content type.
 
-        :param host: BMC IP or hostname.
-        :param username: BMC account username; default is root.
-        :param password: BMC account password.
-        :param port: BMC TCP port (default 443); accepts an int or str.
+        :param host: BMC IP or hostname; effective default is an empty string.
+        :param username: BMC account username; effective default is ``root``.
+        :param password: BMC account password; effective default is empty.
+        :param port: BMC TCP port; effective default 443; accepts int or str.
         :param insecure: when True (the default) TLS certificate verification is
             skipped. BMCs ship self-signed certificates, so verification is
             opt-in: pass ``insecure=False`` to verify the server certificate.
@@ -211,8 +215,8 @@ class RedfishManager:
         :param is_debug: when True, include exception tracebacks in error logs.
         :param kwargs: extensibility per the constructor contract; legacy
             ``redfish_*``/``idrac_*`` connection aliases are still accepted
-            here for one wave (the canonical spelling wins on conflict), then
-            they live only at the CLI/env edge (config.py, argparse).
+            here for one wave (a passed canonical spelling wins on conflict),
+            then they live only at the CLI/env edge (config.py, argparse).
         """
         host = self._coalesce_ctor_alias(
             kwargs, host, "", "redfish_ip", "idrac_ip")
@@ -360,10 +364,10 @@ class RedfishManager:
         _redfish_cache = kwargs.pop("redfish_cache", None)
 
         inst = disp(
-            host=_host,
-            username=_username,
-            password=_password,
-            port=_port,
+            idrac_ip=_host,
+            idrac_username=_username,
+            idrac_password=_password,
+            idrac_port=_port,
             insecure=_insecure,
             is_http=_is_http
         )
@@ -409,10 +413,10 @@ class RedfishManager:
         module_logger.debug(f"dispatching {name} to Redfish port {_port}")
 
         inst = disp(
-            host=_host,
-            username=_username,
-            password=_password,
-            port=_port,
+            idrac_ip=_host,
+            idrac_username=_username,
+            idrac_password=_password,
+            idrac_port=_port,
             insecure=_insecure,
             is_http=_is_http
         )

--- a/redfish_ctl/vendor_profile.py
+++ b/redfish_ctl/vendor_profile.py
@@ -23,10 +23,26 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from typing import Callable, Dict, Optional, Tuple, Type
 
+import requests
+
+from .cmd_exceptions import AuthenticationFailed, ResourceNotFound
 from .discover.classifier import classify_vendor
-from .redfish_exceptions import ProfileRegistrationCollision
+from .redfish_exceptions import (
+    ProfileRegistrationCollision,
+    RedfishForbidden,
+    RedfishUnauthorized,
+)
+from .redfish_shared import (
+    RedfishApi,
+    RedfishApiRespond,
+    RedfishJson,
+    RedfishJsonSpec,
+)
+from .redfish_task_state import TERMINAL_TASK_STATES, TaskState, TaskStatus
+from .telemetry import tracing
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +139,22 @@ def profile_for_connection(host: str, port: int,
         return _PROFILE_CACHE.setdefault(key, profile)
 
 
+def cached_profile(host: str, port: int) -> Optional["DmtfProfile"]:
+    """Return the connection's cached profile without probing or caching.
+
+    A pure peek: unlike :func:`profile_for_connection` it never loads a
+    ServiceRoot and never writes the cache, so a caller can consult prior
+    evidence (an earlier classification on this connection) before deciding
+    how to resolve.
+
+    :param host: BMC host or IP (the cache key with ``port``).
+    :param port: BMC port.
+    :return: the cached profile instance, or None when never classified.
+    """
+    with _CACHE_LOCK:
+        return _PROFILE_CACHE.get((host, int(port)))
+
+
 def clear_profile_cache() -> None:
     """Reset the connection cache and fallback counters (test isolation)."""
     with _CACHE_LOCK:
@@ -157,77 +189,214 @@ class DmtfProfile:
             inst = cls._instances[cls] = cls()
         return inst
 
-    def decode_status(self, status_code: int):
+    #: DMTF status rows (no 201=Created — Created is a Dell addition; the
+    #: neutral enum has no such member, per architecture.yaml state_decode).
+    _status_map = {
+        200: RedfishApiRespond.Ok,
+        202: RedfishApiRespond.AcceptedTaskGenerated,
+        204: RedfishApiRespond.Success,
+    }
+
+    def decode_status(self, status_code: int) -> RedfishApiRespond:
         """Fold an HTTP status code into the neutral RedfishApiRespond signal.
 
-        CHIP: relocate the DMTF mapping (200/202/204 rows, NO 201=Created) —
-        source: the neutral rows of ``idrac_manager.py`` ``_http_code_mapping``
-        (:186-191) minus the Dell 201 row, per architecture.yaml state_decode.
+        The DMTF mapping (200/202/204 rows, any other 2xx folds to Success)
+        relocated from the success branch of the neutral
+        ``default_error_handler``; the Dell-only 201=Created row lives in
+        :class:`~redfish_ctl.dell_profile.DellProfile`.
 
         :param status_code: HTTP status from a BMC response.
-        :return: the ``RedfishApiRespond`` signal.
-        :raises NotImplementedError: until the implementation pass lands.
+        :return: the ``RedfishApiRespond`` signal; ``Error`` for any non-2xx
+            (the raising path is :meth:`error_handler`).
         """
-        raise NotImplementedError("CHIP: relocate DMTF status map "
-                                  "(idrac_manager.py:186-191 minus 201)")
+        if 200 <= status_code < 300:
+            return self._status_map.get(status_code, RedfishApiRespond.Success)
+        return RedfishApiRespond.Error
 
-    def error_handler(self, response, expected=None):
-        """Decode a response into (signal, error) per DMTF semantics.
+    def error_handler(self, response, manager=None, expected=None):
+        """Decode a response per DMTF semantics: fold 2xx, raise typed errors.
 
-        CHIP: relocate the NEUTRAL ``default_error_handler`` body —
-        source: ``redfish_manager.py:961`` (a @staticmethod today; every call
-        site is self-bound, so the conversion is safe per the judge audit).
+        Body relocated from the neutral ``RedfishManager.default_error_handler``
+        (a @staticmethod, kept as a thin delegate to this method): 2xx folds via
+        :meth:`decode_status`; 401/403 raise the neutral exceptions; every other
+        error raises ``ResourceNotFound`` carrying the parsed RedfishError
+        envelope.
 
         :param response: the ``requests.Response`` to decode.
-        :param expected: optional expected-status override(s).
-        :return: the decoded signal (matching the current chokepoint contract).
-        :raises NotImplementedError: until the implementation pass lands.
+        :param manager: optional connection manager; unused by the neutral
+            profile (the Dell override records the parsed error on it).
+        :param expected: reserved expected-status override; unused today.
+        :return: the folded ``RedfishApiRespond`` for a 2xx status.
+        :raises RedfishUnauthorized: on HTTP 401.
+        :raises RedfishForbidden: on HTTP 403.
+        :raises ResourceNotFound: on any other non-2xx status, carrying the
+            parsed ``RedfishError`` envelope.
         """
-        raise NotImplementedError("CHIP: relocate neutral default_error_handler "
-                                  "(redfish_manager.py:961)")
+        code = response.status_code
+        if 200 <= code < 300:
+            return self.decode_status(code)
+        if code == 401:
+            raise RedfishUnauthorized("Unauthorized access")
+        if code == 403:
+            raise RedfishForbidden("access forbidden")
+        from .redfish_manager import RedfishManager
+        error_msg = RedfishManager.parse_error(response)
+        raise ResourceNotFound(error_msg)
 
-    def parse_task_id(self, response):
-        """Extract a task/job id from a 202-style response, DMTF form.
+    def parse_task_id(self, response) -> str:
+        """Extract a task id from a 202-style response, Location header ONLY.
 
-        CHIP: relocate Location-header parsing ONLY (``job_id_from_header``,
-        redfish_manager.py:1038); the JID_ body-scrape at redfish_manager.py:1072
-        moves to :class:`~redfish_ctl.dell_profile.DellProfile` — after this
-        relocation the NEUTRAL layer contains no Dell literal (pays the
-        known_debt row in architecture.yaml state_decode).
+        The DMTF form per DSP0266: the task monitor URI rides the ``Location``
+        header and the id is its last segment (relocated from
+        ``job_id_from_header``). There is deliberately no body scrape here —
+        the ``JID_`` scrape is Dell-only and lives in
+        :class:`~redfish_ctl.dell_profile.DellProfile`, so the neutral layer
+        holds no Dell literal.
 
-        :param response: the response carrying Location header and/or body.
-        :return: the task id string, or None when the response names none.
-        :raises NotImplementedError: until the implementation pass lands.
+        :param response: the response carrying the Location header.
+        :return: the task id string, or an empty string when absent.
         """
-        raise NotImplementedError("CHIP: relocate job_id_from_header "
-                                  "(redfish_manager.py:1038); JID_ goes to Dell")
+        if response is None:
+            return ""
+        resp_hdr = response.headers
+        if RedfishJsonSpec.Location not in resp_hdr:
+            logging.debug("no task id in the response header "
+                          "(not every api creates a task).")
+            return ""
+        location = resp_hdr[RedfishJsonSpec.Location]
+        job_id = location.split("/")[-1]
+        logging.debug(f"api returned task id {job_id} in the response header.")
+        return job_id
 
-    def fetch_task(self, manager, task_id: str, **kwargs):
+    def fetch_task(self, manager, task_id: str, sleep_time: int = 10,
+                   wait_for_state: Optional[TaskState] = None,
+                   timeout: Optional[float] = None, **kwargs):
         """Poll one task to a terminal state, DMTF ``/TaskService/Tasks/{id}``.
 
-        CHIP: relocate the neutral fetch path (redfish_manager.py:1164 region)
-        — transport stays on ``manager`` (the profile is stateless; it borrows
-        the connection, mirroring how commands call ``self.base_query``).
+        Body relocated from the neutral ``RedfishManager.fetch_task``:
+        202 while running, 200 once a state is carried, 404/410 when a
+        cancelled task is reaped, ``Retry-After`` honored when larger than
+        ``sleep_time``. Transport stays on ``manager`` (the profile is
+        stateless; it borrows the connection).
 
         :param manager: the connection's manager (transport provider).
-        :param task_id: the task id to poll.
-        :return: the terminal task payload (matching the current contract).
-        :raises NotImplementedError: until the implementation pass lands.
+        :param task_id: the ``Id`` of the task, as returned when created.
+        :param sleep_time: seconds between polls; ``Retry-After`` wins when larger.
+        :param wait_for_state: return as soon as this state is observed.
+        :param timeout: optional wall-clock budget in seconds.
+        :param kwargs: tolerated cross-vendor keywords (e.g. the Dell form's
+            ``wait_for``); not consulted by the DMTF poll.
+        :return: the last observed :class:`TaskState`, or ``None`` if the task
+            never reported a recognised state.
+        :raise AuthenticationFailed: if the service returns HTTP 401.
         """
-        raise NotImplementedError("CHIP: relocate neutral fetch_task "
-                                  "(redfish_manager.py:1164)")
+        url = f"{manager._default_method}{manager.redfish_ip}{RedfishApi.Tasks}{task_id}"
+        started = time.monotonic()
+        task_state: Optional[TaskState] = None
+        poll_count = 0
 
-    def get_task_state(self, manager, task_id: str, **kwargs):
-        """Read one task's current state, DMTF TaskState vocabulary.
+        # One INTERNAL span for the whole poll; each api_get_call below nests
+        # as a CLIENT child automatically (the OTel context is the call stack).
+        with tracing.poll_task_span() as poll_span:
+            try:
+                while True:
+                    resp = manager.api_get_call(url, {})
+                    poll_count += 1
+                    code = resp.status_code
 
-        CHIP: neutral counterpart of the Dell override at idrac_manager.py:374.
+                    if code == 401:
+                        raise AuthenticationFailed("task service returned 401.")
+                    # A reaped/cancelled task monitor returns 410 Gone or 404
+                    # Not Found; a 5xx ends the wait. Keep the last state seen.
+                    if code in (404, 410) or code >= 500:
+                        manager.logger.info(
+                            f"task {task_id} monitor returned {code}; stopping poll."
+                        )
+                        break
+
+                    state, _status = self.get_task_state(manager, resp)
+                    if state is not None:
+                        task_state = state
+                    if wait_for_state is not None and task_state == wait_for_state:
+                        break
+                    if task_state in TERMINAL_TASK_STATES:
+                        break
+
+                    try:
+                        retry_after = int(resp.headers.get("Retry-After", 0) or 0)
+                    except (TypeError, ValueError):
+                        retry_after = 0
+                    delay = max(int(sleep_time or 0), retry_after)
+
+                    if timeout is not None and (time.monotonic() - started) >= timeout:
+                        manager.logger.info(
+                            f"task {task_id} poll timed out after {timeout}s."
+                        )
+                        break
+                    time.sleep(delay)
+            finally:
+                manager._set_poll_span_attributes(
+                    poll_span, poll_count, sleep_time, started, task_state
+                )
+
+        return task_state
+
+    def get_task_state(self, manager, resp):
+        """Parse a DMTF ``#Task`` response into its state and status.
+
+        Body relocated from the neutral ``RedfishManager.get_task_state``:
+        reads the generic ``TaskState``/``TaskStatus`` properties and raises
+        nothing on a missing key — an absent, non-JSON, or non-spec value maps
+        to ``None`` so the caller keeps its last observed state.
+
+        :param manager: the connection's manager (logging provider).
+        :param resp: a requests.models.Response holding a ``#Task`` body.
+        :return: a ``(TaskState, TaskStatus)`` tuple; either element is ``None``
+            when the body is not a JSON object, the key is absent, or the value
+            is not a DMTF-defined enum member.
+        """
+        try:
+            data = resp.json()
+        except requests.exceptions.JSONDecodeError as json_err:
+            manager.logger.debug(f"task response carried no json body: {json_err}")
+            return None, None
+        if not isinstance(data, dict):
+            return None, None
+
+        def _coerce(enum_cls, value):
+            """Return the enum member for a wire value, or None if not a member.
+
+            :param enum_cls: the enum class to coerce into (TaskState / TaskStatus).
+            :param value: the raw wire value read from the #Task body.
+            :return: the matching enum member, or None when value is not a member.
+            """
+            try:
+                return enum_cls(value)
+            except ValueError:
+                return None
+
+        return (
+            _coerce(TaskState, data.get(RedfishJson.TaskState)),
+            _coerce(TaskStatus, data.get(RedfishJson.TaskStatus)),
+        )
+
+    def get_job(self, manager, job_id: str, data_type: str = "json",
+                do_async: bool = False):
+        """Read one task from the DMTF ``TaskService`` (the neutral job read).
+
+        The vendor-neutral counterpart of the Dell OEM job read: a task on a
+        DMTF service lives at ``/redfish/v1/TaskService/Tasks/{id}`` — there is
+        no ``/Oem/Dell/Jobs`` on a non-Dell box, so routing a job read through
+        the profile is what keeps a Dell OEM URL off foreign BMCs.
 
         :param manager: the connection's manager (transport provider).
-        :param task_id: the task id to read.
-        :return: the task state (matching the current contract).
-        :raises NotImplementedError: until the implementation pass lands.
+        :param job_id: the task id to read.
+        :param data_type: accepted for signature parity with the Dell form.
+        :param do_async: when True the read subscribes to an event loop.
+        :return: the task payload dict from the service.
         """
-        raise NotImplementedError("CHIP: neutral get_task_state (DMTF TaskState)")
+        r = f"{RedfishApi.Tasks}{job_id}"
+        return manager.base_query(r, do_expanded=True, do_async=do_async).data
 
 
 class SupermicroProfile(DmtfProfile):

--- a/redfish_ctl/vendor_profile.py
+++ b/redfish_ctl/vendor_profile.py
@@ -1,0 +1,261 @@
+"""Vendor profiles: per-connection strategy objects owning the vendor chokepoints.
+
+A VendorProfile binds vendor semantics at the axis vendor actually varies on —
+the CONNECTION — instead of class ancestry. The profile owns ONLY the
+chokepoints (status decode, task-id parsing, task/job polling); the neutral
+manager delegates to it, and the ~200 registered command classes never change.
+:class:`DmtfProfile` is the shared base (the DMTF lower denominator); a vendor
+profile overrides only what that vendor genuinely diverges on. Profiles are
+stateless singletons resolved once per connection from the ServiceRoot via the
+existing ``discover.classifier.classify_vendor`` ladder and cached by
+connection fingerprint.
+
+Design record: ``.internal/design-notes/2026-07-24-vendor-dispatch-panel.json``
+(chokepoint-strategy, both judges concur). The chokepoint method BODIES are
+relocated from the managers by the implementation pass; each seam below names
+its exact source anchor. Plumbing-complete today: registration (loud collision),
+resolution (observable generic fallback), ServiceRoot detection, and the
+connection cache.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Callable, Dict, Optional, Tuple, Type
+
+from .discover.classifier import classify_vendor
+from .redfish_exceptions import ProfileRegistrationCollision
+
+logger = logging.getLogger(__name__)
+
+# vendor key -> profile class. Written only by register_profile().
+_PROFILE_REGISTRY: Dict[str, Type["DmtfProfile"]] = {}
+
+# Observable fallback: how many times an unknown vendor fell back to generic,
+# keyed by the unknown vendor string. A silent wrong-profile resolution is the
+# design's worst failure mode; this counter plus one log line makes it loud.
+FALLBACK_COUNTS: Dict[str, int] = {}
+
+# (host, port) -> resolved profile instance; one probe per connection.
+_PROFILE_CACHE: Dict[Tuple[str, int], "DmtfProfile"] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def register_profile(vendor: str, profile_cls: Type["DmtfProfile"]) -> None:
+    """Register a profile class for a vendor key.
+
+    :param vendor: lowercase vendor key (``dell``, ``supermicro``, ...).
+    :param profile_cls: the profile class serving that vendor.
+    :raises ProfileRegistrationCollision: when the key is already registered
+        to a DIFFERENT class — import-time and loud, never last-write-wins.
+    """
+    existing = _PROFILE_REGISTRY.get(vendor)
+    if existing is not None and existing is not profile_cls:
+        raise ProfileRegistrationCollision(
+            f"vendor profile {vendor!r} already registered to "
+            f"{existing.__module__}.{existing.__qualname__}; refusing "
+            f"{profile_cls.__module__}.{profile_cls.__qualname__}")
+    _PROFILE_REGISTRY[vendor] = profile_cls
+
+
+def resolve_profile(vendor: str) -> "DmtfProfile":
+    """Return the profile instance for a vendor key, falling back to generic.
+
+    The generic fallback is OBSERVABLE: it increments
+    :data:`FALLBACK_COUNTS` and logs one structured line, so a misdetected
+    box (the worst failure mode) is counted and visible, never silent.
+
+    :param vendor: vendor key from detection or an explicit override.
+    :return: the vendor's profile instance, or the generic profile.
+    """
+    profile_cls = _PROFILE_REGISTRY.get(vendor)
+    if profile_cls is None:
+        FALLBACK_COUNTS[vendor] = FALLBACK_COUNTS.get(vendor, 0) + 1
+        logger.warning("vendor_profile fallback: vendor=%r has no registered "
+                       "profile; using generic (count=%d)",
+                       vendor, FALLBACK_COUNTS[vendor])
+        profile_cls = _PROFILE_REGISTRY["generic"]
+    return profile_cls.instance()
+
+
+def profile_for_service_root(service_root: Optional[dict]) -> "DmtfProfile":
+    """Resolve a profile from a parsed ServiceRoot document.
+
+    Detection REUSES ``discover.classifier.classify_vendor`` (Oem child key ->
+    ``@odata.type`` -> Manufacturer/Vendor text, never raises).
+
+    :param service_root: parsed ``/redfish/v1`` document, or None.
+    :return: the matching profile instance (generic when unidentifiable).
+    """
+    vendor = classify_vendor(service_root)
+    profile = resolve_profile(vendor)
+    logger.debug("vendor_profile resolved vendor=%s profile=%s",
+                 vendor, type(profile).__name__)
+    return profile
+
+
+def profile_for_connection(host: str, port: int,
+                           service_root_loader: Callable[[], Optional[dict]],
+                           vendor_override: Optional[str] = None) -> "DmtfProfile":
+    """Return the cached profile for a connection, probing at most once.
+
+    :param host: BMC host or IP (the cache key with ``port``).
+    :param port: BMC port.
+    :param service_root_loader: zero-argument callable returning the parsed
+        ServiceRoot (the manager passes its cached ``_service_root`` property,
+        so a connection that already fetched the root pays ZERO extra GETs).
+    :param vendor_override: explicit vendor (``--vendor``/``REDFISH_VENDOR``);
+        skips the probe entirely when set.
+    :return: the connection's profile instance.
+    """
+    key = (host, int(port))
+    with _CACHE_LOCK:
+        cached = _PROFILE_CACHE.get(key)
+    if cached is not None:
+        return cached
+    if vendor_override:
+        profile = resolve_profile(vendor_override)
+    else:
+        profile = profile_for_service_root(service_root_loader())
+    with _CACHE_LOCK:
+        return _PROFILE_CACHE.setdefault(key, profile)
+
+
+def clear_profile_cache() -> None:
+    """Reset the connection cache and fallback counters (test isolation)."""
+    with _CACHE_LOCK:
+        _PROFILE_CACHE.clear()
+    FALLBACK_COUNTS.clear()
+
+
+class DmtfProfile:
+    """The DMTF lower-denominator chokepoint set — the shared profile base.
+
+    Stateless; one instance per class (see :meth:`instance`). A vendor profile
+    subclasses this and overrides ONLY the chokepoints that vendor genuinely
+    diverges on. Method bodies marked CHIP are relocated from the managers by
+    the implementation pass — the anchors are exact and the signatures are the
+    contract; plumbing keeps them NotImplemented so a half-wired tree fails
+    loudly instead of running half-moved semantics.
+    """
+
+    #: vendor key this profile serves; subclasses override.
+    vendor: str = "generic"
+
+    _instances: Dict[type, "DmtfProfile"] = {}
+
+    @classmethod
+    def instance(cls) -> "DmtfProfile":
+        """Return the class's shared stateless instance.
+
+        :return: the one instance of ``cls`` (profiles carry no state).
+        """
+        inst = cls._instances.get(cls)
+        if inst is None:
+            inst = cls._instances[cls] = cls()
+        return inst
+
+    def decode_status(self, status_code: int):
+        """Fold an HTTP status code into the neutral RedfishApiRespond signal.
+
+        CHIP: relocate the DMTF mapping (200/202/204 rows, NO 201=Created) —
+        source: the neutral rows of ``idrac_manager.py`` ``_http_code_mapping``
+        (:186-191) minus the Dell 201 row, per architecture.yaml state_decode.
+
+        :param status_code: HTTP status from a BMC response.
+        :return: the ``RedfishApiRespond`` signal.
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate DMTF status map "
+                                  "(idrac_manager.py:186-191 minus 201)")
+
+    def error_handler(self, response, expected=None):
+        """Decode a response into (signal, error) per DMTF semantics.
+
+        CHIP: relocate the NEUTRAL ``default_error_handler`` body —
+        source: ``redfish_manager.py:961`` (a @staticmethod today; every call
+        site is self-bound, so the conversion is safe per the judge audit).
+
+        :param response: the ``requests.Response`` to decode.
+        :param expected: optional expected-status override(s).
+        :return: the decoded signal (matching the current chokepoint contract).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate neutral default_error_handler "
+                                  "(redfish_manager.py:961)")
+
+    def parse_task_id(self, response):
+        """Extract a task/job id from a 202-style response, DMTF form.
+
+        CHIP: relocate Location-header parsing ONLY (``job_id_from_header``,
+        redfish_manager.py:1038); the JID_ body-scrape at redfish_manager.py:1072
+        moves to :class:`~redfish_ctl.dell_profile.DellProfile` — after this
+        relocation the NEUTRAL layer contains no Dell literal (pays the
+        known_debt row in architecture.yaml state_decode).
+
+        :param response: the response carrying Location header and/or body.
+        :return: the task id string, or None when the response names none.
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate job_id_from_header "
+                                  "(redfish_manager.py:1038); JID_ goes to Dell")
+
+    def fetch_task(self, manager, task_id: str, **kwargs):
+        """Poll one task to a terminal state, DMTF ``/TaskService/Tasks/{id}``.
+
+        CHIP: relocate the neutral fetch path (redfish_manager.py:1164 region)
+        — transport stays on ``manager`` (the profile is stateless; it borrows
+        the connection, mirroring how commands call ``self.base_query``).
+
+        :param manager: the connection's manager (transport provider).
+        :param task_id: the task id to poll.
+        :return: the terminal task payload (matching the current contract).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: relocate neutral fetch_task "
+                                  "(redfish_manager.py:1164)")
+
+    def get_task_state(self, manager, task_id: str, **kwargs):
+        """Read one task's current state, DMTF TaskState vocabulary.
+
+        CHIP: neutral counterpart of the Dell override at idrac_manager.py:374.
+
+        :param manager: the connection's manager (transport provider).
+        :param task_id: the task id to read.
+        :return: the task state (matching the current contract).
+        :raises NotImplementedError: until the implementation pass lands.
+        """
+        raise NotImplementedError("CHIP: neutral get_task_state (DMTF TaskState)")
+
+
+class SupermicroProfile(DmtfProfile):
+    """Supermicro chokepoints — DMTF-conformant today; the seam for quirks.
+
+    Evidenced Supermicro divergences land here (e.g. X10 legacy-era behavior);
+    empty by design until a corpus/live trace proves a divergence.
+    """
+    vendor = "supermicro"
+
+
+class HpeProfile(DmtfProfile):
+    """HPE iLO chokepoints — DMTF-conformant today; the seam for quirks."""
+    vendor = "hpe"
+
+
+class OpenBmcProfile(DmtfProfile):
+    """OpenBMC chokepoints — DMTF-conformant today; the seam for quirks."""
+    vendor = "openbmc"
+
+
+class NvidiaProfile(DmtfProfile):
+    """NVIDIA (GB300-class) chokepoints — DMTF-conformant today; quirk seam."""
+    vendor = "nvidia"
+
+
+register_profile("generic", DmtfProfile)
+register_profile("supermicro", SupermicroProfile)
+register_profile("hpe", HpeProfile)
+register_profile("openbmc", OpenBmcProfile)
+register_profile("nvidia", NvidiaProfile)

--- a/redfish_ctl/vendor_profile.py
+++ b/redfish_ctl/vendor_profile.py
@@ -314,7 +314,7 @@ class DmtfProfile:
                         )
                         break
 
-                    state, _status = self.get_task_state(manager, resp)
+                    state, _status = manager.get_task_state(resp)
                     if state is not None:
                         task_state = state
                     if wait_for_state is not None and task_state == wait_for_state:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,15 +214,18 @@ class MockRedfishService:
     # set below is what tests actually assert against and moves with the vendor.
     JOB_ID = _DELL_JOB_ID
 
-    def __init__(self, fixture_dir: Path, index=None, vendor: str = "dell"):
+    def __init__(self, fixture_dir: Path, index=None, *, vendor: str):
         """Build a mock Redfish service for one vendor's fixture tree.
 
         :param fixture_dir: directory of flattened ``_redfish_v1_*.json`` GET fixtures.
         :param index: optional prebuilt case-insensitive fixture index; the
             module default is used when omitted.
-        :param vendor: fixture-set name (e.g. ``dell``, ``supermicro``,
-            ``supermicro_x10_119``, ``generic``, ``hpe``); selects the
-            vendor-faithful task-realization shape via ``_vendor_task_id``.
+        :param vendor: REQUIRED keyword — the fixture-set lens this mock
+            serves (e.g. ``dell``, ``supermicro``, ``supermicro_x10_119``,
+            ``generic``, ``hpe``); selects the vendor-faithful
+            task-realization shape via ``_vendor_task_id``. A mock without a
+            named lens is the anti-pattern that produced cross-vendor
+            assertions, so omission is a TypeError by design.
         """
         self._dir = fixture_dir
         self._index = index if index is not None else _FIXTURE_INDEX
@@ -337,12 +340,18 @@ def _reset_command_singletons():
     (``idrac_manage_servers`` and friends) on the instance. Without a reset, the
     first vendor a command sees wins for the whole session — which only bites
     cross-vendor tests (e.g. Supermicro then HPE resolve different host ids).
-    Clearing the instance registry before each test isolates them.
+    Clearing the instance registry before each test isolates them. The
+    connection-level vendor-profile cache (``vendor_profile._PROFILE_CACHE``)
+    is cleared alongside for the same reason: a lens classified in one test
+    must not leak its profile into the next.
     """
+    from redfish_ctl import vendor_profile
     from redfish_ctl.idrac_shared import Singleton
     Singleton._instances.clear()
+    vendor_profile.clear_profile_cache()
     yield
     Singleton._instances.clear()
+    vendor_profile.clear_profile_cache()
 
 
 @pytest.fixture
@@ -353,7 +362,7 @@ def redfish_service():
     or pre-seed state. Most tests can use ``redfish_mock`` / ``redfish_api`` instead.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(_FIXTURE_DIR)
+    service = MockRedfishService(_FIXTURE_DIR, vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/dell_lc/test_dell_lc_autodiscovery_dualmode.py
+++ b/tests/dell_lc/test_dell_lc_autodiscovery_dualmode.py
@@ -33,6 +33,7 @@ def dell_lc_mock():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/dell_lc/test_dell_lc_clear_provisioning_dualmode.py
+++ b/tests/dell_lc/test_dell_lc_clear_provisioning_dualmode.py
@@ -35,6 +35,7 @@ def dell_lc_mock():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/dell_lc/test_dell_lc_os_health_update_dualmode.py
+++ b/tests/dell_lc/test_dell_lc_os_health_update_dualmode.py
@@ -31,7 +31,8 @@ def dell_lc_corpus_mock():
     :return: tuple of Redfish manager and mock service.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/dell_lc/test_dell_lc_supportassist_export_dualmode.py
+++ b/tests/dell_lc/test_dell_lc_supportassist_export_dualmode.py
@@ -38,6 +38,7 @@ def dell_lc_mock():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/dell_lc/test_dell_lc_supportassist_status_dualmode.py
+++ b/tests/dell_lc/test_dell_lc_supportassist_status_dualmode.py
@@ -37,7 +37,8 @@ def dell_lc_corpus_mock():
     :return: tuple of Redfish manager and mock service.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/delloem/test_dell_software_update_schedule_dualmode.py
+++ b/tests/delloem/test_dell_software_update_schedule_dualmode.py
@@ -40,6 +40,7 @@ def dell_software_mock():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/idrac_fixtures/_redfish_v1.json
+++ b/tests/idrac_fixtures/_redfish_v1.json
@@ -5,6 +5,12 @@
   "Id": "RootService",
   "Name": "Root Service",
   "RedfishVersion": "1.15.0",
+  "Vendor": "Dell",
+  "Oem": {
+    "Dell": {
+      "@odata.type": "#DellServiceRoot.v1_0_0.ServiceRootSummary"
+    }
+  },
   "Systems": {
     "@odata.id": "/redfish/v1/Systems"
   },

--- a/tests/logs/test_log_clear_dualmode.py
+++ b/tests/logs/test_log_clear_dualmode.py
@@ -42,6 +42,7 @@ def dell_log_mock():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/network/test_dell_network_attributes_dualmode.py
+++ b/tests/network/test_dell_network_attributes_dualmode.py
@@ -24,7 +24,8 @@ def dell_corpus_mock():
     :return: tuple of Redfish manager and mock service.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/network/test_dell_switch_port_refresh_dualmode.py
+++ b/tests/network/test_dell_switch_port_refresh_dualmode.py
@@ -39,6 +39,7 @@ def dell_switch_manager():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/oem/test_dell_card_cert_export_dualmode.py
+++ b/tests/oem/test_dell_card_cert_export_dualmode.py
@@ -26,7 +26,8 @@ ACTION_BASE = f"{CARD_SERVICE}/Actions/DelliDRACCardService"
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_dell_card_group_actions_dualmode.py
+++ b/tests/oem/test_dell_card_group_actions_dualmode.py
@@ -78,7 +78,8 @@ def dell_card_group_mock(tmp_path):
             },
         },
     )
-    service = MockRedfishService(tmp_path, index=_build_fixture_index(tmp_path))
+    service = MockRedfishService(
+        tmp_path, index=_build_fixture_index(tmp_path), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_dell_card_hw_proof_dualmode.py
+++ b/tests/oem/test_dell_card_hw_proof_dualmode.py
@@ -31,7 +31,8 @@ ACTION_TYPE = "#DelliDRACCardService.VerifyHWProofOfPossession"
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_dell_card_key_management_dualmode.py
+++ b/tests/oem/test_dell_card_key_management_dualmode.py
@@ -37,7 +37,8 @@ REKEY_TARGET = (
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_dell_card_sekm_test_dualmode.py
+++ b/tests/oem/test_dell_card_sekm_test_dualmode.py
@@ -30,7 +30,8 @@ ACTION_TYPE = "#DelliDRACCardService.TestSEKMServerConnection"
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_dell_card_test_actions_dualmode.py
+++ b/tests/oem/test_dell_card_test_actions_dualmode.py
@@ -22,7 +22,8 @@ def dell_corpus_mock():
     :return: tuple of Redfish manager and mock service.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_dell_persistent_partition_dualmode.py
+++ b/tests/oem/test_dell_persistent_partition_dualmode.py
@@ -44,6 +44,7 @@ def dell_persistent_mock():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/oem/test_dell_vflash_state_dualmode.py
+++ b/tests/oem/test_dell_vflash_state_dualmode.py
@@ -41,6 +41,7 @@ def dell_vflash_mock():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/oem/test_hpe_chassis_actions_dualmode.py
+++ b/tests/oem/test_hpe_chassis_actions_dualmode.py
@@ -21,7 +21,8 @@ def hpe_corpus_mock():
     :return: tuple of Redfish manager and mock service.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS))
+    service = MockRedfishService(
+        HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS), vendor="hpe")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_hpe_kerberos_keytab_dualmode.py
+++ b/tests/oem/test_hpe_kerberos_keytab_dualmode.py
@@ -31,7 +31,8 @@ def hpe_keytab_mock():
     :return: tuple of Redfish manager and mock service.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS))
+    service = MockRedfishService(
+        HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS), vendor="hpe")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/oem/test_hpe_test_actions_dualmode.py
+++ b/tests/oem/test_hpe_test_actions_dualmode.py
@@ -21,7 +21,8 @@ def hpe_corpus_mock():
     :return: tuple of Redfish manager and mock service.
     """
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS))
+    service = MockRedfishService(
+        HPE_CORPUS, index=_build_fixture_index(HPE_CORPUS), vendor="hpe")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/raid/test_dell_raid_blink_dualmode.py
+++ b/tests/raid/test_dell_raid_blink_dualmode.py
@@ -30,6 +30,7 @@ def dell_raid_manager():
     service = MockRedfishService(
         DELL_CORPUS,
         index=_build_fixture_index(DELL_CORPUS),
+        vendor="dell",
     )
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)

--- a/tests/raid/test_dell_raid_cancel_dualmode.py
+++ b/tests/raid/test_dell_raid_cancel_dualmode.py
@@ -24,7 +24,8 @@ ACTION_BASE = f"{RAID_SERVICE}/Actions/DellRaidService"
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/raid/test_dell_raid_clear_actions_dualmode.py
+++ b/tests/raid/test_dell_raid_clear_actions_dualmode.py
@@ -28,7 +28,8 @@ PRESERVED_TARGET = (
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/raid/test_dell_raid_foreign_config_dualmode.py
+++ b/tests/raid/test_dell_raid_foreign_config_dualmode.py
@@ -26,7 +26,8 @@ UNLOCK_TARGET = f"{RAID_SERVICE}/Actions/DellRaidService.UnLockSecureForeignConf
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/raid/test_dell_raid_pd_actions_dualmode.py
+++ b/tests/raid/test_dell_raid_pd_actions_dualmode.py
@@ -29,7 +29,8 @@ DISK_FQDD = "Disk.Bay.0:Enclosure.Internal.0-1:RAID.Integrated.1-1"
 def dell_corpus_mock():
     """Return a manager and mock service backed by the Dell XR8620t corpus."""
     requests_mock = pytest.importorskip("requests_mock")
-    service = MockRedfishService(DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS))
+    service = MockRedfishService(
+        DELL_CORPUS, index=_build_fixture_index(DELL_CORPUS), vendor="dell")
     with requests_mock.Mocker() as mocker:
         mocker.get(requests_mock.ANY, text=service.get_cb)
         mocker.patch(requests_mock.ANY, text=service.patch_cb)

--- a/tests/test_fleet_async_profiles.py
+++ b/tests/test_fleet_async_profiles.py
@@ -1,0 +1,154 @@
+"""Fleet async-workflow proof across mixed vendor lenses (C3).
+
+The deliberate fleet shape: fire an async mutation at N BMCs, collect the N
+task ids, walk away, and fetch each task later. With vendor bound per
+CONNECTION, one Dell-based command family serves a mixed fleet: the dell
+connection yields a ``JID_`` OEM job id and its fetch consults the
+``/Oem/Dell/Jobs`` queue, while every other connection yields a DMTF
+TaskService id and polls ``/redfish/v1/TaskService/Tasks/{id}`` — never a
+Dell OEM URL. Transport is stubbed at the manager seams (no network); the
+profile binding itself is real classification over each lens's committed
+ServiceRoot fixture.
+Root-module test: flat placement mirrors redfish_ctl/redfish_manager.py.
+
+Author Mus spyroot@gmail.com
+"""
+import json
+from pathlib import Path
+
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import RedfishApiRespond
+
+_TESTS_DIR = Path(__file__).resolve().parent
+
+# lens -> (ServiceRoot fixture, vendor-faithful task id). Only the dell lens
+# ever carries a JID_; the DMTF lenses use a plain TaskService monitor id.
+_FLEET = {
+    "dell": (_TESTS_DIR / "idrac_fixtures" / "_redfish_v1.json",
+             "JID_000000000001"),
+    "supermicro": (_TESTS_DIR / "supermicro_fixtures" / "_redfish_v1.json", "1"),
+    "hpe": (_TESTS_DIR / "hpe_fixtures" / "_redfish_v1.json", "2"),
+    "generic": (_TESTS_DIR / "generic_fixtures" / "_redfish_v1.json", "3"),
+}
+
+
+class _AcceptedResponse:
+    """A 202 Accepted write response carrying the task monitor Location."""
+
+    def __init__(self, task_id):
+        self.status_code = 202
+        self.headers = {
+            "Location": f"/redfish/v1/TaskService/Tasks/{task_id}"}
+
+    def json(self):
+        """Return an empty body, as a 202 task-accept typically has none.
+
+        :return: an empty dict.
+        """
+        return {}
+
+
+class _TaskResponse:
+    """A 200 task read; body shape depends on the URL the fake GET served."""
+
+    def __init__(self, body):
+        self.status_code = 200
+        self.headers = {}
+        self._body = body
+
+    def json(self):
+        """Return the configured task body.
+
+        :return: the body dict this response was built with.
+        """
+        return self._body
+
+
+def _bind_fleet():
+    """Build one manager per lens with its profile bound by real classification.
+
+    :return: dict of lens -> manager, each with the lens root attached.
+    """
+    fleet = {}
+    for lens, (root_path, _tid) in _FLEET.items():
+        mgr = IDracManager(host=f"fleet-{lens}", username="root", password="x")
+        mgr.__dict__["_service_root"] = json.loads(root_path.read_text())
+        # Touch the property once: classification caches per connection.
+        assert mgr.vendor_profile is not None
+        fleet[lens] = mgr
+    return fleet
+
+
+def test_fleet_async_collect_then_fetch(monkeypatch):
+    """Fire async at every lens, collect ids now, fetch each task later.
+
+    Phase 1 (fire): each async POST returns 202 + Location; the collected id
+    is the lens-faithful one (dell JID_, others DMTF).
+    Phase 2 (fetch): each ``fetch_task`` polls that lens's OWN task resource —
+    the dell connection consults ``/Oem/Dell/Jobs``, no other connection ever
+    touches a Dell OEM URL.
+    """
+    fleet = _bind_fleet()
+    calls = {lens: [] for lens in fleet}
+
+    # --- phase 1: async fan-out, collect ids -----------------------------
+    task_ids = {}
+    for lens, mgr in fleet.items():
+        expected_id = _FLEET[lens][1]
+
+        async def _fake_post(*args, _tid=expected_id, **kwargs):
+            """Serve the lens's 202-accept without any network."""
+            return _AcceptedResponse(_tid), RedfishApiRespond.AcceptedTaskGenerated
+
+        monkeypatch.setattr(mgr, "api_async_post_until_complete", _fake_post)
+        result, api_resp = mgr.base_post(
+            "/redfish/v1/Systems/1/Actions/ComputerSystem.Reset",
+            payload={"ResetType": "On"}, do_async=True)
+        assert api_resp == RedfishApiRespond.AcceptedTaskGenerated
+        task_ids[lens] = result.data["task_id"]
+
+    assert task_ids["dell"].startswith("JID_")
+    for lens in ("supermicro", "hpe", "generic"):
+        assert not task_ids[lens].startswith("JID_")
+
+    # --- phase 2: fetch each collected id later --------------------------
+    for lens, mgr in fleet.items():
+        # The Dell job read builds its URL from the manager's members path;
+        # seed the cached property so no discovery crawl is needed.
+        mgr.__dict__["idrac_members"] = "/redfish/v1/Managers/iDRAC.Embedded.1"
+
+        def _fake_get(url, hdr=None, _lens=lens, **kwargs):
+            """Record the polled URL and serve a terminal task/job body."""
+            calls[_lens].append(url)
+            if "/Oem/Dell/Jobs/" in url:
+                return _TaskResponse({"JobState": "Completed"})
+            return _TaskResponse({"TaskState": "Completed", "TaskStatus": "OK"})
+
+        monkeypatch.setattr(fleet[lens], "api_get_call", _fake_get)
+        state = fleet[lens].fetch_task(task_ids[lens], sleep_time=0)
+        assert state is not None
+        assert state.name == "Completed"
+
+    # The dell connection fetched through the OEM job queue.
+    assert any("/Oem/Dell/Jobs/" in url for url in calls["dell"])
+    # No other connection ever touched a Dell OEM URL; each polled the DMTF
+    # TaskService monitor for its own collected id.
+    for lens in ("supermicro", "hpe", "generic"):
+        assert calls[lens], f"{lens} never polled"
+        assert all("/Oem/Dell/" not in url for url in calls[lens])
+        assert any(
+            f"/TaskService/Tasks/{task_ids[lens]}" in url
+            for url in calls[lens])
+
+
+def test_fleet_profiles_bind_per_connection():
+    """Each fleet member resolves ITS box's profile through one manager class.
+
+    Ancestry says Dell everywhere (every command bases IDracManager); the
+    resolved chokepoint set must follow the connection instead.
+    """
+    fleet = _bind_fleet()
+    assert type(fleet["dell"].vendor_profile).vendor == "dell"
+    assert type(fleet["supermicro"].vendor_profile).vendor == "supermicro"
+    assert type(fleet["hpe"].vendor_profile).vendor == "hpe"
+    assert type(fleet["generic"].vendor_profile).vendor == "generic"

--- a/tests/test_manager_constructor.py
+++ b/tests/test_manager_constructor.py
@@ -1,0 +1,131 @@
+"""Constructor-neutralization tests for the manager connection contract.
+
+One credential parameter set exists on the managers — ``host``/``username``/
+``password``/``port`` stored once as ``_host``/``_username``/``_password``/
+``_port`` — and the legacy ``redfish_*``/``idrac_*`` spellings survive only as
+one-wave constructor aliases (and at the CLI/env edge). These tests pin the
+canonical form, the alias coalescing, the Singleton-key stability across the
+two spellings, and the request-count budget of vendor-profile resolution
+(zero BMC round trips of its own).
+Root-module test: flat placement mirrors redfish_ctl/redfish_manager.py.
+
+Author Mus spyroot@gmail.com
+"""
+import inspect
+
+from redfish_ctl.idrac_manager import IDracManager
+from redfish_ctl.idrac_shared import Singleton
+from redfish_ctl.redfish_manager import RedfishManager
+
+
+def test_canonical_construction_stores_one_set():
+    """Canonical kwargs land in the one canonical storage set."""
+    mgr = RedfishManager(host="1.2.3.4", username="u", password="p", port=444)
+    assert mgr._host == "1.2.3.4"
+    assert mgr._username == "u"
+    assert mgr._password == "p"
+    assert mgr._port == 444
+    assert mgr.redfish_ip == "1.2.3.4:444"
+    # Single storage: no parallel private attr survives on the instance.
+    assert "_redfish_ip" not in vars(mgr)
+
+
+def test_legacy_redfish_aliases_coalesce():
+    """``redfish_*`` constructor spellings still construct, canonically stored."""
+    mgr = RedfishManager(redfish_ip="10.0.0.1", redfish_username="a",
+                         redfish_password="b", redfish_port="8443")
+    assert mgr._host == "10.0.0.1"
+    assert mgr._username == "a"
+    assert mgr._password == "b"
+    assert mgr._port == 8443
+
+
+def test_legacy_idrac_aliases_coalesce():
+    """``idrac_*`` constructor spellings still construct, canonically stored."""
+    mgr = IDracManager(idrac_ip="10.0.0.2", idrac_username="c",
+                       idrac_password="d", idrac_port=8080)
+    assert mgr._host == "10.0.0.2"
+    assert mgr._username == "c"
+    assert mgr._password == "d"
+    assert mgr._port == 8080
+
+
+def test_canonical_spelling_wins_over_alias():
+    """On a conflict the canonical keyword outranks the legacy alias."""
+    mgr = RedfishManager(host="canonical", redfish_ip="legacy")
+    assert mgr._host == "canonical"
+
+
+def test_signatures_hold_exactly_one_credential_set():
+    """The triple-password kill: no ``idrac_*``/``redfish_*`` parameters remain.
+
+    The same secret used to exist as ``password``/``redfish_password``/
+    ``idrac_password`` across the two constructors; after the cleanup the
+    aliases are not parameters anywhere — they live only at the CLI/env edge.
+    """
+    for cls in (RedfishManager, IDracManager):
+        names = set(inspect.signature(cls.__init__).parameters)
+        assert {"host", "username", "password", "port"} <= names
+        leaked = {n for n in names
+                  if n.startswith("idrac_") or n.startswith("redfish_")}
+        assert not leaked, f"{cls.__name__} still declares {leaked}"
+
+
+def test_singleton_key_stable_across_spellings():
+    """Canonical vs legacy kwargs for ONE connection yield ONE instance.
+
+    The Singleton fingerprints the connection from either spelling; a key
+    split here would double per-BMC caches mid-migration.
+    """
+    class _Probe(IDracManager, metaclass=Singleton):
+        """Throwaway command-shaped class keyed like a real command."""
+
+        def execute(self, **kwargs):
+            """Satisfy the abstract command surface; never called here."""
+            raise AssertionError("not invoked")
+
+        @staticmethod
+        def register_subcommand(cls):
+            """Satisfy the abstract command surface; never called here."""
+            raise AssertionError("not invoked")
+
+    legacy = _Probe(idrac_ip="h1", idrac_username="u", idrac_password="p")
+    canonical = _Probe(host="h1", username="u", password="p")
+    assert legacy is canonical
+
+
+def test_profile_resolution_spends_zero_requests():
+    """Vendor-profile resolution performs no BMC I/O of its own.
+
+    Budget rule: resolution rides evidence that already exists (a cached
+    classification or an already-fetched ServiceRoot) or falls back to the
+    class default — never a GET of its own. The bound here is 0, stronger
+    than the design's <=1.
+    """
+    mgr = IDracManager(host="192.0.2.9", username="u", password="p")
+    assert mgr.query_counter == 0
+    profile = mgr.vendor_profile
+    assert type(profile).vendor == "dell"
+    assert mgr.query_counter == 0
+    assert "_service_root" not in vars(mgr)
+
+    probed = IDracManager(host="192.0.2.10", username="u", password="p")
+    probed.__dict__["_service_root"] = {"Vendor": "Supermicro"}
+    assert type(probed.vendor_profile).vendor == "supermicro"
+    assert probed.query_counter == 0
+
+
+def test_private_host_alias_writes_through():
+    """The transitional ``_redfish_ip`` view reads and writes ``_host``."""
+    mgr = RedfishManager(host="a", username="u", password="p")
+    mgr._redfish_ip = "9.9.9.9"
+    assert mgr._host == "9.9.9.9"
+    assert mgr.redfish_ip == "9.9.9.9"
+    assert mgr._redfish_ip == "9.9.9.9"
+
+
+def test_unknown_kwargs_are_tolerated():
+    """The constructor keeps ``**kwargs`` extensibility (the spec contract)."""
+    mgr = RedfishManager(host="h", username="u", password="p",
+                         future_extension_knob=True)
+    assert mgr._host == "h"

--- a/tests/test_vendor_profile.py
+++ b/tests/test_vendor_profile.py
@@ -1,0 +1,161 @@
+"""Unit tests for the vendor-profile plumbing (redfish_ctl/vendor_profile.py).
+
+Covers what the plumbing genuinely does today: loud registration collisions,
+observable generic fallback, per-connection caching with test-isolation reset,
+ServiceRoot detection over the REAL committed corpora (resolved through the
+manifest chain — no hardcoded fixture paths), and the seam contract that
+unimplemented chokepoints fail loudly instead of running half-moved semantics.
+Root-module test: flat placement mirrors redfish_ctl/vendor_profile.py.
+
+Author Mus spyroot@gmail.com
+"""
+
+import pytest
+from vendor_corpus import corpus_dir as extract_corpus
+
+from redfish_ctl import dell_profile, vendor_profile
+from redfish_ctl.redfish_exceptions import ProfileRegistrationCollision
+from tools import corpus, corpus_diff
+
+
+@pytest.fixture(autouse=True)
+def _clean_profile_state():
+    """Isolate every test from the module-level cache and counters."""
+    vendor_profile.clear_profile_cache()
+    yield
+    vendor_profile.clear_profile_cache()
+
+
+def test_known_vendors_resolve_to_their_profile_classes():
+    """Each registered vendor key resolves to its own profile class.
+
+    The registry is the whole dispatch surface — a wrong mapping here would
+    hand a vendor another vendor's chokepoints, the exact leak this design
+    exists to stop.
+    """
+    assert type(vendor_profile.resolve_profile("dell")) is dell_profile.DellProfile
+    assert type(vendor_profile.resolve_profile("supermicro")) is vendor_profile.SupermicroProfile
+    assert type(vendor_profile.resolve_profile("hpe")) is vendor_profile.HpeProfile
+    assert type(vendor_profile.resolve_profile("generic")) is vendor_profile.DmtfProfile
+    assert not vendor_profile.FALLBACK_COUNTS
+
+
+def test_unknown_vendor_falls_back_to_generic_observably():
+    """An unknown vendor yields the generic profile AND counts the fallback.
+
+    Silent wrong-profile resolution is the design's worst failure mode; the
+    fallback must be visible (counter + log), never quiet.
+    """
+    profile = vendor_profile.resolve_profile("acme")
+    assert type(profile) is vendor_profile.DmtfProfile
+    assert vendor_profile.FALLBACK_COUNTS == {"acme": 1}
+    vendor_profile.resolve_profile("acme")
+    assert vendor_profile.FALLBACK_COUNTS == {"acme": 2}
+
+
+def test_duplicate_registration_collides_loudly():
+    """Registering a DIFFERENT class under a taken key raises at once.
+
+    Last-write-wins registration is how the flat command registry silently
+    drops classes (architecture dispatch_note); profiles refuse it up front.
+    Re-registering the SAME class stays idempotent (module re-import safety).
+    """
+    class Impostor(vendor_profile.DmtfProfile):
+        """A second class claiming an already-registered vendor key."""
+        vendor = "dell"
+
+    with pytest.raises(ProfileRegistrationCollision, match="dell"):
+        vendor_profile.register_profile("dell", Impostor)
+    vendor_profile.register_profile("dell", dell_profile.DellProfile)  # idempotent
+
+
+def test_connection_cache_probes_once_and_resets():
+    """One probe per (host, port); the reset hook clears it for test isolation."""
+    calls = []
+
+    def loader():
+        """Count ServiceRoot loads; serve a Supermicro-shaped root."""
+        calls.append(1)
+        return {"Vendor": "Supermicro"}
+
+    p1 = vendor_profile.profile_for_connection("10.0.0.1", 443, loader)
+    p2 = vendor_profile.profile_for_connection("10.0.0.1", 443, loader)
+    assert p1 is p2 and len(calls) == 1
+    assert type(p1) is vendor_profile.SupermicroProfile
+    vendor_profile.clear_profile_cache()
+    vendor_profile.profile_for_connection("10.0.0.1", 443, loader)
+    assert len(calls) == 2
+
+
+def test_explicit_vendor_override_skips_the_probe():
+    """--vendor/REDFISH_VENDOR resolves with ZERO ServiceRoot loads.
+
+    The operator's declaration outranks the probe (and saves the round trip —
+    the avoid-BMC-round-trips rule).
+    """
+    def loader():
+        """Fail the test if the probe fires despite an override."""
+        raise AssertionError("probe must not fire when vendor is declared")
+
+    profile = vendor_profile.profile_for_connection(
+        "10.0.0.2", 443, loader, vendor_override="dell")
+    assert type(profile) is dell_profile.DellProfile
+
+
+@pytest.mark.parametrize("row", corpus.load_manifest(),
+                         ids=lambda r: f"{r['vendor']}-{r['model']}")
+def test_detection_over_every_committed_corpus(row):
+    """Each real corpus's ServiceRoot resolves to a sane vendor profile.
+
+    Evidence resolved mechanically (manifest -> tarball -> flattened root);
+    the hard assertion is the anti-leak one: NO non-Dell box may ever resolve
+    to the Dell profile (that is the mis-vendoring this program kills). The
+    positive mapping is asserted where the classifier models the vendor;
+    nvidia (not yet a classifier vocabulary word) must simply be non-Dell.
+    """
+    tarball = corpus._tarball_path(row)
+    if not tarball.exists() or corpus._is_lfs_pointer(tarball):
+        pytest.skip(f"{row['tarball']} not pulled (bare LFS pointer)")
+    fetch = corpus_diff.corpus_fetcher(extract_corpus(tarball, row["arcname"]))
+    root = fetch("/redfish/v1")
+    assert isinstance(root, dict), "corpus lacks a ServiceRoot fixture"
+    profile = vendor_profile.profile_for_service_root(root)
+    if row["vendor"] == "dell":
+        assert type(profile) is dell_profile.DellProfile
+    else:
+        assert type(profile) is not dell_profile.DellProfile, (
+            f"non-Dell corpus {row['vendor']}/{row['model']} resolved the "
+            "Dell profile — vendor semantics would leak")
+    if row["vendor"] in ("supermicro", "hpe"):
+        assert profile.vendor == row["vendor"]
+
+
+def test_unimplemented_chokepoints_fail_loudly():
+    """Every seam raises NotImplementedError until its body is relocated.
+
+    A half-wired tree must crash with the relocation anchor in the message,
+    never silently run partial semantics.
+    """
+    generic = vendor_profile.DmtfProfile.instance()
+    dell = dell_profile.DellProfile.instance()
+    for profile, method, args in [
+        (generic, "decode_status", (200,)),
+        (generic, "parse_task_id", (None,)),
+        (dell, "decode_status", (201,)),
+        (dell, "parse_task_id", (None,)),
+        (dell, "fetch_task", (None, "JID_1")),
+    ]:
+        with pytest.raises(NotImplementedError, match="CHIP"):
+            getattr(profile, method)(*args)
+
+
+def test_manager_property_is_present_and_lazy():
+    """RedfishManager exposes vendor_profile as a property; nothing eager.
+
+    The plumbing must not change the import graph or any behavior until the
+    delegation pass wires call sites — presence and property-ness is the
+    whole contract today.
+    """
+    from redfish_ctl.redfish_manager import RedfishManager
+    assert isinstance(
+        vars(RedfishManager).get("vendor_profile"), property)

--- a/tests/test_vendor_profile.py
+++ b/tests/test_vendor_profile.py
@@ -1,21 +1,56 @@
-"""Unit tests for the vendor-profile plumbing (redfish_ctl/vendor_profile.py).
+"""Unit tests for the vendor profiles (redfish_ctl/vendor_profile.py).
 
-Covers what the plumbing genuinely does today: loud registration collisions,
-observable generic fallback, per-connection caching with test-isolation reset,
-ServiceRoot detection over the REAL committed corpora (resolved through the
-manifest chain — no hardcoded fixture paths), and the seam contract that
-unimplemented chokepoints fail loudly instead of running half-moved semantics.
+Covers registration (loud collisions), observable generic fallback,
+per-connection caching with test-isolation reset, ServiceRoot detection over
+the REAL committed corpora (resolved through the manifest chain — no hardcoded
+fixture paths), the per-lens chokepoint matrix (status decode, error decode,
+task-id parsing — only the dell lens ever sees 201=Created or a ``JID_``
+scrape), and the manager resolution ladder (evidence outranks the class
+default; resolution never spends a BMC round trip).
 Root-module test: flat placement mirrors redfish_ctl/vendor_profile.py.
 
 Author Mus spyroot@gmail.com
 """
+import json
+from pathlib import Path
 
 import pytest
 from vendor_corpus import corpus_dir as extract_corpus
 
 from redfish_ctl import dell_profile, vendor_profile
-from redfish_ctl.redfish_exceptions import ProfileRegistrationCollision
+from redfish_ctl.cmd_exceptions import AuthenticationFailed, ResourceNotFound
+from redfish_ctl.redfish_exceptions import (
+    ProfileRegistrationCollision,
+    RedfishUnauthorized,
+)
 from tools import corpus, corpus_diff
+
+_TESTS_DIR = Path(__file__).resolve().parent
+
+# The per-lens ServiceRoot fixtures the offline mock serves; each must
+# classify to its own vendor so profile resolution works offline per lens.
+_LENS_ROOTS = {
+    "dell": _TESTS_DIR / "idrac_fixtures" / "_redfish_v1.json",
+    "supermicro": _TESTS_DIR / "supermicro_fixtures" / "_redfish_v1.json",
+    "hpe": _TESTS_DIR / "hpe_fixtures" / "_redfish_v1.json",
+    "generic": _TESTS_DIR / "generic_fixtures" / "_redfish_v1.json",
+}
+
+
+class _FakeResponse:
+    """Minimal stand-in response: status, headers, and an optional JSON body."""
+
+    def __init__(self, status_code, headers=None, body=None):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._body = body if body is not None else {}
+
+    def json(self):
+        """Return the configured JSON body.
+
+        :return: the body dict this fake was built with.
+        """
+        return self._body
 
 
 @pytest.fixture(autouse=True)
@@ -130,31 +165,151 @@ def test_detection_over_every_committed_corpus(row):
         assert profile.vendor == row["vendor"]
 
 
-def test_unimplemented_chokepoints_fail_loudly():
-    """Every seam raises NotImplementedError until its body is relocated.
+@pytest.mark.parametrize("vendor", ["dell", "supermicro", "hpe", "generic"])
+def test_decode_status_matrix(vendor):
+    """Per lens: the shared 2xx folds hold, and ONLY dell maps 201=Created.
 
-    A half-wired tree must crash with the relocation anchor in the message,
-    never silently run partial semantics.
+    201=Created is a Dell addition (architecture state_decode); a Created
+    surfacing on any other lens means Dell semantics leaked into the shared
+    base — the exact defect this design exists to stop.
     """
-    generic = vendor_profile.DmtfProfile.instance()
-    dell = dell_profile.DellProfile.instance()
-    for profile, method, args in [
-        (generic, "decode_status", (200,)),
-        (generic, "parse_task_id", (None,)),
-        (dell, "decode_status", (201,)),
-        (dell, "parse_task_id", (None,)),
-        (dell, "fetch_task", (None, "JID_1")),
-    ]:
-        with pytest.raises(NotImplementedError, match="CHIP"):
-            getattr(profile, method)(*args)
+    profile = vendor_profile.resolve_profile(vendor)
+    assert profile.decode_status(200).name == "Ok"
+    assert profile.decode_status(202).name == "AcceptedTaskGenerated"
+    assert profile.decode_status(204).name == "Success"
+    assert profile.decode_status(299).name == "Success"
+    assert profile.decode_status(404).name == "Error"
+    if vendor == "dell":
+        assert profile.decode_status(201).name == "Created"
+    else:
+        assert profile.decode_status(201).name == "Success"
+    # The neutral map itself must hold no Created row.
+    assert 201 not in vendor_profile.DmtfProfile._status_map
+
+
+@pytest.mark.parametrize("vendor", ["dell", "supermicro", "hpe", "generic"])
+def test_error_handler_matrix(vendor):
+    """Per lens: 401 raises the lens's own exception family with its envelope.
+
+    Dell raises ``AuthenticationFailed``/``UnexpectedResponse`` carrying the
+    parsed IDRAC envelope; the DMTF lenses raise ``RedfishUnauthorized``.
+    A cross-family raise means the wrong error handler ran for the box.
+    """
+    profile = vendor_profile.resolve_profile(vendor)
+    body = {"error": {"code": "Base.1.18.GeneralError",
+                      "message": "denied", "@Message.ExtendedInfo": []}}
+    expected = AuthenticationFailed if vendor == "dell" else RedfishUnauthorized
+    with pytest.raises(expected):
+        profile.error_handler(_FakeResponse(401, body=body))
+    with pytest.raises(ResourceNotFound):
+        profile.error_handler(_FakeResponse(404, body=body))
+    assert profile.error_handler(_FakeResponse(204)).name == "Success"
+
+
+def test_dell_error_handler_records_envelope_on_manager():
+    """The Dell decode records the parsed envelope as ``manager._redfish_error``.
+
+    Callers read that attribute after a failed write; losing it during the
+    relocation would silently break the error-envelope contract.
+    """
+    class _Carrier:
+        """Bare attribute carrier standing in for a manager."""
+        _redfish_error = None
+
+    carrier = _Carrier()
+    body = {"error": {"code": "IDRAC.2.9.SYS446", "message": "nope"}}
+    with pytest.raises(ResourceNotFound):
+        dell_profile.DellProfile.instance().error_handler(
+            _FakeResponse(404, body=body), manager=carrier)
+    assert carrier._redfish_error is not None
+    assert carrier._redfish_error.status_code == 404
+
+
+@pytest.mark.parametrize("vendor", ["dell", "supermicro", "hpe", "generic"])
+def test_parse_task_id_matrix(vendor):
+    """Per lens: Location header wins everywhere; only dell scrapes ``JID_``.
+
+    A response with no Location but a ``JID_`` in its body yields the job id
+    on the dell lens ONLY — a non-dell lens returning a ``JID_`` would mean
+    the Dell body-scrape leaked back into the shared path.
+    """
+    profile = vendor_profile.resolve_profile(vendor)
+
+    with_header = _FakeResponse(
+        202, headers={"Location": "/redfish/v1/TaskService/Tasks/42"})
+    assert profile.parse_task_id(with_header) == "42"
+
+    body_only = _FakeResponse(202)
+    body_only.text = '{"Id": "JID_000000000001", "queued": true}'
+    got = profile.parse_task_id(body_only)
+    if vendor == "dell":
+        assert got and got.startswith("JID_")
+    else:
+        assert not got
+        assert not str(got).startswith("JID_")
+
+
+@pytest.mark.parametrize("vendor", ["dell", "supermicro", "hpe", "generic"])
+def test_lens_service_roots_classify_to_their_vendor(vendor):
+    """Each offline lens root resolves to its own profile (mock lens contract).
+
+    The mock serves these roots at ``/redfish/v1``; if one stops classifying,
+    offline per-lens resolution silently degrades to the generic profile.
+    """
+    root = json.loads(_LENS_ROOTS[vendor].read_text())
+    profile = vendor_profile.profile_for_service_root(root)
+    if vendor == "generic":
+        assert type(profile) is vendor_profile.DmtfProfile
+    else:
+        assert profile.vendor == vendor
+
+
+@pytest.mark.parametrize("vendor", ["dell", "supermicro", "hpe", "generic"])
+def test_manager_chokepoint_delegation_per_lens(vendor):
+    """Through the MANAGER delegate: the box's lens picks the decode, not class.
+
+    Every command still declares IDracManager; with the lens's ServiceRoot
+    bound to the connection, ``self.default_error_handler`` must resolve the
+    box's semantics — 201 folds to Created ONLY when the box is Dell. This is
+    the delegation audit that catches a Dell override silently re-shadowing
+    the chokepoint.
+    """
+    from redfish_ctl.idrac_manager import IDracManager
+    mgr = IDracManager(host=f"matrix-{vendor}", username="u", password="p")
+    mgr.__dict__["_service_root"] = json.loads(_LENS_ROOTS[vendor].read_text())
+    assert type(mgr.vendor_profile).vendor == vendor
+    decoded = mgr.default_error_handler(_FakeResponse(201))
+    assert decoded.name == ("Created" if vendor == "dell" else "Success")
+
+
+def test_manager_resolution_ladder_defaults():
+    """No evidence -> the class default: Dell manager presumes dell, base generic.
+
+    Evidence always outranks the presumption: once a root is bound, a
+    Supermicro box resolves supermicro even through the Dell manager class,
+    and the classification is shared with other managers on the connection.
+    """
+    from redfish_ctl.idrac_manager import IDracManager
+    from redfish_ctl.redfish_manager import RedfishManager
+    dell_mgr = IDracManager(host="ladder-a", username="u", password="p")
+    assert type(dell_mgr.vendor_profile) is dell_profile.DellProfile
+    base_mgr = RedfishManager(host="ladder-b", username="u", password="p")
+    assert type(base_mgr.vendor_profile) is vendor_profile.DmtfProfile
+
+    probed = IDracManager(host="ladder-c", username="u", password="p")
+    probed.__dict__["_service_root"] = {"Vendor": "Supermicro"}
+    assert type(probed.vendor_profile) is vendor_profile.SupermicroProfile
+    # The classification is connection-level: a second manager on the same
+    # (host, port) shares it without holding a root of its own.
+    sibling = IDracManager(host="ladder-c", username="u", password="p")
+    assert type(sibling.vendor_profile) is vendor_profile.SupermicroProfile
 
 
 def test_manager_property_is_present_and_lazy():
     """RedfishManager exposes vendor_profile as a property; nothing eager.
 
-    The plumbing must not change the import graph or any behavior until the
-    delegation pass wires call sites — presence and property-ness is the
-    whole contract today.
+    Resolution happens per access with no import-graph change and no I/O of
+    its own — presence and property-ness stay the contract.
     """
     from redfish_ctl.redfish_manager import RedfishManager
     assert isinstance(

--- a/tools/config_loader_baseline.txt
+++ b/tools/config_loader_baseline.txt
@@ -13,7 +13,7 @@ redfish_ctl/discovery/cmd_discovery.py:258
 redfish_ctl/discovery/cmd_discovery.py:260
 redfish_ctl/discovery/cmd_discovery.py:262
 redfish_ctl/fleet/cmd_fleet.py:53
-redfish_ctl/idrac_manager.py:314
+redfish_ctl/idrac_manager.py:255
 redfish_ctl/licenses/cmd_dell_license_actions.py:468
 redfish_ctl/licenses/cmd_dell_license_actions.py:472
 redfish_ctl/licenses/cmd_license_install.py:202
@@ -27,10 +27,10 @@ redfish_ctl/oem/cmd_nvidia_debug_token.py:317
 redfish_ctl/oem/cmd_nvidia_debug_token.py:319
 redfish_ctl/redfish_csdl.py:70
 redfish_ctl/redfish_main.py:177
-redfish_ctl/redfish_manager.py:586
-redfish_ctl/redfish_manager.py:588
-redfish_ctl/redfish_manager.py:590
-redfish_ctl/redfish_manager.py:617
+redfish_ctl/redfish_manager.py:647
+redfish_ctl/redfish_manager.py:649
+redfish_ctl/redfish_manager.py:645
+redfish_ctl/redfish_manager.py:676
 redfish_ctl/telemetry/cmd_exporter.py:1038
 redfish_ctl/telemetry/cmd_exporter.py:1039
 redfish_ctl/telemetry/exporter.py:1539

--- a/tools/span_root_baseline.txt
+++ b/tools/span_root_baseline.txt
@@ -4,7 +4,7 @@
 redfish_ctl/cmd_wait.py:38
 redfish_ctl/discover/cli.py:220
 redfish_ctl/discovery/net_scan.py:61
-redfish_ctl/idrac_manager.py:285
-redfish_ctl/idrac_manager.py:293
-redfish_ctl/redfish_manager.py:552
-redfish_ctl/redfish_manager.py:560
+redfish_ctl/idrac_manager.py:226
+redfish_ctl/idrac_manager.py:234
+redfish_ctl/redfish_manager.py:611
+redfish_ctl/redfish_manager.py:619

--- a/tools/test_layout_baseline.txt
+++ b/tools/test_layout_baseline.txt
@@ -65,6 +65,7 @@ tests/test_telemetry_submit_test_dualmode.py
 tests/test_utils.py
 tests/test_vendor_evidence.py
 tests/test_vendor_portability.py
+tests/test_vendor_profile.py
 tests/test_version_consistency.py
 tests/test_wait.py
 tests/test_wait_dualmode.py

--- a/tools/test_layout_baseline.txt
+++ b/tools/test_layout_baseline.txt
@@ -23,6 +23,7 @@ tests/test_enum_auto_values.py
 tests/test_env_first.py
 tests/test_error_handler.py
 tests/test_fixture_catalog.py
+tests/test_fleet_async_profiles.py
 tests/test_gb300_node2_vendor_corpus.py
 tests/test_generic_vendor.py
 tests/test_gpu_oob_commands.py
@@ -37,6 +38,7 @@ tests/test_invoke_action_csdl.py
 tests/test_lenovo_vendor.py
 tests/test_main.py
 tests/test_main_rooting_g6.py
+tests/test_manager_constructor.py
 tests/test_package_imports.py
 tests/test_power_state_dualmode.py
 tests/test_query.py


### PR DESCRIPTION
Vendor semantics now bind per CONNECTION, not per class ancestry. A small
VendorProfile strategy object owns the vendor chokepoints; the managers
delegate; the ~193 registered command classes are untouched.

## What moved where

| Was | Now |
|---|---|
| `IDracManager._http_code_mapping` (incl. 201=Created) | `DellProfile.decode_status` / `_status_map` |
| Dell `default_error_handler` (IDRAC envelope, typed raises) | `DellProfile.error_handler` |
| neutral `default_error_handler` | `DmtfProfile.error_handler` |
| `job_id_from_header` parsing | `DmtfProfile.parse_task_id` (Location-only) |
| `JID_` body-scrape (`job_id_from_respond`) | `DellProfile._scrape_job_id` — the neutral layer holds no Dell literal |
| Dell `fetch_task`/`get_task_state`/`get_job` + state maps | `DellProfile` |
| neutral `fetch_task`/`get_task_state` | `DmtfProfile` |

Manager chokepoints are same-signature delegates through
`self.vendor_profile`; poll bodies call `manager.get_job`/`get_task_state`
so class-level overrides keep intercepting.

## Resolution (no I/O of its own)

Cached classification for the (host, port) → an already-fetched
`_service_root` classified via `discover.classifier` → the class default
(`IDracManager` presumes dell — exactly the pre-profile behavior). A
connection that never fetched a ServiceRoot pays ZERO extra GETs; a
classified root flips every command singleton on that connection at once.

## Constructor cleanup

One credential parameter set: `host`/`username`/`password`/`port`, stored
once as `_host`/`_username`/`_password`/`_port`. The `redfish_*`/`idrac_*`
spellings are no longer parameters; they coalesce from `**kwargs` for one
wave (a passed canonical spelling wins), then live only at the CLI/env
edge. `redfish_ip` stays as a property; a transitional `_redfish_ip`
property writes through to `_host`.

## Mock lens

`MockRedfishService` requires an explicit `vendor=` lens; every direct
construction names its lens; the Dell overlay ServiceRoot now carries
`Vendor`/`Oem` markers so per-lens detection works offline; the singleton
reset fixture also clears the profile cache.

## Tests added

- Per-lens chokepoint matrix (dell|supermicro|hpe|generic): only dell maps
  201=Created; only dell scrapes `JID_`; per-lens error families; the
  manager-delegate audit (201 through `default_error_handler` per lens).
- `tests/test_fleet_async_profiles.py`: mixed-lens fleet, async fire,
  collect ids (dell `JID_`, others DMTF), fetch later — dell polls
  `/Oem/Dell/Jobs`, no other lens ever touches a Dell OEM URL.
- `tests/test_manager_constructor.py`: canonical + alias coalescing,
  Singleton-key stability across spellings, zero-request profile
  resolution, signature audit (no `idrac_*`/`redfish_*` parameters).

## Deliberately deferred (follow-ups)

- `RedfishManager.default_error_handler` stays a `@staticmethod` delegating
  to the DMTF profile: two suites call it unbound; the per-connection
  delegate lives on `IDracManager`, which every registered command inherits.
- Dispatch still constructs commands with legacy `idrac_*` keywords: the
  dispatch-compat test pins that a legacy-only constructor stays
  dispatchable. Flips when that contract is retired.
- `_http_code_mapping` survives as a transitional `IDracManager` property
  over `DellProfile._status_map` for `read_api_respond` and the
  subscription-lifecycle helper.
- Dell `fetch_task` accepts `timeout` for signature parity but does not
  consult it (matching pre-move behavior).

Existing offline suite green with no assertion edits; config-loader,
span-root, test-layout, and docstring gates clean (line baselines follow
the moved code).
