### PR TITLE
Add the rename-tombstone gate: the old CLI name stays retired

### DIFF
--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -35,6 +35,7 @@ mandatory_ids:
   - repo.config-loader
   - repo.exception-interface
   - repo.test-layout
+  - repo.rename-tombstone
   - repo.span-root
   - repo.no-legacy-resurrection
   - scm.exact-commit
@@ -87,6 +88,7 @@ gates:
   - {id: repo.config-loader, profile: merge, command: scripts/gates/repository/config-loader.sh, required: true, mutates: false}
   - {id: repo.exception-interface, profile: merge, command: scripts/gates/repository/exception-interface.sh, required: true, mutates: false}
   - {id: repo.test-layout, profile: merge, command: scripts/gates/repository/test-layout.sh, required: true, mutates: false}
+  - {id: repo.rename-tombstone, profile: merge, command: scripts/gates/repository/rename-tombstone.sh, required: true, mutates: false}
   - {id: repo.span-root, profile: merge, command: scripts/gates/repository/span-root.sh, required: true, mutates: false}
   - {id: repo.no-legacy-resurrection, profile: merge, command: scripts/gates/repository/no-legacy-resurrection.sh, required: true, mutates: false}
   # --- unit: the offline suite ---

--- a/scripts/gates/repository/rename-tombstone.sh
+++ b/scripts/gates/repository/rename-tombstone.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# repo.rename-tombstone (merge, mutates:false): a renamed-away public name
+# (idrac_ctl -> redfish_ctl) never reappears outside the baselined compat-alias
+# surface; docs cleanups must shrink the baseline (ratchet to the alias alone).
+# Implementation: tools/rename_tombstone_gate.py.
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+exec python3 tools/rename_tombstone_gate.py

--- a/tests/gates/test_rename_tombstone_gate.py
+++ b/tests/gates/test_rename_tombstone_gate.py
@@ -1,0 +1,52 @@
+"""Unit tests for the rename-tombstone gate (tools/rename_tombstone_gate.py).
+
+The gate keeps the renamed-away CLI name (``idrac_ctl`` -> ``redfish_ctl``)
+from resurfacing outside the baselined compat-alias surface, and forces docs
+cleanups to shrink the baseline. These tests pin the counting, the exemption
+of the gate's own files, and the tree-vs-baseline consistency CI relies on.
+
+Author Mus spyroot@gmail.com
+"""
+import importlib.util
+import pathlib
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_spec = importlib.util.spec_from_file_location(
+    "rename_tombstone_gate", REPO_ROOT / "tools" / "rename_tombstone_gate.py")
+gate = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gate)
+
+
+def test_occurrences_exclude_the_gate_and_its_baseline():
+    """The gate's own files never count — explaining the rule is not a hit."""
+    found = gate._occurrences()
+    assert "tools/rename_tombstone_gate.py" not in found
+    assert "tools/rename_tombstone_baseline.txt" not in found
+
+
+def test_occurrences_are_positive_counts_of_tracked_files():
+    """Every reported row is a tracked file with a positive mention count."""
+    found = gate._occurrences()
+    assert found, "the alias surface exists, so the scan cannot be empty"
+    for path, n in found.items():
+        assert n > 0
+        assert not path.startswith("/"), "paths are repo-relative"
+
+
+def test_current_tree_matches_the_baseline_exactly():
+    """The committed tree passes its own gate: no new, no grown, no stale.
+
+    This is the invariant CI enforces via the wrapper; a failure here means
+    either a resurrected mention (use redfish_ctl) or a cleanup that removed
+    mentions without shrinking its baseline row (tighten the ratchet).
+    """
+    assert gate._occurrences() == gate._baseline()
+
+
+def test_baseline_parses_paths_and_counts():
+    """Baseline rows parse as path:count with comments and blanks ignored."""
+    base = gate._baseline()
+    assert base, "baseline unexpectedly empty"
+    for path, n in base.items():
+        assert isinstance(n, int) and n > 0
+        assert not path.startswith("#")

--- a/tools/rename_tombstone_baseline.txt
+++ b/tools/rename_tombstone_baseline.txt
@@ -1,0 +1,35 @@
+# Files sanctioned to mention a renamed-away name (idrac_ctl -> redfish_ctl),
+# as path:count. The legitimate surface is the compat-alias machinery and
+# recorded history; every other row is drain-work for the docs cleanup.
+# A new file or a grown count fails the gate; a cleanup must shrink its row.
+.github/workflows/release.yml:2
+CHANGELOG.md:2
+README.md:4
+docker/Dockerfile:1
+docker/Dockerfile.controller:1
+docker/Dockerfile.dockerignore:2
+docker/Dockerfile.explorer:1
+docker/Dockerfile.test:2
+docs/external/ci.md:1
+docs/external/commands.md:1
+docs/external/releasing.md:1
+idrac_ctl/__init__.py:5
+packaging/idrac_ctl_deprecation/README.md:4
+packaging/idrac_ctl_deprecation/setup.py:9
+redfish_ctl/redfish_main.py:1
+scripts/live_sanity_check/captures/supermicro/gb300/virtual_media_eject.err.json:2
+setup.py:4
+tests/attribute/test_attribute_dualmode.py:2
+tests/attribute/test_cmd_attribute_update.py:2
+tests/discovery/test_discovery_import.py:3
+tests/gates/test_redfish_schema.py:1
+tests/manager/test_manager_reset_dualmode.py:1
+tests/test_cmd_utils.py:1
+tests/test_cmd_utils_save.py:1
+tests/test_emulator_smoke.py:1
+tests/test_hpe_canary.py:1
+tests/test_hpe_vendor.py:1
+tests/test_package_imports.py:1
+tests/test_query.py:1
+tests/test_redfish_ctl_alias.py:8
+tests/test_telemetry_exporter.py:3

--- a/tools/rename_tombstone_gate.py
+++ b/tools/rename_tombstone_gate.py
@@ -1,0 +1,113 @@
+"""Gate: renamed-away names stay gone — the old CLI name never comes back.
+
+The tool was renamed ``idrac_ctl`` -> ``redfish_ctl`` (v1.1.0). The old name
+survives ONLY as the sanctioned backward-compat alias surface (the shim
+package, the packaging that publishes the alias, the alias tests, and the
+history that records the rename). Everywhere else — docs, docstrings, code,
+comments, fixtures — the old name is a resurrection: a reader learns a dead
+name, an agent copies it forward, and the rename erodes one mention at a time.
+
+    python3 tools/rename_tombstone_gate.py
+
+Ratchet: every tracked file containing a renamed-away token is baselined in
+``tools/rename_tombstone_baseline.txt`` as ``path:count``. A NEW file gaining
+the token fails; a sanctioned file gaining MORE mentions fails; a cleanup that
+removes mentions must shrink or drop the baseline row (the stale check makes
+documentation-cleanup PRs tighten the ratchet automatically). The goal is a
+baseline reduced to the alias surface alone.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+# Renamed-away tokens. Add a row when another rename retires a public name.
+_TOKENS = ("idrac_ctl",)
+
+_BASELINE = pathlib.Path(__file__).parent / "rename_tombstone_baseline.txt"
+
+# The gate and its baseline discuss the token by necessity; nothing else is
+# exempt by name (the baseline is the only sanctioning mechanism).
+_SELF = {
+    "tools/rename_tombstone_gate.py",
+    "tools/rename_tombstone_baseline.txt",
+    "tests/gates/test_rename_tombstone_gate.py",
+    "scripts/gates/repository/rename-tombstone.sh",
+}
+
+
+def _occurrences() -> dict[str, int]:
+    """Count token occurrences per tracked text file.
+
+    Binary files are skipped (``git grep -I``); the gate's own files are
+    excluded so explaining the rule never violates it.
+
+    :return: mapping of repo-relative path to total token count.
+    """
+    counts: dict[str, int] = {}
+    for token in _TOKENS:
+        out = subprocess.run(
+            ["git", "grep", "-I", "-c", "--", token],
+            capture_output=True, text=True, check=False).stdout
+        for line in out.splitlines():
+            path, _, n = line.rpartition(":")
+            if not path or path in _SELF:
+                continue
+            counts[path] = counts.get(path, 0) + int(n)
+    return counts
+
+
+def _baseline() -> dict[str, int]:
+    """Return the sanctioned ``path -> count`` rows.
+
+    :return: grandfathered occurrence counts per file.
+    """
+    rows: dict[str, int] = {}
+    if not _BASELINE.exists():
+        return rows
+    for line in _BASELINE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        path, _, n = line.rpartition(":")
+        rows[path] = int(n)
+    return rows
+
+
+def main() -> int:
+    """Report resurrected names, grown counts, and stale baseline rows.
+
+    :return: 0 when clean, 1 on any new/grown occurrence or stale row.
+    """
+    base = _baseline()
+    found = _occurrences()
+    bad = False
+    for path, n in sorted(found.items()):
+        allowed = base.get(path)
+        if allowed is None:
+            print(f"rename-tombstone: {path} — the renamed-away name appears in "
+                  f"a NEW file ({n}x); the tool is redfish_ctl (idrac_ctl is "
+                  "only a compat alias) — use the new name")
+            bad = True
+        elif n > allowed:
+            print(f"rename-tombstone: {path} — mentions grew {allowed} -> {n}; "
+                  "new text must use the new name")
+            bad = True
+    for path, allowed in sorted(base.items()):
+        n = found.get(path, 0)
+        if n < allowed:
+            print(f"rename-tombstone: {path} — baselined {allowed} but found "
+                  f"{n}; shrink the baseline row (ratchet tightens)")
+            bad = True
+    if bad:
+        return 1
+    print(f"rename-tombstone: clean ({len(base)} files carry sanctioned "
+          "alias/history mentions)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Registers `repo.rename-tombstone` (required, merge profile): the renamed-away CLI name (`idrac_ctl` → `redfish_ctl`, v1.1.0) may appear ONLY in the baselined compat-alias surface. Any NEW file gaining the token fails; a sanctioned file gaining MORE mentions fails; a cleanup that removes mentions must shrink its `path:count` baseline row — so the in-flight docs-cleanup PRs tighten the ratchet automatically as they land.

## Baseline

31 files / 70 mentions today: the alias shim package, the packaging that publishes the alias, the deprecation package, the alias tests, recorded history (CHANGELOG, release workflow), and the prose mentions the docs cleanup is draining. End state: the baseline reduces to the alias machinery alone.

## Self-test

The gate flagged its own test file and its own wrapper during development (both discuss the token) — caught on first contact, exempted as gate machinery via the explicit `_SELF` set (the baseline remains the only sanctioning mechanism for everything else).

## Validation

Gate clean against main (31 sanctioned files); tree-vs-baseline equality pinned in `tests/gates/test_rename_tombstone_gate.py`; `meta.gate-registry` OK; shellcheck + ruff + py_compile clean.