### PR TITLE
Serve DSP2043 mockup trees natively in the mock BMC server

### DIFF
--- a/docker/Dockerfile.dmtf-sim
+++ b/docker/Dockerfile.dmtf-sim
@@ -1,0 +1,48 @@
+# DMTF DSP2043 mockup simulator image for the Kubernetes sandbox.
+#
+# Serves a DSP2043 mockup profile natively over read-only HTTP: every request
+# path maps 1:1 to <path>/index.json in the extracted profile tree. Stateless
+# by construction — nothing is written, nothing drifts, nothing needs a reset.
+#
+# Build (the bundle is Git-LFS tracked; run `git lfs pull` first):
+#   docker build -f docker/Dockerfile.dmtf-sim -t redfish-ctl-dmtf-sim:local .
+# Run locally (defaults to the public-rackmount1 profile):
+#   docker run --rm -p 8080:8080 redfish-ctl-dmtf-sim:local
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Pin a numeric uid/gid so Kubernetes can verify runAsNonRoot without a
+# runAsUser override (a named user cannot be checked at admission).
+RUN groupadd --system --gid 10001 dmtfsim \
+    && useradd \
+        --system \
+        --uid 10001 \
+        --gid dmtfsim \
+        --home-dir /home/dmtfsim \
+        --create-home \
+        dmtfsim
+
+WORKDIR /app
+
+COPY --chown=dmtfsim:dmtfsim k8s/sandbox/mock_bmc_server.py \
+    /app/mock_bmc_server.py
+# Bake every profile of the pinned DSP2043 bundle so one image stamps out a
+# simulator per profile: the container args pick the profile via --mockup-dir.
+COPY spec/dmtf/redfish/2026.1/mockups/DSP2043_2026.1.zip /tmp/dsp2043.zip
+RUN python -m zipfile -e /tmp/dsp2043.zip /mockups/ \
+    && rm /tmp/dsp2043.zip \
+    && chown -R dmtfsim:dmtfsim /mockups
+
+USER dmtfsim
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD python -c \
+        "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/redfish/v1/', timeout=2).close()"
+
+ENTRYPOINT ["python", "/app/mock_bmc_server.py"]
+CMD ["--host", "0.0.0.0", "--port", "8080", \
+     "--mockup-dir", "/mockups/DSP2043_2026.1/public-rackmount1"]

--- a/k8s/sandbox/dmtf-sim.yaml
+++ b/k8s/sandbox/dmtf-sim.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dmtf-sim
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: dmtf-sim
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dmtf-sim
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dmtf-sim
+        app.kubernetes.io/component: redfish-sandbox
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+      containers:
+        - name: dmtf-sim
+          image: redfish-ctl-dmtf-sim:local
+          imagePullPolicy: IfNotPresent
+          # The --mockup-dir arg selects which DSP2043 profile this simulator
+          # serves; stamp out one Deployment per profile for more DMTF
+          # reference endpoints (the image bakes the whole bundle).
+          args:
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8080"
+            - --mockup-dir
+            - /mockups/DSP2043_2026.1/public-rackmount1
+          ports:
+            - name: http
+              containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: http
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /redfish/v1/
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            # The mockup mode never writes: request -> file -> response.
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 256Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dmtf-sim
+  namespace: redfish-sandbox
+  labels:
+    app.kubernetes.io/name: dmtf-sim
+    app.kubernetes.io/component: redfish-sandbox
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: dmtf-sim
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -438,50 +438,42 @@ class MockupRequestHandler(BaseHTTPRequestHandler):
 
     The request path maps directly onto the extracted profile directory
     (``/redfish/v1/X/Y`` -> ``<service_root>/X/Y/index.json``) and the payload
-    is returned byte-faithful. Write verbs are refused with 405: a mockup tree
-    is a static spec artifact, not a stateful device.
+    is returned byte-faithful. GET is the mode's ENTIRE method surface (the
+    sim contract, ``specs/sim/dmtf-sim-contract.yaml``, provides nothing
+    else): every other verb — writes, but also HEAD and OPTIONS — is refused
+    with 405, so a caller can never mistake the sim for a device with more
+    behavior than the bundle's files.
     """
 
     server_version = "redfish-ctl-mock-bmc/1.0"
     mockup_dir: Path
     service_root: Path
 
-    def _send_bytes(
-        self,
-        status: int,
-        content: bytes,
-        content_type: str,
-        send_body: bool = True,
-    ) -> None:
+    def _send_bytes(self, status: int, content: bytes, content_type: str) -> None:
         """Send a response with the given status, body bytes, and content type.
 
         :param status: HTTP status code to send.
-        :param content: response body bytes (used for Content-Length always).
+        :param content: response body bytes.
         :param content_type: value for the Content-Type header.
-        :param send_body: whether to write the body (False for HEAD).
         """
         self.send_response(status)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(content)))
         self.end_headers()
-        if send_body:
-            self.wfile.write(content)
+        self.wfile.write(content)
 
-    def _serve(self, send_body: bool) -> None:
-        """Serve the mockup file for the current request path.
-
-        :param send_body: whether to write the response body (False for HEAD).
-        """
+    def _serve(self) -> None:
+        """Serve the mockup file for the current request path."""
         path = _normalize_request_path(self.path)
         if path == "/redfish":
             # DSP0266 1.24.0 section 6.7 Table 4: /redfish is the spec-defined
             # version object, served from redfish/index.json when the profile
-            # ships it and synthesized otherwise.
+            # ships it and synthesized otherwise — the contract's ONE
+            # sanctioned synthesis.
             self._send_bytes(
                 200,
                 mockup_version_object(type(self).mockup_dir),
                 "application/json",
-                send_body,
             )
             return
         target = mockup_file_for_redfish_path(type(self).service_root, self.path)
@@ -497,52 +489,54 @@ class MockupRequestHandler(BaseHTTPRequestHandler):
                 },
                 sort_keys=True,
             ).encode("utf-8")
-            self._send_bytes(404, body, "application/json", send_body)
+            self._send_bytes(404, body, "application/json")
             return
-        self._send_bytes(
-            200, target.read_bytes(), _mockup_content_type(target), send_body
-        )
+        self._send_bytes(200, target.read_bytes(), _mockup_content_type(target))
 
     def do_GET(self) -> None:
         """Handle a GET request by serving the mapped mockup file."""
-        self._serve(send_body=True)
+        self._serve()
 
-    def do_HEAD(self) -> None:
-        """Handle a HEAD request by serving mockup headers without a body."""
-        self._serve(send_body=False)
+    def _reject_non_get(self) -> None:
+        """Refuse any non-GET method with 405 — GET is the entire surface.
 
-    def do_OPTIONS(self) -> None:
-        """Handle an OPTIONS request by advertising the read-only method set."""
-        self.send_response(204)
-        self.send_header("Allow", "GET, HEAD, OPTIONS")
-        self.send_header("Content-Length", "0")
-        self.end_headers()
-
-    def _reject_write(self) -> None:
-        """Refuse a write verb with 405 — the mockup tree is read-only."""
-        content = b'{"error": "read-only DSP2043 mockup"}'
+        Per the sim contract's ``errors.non_get_method`` row, everything but
+        GET returns 405 with ``Allow: GET`` — writes because an accepted write
+        would be invented behavior, HEAD/OPTIONS because they are outside the
+        declared surface. The body is omitted for HEAD per HTTP.
+        """
+        content = b'{"error": "DSP2043 mockup: GET is the only provided method"}'
         self.send_response(405)
-        self.send_header("Allow", "GET, HEAD, OPTIONS")
+        self.send_header("Allow", "GET")
         self.send_header("Content-Type", "application/json")
         self.send_header("Content-Length", str(len(content)))
         self.end_headers()
-        self.wfile.write(content)
+        if self.command != "HEAD":
+            self.wfile.write(content)
+
+    def do_HEAD(self) -> None:
+        """Refuse a HEAD request — the contract provides GET only."""
+        self._reject_non_get()
+
+    def do_OPTIONS(self) -> None:
+        """Refuse an OPTIONS request — the contract provides GET only."""
+        self._reject_non_get()
 
     def do_POST(self) -> None:
-        """Refuse a POST request — the mockup mode is GET-only."""
-        self._reject_write()
+        """Refuse a POST request — the contract provides GET only."""
+        self._reject_non_get()
 
     def do_PATCH(self) -> None:
-        """Refuse a PATCH request — the mockup mode is GET-only."""
-        self._reject_write()
+        """Refuse a PATCH request — the contract provides GET only."""
+        self._reject_non_get()
 
     def do_PUT(self) -> None:
-        """Refuse a PUT request — the mockup mode is GET-only."""
-        self._reject_write()
+        """Refuse a PUT request — the contract provides GET only."""
+        self._reject_non_get()
 
     def do_DELETE(self) -> None:
-        """Refuse a DELETE request — the mockup mode is GET-only."""
-        self._reject_write()
+        """Refuse a DELETE request — the contract provides GET only."""
+        self._reject_non_get()
 
     def log_message(self, format: str, *args: object) -> None:
         """Log a request line only when ``MOCK_BMC_VERBOSE`` is ``1``.

--- a/k8s/sandbox/mock_bmc_server.py
+++ b/k8s/sandbox/mock_bmc_server.py
@@ -1,5 +1,12 @@
 #!/usr/bin/env python3
-"""Serve a captured Redfish corpus over a small HTTP endpoint."""
+"""Serve a captured Redfish corpus or a DSP2043 mockup tree over HTTP.
+
+Two mutually independent read modes exist: ``--corpus-dir`` serves a captured
+crawl flattened to ``_redfish_v1_*.json`` files (with optional write engines),
+and ``--mockup-dir`` serves a DMTF DSP2043 mockup profile natively, mapping
+each request path 1:1 onto ``<path>/index.json`` in the profile tree (GET-only,
+no synthesis, no rewriting).
+"""
 
 from __future__ import annotations
 
@@ -307,6 +314,263 @@ def fixture_for_redfish_path(corpus_dir: Path, request_path: str) -> Path | None
 
     key = "_" + path.strip("/").replace("/", "_") + ".json"
     return _build_fixture_index(Path(corpus_dir)).get(key.lower())
+
+
+# --- DSP2043 native mockup mode --------------------------------------------
+#
+# A DSP2043 mockup profile stores each Redfish resource as <path>/index.json
+# and the directory structure IS the API structure, 1:1. The mock's only job
+# in this mode is to map the request path onto that tree, read the file, and
+# return the DMTF JSON verbatim.
+
+MOCKUP_INDEX = "index.json"
+_MOCKUP_CONTENT_TYPES = {
+    ".xml": "application/xml",
+    ".yaml": "application/yaml",
+    ".yml": "application/yaml",
+}
+
+
+def mockup_service_root(mockup_dir: Path) -> Path:
+    """Resolve the service-root directory of a DSP2043 mockup profile.
+
+    Every 2026.1 bundle profile starts directly at the service root (the
+    profile root's ``index.json`` IS ``/redfish/v1``), but some mockup trees
+    nest the resources under a ``redfish/v1/`` prefix instead; both layouts
+    are probed here, prefix first.
+
+    :param mockup_dir: profile root directory (an extracted bundle profile).
+    :return: the directory whose ``index.json`` is the service root.
+    :raises FileNotFoundError: when neither layout's ``index.json`` exists.
+    """
+    root = Path(mockup_dir)
+    prefixed = root / "redfish" / "v1"
+    if (prefixed / MOCKUP_INDEX).is_file():
+        return prefixed
+    if (root / MOCKUP_INDEX).is_file():
+        return root
+    raise FileNotFoundError(
+        f"no DSP2043 service root under {root}: neither redfish/v1/index.json "
+        f"nor index.json exists"
+    )
+
+
+def mockup_version_object(mockup_dir: Path) -> bytes:
+    """Return the ``/redfish`` version object for a mockup profile.
+
+    DSP0266 1.24.0 section 6.7 Table 4 requires ``/redfish`` to serve the
+    version object. A ``redfish/v1``-prefixed profile ships it as
+    ``redfish/index.json``; a root-direct profile has no such file, so the
+    spec-defined document ``{"v1": "/redfish/v1/"}`` is synthesized — that one
+    payload is defined by the protocol, not vendor data.
+
+    :param mockup_dir: profile root directory (an extracted bundle profile).
+    :return: the version object as UTF-8 JSON bytes.
+    """
+    version_file = Path(mockup_dir) / "redfish" / MOCKUP_INDEX
+    if version_file.is_file():
+        return version_file.read_bytes()
+    return json.dumps({"v1": "/redfish/v1/"}).encode("utf-8")
+
+
+def mockup_file_for_redfish_path(
+    service_root: Path, request_path: str
+) -> Path | None:
+    """Map a Redfish request path 1:1 onto a DSP2043 mockup tree.
+
+    The resolution rule is the DSP2043 layout itself: ``/redfish/v1`` resolves
+    to the service root's ``index.json`` and any subpath resolves to
+    ``<service_root>/<subpath>/index.json``. Trailing slashes are ignored, so
+    both spellings of every URI resolve to the same resource (DSP0266 1.24.0
+    section 6.7 Table 5). Two spec-defined shapes are not ``index.json``
+    resources: ``/redfish/v1/$metadata`` is the XML metadata document, stored
+    by DSP2043 as ``$metadata/index.xml`` (DSP0266 section 6.7 Table 4), and a
+    direct file in the tree (e.g. ``openapi.yaml``) is served verbatim when
+    present. A containment guard keeps any ``..`` segment from escaping the
+    profile tree.
+
+    :param service_root: directory whose ``index.json`` is the service root.
+    :param request_path: raw request path to resolve.
+    :return: the file to serve, or None when the path is outside
+        ``/redfish/v1`` or has no file in the tree.
+    """
+    path = _normalize_request_path(request_path)
+    if path != "/redfish/v1" and not path.startswith("/redfish/v1/"):
+        return None
+    subpath = path[len("/redfish/v1"):].strip("/")
+    root = Path(service_root)
+    if not subpath:
+        return root / MOCKUP_INDEX
+    candidates = [root / subpath / MOCKUP_INDEX]
+    if subpath == "$metadata":
+        # DSP0266 1.24.0 section 6.7 Table 4: /redfish/v1/$metadata is the
+        # OData metadata DOCUMENT (XML, not JSON); DSP2043 stores it as
+        # $metadata/index.xml.
+        candidates.insert(0, root / "$metadata" / "index.xml")
+    candidates.append(root / subpath)
+    root_resolved = root.resolve()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        if not resolved.is_relative_to(root_resolved):
+            # Containment guard: a decoded '..' segment in the URL must never
+            # resolve outside the mockup tree.
+            continue
+        if resolved.is_file():
+            return resolved
+    return None
+
+
+def _mockup_content_type(path: Path) -> str:
+    """Content type for a mockup file, chosen by suffix.
+
+    :param path: the resolved mockup file.
+    :return: ``application/xml``/``application/yaml`` for those suffixes,
+        else ``application/json``.
+    """
+    return _MOCKUP_CONTENT_TYPES.get(path.suffix.lower(), "application/json")
+
+
+class MockupRequestHandler(BaseHTTPRequestHandler):
+    """GET-only handler serving a DSP2043 mockup profile tree 1:1.
+
+    The request path maps directly onto the extracted profile directory
+    (``/redfish/v1/X/Y`` -> ``<service_root>/X/Y/index.json``) and the payload
+    is returned byte-faithful. Write verbs are refused with 405: a mockup tree
+    is a static spec artifact, not a stateful device.
+    """
+
+    server_version = "redfish-ctl-mock-bmc/1.0"
+    mockup_dir: Path
+    service_root: Path
+
+    def _send_bytes(
+        self,
+        status: int,
+        content: bytes,
+        content_type: str,
+        send_body: bool = True,
+    ) -> None:
+        """Send a response with the given status, body bytes, and content type.
+
+        :param status: HTTP status code to send.
+        :param content: response body bytes (used for Content-Length always).
+        :param content_type: value for the Content-Type header.
+        :param send_body: whether to write the body (False for HEAD).
+        """
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        if send_body:
+            self.wfile.write(content)
+
+    def _serve(self, send_body: bool) -> None:
+        """Serve the mockup file for the current request path.
+
+        :param send_body: whether to write the response body (False for HEAD).
+        """
+        path = _normalize_request_path(self.path)
+        if path == "/redfish":
+            # DSP0266 1.24.0 section 6.7 Table 4: /redfish is the spec-defined
+            # version object, served from redfish/index.json when the profile
+            # ships it and synthesized otherwise.
+            self._send_bytes(
+                200,
+                mockup_version_object(type(self).mockup_dir),
+                "application/json",
+                send_body,
+            )
+            return
+        target = mockup_file_for_redfish_path(type(self).service_root, self.path)
+        if target is None:
+            body = json.dumps(
+                {
+                    "error": {
+                        "code": "Base.1.0.GeneralError",
+                        "message": (
+                            f"The resource at the URI {path} was not found."
+                        ),
+                    }
+                },
+                sort_keys=True,
+            ).encode("utf-8")
+            self._send_bytes(404, body, "application/json", send_body)
+            return
+        self._send_bytes(
+            200, target.read_bytes(), _mockup_content_type(target), send_body
+        )
+
+    def do_GET(self) -> None:
+        """Handle a GET request by serving the mapped mockup file."""
+        self._serve(send_body=True)
+
+    def do_HEAD(self) -> None:
+        """Handle a HEAD request by serving mockup headers without a body."""
+        self._serve(send_body=False)
+
+    def do_OPTIONS(self) -> None:
+        """Handle an OPTIONS request by advertising the read-only method set."""
+        self.send_response(204)
+        self.send_header("Allow", "GET, HEAD, OPTIONS")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _reject_write(self) -> None:
+        """Refuse a write verb with 405 — the mockup tree is read-only."""
+        content = b'{"error": "read-only DSP2043 mockup"}'
+        self.send_response(405)
+        self.send_header("Allow", "GET, HEAD, OPTIONS")
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def do_POST(self) -> None:
+        """Refuse a POST request — the mockup mode is GET-only."""
+        self._reject_write()
+
+    def do_PATCH(self) -> None:
+        """Refuse a PATCH request — the mockup mode is GET-only."""
+        self._reject_write()
+
+    def do_PUT(self) -> None:
+        """Refuse a PUT request — the mockup mode is GET-only."""
+        self._reject_write()
+
+    def do_DELETE(self) -> None:
+        """Refuse a DELETE request — the mockup mode is GET-only."""
+        self._reject_write()
+
+    def log_message(self, format: str, *args: object) -> None:
+        """Log a request line only when ``MOCK_BMC_VERBOSE`` is ``1``.
+
+        :param format: printf-style format string from the base handler.
+        """
+        if os.environ.get("MOCK_BMC_VERBOSE") == "1":
+            super().log_message(format, *args)
+
+
+def make_mockup_handler(mockup_dir: Path) -> type[MockupRequestHandler]:
+    """Build a request-handler class bound to a DSP2043 mockup profile.
+
+    :param mockup_dir: profile root directory (an extracted bundle profile).
+    :return: a ``MockupRequestHandler`` subclass configured for the profile.
+    :raises FileNotFoundError: if the directory is missing or holds no
+        service-root ``index.json`` in either supported layout.
+    """
+    root = Path(mockup_dir)
+    if not root.is_dir():
+        raise FileNotFoundError(f"mockup directory not found: {root}")
+
+    class Handler(MockupRequestHandler):
+        pass
+
+    Handler.mockup_dir = root
+    Handler.service_root = mockup_service_root(root)
+    return Handler
 
 
 def _load_trace(trace_path: Path) -> dict[str, Any]:
@@ -1333,14 +1597,50 @@ def make_handler(
     return Handler
 
 
+def _select_handler(
+    corpus_dir: Path | None,
+    replay_trace: Path | None,
+    mutation_rules: Path | None,
+    seed: int,
+    mockup_dir: Path | None,
+) -> type[BaseHTTPRequestHandler]:
+    """Build the handler class the requested serving mode calls for.
+
+    :param corpus_dir: flattened-corpus directory (corpus mode).
+    :param replay_trace: optional ordered write-replay trace (corpus mode only).
+    :param mutation_rules: optional mutation-rules file (corpus mode only).
+    :param seed: RNG seed for mutation-rules failure injection.
+    :param mockup_dir: DSP2043 profile root; selects the GET-only mockup mode.
+    :return: the configured handler class.
+    :raises ValueError: when the mockup mode is combined with a write engine
+        or no serving directory is given.
+    """
+    if mockup_dir is not None:
+        if replay_trace is not None or mutation_rules is not None:
+            raise ValueError(
+                "--mockup-dir is GET-only; --replay/--mutation-rules apply "
+                "to corpus mode"
+            )
+        return make_mockup_handler(mockup_dir)
+    if corpus_dir is None:
+        raise ValueError("either a corpus dir or a mockup dir is required")
+    return make_handler(
+        corpus_dir,
+        replay_trace=replay_trace,
+        mutation_rules=mutation_rules,
+        seed=seed,
+    )
+
+
 @contextmanager
 def run_server(
     host: str,
     port: int,
-    corpus_dir: Path,
+    corpus_dir: Path | None = None,
     replay_trace: Path | None = None,
     mutation_rules: Path | None = None,
     seed: int = 0,
+    mockup_dir: Path | None = None,
 ) -> Iterator[ThreadingHTTPServer]:
     """Run the mock BMC server in a background thread as a context manager.
 
@@ -1353,15 +1653,12 @@ def run_server(
     :param replay_trace: optional ordered write-replay trace file.
     :param mutation_rules: optional order-independent mutation-rules file.
     :param seed: RNG seed for mutation-rules failure injection.
+    :param mockup_dir: DSP2043 profile root to serve natively (GET-only);
+        mutually exclusive with the write engines.
     """
     server = MockBMCServer(
         (host, port),
-        make_handler(
-            corpus_dir,
-            replay_trace=replay_trace,
-            mutation_rules=mutation_rules,
-            seed=seed,
-        ),
+        _select_handler(corpus_dir, replay_trace, mutation_rules, seed, mockup_dir),
     )
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
@@ -1410,6 +1707,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Seed for mutation-rules failure injection (default 0, "
         "overridable via MOCK_BMC_SEED). Same seed replays the same failures.",
     )
+    parser.add_argument(
+        "--mockup-dir",
+        type=Path,
+        default=None,
+        help="Serve a DSP2043 mockup profile natively: each request path maps "
+        "1:1 to <path>/index.json under this directory (GET-only; "
+        "mutually exclusive with --replay/--mutation-rules).",
+    )
     return parser.parse_args(argv)
 
 
@@ -1426,15 +1731,19 @@ def main(argv: list[str] | None = None) -> int:
     try:
         server = MockBMCServer(
             (args.host, args.port),
-            make_handler(
+            _select_handler(
                 args.corpus_dir,
-                replay_trace=args.replay,
-                mutation_rules=args.mutation_rules,
-                seed=args.seed,
+                args.replay,
+                args.mutation_rules,
+                args.seed,
+                args.mockup_dir,
             ),
         )
         host, port = server.server_address
-        print(f"Serving Redfish corpus from {args.corpus_dir} on {host}:{port}")
+        if args.mockup_dir is not None:
+            print(f"Serving DSP2043 mockup from {args.mockup_dir} on {host}:{port}")
+        else:
+            print(f"Serving Redfish corpus from {args.corpus_dir} on {host}:{port}")
         server.serve_forever()
     except (FileNotFoundError, ValueError) as exc:
         print(f"mock-bmc: {exc}", file=sys.stderr)

--- a/tests/k8s/dmtf_mockup.py
+++ b/tests/k8s/dmtf_mockup.py
@@ -1,0 +1,63 @@
+"""Extract the DSP2043 DMTF mockups bundle to a cached temp dir for tests.
+
+The bundle (``spec/dmtf/redfish/2026.1/mockups/DSP2043_2026.1.zip``, tracked by
+Git LFS) stores one mockup profile per directory, each Redfish resource at
+``<path>/index.json``. Tests call :func:`mockup_profile_dir` to extract the
+zip once per process (mirroring ``tests/vendor_corpus.py``) and get back a
+profile root the mock BMC server serves with ``--mockup-dir``.
+"""
+from __future__ import annotations
+
+import atexit
+import shutil
+import tempfile
+import zipfile
+from pathlib import Path
+
+_CACHE: dict[str, Path] = {}
+
+
+def is_lfs_pointer(path: Path) -> bool:
+    """Report whether ``path`` is a bare Git-LFS pointer (not yet pulled).
+
+    :param path: file to probe.
+    :return: True for a pointer stub, False for real content or a read error.
+    """
+    try:
+        with open(path, "rb") as fh:
+            head = fh.read(120)
+    except OSError:
+        return False
+    return head.startswith(b"version https://git-lfs.github.com/spec")
+
+
+def _bundle_root(extracted: Path) -> Path:
+    """Return the single top-level directory of an extracted bundle.
+
+    :param extracted: temp dir the zip was extracted into.
+    :return: the bundle's internal root (e.g. ``DSP2043_2026.1``).
+    :raises ValueError: when the zip did not extract to exactly one root dir.
+    """
+    roots = [entry for entry in extracted.iterdir() if entry.is_dir()]
+    if len(roots) != 1:
+        raise ValueError(
+            f"expected one bundle root under {extracted}, found {len(roots)}"
+        )
+    return roots[0]
+
+
+def mockup_profile_dir(bundle: Path, profile: str) -> Path:
+    """Extract ``bundle`` once (cached) and return one profile's directory.
+
+    :param bundle: path to the DSP2043 ``.zip`` mockups bundle.
+    :param profile: profile directory name (e.g. ``public-telemetry``).
+    :return: the extracted ``<bundle-root>/<profile>`` directory.
+    """
+    key = str(bundle)
+    if key not in _CACHE:
+        tmp = Path(tempfile.mkdtemp(prefix="dsp2043_mockup_"))
+        atexit.register(shutil.rmtree, tmp, ignore_errors=True)
+        with zipfile.ZipFile(bundle) as archive:
+            archive.extractall(tmp)
+        _CACHE[key] = _bundle_root(tmp)
+    return _CACHE[key] / profile

--- a/tests/k8s/test_k8s_mockup_server.py
+++ b/tests/k8s/test_k8s_mockup_server.py
@@ -184,21 +184,30 @@ def test_mockup_mode_refuses_write_engines(tmp_path: Path) -> None:
             pass  # pragma: no cover - the context manager raises on entry.
 
 
-def test_mockup_write_verbs_return_405(tmp_path: Path) -> None:
-    """Every write verb is refused with 405 — the mockup mode is GET-only."""
+def test_mockup_non_get_methods_return_405(tmp_path: Path) -> None:
+    """Every non-GET method is refused with 405 and ``Allow: GET``.
+
+    The sim contract (``specs/sim/dmtf-sim-contract.yaml``) provides GET as
+    the entire method surface: writes because an accepted write would be
+    invented behavior, HEAD/OPTIONS because they are outside the declared
+    surface (a HEAD body is suppressed per HTTP).
+    """
     module = _load_server_module()
     direct = _write_min_profile(tmp_path / "direct", prefixed=False)
 
     with module.run_server("127.0.0.1", 0, mockup_dir=direct) as server:
         base = "http://{}:{}".format(*server.server_address)
-        for method in ("POST", "PATCH", "PUT", "DELETE"):
+        for method in ("POST", "PATCH", "PUT", "DELETE", "HEAD", "OPTIONS"):
+            body = b"{}" if method in ("POST", "PATCH", "PUT") else None
             request = urllib.request.Request(
-                base + "/redfish/v1", data=b"{}", method=method
+                base + "/redfish/v1", data=body, method=method
             )
             with pytest.raises(urllib.error.HTTPError) as exc_info:
                 urllib.request.urlopen(request, timeout=5)
-            assert exc_info.value.code == 405
-            assert exc_info.value.headers["Allow"] == "GET, HEAD, OPTIONS"
+            assert exc_info.value.code == 405, method
+            assert exc_info.value.headers["Allow"] == "GET", method
+            if method == "HEAD":
+                assert exc_info.value.read() == b""
 
 
 # --- the DMTF public-telemetry profile (bundle-backed) --------------------------
@@ -273,16 +282,10 @@ def test_mockup_leaf_resource_is_byte_faithful(profile: Path) -> None:
     with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
         base = "http://{}:{}".format(*server.server_address)
         status, body, content_type = _get_raw(base, leaf)
-        head = urllib.request.Request(base + leaf, method="HEAD")
-        with urllib.request.urlopen(head, timeout=5) as response:
-            head_status = response.status
-            head_length = int(response.headers["Content-Length"])
 
     assert status == 200
     assert body == on_disk
     assert content_type == "application/json"
-    assert head_status == 200
-    assert head_length == len(on_disk)
 
 
 @requires_bundle

--- a/tests/k8s/test_k8s_mockup_server.py
+++ b/tests/k8s/test_k8s_mockup_server.py
@@ -1,0 +1,415 @@
+"""Native DSP2043 mockup mode of the sandbox mock BMC server.
+
+A DSP2043 mockup profile stores each Redfish resource as ``<path>/index.json``
+and the directory tree IS the API structure, 1:1; the profile root's
+``index.json`` is the service root. These tests pin that the ``--mockup-dir``
+mode of ``k8s/sandbox/mock_bmc_server.py`` serves that tree verbatim — no
+synthesis, no rewriting — plus the DSP0266 1.24.0 section 6.7 spec-defined
+URIs (``/redfish``, ``$metadata``, ``odata``, trailing-slash equivalence).
+Bundle-backed tests skip cleanly when the LFS zip is a bare pointer.
+
+Author Mus spyroot@gmail.com
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from dmtf_mockup import is_lfs_pointer, mockup_profile_dir
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SERVER_MODULE = REPO_ROOT / "k8s" / "sandbox" / "mock_bmc_server.py"
+BUNDLE = (
+    REPO_ROOT / "spec" / "dmtf" / "redfish" / "2026.1" / "mockups"
+    / "DSP2043_2026.1.zip"
+)
+METRIC_DEFINITIONS = "/redfish/v1/TelemetryService/MetricDefinitions"
+
+requires_bundle = pytest.mark.skipif(
+    not BUNDLE.exists() or is_lfs_pointer(BUNDLE),
+    reason="DSP2043_2026.1.zip is absent or a bare Git-LFS pointer "
+    "(fetch with: git lfs pull)",
+)
+
+
+def _load_server_module():
+    """Load the mock BMC server module from its file path.
+
+    :return: the imported ``mock_bmc_server`` module object.
+    """
+    spec = importlib.util.spec_from_file_location("mock_bmc_server", SERVER_MODULE)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _get_raw(base: str, path: str) -> tuple[int, bytes, str]:
+    """GET a path from the mock, returning status, raw body, content type.
+
+    :param base: the server's ``http://host:port`` base URL.
+    :param path: request path to fetch.
+    :return: ``(status, body bytes, Content-Type header)``.
+    """
+    try:
+        with urllib.request.urlopen(base + path, timeout=5) as response:
+            return (
+                response.status,
+                response.read(),
+                response.headers.get("Content-Type", ""),
+            )
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read(), exc.headers.get("Content-Type", "")
+
+
+def _subdirs(tree: Path) -> set[str]:
+    """Names of the immediate subdirectories of a mockup collection dir.
+
+    :param tree: the collection's directory in the extracted profile.
+    :return: the set of member directory names.
+    """
+    return {entry.name for entry in tree.iterdir() if entry.is_dir()}
+
+
+@pytest.fixture(scope="module")
+def profile() -> Path:
+    """The extracted ``public-telemetry`` profile root (cached per process)."""
+    return mockup_profile_dir(BUNDLE, "public-telemetry")
+
+
+def _write_min_profile(root: Path, prefixed: bool) -> Path:
+    """Write a minimal synthetic DSP2043 profile tree.
+
+    :param root: directory to create the profile under.
+    :param prefixed: when True nest the tree under a ``redfish/v1/`` prefix
+        and ship a ``redfish/index.json`` version object.
+    :return: the profile root directory.
+    """
+    service = root / "redfish" / "v1" if prefixed else root
+    service.mkdir(parents=True, exist_ok=True)
+    (service / "index.json").write_text(
+        json.dumps({"@odata.id": "/redfish/v1/"}), encoding="utf-8"
+    )
+    if prefixed:
+        (root / "redfish" / "index.json").write_text(
+            json.dumps({"v1": "/redfish/v1/"}), encoding="utf-8"
+        )
+    return root
+
+
+# --- layout probing and resolution (synthetic trees, no bundle needed) ---------
+
+
+def test_mockup_service_root_probes_prefixed_and_root_direct_layouts(
+    tmp_path: Path,
+) -> None:
+    """Both DSP2043 layouts resolve; an empty dir fails closed.
+
+    The 2026.1 bundle profiles start directly at the service root, but other
+    mockup trees nest under ``redfish/v1/`` — the probe must support both so
+    the mode is not bound to one bundle revision.
+    """
+    module = _load_server_module()
+    direct = _write_min_profile(tmp_path / "direct", prefixed=False)
+    prefixed = _write_min_profile(tmp_path / "prefixed", prefixed=True)
+
+    assert module.mockup_service_root(direct) == direct
+    assert module.mockup_service_root(prefixed) == prefixed / "redfish" / "v1"
+
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with pytest.raises(FileNotFoundError, match="no DSP2043 service root"):
+        module.mockup_service_root(empty)
+
+
+def test_mockup_prefixed_layout_serves_version_object_from_file(
+    tmp_path: Path,
+) -> None:
+    """A ``redfish/v1``-prefixed profile serves its own ``redfish/index.json``.
+
+    DSP0266 1.24.0 section 6.7 Table 4 defines ``/redfish``; when the tree
+    ships the document it must be served from the file, not synthesized.
+    """
+    module = _load_server_module()
+    prefixed = _write_min_profile(tmp_path / "prefixed", prefixed=True)
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=prefixed) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, body, _ = _get_raw(base, "/redfish")
+        root_status, root_body, _ = _get_raw(base, "/redfish/v1")
+
+    assert status == 200
+    assert body == (prefixed / "redfish" / "index.json").read_bytes()
+    assert root_status == 200
+    assert json.loads(root_body) == {"@odata.id": "/redfish/v1/"}
+
+
+def test_mockup_resolution_rejects_traversal_and_foreign_paths(
+    tmp_path: Path,
+) -> None:
+    """Paths outside ``/redfish/v1`` and ``..`` traversal resolve to nothing.
+
+    The request path is untrusted input: a decoded ``..`` segment must never
+    escape the profile tree, and non-Redfish paths must not map to files.
+    """
+    module = _load_server_module()
+    direct = _write_min_profile(tmp_path / "direct", prefixed=False)
+    secret = tmp_path / "secret.json"
+    secret.write_text('{"leaked": true}', encoding="utf-8")
+
+    resolve = module.mockup_file_for_redfish_path
+    assert resolve(direct, "/redfish/v1/../secret.json") is None
+    assert resolve(direct, "/redfish/v1/%2e%2e/secret.json") is None
+    assert resolve(direct, "/etc/passwd") is None
+    assert resolve(direct, "/redfish/v1") == direct / "index.json"
+
+
+def test_mockup_mode_refuses_write_engines(tmp_path: Path) -> None:
+    """Combining ``--mockup-dir`` with a write engine fails closed.
+
+    The mockup tree is a static spec artifact; accepting a replay trace or
+    mutation rules would silently drop the writes instead of replaying them.
+    """
+    module = _load_server_module()
+    direct = _write_min_profile(tmp_path / "direct", prefixed=False)
+
+    with pytest.raises(ValueError, match="GET-only"):
+        with module.run_server(
+            "127.0.0.1", 0, mockup_dir=direct, replay_trace=tmp_path / "t.yaml"
+        ):
+            pass  # pragma: no cover - the context manager raises on entry.
+
+
+def test_mockup_write_verbs_return_405(tmp_path: Path) -> None:
+    """Every write verb is refused with 405 — the mockup mode is GET-only."""
+    module = _load_server_module()
+    direct = _write_min_profile(tmp_path / "direct", prefixed=False)
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=direct) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        for method in ("POST", "PATCH", "PUT", "DELETE"):
+            request = urllib.request.Request(
+                base + "/redfish/v1", data=b"{}", method=method
+            )
+            with pytest.raises(urllib.error.HTTPError) as exc_info:
+                urllib.request.urlopen(request, timeout=5)
+            assert exc_info.value.code == 405
+            assert exc_info.value.headers["Allow"] == "GET, HEAD, OPTIONS"
+
+
+# --- the DMTF public-telemetry profile (bundle-backed) --------------------------
+
+
+@requires_bundle
+def test_mockup_serves_service_root_for_both_slash_spellings(
+    profile: Path,
+) -> None:
+    """``/redfish/v1`` and ``/redfish/v1/`` both serve the root ``index.json``.
+
+    DSP0266 1.24.0 section 6.7 Table 5 requires URIs to be processed with and
+    without the trailing slash; the profile root's ``index.json`` IS the
+    service root in the DSP2043 layout.
+    """
+    module = _load_server_module()
+    on_disk = json.loads((profile / "index.json").read_bytes())
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        bare_status, bare_body, _ = _get_raw(base, "/redfish/v1")
+        slash_status, slash_body, _ = _get_raw(base, "/redfish/v1/")
+
+    assert bare_status == 200 and slash_status == 200
+    assert bare_body == slash_body
+    assert json.loads(bare_body) == on_disk
+
+
+@requires_bundle
+def test_mockup_collection_members_mirror_the_directory_tree(
+    profile: Path,
+) -> None:
+    """A collection's Members are exactly its subdirectories — the 1:1 rule.
+
+    The DSP2043 directory structure IS the API structure, so the Members the
+    server returns must match the member directories on disk (enumerated from
+    the tree, not hardcoded); ``PowerConsumedWatts`` is the operator-named
+    example member.
+    """
+    module = _load_server_module()
+    tree = profile / "TelemetryService" / "MetricDefinitions"
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, body, _ = _get_raw(base, METRIC_DEFINITIONS)
+
+    assert status == 200
+    payload = json.loads(body)
+    assert payload == json.loads((tree / "index.json").read_bytes())
+    member_ids = {
+        member["@odata.id"].rstrip("/").rsplit("/", 1)[-1]
+        for member in payload["Members"]
+    }
+    assert member_ids == _subdirs(tree)
+    assert "PowerConsumedWatts" in member_ids
+
+
+@requires_bundle
+def test_mockup_leaf_resource_is_byte_faithful(profile: Path) -> None:
+    """A leaf resource is returned as the exact bytes of its ``index.json``.
+
+    Byte-faithfulness is the mode's contract: the mock reads the DMTF file
+    and returns it — no synthesis, no rewriting, no re-serialization.
+    """
+    module = _load_server_module()
+    leaf = METRIC_DEFINITIONS + "/PowerConsumedWatts"
+    on_disk = (
+        profile / "TelemetryService" / "MetricDefinitions"
+        / "PowerConsumedWatts" / "index.json"
+    ).read_bytes()
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, body, content_type = _get_raw(base, leaf)
+        head = urllib.request.Request(base + leaf, method="HEAD")
+        with urllib.request.urlopen(head, timeout=5) as response:
+            head_status = response.status
+            head_length = int(response.headers["Content-Length"])
+
+    assert status == 200
+    assert body == on_disk
+    assert content_type == "application/json"
+    assert head_status == 200
+    assert head_length == len(on_disk)
+
+
+@requires_bundle
+def test_mockup_missing_resource_returns_dmtf_error_404(profile: Path) -> None:
+    """A path with no ``index.json`` in the tree is a 404 with a DMTF error body.
+
+    Absence in the tree is the only 404 condition in this mode, and the body
+    must be Redfish-shaped (an ``error`` object) so clients parse it.
+    """
+    module = _load_server_module()
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, body, content_type = _get_raw(base, "/redfish/v1/NoSuchResource")
+
+    assert status == 404
+    assert content_type == "application/json"
+    payload = json.loads(body)
+    assert payload["error"]["code"].startswith("Base.")
+    assert "/redfish/v1/NoSuchResource" in payload["error"]["message"]
+
+
+@requires_bundle
+def test_mockup_redfish_version_object_is_spec_defined(profile: Path) -> None:
+    """``/redfish`` serves the version object even on a root-direct profile.
+
+    DSP0266 1.24.0 section 6.7 Table 4 requires ``/redfish``; the 2026.1
+    profiles are root-direct (no ``redfish/index.json``), so the spec-defined
+    ``{"v1": "/redfish/v1/"}`` document is synthesized — the one payload in
+    this mode that is not a file, because the protocol defines it.
+    """
+    module = _load_server_module()
+    assert not (profile / "redfish" / "index.json").exists()
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        bare_status, bare_body, content_type = _get_raw(base, "/redfish")
+        slash_status, slash_body, _ = _get_raw(base, "/redfish/")
+
+    assert bare_status == 200 and slash_status == 200
+    assert content_type == "application/json"
+    assert json.loads(bare_body) == {"v1": "/redfish/v1/"}
+    assert slash_body == bare_body
+
+
+@requires_bundle
+def test_mockup_metadata_document_is_served_as_xml(profile: Path) -> None:
+    """``/redfish/v1/$metadata`` is the XML metadata document, not JSON.
+
+    DSP0266 1.24.0 section 6.7 Table 4 defines ``$metadata`` as the OData
+    CSDL document; DSP2043 stores it as ``$metadata/index.xml`` and the mock
+    must serve it byte-faithful with an XML content type, never JSON-wrapped.
+    """
+    module = _load_server_module()
+    on_disk = (profile / "$metadata" / "index.xml").read_bytes()
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, body, content_type = _get_raw(base, "/redfish/v1/$metadata")
+
+    assert status == 200
+    assert content_type == "application/xml"
+    assert body == on_disk
+
+
+@requires_bundle
+def test_mockup_odata_service_document_is_served(profile: Path) -> None:
+    """``/redfish/v1/odata`` serves the profile's OData service document.
+
+    DSP0266 1.24.0 section 6.7 Table 4 lists the OData service document;
+    ``public-telemetry`` ships it as ``odata/index.json``, so the generic
+    1:1 rule must resolve it with no special casing.
+    """
+    module = _load_server_module()
+    on_disk = (profile / "odata" / "index.json").read_bytes()
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        base = "http://{}:{}".format(*server.server_address)
+        status, body, content_type = _get_raw(base, "/redfish/v1/odata")
+
+    assert status == 200
+    assert content_type == "application/json"
+    assert body == on_disk
+    assert any(
+        entry.get("url") == "/redfish/v1/" for entry in json.loads(body)["value"]
+    )
+
+
+@requires_bundle
+def test_metric_definitions_command_reads_the_dmtf_mockup(profile: Path) -> None:
+    """The real ``metric-definitions`` command walks the served mockup tree.
+
+    End-to-end through the real command path (DMTF-generic lens: this tree is
+    that lens's authoritative source): the command must return one row per
+    MetricReportDefinition member enumerated from the tree itself, with each
+    row's metric count matching the on-disk ``MetricProperties``.
+    """
+    from redfish_ctl.idrac_manager import IDracManager
+    from redfish_ctl.idrac_shared import ApiRequestType
+
+    module = _load_server_module()
+    tree = profile / "TelemetryService" / "MetricReportDefinitions"
+    expected_counts = {
+        name: len(
+            json.loads((tree / name / "index.json").read_bytes()).get(
+                "MetricProperties"
+            )
+            or []
+        )
+        for name in _subdirs(tree)
+    }
+
+    with module.run_server("127.0.0.1", 0, mockup_dir=profile) as server:
+        host, port = server.server_address
+        manager = IDracManager(
+            host=host,
+            port=port,
+            username="root",
+            password="mock",
+            insecure=True,
+            is_http=True,
+        )
+        result = manager.sync_invoke(
+            ApiRequestType.MetricReportDefinitions, "metric-definitions"
+        )
+
+    rows = {row["Definition"]: row for row in result.data}
+    assert set(rows) == set(expected_counts)
+    for name, row in rows.items():
+        assert row["MetricCount"] == expected_counts[name]


### PR DESCRIPTION
## What

Adds a native DSP2043 mockup mode to `k8s/sandbox/mock_bmc_server.py` (`--mockup-dir <profile-root>`), alongside the untouched `--corpus-dir` mode, plus a standing DMTF simulator deployment that serves it.

## The 1:1 rule

A DSP2043 profile stores each Redfish resource as `<path>/index.json` — the directory structure IS the API structure. The profile root's `index.json` is the service root, and e.g. `/redfish/v1/TelemetryService/MetricDefinitions/PowerConsumedWatts` resolves to `<profile-root>/TelemetryService/MetricDefinitions/PowerConsumedWatts/index.json`. The mode's only job is that mapping: read the file, return the DMTF payload byte-faithful. No synthesis, no rewriting. Every 2026.1 profile starts directly at the service root; a `redfish/v1/`-prefixed tree is also supported (probed at init).

## Contract conformance

The implementation follows `specs/sim/dmtf-sim-contract.yaml` (#424), row by row:

- **`protocol.methods: [GET]` / `errors.non_get_method`** — every non-GET method (writes, and also HEAD/OPTIONS) returns 405 with `Allow: GET`; `--replay`/`--mutation-rules` are refused in this mode.
- **`resolution.rule` + `trailing_slash`** — 1:1 path-to-`index.json` mapping; every URI resolves with and without the trailing slash (DSP0266 1.24.0 §6.7 Table 5).
- **`spec_uris`** — `/redfish` version object served from `redfish/index.json` when the profile ships it, synthesized as `{"v1": "/redfish/v1/"}` otherwise (the ONE sanctioned synthesis); `$metadata` served as `application/xml` bytes from `$metadata/index.xml`, never JSON-wrapped; `odata` via the generic rule, 404 only when the profile genuinely lacks it (`public-telemetry` and the sim's default `public-rackmount1` both ship it).
- **`errors.absent_resource` / `guarantees.no_invention`** — absence in the tree is a 404 with a DMTF-style `error` envelope, never a synthesized 200.
- **`guarantees.read_only_posture`** — the deployment declares `readOnlyRootFilesystem` + `runAsNonRoot`.
- **`binding.bundle.sha256`** — the repo bundle hashes to the pinned `481990aa…ddef7`.

## LFS-pointer skip behavior

The bundle (`spec/dmtf/redfish/2026.1/mockups/DSP2043_2026.1.zip`) is Git-LFS tracked. Bundle-backed tests skip cleanly when the zip is absent or still a bare pointer (same pattern as the corpus tests); layout-probe, traversal-guard, method-refusal, and mode-exclusivity tests run on synthetic trees and always execute. The extractor (`tests/k8s/dmtf_mockup.py`) unpacks the zip once per process with atexit cleanup, mirroring `tests/vendor_corpus.py`.

## Standing DMTF simulator

`docker/Dockerfile.dmtf-sim` bakes the extracted bundle; `k8s/sandbox/dmtf-sim.yaml` deploys it with a read-only root filesystem (the server never writes — stateless file serving needs no reset/lifecycle handling) and the served profile selectable per container arg, so one Deployment per profile stamps out more reference endpoints.

## Tests

- `tests/k8s/test_k8s_mockup_server.py`: service root (both slash spellings), collection Members mirroring the directory tree, byte-faithful leaf, DMTF-style 404, `/redfish` version object, `$metadata` as XML, odata document, both profile layouts, traversal containment, non-GET 405s, write-engine exclusivity, and one real-command integration test (`metric-definitions` against the served `public-telemetry` tree, DMTF-generic lens).
