### PR TITLE
Add the DMTF sim endpoint and the fail-closed dmtf_sim_live test lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
           fi
       - name: Offline tests (no BMC, no IDRAC_IP)
         if: steps.changes.outputs.docs_only != 'true'
-        run: pytest -q
+        # dmtf_sim_live is a private-CI integration lane (needs the deployed sim);
+        # exclude it here so GitHub CI stays offline and green.
+        run: pytest -q -m "not dmtf_sim_live"
       - name: Offline tests (docs-only fast path — docs-coupled tests)
         # Docs edits can still break tests that read docs/ or any Markdown
         # file (path links, Makefile/docker doc contracts, simulator-contract
@@ -78,13 +80,13 @@ jobs:
         run: |
           if grep -qlE '\bdocs/|\.md\b' tests/conftest.py tests/test_utils.py tests/vendor_corpus.py 2>/dev/null; then
             echo "shared test helper is docs-coupled; running the full suite"
-            pytest -q
+            pytest -q -m "not dmtf_sim_live"
             exit 0
           fi
           files="$(grep -rlE '\bdocs/|\.md\b' tests/test_*.py || true)"
           if [ -n "$files" ]; then
             # shellcheck disable=SC2086
-            pytest -q $files
+            pytest -q -m "not dmtf_sim_live" $files
           else
             echo "no docs-coupled tests detected"
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pythonpath = ["."]
 markers = [
     "live: integration test that requires a reachable iDRAC (set IDRAC_IP to run)",
     "schema: validates fixtures against DMTF Redfish schemas (run tools/fetch_schemas.sh first)",
+    "dmtf_sim_live: integration test against the deployed DMTF sim; fails closed (raises, never skips) when REDFISH_IP/REDFISH_PORT are unset. Runs only in private CI with -m dmtf_sim_live; the offline suite excludes it with -m 'not dmtf_sim_live'.",
 ]
 filterwarnings = [
     "ignore:Unverified HTTPS request",

--- a/redfish_ctl/config.py
+++ b/redfish_ctl/config.py
@@ -235,6 +235,75 @@ def endpoint_defaults(strict: bool = True) -> EndpointConfig:
     )
 
 
+@dataclass(frozen=True)
+class DmtfSimEndpoint:
+    """Resolved endpoint for the persistent DMTF simulator.
+
+    :param host: Kubernetes Service hostname or BMC IP address.
+    :param port: simulator HTTP port.
+    :param is_http: always True for the DMTF simulator contract.
+    """
+
+    host: str
+    port: int
+    is_http: bool = True
+
+
+def required_dmtf_sim_endpoint() -> DmtfSimEndpoint:
+    """Return the mandatory persistent DMTF simulator endpoint.
+
+    The DMTF CI lane requires the canonical ``REDFISH_*`` names. Deprecated
+    ``IDRAC_*`` aliases remain available to normal redfish_ctl callers, but they
+    must not become the CI contract between the builder and redfish_ctl.
+
+    :return: validated simulator host, port, and transport.
+    :raises RuntimeError: when the endpoint is absent or malformed.
+    :raises ConfigurationConflict: when canonical and legacy values conflict.
+    """
+    # Fail explicitly when the builder did not supply the canonical contract.
+    if "REDFISH_IP" not in os.environ:
+        raise RuntimeError(
+            "REDFISH_IP is missing. The builder must provide the persistent "
+            "DMTF simulator Service hostname."
+        )
+
+    if "REDFISH_PORT" not in os.environ:
+        raise RuntimeError(
+            "REDFISH_PORT is missing. The builder must provide the persistent "
+            "DMTF simulator Service port."
+        )
+
+    # env_first preserves the repository-wide alias-conflict behavior.
+    host = (
+        env_first("REDFISH_IP", "IDRAC_IP", default=None, strict=True) or ""
+    ).strip()
+    port_raw = (
+        env_first("REDFISH_PORT", "IDRAC_PORT", default=None, strict=True) or ""
+    ).strip()
+
+    if not host:
+        raise RuntimeError("REDFISH_IP must not be empty")
+
+    if host.startswith(("http://", "https://")):
+        raise RuntimeError(
+            "REDFISH_IP must contain only a hostname or IP address, "
+            "not a URL scheme"
+        )
+
+    if "/" in host:
+        raise RuntimeError("REDFISH_IP must not contain a URI path")
+
+    try:
+        port = int(port_raw)
+    except ValueError as exc:
+        raise RuntimeError("REDFISH_PORT must be an integer") from exc
+
+    if not 1 <= port <= 65535:
+        raise RuntimeError("REDFISH_PORT must be between 1 and 65535")
+
+    return DmtfSimEndpoint(host=host, port=port, is_http=True)
+
+
 def exporter_identity_env(
         overridden: tuple[str, ...] = ()) -> dict[str, Optional[str]]:
     """Return conflict-aware environment values for exporter identity.

--- a/scripts/gates/unit/all.sh
+++ b/scripts/gates/unit/all.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
-# unit.all (merge): the full offline unit suite.
+# unit.all (merge): the full OFFLINE unit suite. Excludes the dmtf_sim_live lane
+# — an integration lane that needs the deployed DMTF sim plus REDFISH_IP/
+# REDFISH_PORT and FAILS CLOSED when they are absent. That lane runs in private
+# CI with `pytest -m dmtf_sim_live`; here it is deselected so GitHub CI and this
+# offline gate stay green without the sim.
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
-exec pytest -q
+exec pytest -q -m "not dmtf_sim_live"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -434,3 +434,34 @@ def redfish_api(request):
         service = request.getfixturevalue("redfish_service")
         yield _make_idrac("mock-idrac", "root", "mock")
         _ = service  # keep the mock mounted for the test duration
+
+
+@pytest.fixture
+def dmtf_sim_endpoint(request: pytest.FixtureRequest):
+    """Return the mandatory endpoint for a ``dmtf_sim_live`` test.
+
+    Fails CLOSED: only a ``dmtf_sim_live`` test may use it, and it never skips —
+    a missing or malformed endpoint fails the test loudly (a skip would hide a
+    broken private-CI deploy). The endpoint is resolved by the single config
+    loader; no second environment variable is read here.
+
+    :param request: the pytest request, used to require the ``dmtf_sim_live`` marker.
+    :return: the validated persistent DMTF simulator endpoint.
+    :raises pytest.UsageError: when a test without the marker uses this fixture.
+    """
+    from redfish_ctl.config import (
+        ConfigurationConflict,
+        required_dmtf_sim_endpoint,
+    )
+
+    if request.node.get_closest_marker("dmtf_sim_live") is None:
+        raise pytest.UsageError(
+            "dmtf_sim_endpoint may only be used by tests marked dmtf_sim_live"
+        )
+    try:
+        return required_dmtf_sim_endpoint()
+    except (RuntimeError, ConfigurationConflict) as exc:
+        pytest.fail(
+            f"Persistent DMTF simulator endpoint is invalid: {exc}",
+            pytrace=False,
+        )

--- a/tests/k8s/test_dmtf_sim_live.py
+++ b/tests/k8s/test_dmtf_sim_live.py
@@ -1,0 +1,63 @@
+"""Live consumer tests against the deployed DMTF simulator (private CI only).
+
+These are marked ``dmtf_sim_live``: they FAIL CLOSED through the
+``dmtf_sim_endpoint`` fixture (which raises, never skips, when REDFISH_IP /
+REDFISH_PORT are unset), and the offline suite deselects them with
+``-m 'not dmtf_sim_live'``. They run only in private CI, where the sim is
+deployed and the endpoint is injected. The sim serves DMTF-generic content, so
+the product-neutral ``RedfishManager`` lens is the one under test — no vendor
+(Dell/iDRAC/Supermicro) assumption is made. The endpoint is host + port +
+``is_http`` (a URL is derived locally when a raw request needs one; no second
+environment variable, no full URL passed to redfish_ctl).
+
+    redfish_ctl --ip "$REDFISH_IP" --port "$REDFISH_PORT" --use-http metric-definitions
+
+Author Mus spyroot@gmail.com
+"""
+import pytest
+import requests
+
+from redfish_ctl.idrac_shared import ApiRequestType
+from redfish_ctl.redfish_manager import RedfishManager
+
+pytestmark = pytest.mark.dmtf_sim_live
+
+
+def test_metric_definitions_from_persistent_sim(dmtf_sim_endpoint):
+    """Invoking a telemetry command against the sim returns metric definitions.
+
+    Proves the telemetry read/decode path works against DMTF-truth telemetry
+    resources through the generic lens; the same invoke emits the metrics/spans
+    the existing Splunk gates validate (Splunk cannot tell hardware from virtual).
+
+    :param dmtf_sim_endpoint: the fail-closed persistent-sim endpoint fixture.
+    :return: None.
+    """
+    manager = RedfishManager(
+        host=dmtf_sim_endpoint.host,
+        port=dmtf_sim_endpoint.port,
+        username="root",
+        password="mock",
+        insecure=True,
+        is_http=dmtf_sim_endpoint.is_http,
+    )
+    result = manager.sync_invoke(
+        ApiRequestType.MetricReportDefinitions,
+        "metric-definitions",
+    )
+    assert result.error is None
+    assert result.data
+
+
+def test_dmtf_service_root(dmtf_sim_endpoint):
+    """The sim answers the Redfish service root over the one endpoint.
+
+    Derives the URL locally from the canonical host + port — no second variable
+    and no full endpoint URL is passed to redfish_ctl.
+
+    :param dmtf_sim_endpoint: the fail-closed persistent-sim endpoint fixture.
+    :return: None.
+    """
+    base_url = f"http://{dmtf_sim_endpoint.host}:{dmtf_sim_endpoint.port}"
+    response = requests.get(f"{base_url}/redfish/v1/", timeout=10)
+    assert response.status_code == 200

--- a/tests/test_env_first.py
+++ b/tests/test_env_first.py
@@ -9,7 +9,7 @@ import warnings
 
 import pytest
 
-from redfish_ctl.config import ConfigurationConflict
+from redfish_ctl.config import ConfigurationConflict, required_dmtf_sim_endpoint
 from redfish_ctl.redfish_shared import env_first
 
 
@@ -70,3 +70,86 @@ def test_default_is_none_without_arg(monkeypatch):
     """No default given -> None when nothing is set."""
     monkeypatch.delenv("REDFISH_NOPE", raising=False)
     assert env_first("REDFISH_NOPE") is None
+
+
+def _clear_endpoint_env(monkeypatch):
+    """Remove every endpoint env name so a test starts from a clean slate.
+
+    :param monkeypatch: the pytest monkeypatch fixture.
+    :return: None.
+    """
+    for name in ("REDFISH_IP", "IDRAC_IP", "REDFISH_PORT", "IDRAC_PORT"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_dmtf_sim_endpoint_ok(monkeypatch):
+    """Canonical REDFISH_IP/REDFISH_PORT present -> a validated http endpoint."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_IP", "dmtf-sim.dmtf-bmc.svc.cluster.local")
+    monkeypatch.setenv("REDFISH_PORT", "80")
+    ep = required_dmtf_sim_endpoint()
+    assert ep.host == "dmtf-sim.dmtf-bmc.svc.cluster.local"
+    assert ep.port == 80
+    assert ep.is_http is True
+
+
+def test_dmtf_sim_endpoint_missing_ip_fails_closed(monkeypatch):
+    """Missing REDFISH_IP raises (fail-closed) — it never returns a partial value."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_PORT", "80")
+    with pytest.raises(RuntimeError, match="REDFISH_IP is missing"):
+        required_dmtf_sim_endpoint()
+
+
+def test_dmtf_sim_endpoint_missing_port_fails_closed(monkeypatch):
+    """Missing REDFISH_PORT raises (fail-closed)."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_IP", "sim")
+    with pytest.raises(RuntimeError, match="REDFISH_PORT is missing"):
+        required_dmtf_sim_endpoint()
+
+
+def test_dmtf_sim_endpoint_rejects_url_scheme(monkeypatch):
+    """A URL in REDFISH_IP is rejected — the endpoint is host+port, never a URL."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_IP", "http://sim")
+    monkeypatch.setenv("REDFISH_PORT", "80")
+    with pytest.raises(RuntimeError, match="not a URL scheme"):
+        required_dmtf_sim_endpoint()
+
+
+def test_dmtf_sim_endpoint_rejects_uri_path(monkeypatch):
+    """A URI path in REDFISH_IP is rejected."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_IP", "sim/redfish")
+    monkeypatch.setenv("REDFISH_PORT", "80")
+    with pytest.raises(RuntimeError, match="must not contain a URI path"):
+        required_dmtf_sim_endpoint()
+
+
+def test_dmtf_sim_endpoint_rejects_non_integer_port(monkeypatch):
+    """A non-integer port is rejected."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_IP", "sim")
+    monkeypatch.setenv("REDFISH_PORT", "notaport")
+    with pytest.raises(RuntimeError, match="must be an integer"):
+        required_dmtf_sim_endpoint()
+
+
+def test_dmtf_sim_endpoint_rejects_out_of_range_port(monkeypatch):
+    """A port outside 1..65535 is rejected."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_IP", "sim")
+    monkeypatch.setenv("REDFISH_PORT", "70000")
+    with pytest.raises(RuntimeError, match="between 1 and 65535"):
+        required_dmtf_sim_endpoint()
+
+
+def test_dmtf_sim_endpoint_conflict_on_alias_mismatch(monkeypatch):
+    """REDFISH_IP and IDRAC_IP set to different values -> ConfigurationConflict."""
+    _clear_endpoint_env(monkeypatch)
+    monkeypatch.setenv("REDFISH_IP", "sim-a")
+    monkeypatch.setenv("IDRAC_IP", "sim-b")
+    monkeypatch.setenv("REDFISH_PORT", "80")
+    with pytest.raises(ConfigurationConflict):
+        required_dmtf_sim_endpoint()


### PR DESCRIPTION
## What (Slice A of the DMTF sim program)

`config.py`: `DmtfSimEndpoint` + `required_dmtf_sim_endpoint` — the persistent sim is reached through the ONE endpoint (`REDFISH_IP` + `REDFISH_PORT` + `is_http`), resolved by the single loader with `IDRAC_*` a silent fallback. **No second variable, no URL.** Validates host/port and **fails closed**.

`dmtf_sim_live` marker + `dmtf_sim_endpoint` fixture: a **private-CI** integration lane that fails closed (raises, never skips) when the endpoint is absent — a skip would hide a broken deploy. The offline suite (`unit.all` + all three `ci.yml` pytest invocations) deselects it with `-m "not dmtf_sim_live"`, so **GitHub CI stays green without the sim**; the lane runs only in private CI.

## Additive and safe

The existing GB300/Supermicro suite is untouched — the sim is a new **lens** added beside the vendor lenses through the same `RedfishManager.sync_invoke` interface (not a per-vendor zoo).

## Tests

- **Offline (GitHub CI):** `test_env_first.py` +8 tests for endpoint validation — happy path, missing IP/port (fail-closed), URL-scheme/path rejection, non-integer/out-of-range port, alias conflict.
- **Live (private CI only):** `tests/k8s/test_dmtf_sim_live.py` — a telemetry invoke (`metric-definitions` via the DMTF-generic `RedfishManager`) and a raw service-root GET (URL derived locally from host+port).

Locally verified: syntax, all 7 endpoint branches, config-loader/single-connection/test-layout gates, ruff ≤100, ci.yml parses.