### PR TITLE
Add required CI smoke inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ inventory/*
 !inventory/ci/
 inventory/ci/*
 !inventory/ci/go-no-go.yaml
+!inventory/ci/smoke-tests.yaml
 
 # macOS / stray test output
 .DS_Store
@@ -216,4 +217,3 @@ tests/popen_test.py
 # De-duplicated corpus: the redundant orig/ backup tree is never committed
 tests/supermicro_gb300_corpus/json_responses/orig/
 bios_firmware/
-

--- a/inventory/ci/smoke-tests.yaml
+++ b/inventory/ci/smoke-tests.yaml
@@ -1,0 +1,31 @@
+apiVersion: homelab.embedings.ai/v1alpha1
+kind: CiSmokeInventory
+metadata:
+  name: redfish-ctl-required-ci-smoke-tests
+spec:
+  smokeTests:
+    - job: gate-merge
+      class: wiring
+      command: './scripts/check.sh --profile "${MERGE_PROFILE:-merge}"'
+      requiredTools: [bash, conda, git, git-lfs]
+      artifactUnderTest:
+        type: repository
+        digestSource: git-commit
+      mutation: none
+      timeoutSeconds: 3600
+      evidencePath: reports/smoke/gate-merge.json
+      cleanupPolicy: reports-only
+      releaseBlocking: true
+
+    - job: gate-integration
+      class: wiring
+      command: ./scripts/check.sh --profile integration
+      requiredTools: [bash, conda, git, git-lfs, jq, yq]
+      artifactUnderTest:
+        type: repository-and-gitlab-integration
+        digestSource: git-commit-and-pipeline
+      mutation: none
+      timeoutSeconds: 1800
+      evidencePath: reports/smoke/gate-integration.json
+      cleanupPolicy: reports-only
+      releaseBlocking: true

--- a/tests/gates/test_meta_detection.py
+++ b/tests/gates/test_meta_detection.py
@@ -69,6 +69,38 @@ def _write_gitlab(tmp_path, body: str):
     (tmp_path / ".gitlab-ci.yml").write_text(textwrap.dedent(body))
 
 
+def _write_smoke_inventory(tmp_path, jobs: list[str]):
+    """Write a minimal valid smoke inventory for the requested GitLab jobs.
+
+    :param tmp_path: pytest temporary directory used as ``REPO_ROOT``.
+    :param jobs: exact job names to register.
+    """
+    records = "\n".join(textwrap.dedent(f"""
+        - job: {job}
+          class: wiring
+          command: ./scripts/check.sh --profile merge
+          requiredTools: [bash]
+          artifactUnderTest:
+            type: repository
+            digestSource: git-commit
+          mutation: none
+          timeoutSeconds: 600
+          evidencePath: reports/smoke/{job}.json
+          cleanupPolicy: reports-only
+          releaseBlocking: true
+    """).strip("\n") for job in jobs)
+    path = tmp_path / "inventory" / "ci" / "smoke-tests.yaml"
+    path.parent.mkdir(parents=True)
+    path.write_text(textwrap.dedent("""
+        apiVersion: homelab.embedings.ai/v1alpha1
+        kind: CiSmokeInventory
+        metadata:
+          name: test-smoke-inventory
+        spec:
+          smokeTests:
+    """) + textwrap.indent(records, "    ") + "\n")
+
+
 def test_detects_allow_failure(tmp_path, monkeypatch):
     """A GitLab job with allow_failure:true is a failure."""
     _write_gitlab(tmp_path, """
@@ -211,3 +243,45 @@ def test_detects_missing_diagnostic_job(tmp_path, monkeypatch):
     reg["diagnostic_jobs"] = ["focused-gate"]
     failures, _ = gate_meta._check_gitlab(reg)
     assert any("diagnostic GitLab job missing" in f for f in failures)
+
+
+def test_detects_missing_smoke_inventory(tmp_path, monkeypatch):
+    """A required smoke inventory missing from the exact tree fails closed."""
+    _write_gitlab(tmp_path, """
+        gate-merge:
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+    """)
+    monkeypatch.setattr(gate_meta, "REPO_ROOT", tmp_path)
+    failures = gate_meta._check_smoke_inventory(_valid_registry())
+    assert any("inventory missing" in failure for failure in failures)
+
+
+def test_detects_smoke_inventory_closed_world_drift(tmp_path, monkeypatch):
+    """Missing, extra, and duplicate smoke records are rejected together."""
+    _write_gitlab(tmp_path, """
+        gate-merge:
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+        ghost-job:
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+    """)
+    _write_smoke_inventory(tmp_path, ["ghost-job", "ghost-job"])
+    monkeypatch.setattr(gate_meta, "REPO_ROOT", tmp_path)
+    failures = gate_meta._check_smoke_inventory(_valid_registry())
+    assert any("duplicate" in failure for failure in failures)
+    assert any("missing smoke" in failure for failure in failures)
+    assert any("non-required" in failure for failure in failures)
+
+
+def test_smoke_inventory_accepts_exact_required_job_set(tmp_path, monkeypatch):
+    """One valid record for each required job satisfies the closed-world check."""
+    _write_gitlab(tmp_path, """
+        gate-merge:
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+    """)
+    _write_smoke_inventory(tmp_path, ["gate-merge"])
+    monkeypatch.setattr(gate_meta, "REPO_ROOT", tmp_path)
+    assert gate_meta._check_smoke_inventory(_valid_registry()) == []

--- a/tests/gates/test_no_agent_files.py
+++ b/tests/gates/test_no_agent_files.py
@@ -56,22 +56,24 @@ def test_flags_agent_only_directories():
     assert agent_name_guard.is_agent_file("inventory/home-lab/cluster.yaml")
 
 
-def test_allows_the_standards_required_go_no_go_inventory_file():
-    """The public go/no-go profile is the one tracked inventory exception."""
+def test_allows_the_standards_required_ci_inventory_files():
+    """The public go/no-go profile and smoke inventory are tracked exceptions."""
     assert not agent_name_guard.is_agent_file("inventory/ci/go-no-go.yaml")
+    assert not agent_name_guard.is_agent_file("inventory/ci/smoke-tests.yaml")
 
 
 def test_rejects_sibling_and_other_inventory_files():
-    """Only the exact go/no-go profile is allowed under the denied inventory prefix."""
+    """Only the exact public CI bindings are allowed under the denied inventory prefix."""
     assert agent_name_guard.is_agent_file("inventory/ci/extra.yaml")
     assert agent_name_guard.is_agent_file("inventory/go-no-go.yaml")
     assert agent_name_guard.is_agent_file("inventory/home-lab/cluster.yaml")
 
 
-def test_file_scan_keeps_only_the_allowed_inventory_file(monkeypatch):
-    """A tracked go/no-go profile is ignored while adjacent inventory files still fail."""
+def test_file_scan_keeps_only_the_allowed_inventory_files(monkeypatch):
+    """Tracked CI bindings are ignored while adjacent inventory files still fail."""
     stdout = "\n".join([
         "inventory/ci/go-no-go.yaml",
+        "inventory/ci/smoke-tests.yaml",
         "inventory/ci/extra.yaml",
         "redfish_ctl/redfish_manager.py",
     ])

--- a/tools/agent_name_guard.py
+++ b/tools/agent_name_guard.py
@@ -39,8 +39,12 @@ _AGENT_FILE_GLOBS = [
 _AGENT_DIR_PREFIXES = (".codex/", ".claude/", ".agent-review/", ".internal/",
                        "docs/internal/", "inventory/")
 
-# inventory/ci/go-no-go.yaml is the public standards GoNoGoProfile binding.
-_ALLOWED_AGENT_FILE_PATHS = {"inventory/ci/go-no-go.yaml"}
+# These files are the public standards CI bindings allowed under the otherwise
+# private inventory tree.
+_ALLOWED_AGENT_FILE_PATHS = {
+    "inventory/ci/go-no-go.yaml",
+    "inventory/ci/smoke-tests.yaml",
+}
 
 # Agent-tool names (word-bounded) plus specialist-agent role names (either separator).
 _IDENTITIES = [

--- a/tools/gate_meta.py
+++ b/tools/gate_meta.py
@@ -23,6 +23,10 @@ GITLAB_GLOBAL_KEYS = frozenset({
     "default", "include", "stages", "variables", "workflow", "spec",
     "image", "services", "before_script", "after_script", "cache", "types",
 })
+SMOKE_CLASSES = frozenset({
+    "wiring", "offline-component", "ephemeral-integration",
+    "protected-live", "recovery", "status-reflection",
+})
 
 
 def _load_registry() -> dict:
@@ -140,6 +144,129 @@ def _check_modules() -> tuple[list[str], bool]:
     return failures, True
 
 
+def _real_gitlab_jobs(ci: dict) -> dict:
+    """Return analyzable top-level GitLab jobs from a parsed pipeline.
+
+    :param ci: parsed ``.gitlab-ci.yml`` mapping.
+    :return: real job mappings, excluding global keywords and hidden templates.
+    """
+    return {
+        name: job
+        for name, job in ci.items()
+        if name not in GITLAB_GLOBAL_KEYS
+        and isinstance(job, dict)
+        and not name.startswith(".")
+    }
+
+
+def _script_lines(job: dict) -> list[str]:
+    """Normalize a GitLab job's script into individual command strings.
+
+    :param job: parsed GitLab job mapping.
+    :return: script commands, or an empty list when the job has no script.
+    """
+    script = job.get("script") or []
+    if isinstance(script, str):
+        return [script]
+    return [str(line) for line in script]
+
+
+def _check_smoke_inventory(registry: dict) -> list[str]:
+    """Enforce exact closed-world coverage of the required GitLab jobs.
+
+    :param registry: parsed gate registry containing ``required_jobs``.
+    :return: validation failure messages; empty means the inventory is consistent.
+    """
+    import yaml
+
+    inventory_path = REPO_ROOT / "inventory" / "ci" / "smoke-tests.yaml"
+    ci_path = REPO_ROOT / ".gitlab-ci.yml"
+    if not inventory_path.is_file():
+        return ["CI smoke inventory missing: inventory/ci/smoke-tests.yaml"]
+    if not ci_path.is_file():
+        return ["CI smoke inventory cannot be checked without .gitlab-ci.yml"]
+
+    try:
+        inventory = yaml.safe_load(inventory_path.read_text(encoding="utf-8")) or {}
+        ci = yaml.safe_load(ci_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        return [f"CI smoke inventory input is invalid YAML: {exc}"]
+
+    failures: list[str] = []
+    if inventory.get("apiVersion") != "homelab.embedings.ai/v1alpha1":
+        failures.append("CI smoke inventory apiVersion mismatch")
+    if inventory.get("kind") != "CiSmokeInventory":
+        failures.append("CI smoke inventory kind mismatch")
+
+    spec = inventory.get("spec") or {}
+    records = spec.get("smokeTests") if isinstance(spec, dict) else None
+    if not isinstance(records, list) or not records:
+        return failures + ["CI smoke inventory has no spec.smokeTests records"]
+
+    jobs = [record.get("job") for record in records if isinstance(record, dict)]
+    if len(jobs) != len(records) or any(not isinstance(job, str) or not job for job in jobs):
+        failures.append("every CI smoke record must declare a non-empty job")
+        return failures
+
+    duplicates = sorted({job for job in jobs if jobs.count(job) > 1})
+    if duplicates:
+        failures.append(f"duplicate CI smoke records: {duplicates}")
+
+    required_jobs = set(registry.get("required_jobs") or [])
+    smoke_jobs = set(jobs)
+    missing = sorted(required_jobs - smoke_jobs)
+    extra = sorted(smoke_jobs - required_jobs)
+    if missing:
+        failures.append(f"required CI jobs missing smoke records: {missing}")
+    if extra:
+        failures.append(f"smoke records reference non-required CI jobs: {extra}")
+
+    real_jobs = _real_gitlab_jobs(ci)
+    for record in records:
+        job = record["job"]
+        ci_job = real_jobs.get(job)
+        if ci_job is None:
+            failures.append(f"smoke record references missing GitLab job: {job}")
+            continue
+
+        smoke_class = record.get("class")
+        if smoke_class not in SMOKE_CLASSES:
+            failures.append(f"{job} smoke class is invalid: {smoke_class}")
+
+        command = record.get("command")
+        if not isinstance(command, str) or not command:
+            failures.append(f"{job} smoke command is missing")
+        elif command not in _script_lines(ci_job):
+            failures.append(
+                f"{job} smoke command is stale or not wired in .gitlab-ci.yml: {command}"
+            )
+
+        tools = record.get("requiredTools")
+        if (not isinstance(tools, list) or not tools
+                or any(not isinstance(tool, str) or not tool for tool in tools)
+                or len(tools) != len(set(tools))):
+            failures.append(f"{job} requiredTools must be a non-empty unique string list")
+
+        artifact = record.get("artifactUnderTest")
+        if (not isinstance(artifact, dict) or not artifact.get("type")
+                or not artifact.get("digestSource")):
+            failures.append(f"{job} artifactUnderTest needs type and digestSource")
+
+        if record.get("mutation") in (None, ""):
+            failures.append(f"{job} mutation classification is missing")
+        timeout = record.get("timeoutSeconds")
+        if not isinstance(timeout, int) or isinstance(timeout, bool) or not 1 <= timeout <= 3600:
+            failures.append(f"{job} timeoutSeconds must be an integer from 1 through 3600")
+        if record.get("evidencePath") != f"reports/smoke/{job}.json":
+            failures.append(f"{job} evidencePath must be reports/smoke/{job}.json")
+        if record.get("cleanupPolicy") in (None, "", "none", "not-applicable"):
+            failures.append(f"{job} cleanupPolicy is missing")
+        if record.get("releaseBlocking") is not True:
+            failures.append(f"{job} smoke must be releaseBlocking")
+
+    return failures
+
+
 def _check_gitlab(registry: dict) -> tuple[list[str], bool]:
     """Checks 4, 5 & 8 against ``.gitlab-ci.yml`` when it exists.
 
@@ -159,11 +286,8 @@ def _check_gitlab(registry: dict) -> tuple[list[str], bool]:
             "gitlab: top-level 'include:' makes the pipeline unanalyzable by the meta-gate — jobs "
             "can be defined outside .gitlab-ci.yml; inline them or teach the meta-gate to resolve it")
     default_tags = (ci.get("default") or {}).get("tags") or []
-    real_jobs = {}
-    for name, job in ci.items():
-        if name in GITLAB_GLOBAL_KEYS or not isinstance(job, dict) or name.startswith("."):
-            continue  # reserved global keyword or hidden template, not a job
-        real_jobs[name] = job
+    real_jobs = _real_gitlab_jobs(ci)
+    for name, job in real_jobs.items():
         if job.get("allow_failure") is True:
             failures.append(f"gitlab job {name}: allow_failure:true is forbidden")
         tags = job["tags"] if "tags" in job else default_tags
@@ -203,7 +327,8 @@ def run() -> tuple[bool, list[str], list[str]]:
     """
     registry = _load_registry()
     failures = (_check_commands(registry) + _check_mandatory_ids(registry)
-                + _check_no_unregistered_scripts(registry))
+                + _check_no_unregistered_scripts(registry)
+                + _check_smoke_inventory(registry))
     skipped: list[str] = []
     mod_fail, mod_ran = _check_modules()
     failures += mod_fail


### PR DESCRIPTION
## Summary
- add a closed-world smoke inventory for the required merge and integration jobs
- validate exact job coverage, record shape, and command wiring in the existing meta-gate
- keep the public inventory allowlist limited to the two standards bindings

## Validation
- required CI pending