### PR TITLE
Verify protected DMTF simulator readiness

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,11 +9,17 @@
 # docs/external/ci.md.
 stages: [validate, integration, deploy, publish]
 
+include:
+  - project: spyroot/builder
+    ref: bdf2c0c23332814075d7d3809ecffe09c37d1800
+    file: /ci/templates/project-service.yml
+
 # The shared toolbox image is the ONLY CI image. It supplies the runtime (conda,
 # git-lfs, gate tools); this project supplies its dependencies via environment.yml.
-# Registry and tag come from builder inventory/images/shared-images.yaml.
+# Registry and digest come from builder inventory/images/shared-images.yaml.
 default:
-  image: harbor.rnd.embedings.ai:30443/spyroot/builder/toolbox:latest
+  image: &builder-toolbox >-
+    harbor.rnd.embedings.ai/spyroot/builder/toolbox@sha256:bba5761e8248eec533b270a4d16966f8440ba2a81287e7ff63907c8b3a483fc9
   tags: [homelab-k8s]
   before_script:
     # Corpora and the DMTF spec bundles are Git LFS; without this the suite runs
@@ -32,6 +38,11 @@ variables:
   # Gates resolve pytest/ruff through the project environment, never a
   # pre-installed toolchain in the image.
   CONDA_ENV: redfish_ctl
+  BUILDER_PROJECT_CONSUMER: redfish_ctl
+  DMTF_RELEASE: "2026.1"
+  PROJECT_LIVE_TEST_COMMAND: >-
+    pytest -q -m dmtf_sim_live
+    tests/k8s/test_dmtf_sim_live.py::test_dmtf_service_root
 
 .private-api-web:
   rules:
@@ -142,22 +153,123 @@ k8s-live-check:
       kubectl get nodes -o wide
       kubectl get crd 2>/dev/null | grep -i redfish || echo "(no redfish CRDs registered)"
 
-# Live apply: protected branch ONLY, manual, serialized (resource_group), never from a merge request.
-deploy-apply:
+# Builder owns publication, the immutable deploy plan, protected mutation, and
+# exact-commit read-back. The consumer names each job so the provider template's
+# artifact DAG remains closed and auditable.
+project-service-image-publish:
+  extends: .builder-project-image-publish
   stage: deploy
-  tags: [homelab-k8s]
-  environment:
-    name: production
-  resource_group: homelab-apply
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-protected]
+  allow_failure: false
+  before_script:
+    - git lfs install --local
+    - >-
+      git lfs pull
+      --include='spec/dmtf/redfish/2026.1/mockups/DSP2043_2026.1.zip'
   rules:
-    - <<: *private-api-web
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
       when: manual
-  variables:
-    MUTATION_LOCK: "$CI_JOB_ID"
-  script:
-    - ./scripts/check.sh --profile deploy
+    - when: never
+
+project-service-chart-publish:
+  extends: .builder-project-chart-publish
+  stage: deploy
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-protected]
+  allow_failure: false
+  before_script: []
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: manual
+    - when: never
+
+project-service-deploy-plan:
+  extends: .builder-project-deploy-plan
+  stage: deploy
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-protected]
+  allow_failure: false
+  before_script: []
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: on_success
+    - when: never
+
+project-service-deploy:
+  extends: .builder-project-deploy
+  stage: deploy
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-protected]
+  allow_failure: false
+  before_script: []
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: manual
+    - when: never
+
+project-service-verify:
+  extends: .builder-project-verify
+  stage: deploy
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-protected]
+  allow_failure: false
+  before_script: []
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: on_success
+    - when: never
+
+project-service-live-test:
+  extends: .builder-project-live-test
+  stage: deploy
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-validation]
+  allow_failure: false
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: on_success
+    - when: never
+
+project-service-rollback:
+  extends: .builder-project-rollback
+  stage: deploy
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-protected]
+  allow_failure: false
+  before_script: []
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: manual
+    - when: never
+
+project-service-release-evidence:
+  extends: .builder-project-release-evidence
+  stage: publish
+  image: *builder-toolbox
+  tags: [homelab-k8s, homelab-k8s-validation]
+  allow_failure: false
+  before_script: []
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
+    - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+      when: on_success
+    - when: never
 
 # Gated outbound mirror: internal GitLab is the source of truth; this is the ONLY path to public GitHub.
 # Runs the boundary gates (agent files/names/secrets) FIRST, then pushes on pass. Protected default
@@ -166,6 +278,8 @@ publish-github:
   stage: publish
   tags: [homelab-k8s]
   rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+      when: never
     - <<: *private-api-web
       when: never
     - if: >-

--- a/charts/dmtf-sim/templates/deployment.yaml
+++ b/charts/dmtf-sim/templates/deployment.yaml
@@ -1,6 +1,8 @@
 {{- $bundleRoot := printf "/mockups/DSP2043_%s" .Values.dmtf.bundleRelease -}}
 {{- $mockupDir := printf "%s/%s" $bundleRoot .Values.dmtf.profile -}}
 {{- $sourceCommit := required "provenance.sourceCommit must be an exact 40-character commit SHA" .Values.provenance.sourceCommit -}}
+{{- $imageRepository := required "image.repository must be the published simulator repository" .Values.image.repository -}}
+{{- $imageDigest := required "image.digest must be the published sha256 digest" .Values.image.digest -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -53,11 +55,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: dmtf-sim
-          {{- if .Values.image.digest }}
-          image: {{ printf "%s@%s" .Values.image.repository .Values.image.digest | quote }}
-          {{- else }}
-          image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
-          {{- end }}
+          image: {{ printf "%s@%s" $imageRepository $imageDigest | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --host

--- a/charts/dmtf-sim/templates/networkpolicy.yaml
+++ b/charts/dmtf-sim/templates/networkpolicy.yaml
@@ -19,6 +19,11 @@ spec:
   ingress:
     - from:
         - podSelector: {}
+        {{- range .Values.networkPolicy.allowedNamespaceLabels }}
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml . | nindent 14 }}
+        {{- end }}
       ports:
         - protocol: TCP
           port: {{ .Values.containerPort }}

--- a/charts/dmtf-sim/templates/tests/test-connection.yaml
+++ b/charts/dmtf-sim/templates/tests/test-connection.yaml
@@ -1,3 +1,5 @@
+{{- $imageRepository := required "image.repository must be the published simulator repository" .Values.image.repository -}}
+{{- $imageDigest := required "image.digest must be the published sha256 digest" .Values.image.digest -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -30,11 +32,7 @@ spec:
       type: RuntimeDefault
   containers:
     - name: test-connection
-      {{- if .Values.image.digest }}
-      image: {{ printf "%s@%s" .Values.image.repository .Values.image.digest | quote }}
-      {{- else }}
-      image: {{ printf "%s:%s" .Values.image.repository .Values.image.tag | quote }}
-      {{- end }}
+      image: {{ printf "%s@%s" $imageRepository $imageDigest | quote }}
       imagePullPolicy: {{ .Values.image.pullPolicy }}
       command:
         - python

--- a/charts/dmtf-sim/values.schema.json
+++ b/charts/dmtf-sim/values.schema.json
@@ -25,16 +25,11 @@
     "image": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["repository", "tag", "digest", "pullPolicy"],
+      "required": ["repository", "digest", "pullPolicy"],
       "properties": {
         "repository": {
           "type": "string",
-          "minLength": 1,
-          "pattern": "^[A-Za-z0-9][A-Za-z0-9._:/-]*$"
-        },
-        "tag": {
-          "type": "string",
-          "pattern": "^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$"
+          "pattern": "^$|^[A-Za-z0-9][A-Za-z0-9._:/-]*$"
         },
         "digest": {
           "type": "string",
@@ -151,10 +146,27 @@
     "networkPolicy": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["enabled"],
+      "required": ["enabled", "allowedNamespaceLabels"],
       "properties": {
         "enabled": {
           "type": "boolean"
+        },
+        "allowedNamespaceLabels": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["homelab.embedings.ai/ci-class"],
+            "properties": {
+              "homelab.embedings.ai/ci-class": {
+                "type": "string",
+                "enum": ["validation", "protected"]
+              }
+            }
+          }
         }
       }
     },

--- a/charts/dmtf-sim/values.yaml
+++ b/charts/dmtf-sim/values.yaml
@@ -1,8 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: harbor.rnd.embedings.ai:30443/spyroot/redfish-dmtf-sim
-  tag: "2026.1"
+  repository: ""
   digest: ""
   pullPolicy: IfNotPresent
 
@@ -29,6 +28,9 @@ serviceAccount:
 
 networkPolicy:
   enabled: true
+  allowedNamespaceLabels:
+    - homelab.embedings.ai/ci-class: validation
+    - homelab.embedings.ai/ci-class: protected
 
 resources:
   requests:

--- a/docs/external/ci.md
+++ b/docs/external/ci.md
@@ -49,6 +49,33 @@ pipelines continue to select `gate-merge` through their normal GitLab rules.
 Pipeline credentials come from the configured Internal GitLab CI binding; do
 not copy tokens into the repository or pass them on the command line.
 
+## Protected DMTF simulator deployment
+
+Run the simulator deployment only from the protected default-branch pipeline
+in Internal GitLab. The exact provider template is allow-listed by
+`trusted_includes` in `gates/manifest.yaml`; see [Trusted provider
+includes](gates.md#trusted-provider-includes). The pipeline supplies
+`BUILDER_PROJECT_CONSUMER=redfish_ctl`, `DMTF_RELEASE`, and
+`PROJECT_LIVE_TEST_COMMAND`. The provider binding supplies `REDFISH_IP` and
+`REDFISH_PORT` to the live test.
+
+1. Play `project-service-image-publish` and
+   `project-service-chart-publish`. Their exact-commit receipts supply the
+   image repository, image digest, chart version, and source commit; the chart
+   has no mutable tag fallback.
+2. Wait for `project-service-deploy-plan`, then play
+   `project-service-deploy`. Both mutation jobs are protected, serialized, and
+   unavailable to merge-request pipelines.
+3. Require terminal success from `project-service-verify`,
+   `project-service-live-test`, and `project-service-release-evidence`. The
+   live test reads `/redfish/v1/` through `RedfishManager`; a pod readiness
+   probe or HTTP status alone is not the release evidence.
+
+`project-service-rollback` is the protected manual recovery path. The pull
+credential prerequisite is documented under [Private DMTF simulator
+image](secrets.md#private-dmtf-simulator-image), and the served resource
+contract is [Redfish Simulator Contract](simulator-contract.md).
+
 ## Supplemental `ci.yml` check
 
 Triggers on pushes to `main` and on every pull request.

--- a/docs/external/gates.md
+++ b/docs/external/gates.md
@@ -28,6 +28,16 @@ candidate ref so the configured GitLab pipeline runs it. A gate never runs on a 
 - **deploy** — live apply. Protected pipeline only, manual, serialized. Never reachable from a
   merge-request pipeline.
 
+## Trusted provider includes
+
+`trusted_includes` in `gates/manifest.yaml` is the only allow-list for
+provider-owned GitLab templates. Each entry pins the provider project, exact
+40-character commit, template file, permitted hidden templates, and their
+mutation classification. A local wrapper must still declare its stage, runner tags, rules, and
+`allow_failure: false`, so `tools/gate_meta.py` can reject a floating include,
+unknown template, or merge-request-reachable mutation. The protected simulator
+job sequence is documented in [CI/CD Pipeline](ci.md#protected-dmtf-simulator-deployment).
+
 ## The gates
 
 | id | profile | mutates | what it checks | fails when |

--- a/docs/external/secrets.md
+++ b/docs/external/secrets.md
@@ -61,7 +61,18 @@ Provide both as masked, protected CI variables or through the configured secret
 provider. Do not reuse the exporter ingest token: ingest and API-query scopes
 serve different endpoints. See [Telemetry liveness checks](gates.md#telemetry-liveness-checks).
 
-## Image pull (only if the images are private)
+## Image pull
+
+### Private DMTF simulator image
+
+`harbor-registry-pull`, defined by the Builder project-service binding and
+provisioned by its protected bootstrap, is the image-pull `Secret` referenced
+by `charts/dmtf-sim/values.yaml`. It must exist in the `dmtf-bmc` namespace;
+operators do not copy its credential into chart values or pipeline variables.
+See [Protected DMTF simulator deployment](ci.md#protected-dmtf-simulator-deployment)
+for the publish and deploy sequence.
+
+### Public GHCR images
 
 The published images (`redfish-ctl`, `redfish-ctl-controller`, `redfish-ctl-mock-bmc`) are intended to
 be public on GHCR, so no pull secret is needed. Verify with an anonymous pull before assuming it:

--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -20,6 +20,23 @@ required_jobs:
 diagnostic_jobs:
   - focused-gate
 
+# GitLab resolves this content-addressed provider template before creating a
+# pipeline. The meta-gate permits only these hidden templates from this exact
+# immutable include; floating refs and unknown external templates remain fatal.
+trusted_includes:
+  - project: spyroot/builder
+    ref: bdf2c0c23332814075d7d3809ecffe09c37d1800
+    file: /ci/templates/project-service.yml
+    templates:
+      - {name: .builder-project-image-publish, mutates: true}
+      - {name: .builder-project-chart-publish, mutates: true}
+      - {name: .builder-project-deploy-plan, mutates: false}
+      - {name: .builder-project-deploy, mutates: true}
+      - {name: .builder-project-verify, mutates: false}
+      - {name: .builder-project-live-test, mutates: false}
+      - {name: .builder-project-rollback, mutates: true}
+      - {name: .builder-project-release-evidence, mutates: false}
+
 mandatory_ids:
   - meta.gate-registry
   - meta.ci-runner-tags

--- a/schemas/gates.schema.json
+++ b/schemas/gates.schema.json
@@ -37,6 +37,48 @@
         "minLength": 1
       }
     },
+    "trusted_includes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["project", "ref", "file", "templates"],
+        "properties": {
+          "project": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$"
+          },
+          "ref": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{40}$"
+          },
+          "file": {
+            "type": "string",
+            "pattern": "^/[^\\n]+\\.ya?ml$"
+          },
+          "templates": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["name", "mutates"],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^\\.[A-Za-z0-9_.-]+$"
+                },
+                "mutates": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "mandatory_ids": {
       "type": "array",
       "minItems": 1,

--- a/scripts/gates/kubernetes/dmtf_sim_values.bash
+++ b/scripts/gates/kubernetes/dmtf_sim_values.bash
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Sourceable deterministic image identity for offline DMTF simulator chart gates.
+
+dmtf_sim_set_helm_values() {
+  local source_commit="${1:?source commit is required}"
+  local image_repository="registry.invalid/redfish/dmtf-sim"
+  local image_digest="sha256:$(printf '0%.0s' {1..64})"
+
+  DMTF_SIM_HELM_VALUES=(
+    --set-string "provenance.sourceCommit=$source_commit"
+    --set-string "image.repository=$image_repository"
+    --set-string "image.digest=$image_digest"
+  )
+}

--- a/scripts/gates/kubernetes/policy.sh
+++ b/scripts/gates/kubernetes/policy.sh
@@ -3,6 +3,7 @@
 # in the toolchain (a missing policy engine FAILS the gate — never an implicit pass).
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+source scripts/gates/kubernetes/dmtf_sim_values.bash
 if ! command -v kube-linter >/dev/null 2>&1; then
   echo "kubernetes.policy: kube-linter not installed in this gate environment" >&2
   exit 1
@@ -19,11 +20,12 @@ if [[ ! "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then
   echo "kubernetes.policy: exact source commit is unavailable" >&2
   exit 1
 fi
+dmtf_sim_set_helm_values "$source_commit"
 rendered_dmtf="$(mktemp)"
 trap 'rm -f -- "$rendered_dmtf"' EXIT
 helm template dmtf-sim charts/dmtf-sim \
   --namespace dmtf-bmc \
-  --set-string provenance.sourceCommit="$source_commit" >"$rendered_dmtf"
+  "${DMTF_SIM_HELM_VALUES[@]}" >"$rendered_dmtf"
 kube-linter lint \
   k8s/ \
   charts/redfish-controller/ \

--- a/scripts/gates/kubernetes/render.sh
+++ b/scripts/gates/kubernetes/render.sh
@@ -4,6 +4,7 @@
 # lint strictly and render every chart. No cluster contact is made.
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+source scripts/gates/kubernetes/dmtf_sim_values.bash
 
 # YAML syntax gate over static (non-__PLACEHOLDER__) manifests.
 python - <<'PY'
@@ -38,23 +39,25 @@ if [[ ! "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then
   exit 1
 fi
 
+dmtf_sim_set_helm_values "$source_commit"
+
 helm lint --strict charts/redfish-controller >/dev/null
 helm template redfish-controller charts/redfish-controller \
   --namespace redfish-system >/dev/null
 helm lint --strict charts/dmtf-sim \
-  --set-string provenance.sourceCommit="$source_commit" >/dev/null
+  "${DMTF_SIM_HELM_VALUES[@]}" >/dev/null
 helm template dmtf-sim charts/dmtf-sim \
   --namespace dmtf-bmc \
   --skip-tests \
-  --set-string provenance.sourceCommit="$source_commit" >/dev/null
+  "${DMTF_SIM_HELM_VALUES[@]}" >/dev/null
 helm template dmtf-sim charts/dmtf-sim \
   --namespace dmtf-bmc \
   --show-only templates/tests/test-connection.yaml \
-  --set-string provenance.sourceCommit="$source_commit" >/dev/null
+  "${DMTF_SIM_HELM_VALUES[@]}" >/dev/null
 
 if helm template dmtf-sim charts/dmtf-sim \
   --namespace dmtf-bmc \
-  --set-string provenance.sourceCommit="$source_commit" \
+  "${DMTF_SIM_HELM_VALUES[@]}" \
   --set-string dmtf.profile=no-such-profile >/dev/null 2>&1; then
   echo "kubernetes.render: dmtf-sim accepted an unknown profile" >&2
   exit 1

--- a/scripts/gates/kubernetes/schema.sh
+++ b/scripts/gates/kubernetes/schema.sh
@@ -3,6 +3,7 @@
 # kubeconform in the toolchain (a missing validator FAILS the gate).
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
+source scripts/gates/kubernetes/dmtf_sim_values.bash
 if ! command -v kubeconform >/dev/null 2>&1; then
   echo "kubernetes.schema: kubeconform not installed in this gate environment" >&2
   exit 1
@@ -19,6 +20,7 @@ if [[ ! "$source_commit" =~ ^[0-9a-f]{40}$ ]]; then
   echo "kubernetes.schema: exact source commit is unavailable" >&2
   exit 1
 fi
+dmtf_sim_set_helm_values "$source_commit"
 # Validate concrete manifests first. Skip Helm templates and placeholder
 # manifests here; rendered chart output is validated separately below.
 files="$(git ls-files 'k8s/**/*.yaml' 'charts/**/*.yaml' | while read -r f; do
@@ -36,12 +38,12 @@ helm template redfish-controller charts/redfish-controller \
 helm template dmtf-sim charts/dmtf-sim \
   --namespace dmtf-bmc \
   --skip-tests \
-  --set-string provenance.sourceCommit="$source_commit" |
+  "${DMTF_SIM_HELM_VALUES[@]}" |
   kubeconform -ignore-missing-schemas -summary
 helm template dmtf-sim charts/dmtf-sim \
   --namespace dmtf-bmc \
   --show-only templates/tests/test-connection.yaml \
-  --set-string provenance.sourceCommit="$source_commit" |
+  "${DMTF_SIM_HELM_VALUES[@]}" |
   kubeconform -ignore-missing-schemas -summary
 static_count="$(echo "$files" | wc -l | tr -d ' ')"
 echo "kubernetes.schema: OK (${static_count} static manifests + rendered charts)"

--- a/scripts/gates/repository/shellcheck.sh
+++ b/scripts/gates/repository/shellcheck.sh
@@ -6,7 +6,13 @@ if ! command -v shellcheck >/dev/null 2>&1; then
   echo "repo.shellcheck: shellcheck not installed in this gate environment" >&2
   exit 1
 fi
-mapfile -t files < <(git ls-files 'scripts/*.sh' 'scripts/gates/**/*.sh' 'docker/**/*.sh')
+mapfile -t files < <(
+  git ls-files \
+    'scripts/*.sh' \
+    'scripts/gates/**/*.sh' \
+    'scripts/gates/**/*.bash' \
+    'docker/**/*.sh'
+)
 # The repo tracks shell scripts under these pathspecs, so an empty set means the listing failed or the
 # pathspecs went stale — not that there is nothing to check. Passing here would mean the gate proved
 # nothing, so it fails instead.

--- a/specs/sim/dmtf-sim-contract.yaml
+++ b/specs/sim/dmtf-sim-contract.yaml
@@ -1,7 +1,6 @@
-# DMTF SIM — machine-readable contract. Written for AGENTS, not humans.
-# An agent parses this to CONSUME the sim correctly without re-deriving its
-# behavior, and to REVIEW any sim change: an implementation that disagrees
-# with this file is the bug (same authority rule as the architecture spec).
+# DMTF SIM — machine-readable contract.
+# Consumers use this contract without re-deriving simulator behavior. An
+# implementation that disagrees with this file is the bug.
 # Conformance is PROVEN, not promised: the consistency check named under
 # `conformance` interrogates every URI the bundle declares.
 schema: redfish_ctl.dmtf_sim_contract/v1
@@ -24,7 +23,7 @@ binding:
     proof: "tools/mockup_consistency_check.py — harvests EVERY @odata.id the
       bundle itself declares, interrogates the sim, asserts 1:1 (see
       guarantees.fidelity); exit 0 is the gate for every deliverable built on
-      the sim (queue item dmtf-sim-deployment D0)"
+      the sim"
 
 # ---------------------------------------------------------------------------
 # PROVIDES — the full caller-visible surface. Nothing else exists.
@@ -84,7 +83,7 @@ guarantees:
     declare readOnlyRootFilesystem + runAsNonRoot as a matter of contract."
 
 # ---------------------------------------------------------------------------
-# NOT PROVIDED — agents must not test these against this sim.
+# NOT PROVIDED — unsupported behavior must not be tested against this sim.
 # ---------------------------------------------------------------------------
 not_provided:
   mutation: "no POST/PATCH/DELETE semantics — no subscription create, no BIOS
@@ -109,14 +108,12 @@ not_provided:
 consumers:
   - {use: dmtf_generic_lens_tests, how: "in-process/subprocess server in
       tests/k8s/; the DMTF side of dual-lens assertions"}
-  - {use: overlap_diff, how: "the DMTF side of the executable 5-check diff
-      (queue item dmtf-overlap-diff): same command against sim and corpus,
-      diff = subset|full|full_plus_oem"}
+  - {use: overlap_diff, how: "the DMTF side of the executable 5-check diff:
+      same command against sim and corpus, diff = subset|full|full_plus_oem"}
   - {use: telemetry_loop, how: "T2: telemetry requests read FROM the bundle's
       own JSON, sent to the sim, telemetry mocked back to the caller"}
-  - {use: persistent_reference, how: "the deployed pod (charts/dmtf-sim,
-      queue item dmtf-sim-deployment D1-D7 approved 2026-07-25): a standing
-      DMTF BMC address for smoke/admission tests and live-diff targets"}
+  - {use: persistent_reference, how: "the charts/dmtf-sim pod provides a
+      standing DMTF BMC address for smoke/admission tests and live-diff targets"}
   - {use: live_diff_target, how: "tools/corpus.py live-diff --ip <sim> proves
       pod == bundle over the network; the same engine, zero new code"}
 
@@ -128,6 +125,6 @@ deployment:
     used by unit tests)"
   subprocess: "python k8s/sandbox/mock_bmc_server.py --mockup-dir <root>
     --port <p> (used by the conformance proof and integration tests)"
-  persistent_pod: "k8s/sandbox/dmtf-sim.yaml today; charts/dmtf-sim once the
-    deployment deliverables land (image from Harbor via the private CI, the
-    bundle BAKED at build time — no runtime LFS, no PVC)"
+  persistent_pod: "charts/dmtf-sim deploys the persistent pod; the Harbor
+    image is digest-pinned and the bundle is baked at build time — no runtime
+    LFS and no PVC"

--- a/tests/gates/test_dmtf_sim_chart.py
+++ b/tests/gates/test_dmtf_sim_chart.py
@@ -24,6 +24,8 @@ BUNDLE = (
 )
 BUNDLE_SHA256 = "481990aa1e77a675b5cc919483b4bc2dd8e832f91ba9b0e3f001ee2b2c8ddef7"
 TEST_COMMIT = "c" * 40
+TEST_IMAGE_REPOSITORY = "registry.invalid/redfish/dmtf-sim"
+TEST_IMAGE_DIGEST = "sha256:" + "0" * 64
 ANNOTATIONS = {
     "dmtf.redfish.ctl.dev/bundle-release": "2026.1",
     "dmtf.redfish.ctl.dev/bundle-sha256": BUNDLE_SHA256,
@@ -52,6 +54,10 @@ def _helm_command(*extra_args: str, include_tests: bool = False) -> list[str]:
         "dmtf-bmc",
         "--set-string",
         f"provenance.sourceCommit={TEST_COMMIT}",
+        "--set-string",
+        f"image.repository={TEST_IMAGE_REPOSITORY}",
+        "--set-string",
+        f"image.digest={TEST_IMAGE_DIGEST}",
     ]
     if not include_tests:
         command.append("--skip-tests")
@@ -104,17 +110,24 @@ def test_chart_metadata_schema_defaults_and_strict_lint() -> None:
     assert chart["name"] == "dmtf-sim"
     assert chart["type"] == "application"
     assert chart["appVersion"] == "2026.1"
-    assert values["image"]["repository"] == (
-        "harbor.rnd.embedings.ai:30443/spyroot/redfish-dmtf-sim"
-    )
-    assert values["image"]["tag"] == "2026.1"
+    assert values["image"]["repository"] == ""
+    assert "tag" not in values["image"]
+    assert values["image"]["digest"] == ""
     assert values["service"] == {"type": "ClusterIP", "port": 80}
     assert values["imagePullSecrets"] == ["harbor-registry-pull"]
     assert values["dmtf"]["bundleRelease"] == "2026.1"
     assert values["dmtf"]["bundleSha256"] == BUNDLE_SHA256
     assert values["dmtf"]["profile"] == "public-rackmount1"
     assert values["provenance"]["sourceCommit"] == ""
+    assert values["networkPolicy"]["allowedNamespaceLabels"] == [
+        {"homelab.embedings.ai/ci-class": "validation"},
+        {"homelab.embedings.ai/ci-class": "protected"},
+    ]
     assert schema["additionalProperties"] is False
+    image_schema = schema["properties"]["image"]
+    assert set(image_schema["required"]) == {"repository", "digest", "pullPolicy"}
+    assert "tag" not in image_schema["properties"]
+    assert image_schema["properties"]["digest"]["pattern"] == "^$|^sha256:[0-9a-f]{64}$"
 
     result = subprocess.run(
         [
@@ -124,6 +137,10 @@ def test_chart_metadata_schema_defaults_and_strict_lint() -> None:
             str(CHART_DIR),
             "--set-string",
             f"provenance.sourceCommit={TEST_COMMIT}",
+            "--set-string",
+            f"image.repository={TEST_IMAGE_REPOSITORY}",
+            "--set-string",
+            f"image.digest={TEST_IMAGE_DIGEST}",
         ],
         capture_output=True,
         text=True,
@@ -139,9 +156,13 @@ def test_render_requires_exact_source_commit_provenance() -> None:
             "template",
             "dmtf-sim",
             str(CHART_DIR),
-            "--namespace",
-            "dmtf-bmc",
-            "--skip-tests",
+                "--namespace",
+                "dmtf-bmc",
+                "--skip-tests",
+                "--set-string",
+                f"image.repository={TEST_IMAGE_REPOSITORY}",
+                "--set-string",
+                f"image.digest={TEST_IMAGE_DIGEST}",
         ],
         capture_output=True,
         text=True,
@@ -235,8 +256,8 @@ def test_default_render_is_namespace_scoped_and_has_no_external_surface() -> Non
     assert forbidden_fields.isdisjoint(_walk_keys(docs))
 
 
-def test_image_tag_digest_and_pull_secret_are_templated() -> None:
-    """Repository overrides, digest pinning, tags, and pull Secret names render."""
+def test_image_digest_and_pull_secret_are_templated() -> None:
+    """Repository overrides, digest pinning, and pull Secret names render."""
     digest = "sha256:" + "a" * 64
     digest_docs = _template(
         "--set-string",
@@ -245,21 +266,52 @@ def test_image_tag_digest_and_pull_secret_are_templated() -> None:
         f"image.digest={digest}",
         "--set-string",
         "imagePullSecrets[0]=custom-pull",
+        include_tests=True,
     )
     deployment = _by_kind(digest_docs, "Deployment")
+    hook = _by_kind(digest_docs, "Pod")
     pod_spec = deployment["spec"]["template"]["spec"]
     assert pod_spec["containers"][0]["image"] == f"registry.invalid/team/sim@{digest}"
     assert pod_spec["imagePullSecrets"] == [{"name": "custom-pull"}]
+    assert hook["spec"]["containers"][0]["image"] == f"registry.invalid/team/sim@{digest}"
+    assert hook["spec"]["imagePullSecrets"] == [{"name": "custom-pull"}]
 
-    tag_docs = _template(
-        "--set-string",
-        "image.repository=registry.invalid/team/sim",
-        "--set-string",
-        "image.tag=verified-tag",
+
+def test_image_tag_fallback_and_missing_identity_are_rejected() -> None:
+    """The simulator image identity is repository plus sha256 digest only."""
+    digest = "sha256:" + "b" * 64
+    invalid_cases = (
+        ("--set-string", "image.digest="),
+        ("--set-string", "image.repository=", "--set-string", f"image.digest={digest}"),
+        (
+            "--set-string",
+            "image.tag=verified-tag",
+            "--set-string",
+            "image.digest=",
+        ),
     )
-    tag_deployment = _by_kind(tag_docs, "Deployment")
-    tag_container = tag_deployment["spec"]["template"]["spec"]["containers"][0]
-    assert tag_container["image"] == "registry.invalid/team/sim:verified-tag"
+
+    for invalid_args in invalid_cases:
+        result = subprocess.run(
+            _helm_command(*invalid_args),
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_chart_templates_do_not_contain_tag_fallback() -> None:
+    """Chart templates must not carry a dead tag path beside the digest contract."""
+    rendered_sources = "\n".join(
+        (CHART_DIR / path).read_text(encoding="utf-8")
+        for path in (
+            "templates/deployment.yaml",
+            "templates/tests/test-connection.yaml",
+        )
+    )
+
+    assert ".Values.image.tag" not in rendered_sources
+    assert "if .Values.image.digest" not in rendered_sources
 
 
 def test_pull_secret_is_name_only_and_no_secret_resource_is_rendered() -> None:
@@ -339,15 +391,31 @@ def test_profile_argument_provenance_and_workload_security() -> None:
     assert container["securityContext"]["capabilities"] == {"drop": ["ALL"]}
 
 
-def test_network_policy_allows_only_same_namespace_clients() -> None:
-    """Default ingress is restricted to simulator traffic from its namespace."""
+def test_network_policy_allows_only_registered_client_namespaces() -> None:
+    """Ingress admits same-namespace pods and the two provider-bound CI classes."""
     policy = _by_kind(_template(), "NetworkPolicy")
 
     assert policy["spec"]["policyTypes"] == ["Ingress"]
     assert "egress" not in policy["spec"]
     assert policy["spec"]["ingress"] == [
         {
-            "from": [{"podSelector": {}}],
+            "from": [
+                {"podSelector": {}},
+                {
+                    "namespaceSelector": {
+                        "matchLabels": {
+                            "homelab.embedings.ai/ci-class": "validation"
+                        }
+                    }
+                },
+                {
+                    "namespaceSelector": {
+                        "matchLabels": {
+                            "homelab.embedings.ai/ci-class": "protected"
+                        }
+                    }
+                },
+            ],
             "ports": [{"protocol": "TCP", "port": 8080}],
         }
     ]

--- a/tests/gates/test_gate_meta.py
+++ b/tests/gates/test_gate_meta.py
@@ -2,6 +2,7 @@
 import ast
 import json
 import re
+import textwrap
 from pathlib import Path
 
 import yaml
@@ -10,6 +11,24 @@ from tools import gate_meta
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CI_FILE = REPO_ROOT / ".gitlab-ci.yml"
+BUILDER_PROJECT_INCLUDE_FILE = "/ci/templates/project-service.yml"
+PROJECT_SERVICE_JOBS = {
+    "project-service-image-publish": ".builder-project-image-publish",
+    "project-service-chart-publish": ".builder-project-chart-publish",
+    "project-service-deploy-plan": ".builder-project-deploy-plan",
+    "project-service-deploy": ".builder-project-deploy",
+    "project-service-verify": ".builder-project-verify",
+    "project-service-live-test": ".builder-project-live-test",
+    "project-service-rollback": ".builder-project-rollback",
+    "project-service-release-evidence": ".builder-project-release-evidence",
+}
+PROJECT_SERVICE_TEMPLATE_NAMES = set(PROJECT_SERVICE_JOBS.values())
+MUTATING_PROJECT_SERVICE_TEMPLATES = {
+    ".builder-project-image-publish",
+    ".builder-project-chart-publish",
+    ".builder-project-deploy",
+    ".builder-project-rollback",
+}
 
 
 def _ci_config() -> dict:
@@ -32,6 +51,67 @@ def _script_lines(job: dict) -> list[str]:
     if isinstance(script, str):
         return [script]
     return [str(line) for line in script]
+
+
+def _trusted_project_service_registry(
+    *,
+    required_jobs: list[str] | None = None,
+) -> dict:
+    """Return the minimal registry contract for one trusted Builder include.
+
+    :param required_jobs: GitLab job names the meta-gate must find.
+    :return: a registry dict suitable for direct ``gate_meta`` unit checks.
+    """
+    return {
+        "version": 1,
+        "runner_tag": "homelab-k8s",
+        "required_jobs": required_jobs or ["gate-merge"],
+        "mandatory_ids": [],
+        "trusted_includes": [
+            {
+                "project": "spyroot/builder",
+                "ref": "a" * 40,
+                "file": BUILDER_PROJECT_INCLUDE_FILE,
+                "templates": [
+                    {
+                        "name": name,
+                        "mutates": name in MUTATING_PROJECT_SERVICE_TEMPLATES,
+                    }
+                    for name in sorted(PROJECT_SERVICE_TEMPLATE_NAMES)
+                ],
+            }
+        ],
+        "gates": [],
+    }
+
+
+def _check_temp_gitlab(
+    tmp_path: Path,
+    monkeypatch,
+    body: str,
+    registry: dict,
+) -> tuple[list[str], bool]:
+    """Run the GitLab meta-check against a temporary pipeline file."""
+    (tmp_path / ".gitlab-ci.yml").write_text(textwrap.dedent(body), encoding="utf-8")
+    monkeypatch.setattr(gate_meta, "REPO_ROOT", tmp_path)
+    return gate_meta._check_gitlab(registry)
+
+
+def _registry_trusted_include() -> dict:
+    """Return the single trusted include declared by the live gate registry."""
+    registry = gate_meta._load_registry()
+    records = registry.get("trusted_includes") or []
+    assert len(records) == 1, "the provider include contract must be single-sourced"
+    include = records[0]
+    assert include["project"] == "spyroot/builder"
+    assert include["file"] == BUILDER_PROJECT_INCLUDE_FILE
+    assert re.fullmatch(r"[0-9a-f]{40}", include["ref"])
+    contracts = {item["name"]: item["mutates"] for item in include["templates"]}
+    assert set(contracts) == PROJECT_SERVICE_TEMPLATE_NAMES
+    assert {
+        name for name, mutates in contracts.items() if mutates
+    } == MUTATING_PROJECT_SERVICE_TEMPLATES
+    return include
 
 
 _ALLOWED_GITLAB_EXPR_NODES = (
@@ -199,6 +279,234 @@ def test_registry_declares_exactly_one_diagnostic_focused_gate_job() -> None:
     assert "focused-gate" not in registry.get("required_jobs", [])
 
 
+def test_registry_pins_exact_builder_project_service_include() -> None:
+    """The only trusted provider include is a registry-declared exact commit."""
+    _registry_trusted_include()
+
+
+def test_meta_gate_accepts_registry_trusted_include_and_allowed_template(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A trusted exact include plus a locally guarded allowed template is analyzable."""
+    registry = _trusted_project_service_registry(
+        required_jobs=["gate-merge", "project-service-deploy-plan"]
+    )
+    ref = registry["trusted_includes"][0]["ref"]
+
+    failures, ran = _check_temp_gitlab(
+        tmp_path,
+        monkeypatch,
+        f"""
+        include:
+          - project: spyroot/builder
+            ref: {ref}
+            file: {BUILDER_PROJECT_INCLUDE_FILE}
+
+        gate-merge:
+          stage: validate
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+
+        project-service-deploy-plan:
+          stage: validate
+          tags: [homelab-k8s]
+          allow_failure: false
+          rules:
+            - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+              when: never
+            - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+              when: on_success
+            - when: never
+          extends: .builder-project-deploy-plan
+        """,
+        registry,
+    )
+
+    assert ran
+    assert failures == []
+
+
+def test_meta_gate_rejects_floating_or_untrusted_provider_include() -> None:
+    """Floating refs, unknown providers, unknown files, and local includes fail closed."""
+    registry = _trusted_project_service_registry()
+    ref = registry["trusted_includes"][0]["ref"]
+    cases = (
+        {"project": "spyroot/builder", "ref": "main", "file": BUILDER_PROJECT_INCLUDE_FILE},
+        {"project": "spyroot/other", "ref": ref, "file": BUILDER_PROJECT_INCLUDE_FILE},
+        {"project": "spyroot/builder", "ref": ref, "file": "/ci/templates/other.yml"},
+        {"local": "ci/project-service.yml"},
+    )
+
+    for include in cases:
+        failures, allowed_templates = gate_meta._check_trusted_includes(
+            {"include": [include]}, registry
+        )
+        assert failures, include
+        assert set(allowed_templates) == PROJECT_SERVICE_TEMPLATE_NAMES
+
+
+def test_meta_gate_rejects_unknown_external_template(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A local job may extend only templates declared by the trusted include contract."""
+    registry = _trusted_project_service_registry()
+    ref = registry["trusted_includes"][0]["ref"]
+
+    failures, ran = _check_temp_gitlab(
+        tmp_path,
+        monkeypatch,
+        f"""
+        include:
+          - project: spyroot/builder
+            ref: {ref}
+            file: {BUILDER_PROJECT_INCLUDE_FILE}
+
+        gate-merge:
+          stage: validate
+          tags: [homelab-k8s]
+          allow_failure: false
+          rules:
+            - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
+          extends: .builder-project-unknown
+        """,
+        registry,
+    )
+
+    assert ran
+    assert any("untrusted external templates" in failure for failure in failures)
+
+
+def test_meta_gate_rejects_unconditional_project_service_deploy(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """An unconditional provider deploy override cannot bypass the MR fence."""
+    registry = _trusted_project_service_registry(
+        required_jobs=["project-service-deploy"]
+    )
+    ref = registry["trusted_includes"][0]["ref"]
+
+    failures, ran = _check_temp_gitlab(
+        tmp_path,
+        monkeypatch,
+        f"""
+        include:
+          - project: spyroot/builder
+            ref: {ref}
+            file: {BUILDER_PROJECT_INCLUDE_FILE}
+
+        project-service-deploy:
+          stage: deploy
+          tags: [homelab-k8s]
+          allow_failure: false
+          rules:
+            - when: manual
+          extends: .builder-project-deploy
+        """,
+        registry,
+    )
+
+    assert ran
+    assert any("does not preserve" in failure for failure in failures)
+
+
+def test_meta_gate_rejects_early_rules_for_every_provider_mutation(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Publication, deployment, and rollback require a leading MR deny."""
+    registry = _trusted_project_service_registry()
+    ref = registry["trusted_includes"][0]["ref"]
+
+    for index, template in enumerate(sorted(MUTATING_PROJECT_SERVICE_TEMPLATES)):
+        job_name = f"unsafe-mutation-{index}"
+        failures, ran = _check_temp_gitlab(
+            tmp_path,
+            monkeypatch,
+            f"""
+            include:
+              - project: spyroot/builder
+                ref: {ref}
+                file: {BUILDER_PROJECT_INCLUDE_FILE}
+
+            gate-merge:
+              stage: validate
+              tags: [homelab-k8s]
+              script: [./scripts/check.sh --profile merge]
+
+            {job_name}:
+              stage: deploy
+              tags: [homelab-k8s]
+              allow_failure: false
+              rules:
+                - if: '$CI_COMMIT_REF_PROTECTED == "true"'
+                  when: manual
+                - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+                  when: never
+                - when: never
+              extends: {template}
+            """,
+            registry,
+        )
+
+        assert ran
+        assert any("does not preserve" in failure for failure in failures), template
+
+
+def test_gitlab_consumes_builder_project_service_contract_without_local_secrets() -> None:
+    """The real pipeline wires the exact include and local project-service wrappers."""
+    trusted_include = _registry_trusted_include()
+    ci = _ci_config()
+    raw_includes = ci.get("include") or []
+    includes = raw_includes if isinstance(raw_includes, list) else [raw_includes]
+    include_identities = {
+        gate_meta._include_key(include)
+        for include in includes
+        if gate_meta._include_key(include) is not None
+    }
+
+    assert (
+        trusted_include["project"],
+        trusted_include["ref"],
+        trusted_include["file"],
+    ) in include_identities
+
+    jobs = _gitlab_jobs()
+    missing_jobs = sorted(set(PROJECT_SERVICE_JOBS) - set(jobs))
+    assert missing_jobs == []
+
+    for name in sorted(PROJECT_SERVICE_JOBS):
+        job = jobs[name]
+        extended = gate_meta._external_templates(job)
+        job_text = repr(job)
+        assert extended, f"{name} must inherit a trusted provider template"
+        assert extended == [PROJECT_SERVICE_JOBS[name]]
+        trusted_names = {item["name"] for item in trusted_include["templates"]}
+        assert set(extended) <= trusted_names
+        mutates = PROJECT_SERVICE_JOBS[name] in MUTATING_PROJECT_SERVICE_TEMPLATES
+        expected_when = "manual" if mutates else "on_success"
+        assert gate_meta._protected_template_rules_match(job, expected_when)
+        assert job.get("stage") in {"validate", "integration", "deploy", "publish"}
+        assert "homelab-k8s" in job.get("tags", [])
+        assert job.get("allow_failure") is False
+        assert job.get("rules"), f"{name} must declare local rules"
+        assert "script" not in job, f"{name} must not shadow the provider template body"
+        assert "trigger" not in job, f"{name} must not hide work in a child pipeline"
+        assert "/Users/" not in job_text
+        assert "~/" not in job_text
+        assert "PRIVATE-TOKEN" not in job_text
+        assert "Authorization:" not in job_text
+
+    image_publish_setup = "\n".join(
+        str(line)
+        for line in jobs["project-service-image-publish"].get("before_script", [])
+    )
+    assert "git lfs install --local" in image_publish_setup
+    assert "DSP2043_2026.1.zip" in image_publish_setup
+
+
 def test_gitlab_uses_full_history_checkout_for_exact_ref_dispatches() -> None:
     """Direct exact-ref pipelines need origin/main history for repo.format merge-base."""
     variables = _ci_config().get("variables") or {}
@@ -253,7 +561,12 @@ def test_internal_api_web_merge_dispatch_selects_only_gate_merge() -> None:
 
 def test_focused_and_merge_dispatch_exclude_private_follow_on_jobs() -> None:
     """API/web dispatch cannot also enqueue integration, deploy, or publish jobs."""
-    forbidden = {"gate-integration", "k8s-live-check", "deploy-apply", "publish-github"}
+    forbidden = {
+        "gate-integration",
+        "k8s-live-check",
+        "publish-github",
+        *PROJECT_SERVICE_JOBS,
+    }
     focused = set(_selected_jobs(
         CI_PIPELINE_SOURCE="api",
         FOCUSED_GATE="unit.all",
@@ -279,5 +592,5 @@ def test_other_gitlab_hosts_open_no_private_dispatch_route() -> None:
         )
         assert "focused-gate" not in selected
         assert "gate-merge" not in selected
-        assert "deploy-apply" not in selected
+        assert set(selected).isdisjoint(PROJECT_SERVICE_JOBS)
         assert "publish-github" not in selected

--- a/tests/k8s/test_dmtf_sim_live.py
+++ b/tests/k8s/test_dmtf_sim_live.py
@@ -1,63 +1,48 @@
 """Live consumer tests against the deployed DMTF simulator (private CI only).
 
-These are marked ``dmtf_sim_live``: they FAIL CLOSED through the
+This test is marked ``dmtf_sim_live`` and FAILS CLOSED through the
 ``dmtf_sim_endpoint`` fixture (which raises, never skips, when REDFISH_IP /
-REDFISH_PORT are unset), and the offline suite deselects them with
-``-m 'not dmtf_sim_live'``. They run only in private CI, where the sim is
+REDFISH_PORT are unset); the offline suite deselects it with
+``-m 'not dmtf_sim_live'``. It runs only in private CI, where the sim is
 deployed and the endpoint is injected. The sim serves DMTF-generic content, so
 the product-neutral ``RedfishManager`` lens is the one under test — no vendor
 (Dell/iDRAC/Supermicro) assumption is made. The endpoint is host + port +
-``is_http`` (a URL is derived locally when a raw request needs one; no second
-environment variable, no full URL passed to redfish_ctl).
-
-    redfish_ctl --host "$REDFISH_IP" --port "$REDFISH_PORT" --use-http metric-definitions
+``is_http``; no second environment variable or full URL is passed to
+``redfish_ctl``.
 
 Author Mus spyroot@gmail.com
 """
 import pytest
-import requests
 
-from redfish_ctl.redfish_api_common import ApiRequestType
 from redfish_ctl.redfish_manager import RedfishManager
 
 pytestmark = pytest.mark.dmtf_sim_live
 
 
-def test_metric_definitions_from_persistent_sim(dmtf_sim_endpoint):
-    """Invoking a telemetry command against the sim returns metric definitions.
+def _manager(endpoint):
+    """Create the generic manager for the one provider-resolved endpoint.
 
-    Proves the telemetry read/decode path works against DMTF-truth telemetry
-    resources through the generic lens; the same invoke emits the metrics/spans
-    the existing Splunk gates validate (Splunk cannot tell hardware from virtual).
-
-    :param dmtf_sim_endpoint: the fail-closed persistent-sim endpoint fixture.
-    :return: None.
+    :param endpoint: the fail-closed persistent-simulator endpoint fixture.
+    :return: a product-neutral Redfish manager.
     """
-    manager = RedfishManager(
-        host=dmtf_sim_endpoint.host,
-        port=dmtf_sim_endpoint.port,
-        username="root",
-        password="mock",
+    return RedfishManager(
+        host=endpoint.host,
+        port=endpoint.port,
         insecure=True,
-        is_http=dmtf_sim_endpoint.is_http,
+        is_http=endpoint.is_http,
     )
-    result = manager.sync_invoke(
-        ApiRequestType.SupermicroMetricReportDefinitions,
-        "metric-definitions",
-    )
-    assert result.error is None
-    assert result.data
 
 
 def test_dmtf_service_root(dmtf_sim_endpoint):
     """The sim answers the Redfish service root over the one endpoint.
 
-    Derives the URL locally from the canonical host + port — no second variable
-    and no full endpoint URL is passed to redfish_ctl.
+    Uses the generic manager so readiness proves the same HTTP stack that
+    commands use, rather than a separate raw HTTP client.
 
     :param dmtf_sim_endpoint: the fail-closed persistent-sim endpoint fixture.
     :return: None.
     """
-    base_url = f"http://{dmtf_sim_endpoint.host}:{dmtf_sim_endpoint.port}"
-    response = requests.get(f"{base_url}/redfish/v1/", timeout=10)
-    assert response.status_code == 200
+    result = _manager(dmtf_sim_endpoint).base_query("/redfish/v1/")
+    assert result.error is None
+    assert isinstance(result.data, dict)
+    assert result.data.get("@odata.id") == "/redfish/v1/"

--- a/tools/gate_meta.py
+++ b/tools/gate_meta.py
@@ -171,6 +171,134 @@ def _script_lines(job: dict) -> list[str]:
     return [str(line) for line in script]
 
 
+def _include_key(include: object) -> tuple[str, str, str] | None:
+    """Return the immutable identity of one supported GitLab project include.
+
+    :param include: parsed item from the top-level GitLab ``include`` value.
+    :return: ``(project, ref, file)`` for a complete project include, otherwise
+        ``None``.
+    """
+    if not isinstance(include, dict):
+        return None
+    project = include.get("project")
+    ref = include.get("ref")
+    file = include.get("file")
+    if not all(isinstance(value, str) and value for value in (project, ref, file)):
+        return None
+    return project, ref, file
+
+
+def _trusted_include_contract(
+    registry: dict,
+) -> tuple[set[tuple[str, str, str]], dict[str, dict]]:
+    """Return closed-world include identities and external template contracts.
+
+    :param registry: parsed gate registry containing ``trusted_includes``.
+    :return: immutable include identities plus hidden-template contracts by name.
+    """
+    identities: set[tuple[str, str, str]] = set()
+    templates: dict[str, dict] = {}
+    for include in registry.get("trusted_includes") or []:
+        identity = _include_key(include)
+        if identity is not None:
+            identities.add(identity)
+        for template in include.get("templates") or []:
+            templates[template["name"]] = template
+    return identities, templates
+
+
+def _check_trusted_includes(
+    ci: dict, registry: dict
+) -> tuple[list[str], dict[str, dict]]:
+    """Validate exact external includes and return their allowed templates.
+
+    The gate never downloads provider YAML. It trusts only an exact commit and
+    closed-world template list declared in the schema-validated local registry;
+    GitLab resolves that immutable content before any job can start.
+
+    :param ci: parsed GitLab pipeline.
+    :param registry: parsed gate registry.
+    :return: validation failures and allowed external template contracts.
+    """
+    expected, templates = _trusted_include_contract(registry)
+    raw_includes = ci.get("include") or []
+    includes = raw_includes if isinstance(raw_includes, list) else [raw_includes]
+    observed: set[tuple[str, str, str]] = set()
+    failures: list[str] = []
+    for include in includes:
+        identity = _include_key(include)
+        if identity is None:
+            failures.append(
+                "gitlab: every external include must declare project, exact ref, and file"
+            )
+            continue
+        if identity not in expected:
+            failures.append(
+                "gitlab: include is not an exact registry-trusted provider artifact: "
+                f"{identity[0]}@{identity[1]}:{identity[2]}"
+            )
+            continue
+        observed.add(identity)
+    for missing in sorted(expected - observed):
+        failures.append(
+            "gitlab: trusted provider include is declared but not consumed: "
+            f"{missing[0]}@{missing[1]}:{missing[2]}"
+        )
+    return failures, templates
+
+
+def _external_templates(job: dict) -> list[str]:
+    """Return normalized template names from a job's ``extends`` value.
+
+    :param job: parsed GitLab job.
+    :return: ordered template names, or an empty list when not extended.
+    """
+    value = job.get("extends")
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    return []
+
+
+def _merge_request_explicitly_blocked(job: dict) -> bool:
+    """Report whether the leading rule explicitly denies merge requests.
+
+    GitLab evaluates rules in order. A leading matching rule with ``when:
+    never`` makes later protected-branch rules unreachable from a merge request.
+
+    :param job: parsed GitLab job.
+    :return: True when merge-request pipelines are explicitly denied.
+    """
+    rules = job.get("rules") or []
+    if not rules or not isinstance(rules[0], dict):
+        return False
+    return rules[0] == {
+        "if": '$CI_PIPELINE_SOURCE == "merge_request_event"',
+        "when": "never",
+    }
+
+
+def _protected_template_rules_match(job: dict, protected_when: str) -> bool:
+    """Require the exact local rule fence for a provider-owned template.
+
+    :param job: parsed local wrapper job.
+    :param protected_when: required protected-ref behavior from the registry.
+    :return: True only for MR deny, protected-ref action, then terminal deny.
+    """
+    return (job.get("rules") or []) == [
+        {
+            "if": '$CI_PIPELINE_SOURCE == "merge_request_event"',
+            "when": "never",
+        },
+        {
+            "if": '$CI_COMMIT_REF_PROTECTED == "true"',
+            "when": protected_when,
+        },
+        {"when": "never"},
+    ]
+
+
 def _check_smoke_inventory(registry: dict) -> list[str]:
     """Enforce exact closed-world coverage of the required GitLab jobs.
 
@@ -280,11 +408,7 @@ def _check_gitlab(registry: dict) -> tuple[list[str], bool]:
         return [], False
     ci = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     runner_tag = registry.get("runner_tag", "homelab-k8s")
-    failures: list[str] = []
-    if "include" in ci:
-        failures.append(
-            "gitlab: top-level 'include:' makes the pipeline unanalyzable by the meta-gate — jobs "
-            "can be defined outside .gitlab-ci.yml; inline them or teach the meta-gate to resolve it")
+    failures, trusted_templates = _check_trusted_includes(ci, registry)
     default_tags = (ci.get("default") or {}).get("tags") or []
     real_jobs = _real_gitlab_jobs(ci)
     for name, job in real_jobs.items():
@@ -293,19 +417,51 @@ def _check_gitlab(registry: dict) -> tuple[list[str], bool]:
         tags = job["tags"] if "tags" in job else default_tags
         if runner_tag not in (tags or []):
             failures.append(f"gitlab job {name}: missing runner tag '{runner_tag}'")
-        # A live-apply/deploy job must not run in a merge-request pipeline.
-        text = repr(job.get("rules")) + repr(job.get("only"))
-        looks_apply = ("apply" in name or "deploy" in name or job.get("mutates") is True)
-        if looks_apply and "merge_request" in text:
-            failures.append(f"gitlab job {name}: live-apply reachable in a merge-request pipeline")
         # Fail closed on a job whose effective body this gate cannot resolve.
-        unresolved = [key for key in ("extends", "trigger") if key in job]
-        if unresolved:
+        extended = _external_templates(job)
+        unknown_templates = sorted(set(extended) - set(trusted_templates))
+        if "trigger" in job:
             failures.append(
-                f"gitlab job {name}: uses {'/'.join(unresolved)} — the meta-gate cannot resolve its "
-                f"effective tags/allow_failure/rules; inline the job body")
-        elif "script" not in job:
-            failures.append(f"gitlab job {name}: no script — not analyzable, inline the job body")
+                f"gitlab job {name}: uses trigger — the meta-gate cannot resolve its effective job")
+        elif "extends" in job and not extended:
+            failures.append(f"gitlab job {name}: has an invalid extends value")
+        elif unknown_templates:
+            failures.append(
+                f"gitlab job {name}: extends untrusted external templates: {unknown_templates}")
+        elif extended:
+            if len(extended) != 1:
+                failures.append(
+                    f"gitlab job {name}: exactly one trusted external template is required")
+                continue
+            contract = trusted_templates[extended[0]]
+            protected_when = "manual" if contract["mutates"] else "on_success"
+            if "tags" not in job:
+                failures.append(
+                    f"gitlab job {name}: trusted external job must declare local runner tags")
+            if job.get("allow_failure") is not False:
+                failures.append(
+                    f"gitlab job {name}: trusted external job must declare allow_failure:false")
+            if not _protected_template_rules_match(
+                job, protected_when
+            ):
+                failures.append(
+                    f"gitlab job {name}: trusted external job does not preserve "
+                    "the registry-declared protected rules")
+            if not job.get("stage"):
+                failures.append(
+                    f"gitlab job {name}: trusted external job must declare a local stage")
+        else:
+            protected_action = any(
+                token in name
+                for token in ("apply", "deploy", "publish", "rollback")
+            )
+            if protected_action and not _merge_request_explicitly_blocked(job):
+                failures.append(
+                    f"gitlab job {name}: mutation is not explicitly denied "
+                    "in a merge-request pipeline")
+            if "script" not in job:
+                failures.append(
+                    f"gitlab job {name}: no script — not analyzable, inline the job body")
     required_jobs = registry.get("required_jobs") or []
     if not required_jobs:
         failures.append(


### PR DESCRIPTION
## Summary
- consume the immutable project-service template and expose the protected publication/deploy evidence chain
- require a digest-pinned simulator image, materialize the DMTF bundle, and admit only registered CI namespace classes
- verify `/redfish/v1/` through `RedfishManager` and document the operator path

## Validation
- local gate execution intentionally not used
- required exact-head CI and protected deployment smoke pending