### PR TITLE
Bind DMTF simulator CI to protected Builder provider

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,11 +73,25 @@ variables:
         ($FOCUSED_GATE == null || $FOCUSED_GATE == "") &&
         $MERGE_PROFILE == "merge"
 
+.project-ci-selector-deny:
+  rules:
+    - &project-ci-selector-deny
+      if: >-
+        ($FOCUSED_GATE != null && $FOCUSED_GATE != "") ||
+        $MERGE_PROFILE == "merge" ||
+        (($PROJECT_CI_PROFILE != null && $PROJECT_CI_PROFILE != "") &&
+        $PROJECT_CI_PROFILE != "protected") ||
+        ($PROJECT_CI_SMOKE != null && $PROJECT_CI_SMOKE != "")
+      when: never
+
 gate-merge:
   stage: validate
   tags: [homelab-k8s]
   rules:
-    - if: '$PROJECT_CI_PROFILE == "focused" || $PROJECT_CI_PROFILE == "full"'
+    - if: >-
+        $PROJECT_CI_PROFILE == "focused" ||
+        $PROJECT_CI_PROFILE == "full" ||
+        ($PROJECT_CI_SMOKE != null && $PROJECT_CI_SMOKE != "")
       when: never
     - <<: *focused-dispatch
       when: never
@@ -160,6 +174,7 @@ project-service-image-publish:
       git lfs pull
       --include='spec/dmtf/redfish/2026.1/mockups/DSP2043_2026.1.zip'
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -174,6 +189,7 @@ project-service-chart-publish:
   allow_failure: false
   before_script: []
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -188,6 +204,7 @@ project-service-deploy-plan:
   allow_failure: false
   before_script: []
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -202,6 +219,7 @@ project-service-deploy:
   allow_failure: false
   before_script: []
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -216,6 +234,7 @@ project-service-verify:
   allow_failure: false
   before_script: []
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -229,6 +248,7 @@ project-service-live-test:
   tags: [homelab-k8s, homelab-k8s-validation]
   allow_failure: false
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -243,6 +263,7 @@ project-service-rollback:
   allow_failure: false
   before_script: []
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'
@@ -257,6 +278,7 @@ project-service-release-evidence:
   allow_failure: false
   before_script: []
   rules:
+    - *project-ci-selector-deny
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
       when: never
     - if: '$CI_COMMIT_REF_PROTECTED == "true"'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,12 +7,15 @@
 # Job rules below isolate diagnostic, merge, integration, protected deployment,
 # scheduled canary, and publication paths. Operator guidance lives in
 # docs/external/ci.md.
-stages: [validate, integration, deploy, publish]
+stages: [project-ci-validation, validate, integration, deploy, publish]
 
 include:
   - project: spyroot/builder
-    ref: bdf2c0c23332814075d7d3809ecffe09c37d1800
+    ref: 1511171608f913833004e29558468d8e481fd947
     file: /ci/templates/project-service.yml
+  - project: spyroot/builder
+    ref: 1511171608f913833004e29558468d8e481fd947
+    file: /ci/templates/project-ci-resource-jobs.yml
 
 # The shared toolbox image is the ONLY CI image. It supplies the runtime (conda,
 # git-lfs, gate tools); this project supplies its dependencies via environment.yml.
@@ -38,6 +41,8 @@ variables:
   # Gates resolve pytest/ruff through the project environment, never a
   # pre-installed toolchain in the image.
   CONDA_ENV: redfish_ctl
+  EXPECTED_PROVIDER_REVISION: 1511171608f913833004e29558468d8e481fd947
+  PROJECT_CI_CPU_COMMAND: ./tools/project-ci-cpu-validation.sh
   BUILDER_PROJECT_CONSUMER: redfish_ctl
   DMTF_RELEASE: "2026.1"
   PROJECT_LIVE_TEST_COMMAND: >-
@@ -68,25 +73,12 @@ variables:
         ($FOCUSED_GATE == null || $FOCUSED_GATE == "") &&
         $MERGE_PROFILE == "merge"
 
-focused-gate:
-  stage: validate
-  tags: [homelab-k8s]
-  rules:
-    - *focused-dispatch
-    - when: never
-  script:
-    # A focused result proves only this gate at this commit. It is not merge or release evidence.
-    - ./scripts/check.sh --profile merge --gate "${FOCUSED_GATE:-unit.all}"
-  artifacts:
-    when: always
-    paths:
-      - reports/gate-report.sanitized.json
-      - reports/gates/
-
 gate-merge:
   stage: validate
   tags: [homelab-k8s]
   rules:
+    - if: '$PROJECT_CI_PROFILE == "focused" || $PROJECT_CI_PROFILE == "full"'
+      when: never
     - <<: *focused-dispatch
       when: never
     - *merge-profile-dispatch

--- a/check.sh
+++ b/check.sh
@@ -27,7 +27,7 @@ spec:
     - job: project-ci-cpu-validation
       class: wiring
       command: 'bash -lc "$PROJECT_CI_CPU_COMMAND"'
-      requiredTools: [bash, conda, git, git-lfs, python3]
+      requiredTools: [bash, conda, git, git-lfs, jq, python3, setsid]
       artifactUnderTest:
         type: repository-and-provider-resource-job
         digestSource: git-commit-and-builder-revision

--- a/check.sh
+++ b/check.sh
@@ -24,6 +24,19 @@ metadata:
   name: redfish-ctl-required-ci-smoke-tests
 spec:
   smokeTests:
+    - job: project-ci-cpu-validation
+      class: wiring
+      command: 'bash -lc "$PROJECT_CI_CPU_COMMAND"'
+      requiredTools: [bash, conda, git, git-lfs, python3]
+      artifactUnderTest:
+        type: repository-and-provider-resource-job
+        digestSource: git-commit-and-builder-revision
+      mutation: none
+      timeoutSeconds: 3600
+      evidencePath: reports/smoke/project-ci-cpu-validation.json
+      cleanupPolicy: reports-only
+      releaseBlocking: true
+
     - job: gate-merge
       class: wiring
       command: './scripts/check.sh --profile "${MERGE_PROFILE:-merge}"'

--- a/gates/manifest.yaml
+++ b/gates/manifest.yaml
@@ -12,20 +12,17 @@ runner_tag: homelab-k8s
 # GitLab jobs that MUST exist and MUST NOT use allow_failure (meta.required-jobs checks these when
 # .gitlab-ci.yml is present).
 required_jobs:
+  - project-ci-cpu-validation
   - gate-merge
   - gate-integration
   - gate-scheduled
 
-# Diagnostic evidence is exact-commit but never merge or release evidence.
-diagnostic_jobs:
-  - focused-gate
-
 # GitLab resolves this content-addressed provider template before creating a
-# pipeline. The meta-gate permits only these hidden templates from this exact
-# immutable include; floating refs and unknown external templates remain fatal.
+# pipeline. The meta-gate permits only these hidden templates or concrete jobs
+# from the exact immutable includes; floating refs and unknown content fail.
 trusted_includes:
   - project: spyroot/builder
-    ref: bdf2c0c23332814075d7d3809ecffe09c37d1800
+    ref: 1511171608f913833004e29558468d8e481fd947
     file: /ci/templates/project-service.yml
     templates:
       - {name: .builder-project-image-publish, mutates: true}
@@ -36,6 +33,25 @@ trusted_includes:
       - {name: .builder-project-live-test, mutates: false}
       - {name: .builder-project-rollback, mutates: true}
       - {name: .builder-project-release-evidence, mutates: false}
+  - project: spyroot/builder
+    ref: 1511171608f913833004e29558468d8e481fd947
+    file: /ci/templates/project-ci-resource-jobs.yml
+    jobs:
+      - name: project-ci-cpu-validation
+        required: true
+        mutates: false
+        stage: project-ci-validation
+        image: >-
+          harbor.rnd.embedings.ai/spyroot/builder/toolbox@sha256:bba5761e8248eec533b270a4d16966f8440ba2a81287e7ff63907c8b3a483fc9
+        tags: [homelab-k8s, homelab-k8s-validation]
+        allowFailure: false
+        script:
+          - >-
+            test -n "${PROJECT_CI_CPU_COMMAND:-}" || {
+            printf "BLOCKER: PROJECT_CI_CPU_COMMAND is required\n" >&2;
+            printf "SAFE_NEXT_STEP: scripts/check.sh --profile github\n" >&2;
+            exit 78; }
+          - bash -lc "$PROJECT_CI_CPU_COMMAND"
 
 mandatory_ids:
   - meta.gate-registry

--- a/inventory/ci/smoke-tests.yaml
+++ b/inventory/ci/smoke-tests.yaml
@@ -4,6 +4,19 @@ metadata:
   name: redfish-ctl-required-ci-smoke-tests
 spec:
   smokeTests:
+    - job: project-ci-cpu-validation
+      class: wiring
+      command: 'bash -lc "$PROJECT_CI_CPU_COMMAND"'
+      requiredTools: [bash, conda, git, git-lfs, python3]
+      artifactUnderTest:
+        type: repository-and-provider-resource-job
+        digestSource: git-commit-and-builder-revision
+      mutation: none
+      timeoutSeconds: 3600
+      evidencePath: reports/smoke/project-ci-cpu-validation.json
+      cleanupPolicy: reports-only
+      releaseBlocking: true
+
     - job: gate-merge
       class: wiring
       command: './scripts/check.sh --profile "${MERGE_PROFILE:-merge}"'

--- a/inventory/ci/smoke-tests.yaml
+++ b/inventory/ci/smoke-tests.yaml
@@ -7,7 +7,7 @@ spec:
     - job: project-ci-cpu-validation
       class: wiring
       command: 'bash -lc "$PROJECT_CI_CPU_COMMAND"'
-      requiredTools: [bash, conda, git, git-lfs, python3]
+      requiredTools: [bash, conda, git, git-lfs, jq, python3, setsid]
       artifactUnderTest:
         type: repository-and-provider-resource-job
         digestSource: git-commit-and-builder-revision

--- a/schemas/gates.schema.json
+++ b/schemas/gates.schema.json
@@ -43,7 +43,11 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["project", "ref", "file", "templates"],
+        "required": ["project", "ref", "file"],
+        "anyOf": [
+          {"required": ["templates"]},
+          {"required": ["jobs"]}
+        ],
         "properties": {
           "project": {
             "type": "string",
@@ -72,6 +76,50 @@
                 },
                 "mutates": {
                   "type": "boolean"
+                }
+              }
+            }
+          },
+          "jobs": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "name",
+                "required",
+                "mutates",
+                "stage",
+                "image",
+                "tags",
+                "allowFailure",
+                "script"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[A-Za-z0-9][A-Za-z0-9_.-]*$"
+                },
+                "required": {"const": true},
+                "mutates": {"type": "boolean"},
+                "stage": {"type": "string", "minLength": 1},
+                "image": {
+                  "type": "string",
+                  "pattern": "^[^\\s]+@sha256:[0-9a-f]{64}$"
+                },
+                "tags": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": {"type": "string", "minLength": 1}
+                },
+                "allowFailure": {"const": false},
+                "script": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {"type": "string", "minLength": 1}
                 }
               }
             }

--- a/scripts/gates/repository/no-secrets.sh
+++ b/scripts/gates/repository/no-secrets.sh
@@ -7,5 +7,5 @@ if ! command -v gitleaks >/dev/null 2>&1; then
   echo "repo.no-secrets: gitleaks not installed in this gate environment" >&2
   exit 1
 fi
-gitleaks detect --no-banner --redact --source . \
+gitleaks detect --no-banner --redact --log-level error --source . \
   && echo "repo.no-secrets: OK"

--- a/tests/gates/test_gate_meta.py
+++ b/tests/gates/test_gate_meta.py
@@ -363,6 +363,13 @@ def test_meta_gate_accepts_registry_trusted_include_and_allowed_template(
           tags: [homelab-k8s]
           allow_failure: false
           rules:
+            - if: >-
+                ($FOCUSED_GATE != null && $FOCUSED_GATE != "") ||
+                $MERGE_PROFILE == "merge" ||
+                (($PROJECT_CI_PROFILE != null && $PROJECT_CI_PROFILE != "") &&
+                $PROJECT_CI_PROFILE != "protected") ||
+                ($PROJECT_CI_SMOKE != null && $PROJECT_CI_SMOKE != "")
+              when: never
             - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
               when: never
             - if: '$CI_COMMIT_REF_PROTECTED == "true"'

--- a/tests/gates/test_gate_meta.py
+++ b/tests/gates/test_gate_meta.py
@@ -247,6 +247,7 @@ def _selected_jobs(**overrides: str | None) -> list[str]:
         "FOCUSED_GATE": None,
         "MERGE_PROFILE": None,
         "PROJECT_CI_PROFILE": None,
+        "PROJECT_CI_SMOKE": None,
     }
     variables.update(overrides)
     return [name for name, job in _gitlab_jobs().items() if _job_selected(job, variables)]
@@ -649,6 +650,8 @@ def test_internal_api_web_focused_dispatch_selects_no_competing_local_job() -> N
     for source in ("api", "web"):
         selected = _selected_jobs(
             CI_PIPELINE_SOURCE=source,
+            CI_COMMIT_BRANCH="main",
+            CI_COMMIT_REF_PROTECTED="true",
             FOCUSED_GATE="unit.all",
             MERGE_PROFILE=None,
             PROJECT_CI_PROFILE="focused",
@@ -662,11 +665,49 @@ def test_builder_full_dispatch_fences_the_local_merge_job() -> None:
         selected = _selected_jobs(
             CI_PIPELINE_SOURCE=source,
             CI_COMMIT_BRANCH="main",
+            CI_COMMIT_REF_PROTECTED="true",
             FOCUSED_GATE=None,
             MERGE_PROFILE=None,
             PROJECT_CI_PROFILE="full",
         )
         assert "gate-merge" not in selected
+        assert set(selected).isdisjoint(PROJECT_SERVICE_JOBS)
+
+
+def test_project_ci_smoke_dispatch_fences_project_service_jobs() -> None:
+    """A targeted provider smoke selects no competing local CI job."""
+    selected = set(_selected_jobs(
+        CI_PIPELINE_SOURCE="api",
+        CI_COMMIT_BRANCH="main",
+        CI_COMMIT_REF_PROTECTED="true",
+        PROJECT_CI_SMOKE=PROJECT_CI_CPU_JOB,
+    ))
+
+    assert selected == set()
+
+
+def test_protected_profile_keeps_project_service_dag_reachable() -> None:
+    """The explicit protected profile is not mistaken for read-only project CI."""
+    selected = set(_selected_jobs(
+        CI_PIPELINE_SOURCE="api",
+        CI_COMMIT_BRANCH="main",
+        CI_COMMIT_REF_PROTECTED="true",
+        PROJECT_CI_PROFILE="protected",
+    ))
+
+    assert set(PROJECT_SERVICE_JOBS) <= selected
+
+
+def test_unknown_project_ci_profile_fails_closed_on_protected_main() -> None:
+    """A selector typo cannot expose the protected project-service DAG."""
+    for profile in ("protectd", "unknown", "FULL"):
+        selected = set(_selected_jobs(
+            CI_PIPELINE_SOURCE="api",
+            CI_COMMIT_BRANCH="main",
+            CI_COMMIT_REF_PROTECTED="true",
+            PROJECT_CI_PROFILE=profile,
+        ))
+        assert selected.isdisjoint(PROJECT_SERVICE_JOBS), profile
 
 
 def test_internal_api_web_merge_dispatch_selects_only_gate_merge() -> None:
@@ -674,6 +715,8 @@ def test_internal_api_web_merge_dispatch_selects_only_gate_merge() -> None:
     for source in ("api", "web"):
         selected = _selected_jobs(
             CI_PIPELINE_SOURCE=source,
+            CI_COMMIT_BRANCH="main",
+            CI_COMMIT_REF_PROTECTED="true",
             FOCUSED_GATE=None,
             MERGE_PROFILE="merge",
         )

--- a/tests/gates/test_gate_meta.py
+++ b/tests/gates/test_gate_meta.py
@@ -11,7 +11,24 @@ from tools import gate_meta
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CI_FILE = REPO_ROOT / ".gitlab-ci.yml"
+EXPECTED_BUILDER_REF = "1511171608f913833004e29558468d8e481fd947"
 BUILDER_PROJECT_INCLUDE_FILE = "/ci/templates/project-service.yml"
+BUILDER_RESOURCE_JOBS_INCLUDE_FILE = "/ci/templates/project-ci-resource-jobs.yml"
+PROJECT_CI_CPU_JOB = "project-ci-cpu-validation"
+BUILDER_INCLUDE_FILES = {
+    BUILDER_PROJECT_INCLUDE_FILE,
+    BUILDER_RESOURCE_JOBS_INCLUDE_FILE,
+}
+PROJECT_SERVICE_JOB_ORDER = [
+    "project-service-image-publish",
+    "project-service-chart-publish",
+    "project-service-deploy-plan",
+    "project-service-deploy",
+    "project-service-verify",
+    "project-service-live-test",
+    "project-service-rollback",
+    "project-service-release-evidence",
+]
 PROJECT_SERVICE_JOBS = {
     "project-service-image-publish": ".builder-project-image-publish",
     "project-service-chart-publish": ".builder-project-chart-publish",
@@ -98,20 +115,43 @@ def _check_temp_gitlab(
 
 
 def _registry_trusted_include() -> dict:
-    """Return the single trusted include declared by the live gate registry."""
+    """Return the trusted project-service include declared by the live gate registry."""
+    return _registry_trusted_includes()[BUILDER_PROJECT_INCLUDE_FILE]
+
+
+def _registry_trusted_includes() -> dict[str, dict]:
+    """Return the exact Builder includes declared by the live gate registry."""
     registry = gate_meta._load_registry()
     records = registry.get("trusted_includes") or []
-    assert len(records) == 1, "the provider include contract must be single-sourced"
-    include = records[0]
-    assert include["project"] == "spyroot/builder"
-    assert include["file"] == BUILDER_PROJECT_INCLUDE_FILE
-    assert re.fullmatch(r"[0-9a-f]{40}", include["ref"])
-    contracts = {item["name"]: item["mutates"] for item in include["templates"]}
+    by_file = {include.get("file"): include for include in records}
+    assert len(records) == len(BUILDER_INCLUDE_FILES), "unexpected duplicate provider includes"
+    assert set(by_file) == BUILDER_INCLUDE_FILES, (
+        "the provider include contract must consume project-service and resource templates"
+    )
+    for include in by_file.values():
+        assert include["project"] == "spyroot/builder"
+        assert include["ref"] == EXPECTED_BUILDER_REF
+        assert re.fullmatch(r"[0-9a-f]{40}", include["ref"])
+
+    service_include = by_file[BUILDER_PROJECT_INCLUDE_FILE]
+    contracts = {item["name"]: item["mutates"] for item in service_include["templates"]}
     assert set(contracts) == PROJECT_SERVICE_TEMPLATE_NAMES
     assert {
         name for name, mutates in contracts.items() if mutates
     } == MUTATING_PROJECT_SERVICE_TEMPLATES
-    return include
+    resource_jobs = by_file[BUILDER_RESOURCE_JOBS_INCLUDE_FILE].get("jobs") or []
+    assert [job["name"] for job in resource_jobs] == [PROJECT_CI_CPU_JOB]
+    resource_job = resource_jobs[0]
+    assert resource_job["required"] is True
+    assert resource_job["mutates"] is False
+    assert resource_job["allowFailure"] is False
+    assert "homelab-k8s" in resource_job["tags"]
+    assert re.fullmatch(
+        r"harbor\.rnd\.embedings\.ai/spyroot/builder/toolbox@sha256:[0-9a-f]{64}",
+        resource_job["image"],
+    )
+    assert 'bash -lc "$PROJECT_CI_CPU_COMMAND"' in resource_job["script"]
+    return by_file
 
 
 _ALLOWED_GITLAB_EXPR_NODES = (
@@ -206,6 +246,7 @@ def _selected_jobs(**overrides: str | None) -> list[str]:
         "CI_COMMIT_REF_PROTECTED": "false",
         "FOCUSED_GATE": None,
         "MERGE_PROFILE": None,
+        "PROJECT_CI_PROFILE": None,
     }
     variables.update(overrides)
     return [name for name, job in _gitlab_jobs().items() if _job_selected(job, variables)]
@@ -272,16 +313,24 @@ def test_every_gate_declares_profile_and_mutates():
         assert isinstance(gate.get("mutates"), bool), f"{gate.get('id')} lacks a bool 'mutates'"
 
 
-def test_registry_declares_exactly_one_diagnostic_focused_gate_job() -> None:
-    """The focused CI job is diagnostic-only and cannot replace required merge evidence."""
+def test_registry_requires_the_builder_cpu_resource_job() -> None:
+    """The exact provider job is required and has one closed-world smoke record."""
     registry = gate_meta._load_registry()
-    assert registry.get("diagnostic_jobs") == ["focused-gate"]
-    assert "focused-gate" not in registry.get("required_jobs", [])
+    assert registry.get("diagnostic_jobs") is None
+    assert PROJECT_CI_CPU_JOB in registry.get("required_jobs", [])
+
+    smoke_inventory = yaml.safe_load(
+        (REPO_ROOT / "inventory" / "ci" / "smoke-tests.yaml").read_text(
+            encoding="utf-8"
+        )
+    )
+    smoke_jobs = [record["job"] for record in smoke_inventory["spec"]["smokeTests"]]
+    assert smoke_jobs.count(PROJECT_CI_CPU_JOB) == 1
 
 
 def test_registry_pins_exact_builder_project_service_include() -> None:
-    """The only trusted provider include is a registry-declared exact commit."""
-    _registry_trusted_include()
+    """Both trusted provider includes are registry-declared exact commits."""
+    _registry_trusted_includes()
 
 
 def test_meta_gate_accepts_registry_trusted_include_and_allowed_template(
@@ -457,7 +506,8 @@ def test_meta_gate_rejects_early_rules_for_every_provider_mutation(
 
 def test_gitlab_consumes_builder_project_service_contract_without_local_secrets() -> None:
     """The real pipeline wires the exact include and local project-service wrappers."""
-    trusted_include = _registry_trusted_include()
+    trusted_includes = _registry_trusted_includes()
+    trusted_include = trusted_includes[BUILDER_PROJECT_INCLUDE_FILE]
     ci = _ci_config()
     raw_includes = ci.get("include") or []
     includes = raw_includes if isinstance(raw_includes, list) else [raw_includes]
@@ -467,11 +517,11 @@ def test_gitlab_consumes_builder_project_service_contract_without_local_secrets(
         if gate_meta._include_key(include) is not None
     }
 
-    assert (
-        trusted_include["project"],
-        trusted_include["ref"],
-        trusted_include["file"],
-    ) in include_identities
+    expected_include_identities = {
+        (include["project"], include["ref"], include["file"])
+        for include in trusted_includes.values()
+    }
+    assert include_identities == expected_include_identities
 
     jobs = _gitlab_jobs()
     missing_jobs = sorted(set(PROJECT_SERVICE_JOBS) - set(jobs))
@@ -507,45 +557,116 @@ def test_gitlab_consumes_builder_project_service_contract_without_local_secrets(
     assert "DSP2043_2026.1.zip" in image_publish_setup
 
 
+def test_gitlab_project_service_variables_bind_builder_revision_and_live_suite() -> None:
+    """The consumer passes exact provider identity and the DMTF live command to Builder."""
+    variables = _ci_config().get("variables") or {}
+
+    assert variables.get("EXPECTED_PROVIDER_REVISION") == EXPECTED_BUILDER_REF
+    assert variables.get("PROJECT_CI_CPU_COMMAND") == (
+        "./tools/project-ci-cpu-validation.sh"
+    )
+    assert variables.get("BUILDER_PROJECT_CONSUMER") == "redfish_ctl"
+    assert variables.get("DMTF_RELEASE") == "2026.1"
+    assert variables.get("PROJECT_LIVE_TEST_COMMAND") == (
+        "pytest -q -m dmtf_sim_live "
+        "tests/k8s/test_dmtf_sim_live.py::test_dmtf_service_root"
+    )
+
+
+def test_gitlab_uses_digest_pinned_builder_images_for_project_service_jobs() -> None:
+    """All consumer-owned project-service wrappers override Builder's floating image."""
+    ci = _ci_config()
+    default_image = str((ci.get("default") or {}).get("image") or "")
+    assert re.fullmatch(r"harbor\.rnd\.embedings\.ai/spyroot/builder/toolbox@sha256:[0-9a-f]{64}",
+                        default_image)
+
+    jobs = _gitlab_jobs()
+    for name in PROJECT_SERVICE_JOB_ORDER:
+        image = str(jobs[name].get("image") or "")
+        assert image == default_image, f"{name} must use the digest-pinned toolbox image"
+        assert ":latest" not in image
+
+
+def test_gitlab_project_service_jobs_leave_artifact_dag_to_builder_templates() -> None:
+    """The local wrappers name the canonical DAG jobs without shadowing Builder artifacts."""
+    jobs = _gitlab_jobs()
+    observed = [name for name in jobs if name in PROJECT_SERVICE_JOBS]
+    assert observed == PROJECT_SERVICE_JOB_ORDER
+
+    expected_stage = {
+        **{name: "deploy" for name in PROJECT_SERVICE_JOB_ORDER[:-1]},
+        "project-service-release-evidence": "publish",
+    }
+    for name in PROJECT_SERVICE_JOB_ORDER:
+        job = jobs[name]
+        assert job.get("stage") == expected_stage[name]
+        assert gate_meta._external_templates(job) == [PROJECT_SERVICE_JOBS[name]]
+        for inherited_key in ("script", "needs", "dependencies", "artifacts", "resource_group"):
+            assert inherited_key not in job, f"{name} must inherit Builder {inherited_key}"
+
+
+def test_gitlab_contains_no_direct_project_service_deploy_bypass() -> None:
+    """The consumer never applies Helm or picks an independent simulator image tag."""
+    raw = CI_FILE.read_text(encoding="utf-8")
+
+    forbidden_patterns = {
+        r"\bhelm\s+upgrade\b": "direct Helm upgrade bypasses the Builder deploy executor",
+        r"\bkubectl\s+apply\b": "direct kubectl apply bypasses the Builder deploy executor",
+        r"redfish-dmtf-sim:[^\s\"']+": "floating simulator image tags are not deploy identities",
+    }
+    for pattern, reason in forbidden_patterns.items():
+        assert re.search(pattern, raw) is None, reason
+
+    variables = _ci_config().get("variables") or {}
+    forbidden_variables = {
+        "DMTF_SIM_IMAGE_TAG",
+        "PROJECT_SERVICE_IMAGE_TAG",
+        "SIM_IMAGE_TAG",
+    }
+    assert set(variables).isdisjoint(forbidden_variables)
+
+
 def test_gitlab_uses_full_history_checkout_for_exact_ref_dispatches() -> None:
     """Direct exact-ref pipelines need origin/main history for repo.format merge-base."""
     variables = _ci_config().get("variables") or {}
     assert variables.get("GIT_DEPTH") == "0"
 
 
-def test_gitlab_declares_exactly_one_focused_gate_job() -> None:
-    """Only one job may consume FOCUSED_GATE and it must go through check.sh."""
+def test_gitlab_leaves_focused_execution_to_the_builder_resource_job() -> None:
+    """No local job competes with the exact included CPU resource job."""
     jobs = _gitlab_jobs()
     focused_jobs = [
         name
         for name, job in jobs.items()
         if any("--gate" in line and "FOCUSED_GATE" in line for line in _script_lines(job))
     ]
-    assert focused_jobs == ["focused-gate"]
-
-    focused = jobs["focused-gate"]
-    rules_text = repr(focused.get("rules"))
-    script = "\n".join(_script_lines(focused))
-    assert focused.get("stage") == "validate"
-    assert "homelab-k8s" in focused.get("tags", [])
-    assert '$CI_SERVER_HOST == "gitlab.rnd.embedings.ai"' in rules_text
-    assert '$CI_PIPELINE_SOURCE == "web"' in rules_text
-    assert '$CI_PIPELINE_SOURCE == "api"' in rules_text
-    assert "$FOCUSED_GATE != null" in rules_text
-    assert '$FOCUSED_GATE != ""' in rules_text
-    assert './scripts/check.sh --profile merge --gate "${FOCUSED_GATE:-unit.all}"' in script
-    assert "scripts/gates/run.sh" not in script
+    assert focused_jobs == []
+    assert PROJECT_CI_CPU_JOB not in jobs
 
 
-def test_internal_api_web_focused_dispatch_selects_only_the_focused_job() -> None:
-    """Internal API/web dispatch with FOCUSED_GATE creates diagnostic evidence only."""
+def test_internal_api_web_focused_dispatch_selects_no_competing_local_job() -> None:
+    """Focused provider dispatch leaves the local job set empty."""
     for source in ("api", "web"):
         selected = _selected_jobs(
             CI_PIPELINE_SOURCE=source,
             FOCUSED_GATE="unit.all",
             MERGE_PROFILE=None,
+            PROJECT_CI_PROFILE="focused",
         )
-        assert selected == ["focused-gate"]
+        assert selected == []
+
+
+def test_builder_full_dispatch_fences_the_local_merge_job() -> None:
+    """The provider full profile is the only merge-suite owner in that pipeline."""
+    for source in ("api", "web"):
+        selected = _selected_jobs(
+            CI_PIPELINE_SOURCE=source,
+            CI_COMMIT_BRANCH="main",
+            FOCUSED_GATE=None,
+            MERGE_PROFILE=None,
+            PROJECT_CI_PROFILE="full",
+        )
+        assert "gate-merge" not in selected
 
 
 def test_internal_api_web_merge_dispatch_selects_only_gate_merge() -> None:
@@ -589,8 +710,8 @@ def test_other_gitlab_hosts_open_no_private_dispatch_route() -> None:
             CI_PIPELINE_SOURCE="api",
             FOCUSED_GATE="unit.all",
             MERGE_PROFILE="merge",
+            PROJECT_CI_PROFILE="focused",
         )
-        assert "focused-gate" not in selected
         assert "gate-merge" not in selected
         assert set(selected).isdisjoint(PROJECT_SERVICE_JOBS)
         assert "publish-github" not in selected

--- a/tests/gates/test_gate_scripts.py
+++ b/tests/gates/test_gate_scripts.py
@@ -70,6 +70,45 @@ def test_registry_commands_exist_and_are_executable() -> None:
     assert not not_executable, f"registry commands are not executable: {not_executable}"
 
 
+def test_no_secrets_suppresses_success_progress_stderr(tmp_path: Path) -> None:
+    """The secret gate keeps successful gitleaks progress off stderr."""
+    command_dir = tmp_path / "bin"
+    command_dir.mkdir()
+    args_path = tmp_path / "gitleaks.args"
+    fake_gitleaks = command_dir / "gitleaks"
+    fake_gitleaks.write_text(
+        "#!/bin/bash\n"
+        "printf '%s\\n' \"$@\" >\"$GITLEAKS_ARGS_PATH\"\n",
+        encoding="utf-8",
+    )
+    fake_gitleaks.chmod(0o755)
+
+    script = REPO_ROOT / "scripts" / "gates" / "repository" / "no-secrets.sh"
+    proc = subprocess.run(
+        [str(script)],
+        capture_output=True,
+        text=True,
+        env={
+            **os.environ,
+            "GITLEAKS_ARGS_PATH": str(args_path),
+            "PATH": f"{command_dir}:{os.environ['PATH']}",
+        },
+    )
+
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert proc.stderr == ""
+    args = args_path.read_text(encoding="utf-8").splitlines()
+    assert args == [
+        "detect",
+        "--no-banner",
+        "--redact",
+        "--log-level",
+        "error",
+        "--source",
+        ".",
+    ]
+
+
 def test_run_sh_loads_the_registry_and_rejects_an_unknown_profile() -> None:
     """run.sh reads the real registry, and an unregistered profile is an error, not a silent pass.
 

--- a/tests/gates/test_meta_detection.py
+++ b/tests/gates/test_meta_detection.py
@@ -26,6 +26,32 @@ def _valid_registry():
     }
 
 
+def _registry_with_external_job() -> dict:
+    """Return a closed-world contract for one exact concrete provider job."""
+    registry = _valid_registry()
+    registry["required_jobs"].append("project-ci-cpu-validation")
+    registry["trusted_includes"] = [
+        {
+            "project": "spyroot/builder",
+            "ref": "a" * 40,
+            "file": "/ci/templates/project-ci-resource-jobs.yml",
+            "jobs": [
+                {
+                    "name": "project-ci-cpu-validation",
+                    "required": True,
+                    "mutates": False,
+                    "stage": "project-ci-validation",
+                    "image": "registry.example/toolbox@sha256:" + "b" * 64,
+                    "tags": ["homelab-k8s", "homelab-k8s-validation"],
+                    "allowFailure": False,
+                    "script": ["./scripts/check.sh --profile merge"],
+                }
+            ],
+        }
+    ]
+    return registry
+
+
 def test_detects_missing_mandatory_id():
     """A mandatory ID absent from the registry is a failure."""
     reg = _valid_registry()
@@ -124,6 +150,46 @@ def test_detects_missing_runner_tag(tmp_path, monkeypatch):
     monkeypatch.setattr(gate_meta, "REPO_ROOT", tmp_path)
     failures, _ = gate_meta._check_gitlab(_valid_registry())
     assert any("runner tag" in f for f in failures)
+
+
+def test_accepts_required_job_from_exact_trusted_include(tmp_path, monkeypatch):
+    """A concrete provider job can satisfy required-job coverage without a copy."""
+    _write_gitlab(tmp_path, f"""
+        include:
+          - project: spyroot/builder
+            ref: {'a' * 40}
+            file: /ci/templates/project-ci-resource-jobs.yml
+        gate-merge:
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+    """)
+    monkeypatch.setattr(gate_meta, "REPO_ROOT", tmp_path)
+
+    failures, ran = gate_meta._check_gitlab(_registry_with_external_job())
+
+    assert ran
+    assert failures == []
+
+
+def test_rejects_local_shadow_of_trusted_concrete_job(tmp_path, monkeypatch):
+    """The consumer cannot silently replace an exact included resource job."""
+    _write_gitlab(tmp_path, f"""
+        include:
+          - project: spyroot/builder
+            ref: {'a' * 40}
+            file: /ci/templates/project-ci-resource-jobs.yml
+        gate-merge:
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+        project-ci-cpu-validation:
+          tags: [homelab-k8s]
+          script: [./scripts/check.sh --profile merge]
+    """)
+    monkeypatch.setattr(gate_meta, "REPO_ROOT", tmp_path)
+
+    failures, _ = gate_meta._check_gitlab(_registry_with_external_job())
+
+    assert any("shadows a trusted concrete provider job" in failure for failure in failures)
 
 
 def test_detects_live_apply_in_merge_request(tmp_path, monkeypatch):

--- a/tests/gates/test_project_ci_cpu_validation.py
+++ b/tests/gates/test_project_ci_cpu_validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import signal
 import subprocess
 import time
@@ -417,7 +418,7 @@ def test_successful_dependency_yq_warning_is_sanitized(tmp_path: Path) -> None:
     dependency = tmp_path / "dependency.sh"
     dependency.write_text(
         "#!/bin/bash\n"
-        f"printf '%s\\n' '{YQ_MERGE_ANCHOR_WARNING}' >&2\n",
+        f"printf '%s\\n' {shlex.quote(YQ_MERGE_ANCHOR_WARNING)} >&2\n",
         encoding="utf-8",
     )
     dependency.chmod(0o755)

--- a/tests/gates/test_project_ci_cpu_validation.py
+++ b/tests/gates/test_project_ci_cpu_validation.py
@@ -15,6 +15,8 @@ ADAPTER = REPO_ROOT / "tools" / "project-ci-cpu-validation.sh"
 YQ_MERGE_ANCHOR_WARNING = (
     'time=2026-08-30T00:00:00Z level=WARN '
     'msg="--yaml-fix-merge-anchor-to-spec is false; '
+    "causing merge anchors to override the existing values which isn't "
+    "to the yaml spec. "
     'this flag will default to true in late 2025."'
 )
 

--- a/tests/gates/test_project_ci_cpu_validation.py
+++ b/tests/gates/test_project_ci_cpu_validation.py
@@ -1,0 +1,75 @@
+"""Focused tests for the Builder CPU resource-job consumer adapter."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ADAPTER = REPO_ROOT / "tools" / "project-ci-cpu-validation.sh"
+
+
+def _resolve_mode(focused_gate: str, project_profile: str) -> subprocess.CompletedProcess[str]:
+    """Call only the sourceable selection core without executing project gates."""
+    return subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; project_ci_cpu_mode "$2" "$3"',
+            "project-ci-cpu-validation-test",
+            str(ADAPTER),
+            focused_gate,
+            project_profile,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_focused_gate_selects_one_focused_execution() -> None:
+    result = _resolve_mode("unit.all", "focused")
+
+    assert result.returncode == 0
+    assert result.stdout == "focused\n"
+    assert result.stderr == ""
+
+
+def test_focused_gate_is_compatible_with_legacy_empty_profile() -> None:
+    result = _resolve_mode("unit.all", "")
+
+    assert result.returncode == 0
+    assert result.stdout == "focused\n"
+
+
+def test_full_profile_selects_one_full_execution() -> None:
+    result = _resolve_mode("", "full")
+
+    assert result.returncode == 0
+    assert result.stdout == "full\n"
+    assert result.stderr == ""
+
+
+def test_conflicting_focused_and_full_inputs_fail_closed() -> None:
+    result = _resolve_mode("unit.all", "full")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "cannot be combined" in result.stderr
+
+
+def test_focused_profile_without_gate_fails_closed() -> None:
+    result = _resolve_mode("", "focused")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "requires FOCUSED_GATE" in result.stderr
+
+
+def test_missing_profile_and_gate_fail_closed() -> None:
+    result = _resolve_mode("", "")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "must be focused or full" in result.stderr

--- a/tests/gates/test_project_ci_cpu_validation.py
+++ b/tests/gates/test_project_ci_cpu_validation.py
@@ -375,6 +375,32 @@ def test_gate_dependency_success_returns_terminal_result() -> None:
     assert "evidence_path= error_class=none" in result.stdout
 
 
+def test_successful_dependency_yq_warning_is_sanitized(tmp_path: Path) -> None:
+    dependency = tmp_path / "dependency.sh"
+    dependency.write_text(
+        "#!/bin/bash\n"
+        "printf 'level=WARN msg=\"yq wrote advisory warning\"\\n' >&2\n",
+        encoding="utf-8",
+    )
+    dependency.chmod(0o755)
+
+    result = _run_gate_dependency(str(dependency), mode="full")
+    combined = result.stdout + result.stderr
+
+    assert result.returncode == 0
+    assert "status=passed" in result.stdout
+    assert "warning_count=1" in result.stdout
+    assert "cleanup_status=passed" in result.stdout
+    assert "error_class=none" in result.stdout
+    assert "level=warning" in result.stderr
+    assert "result=passed" in result.stderr
+    assert "stderr-lines=1" in result.stderr
+    assert "classes=auth:0,network:0,warning:1,error:0,other:0" in result.stderr
+    assert "redaction=full" in result.stderr
+    assert "level=WARN" not in combined
+    assert "yq wrote advisory warning" not in combined
+
+
 def test_dependency_stderr_is_counted_but_not_replayed(tmp_path: Path) -> None:
     dependency = tmp_path / "dependency.sh"
     dependency.write_text(
@@ -384,10 +410,12 @@ def test_dependency_stderr_is_counted_but_not_replayed(tmp_path: Path) -> None:
     dependency.chmod(0o755)
 
     result = _run_gate_dependency(str(dependency), mode="full")
+    combined = result.stdout + result.stderr
 
     assert result.returncode == 2
-    assert "private dependency detail" not in result.stderr
+    assert "private dependency detail" not in combined
     assert "stderr-lines=1" in result.stderr
+    assert "classes=auth:0,network:0,warning:0,error:0,other:1" in result.stderr
     assert "redaction=full" in result.stderr
     assert "warning_count=1" in result.stdout
     assert "status=failed" in result.stdout

--- a/tests/gates/test_project_ci_cpu_validation.py
+++ b/tests/gates/test_project_ci_cpu_validation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import os
 import re
-import shlex
 import signal
 import subprocess
 import time
@@ -13,13 +12,6 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ADAPTER = REPO_ROOT / "tools" / "project-ci-cpu-validation.sh"
-YQ_MERGE_ANCHOR_WARNING = (
-    'time=2026-08-30T00:00:00Z level=WARN '
-    'msg="--yaml-fix-merge-anchor-to-spec is false; '
-    "causing merge anchors to override the existing values which isn't "
-    "to the yaml spec. "
-    'this flag will default to true in late 2025."'
-)
 
 
 def _resolve_mode(
@@ -82,37 +74,6 @@ def _run_adapter(
     return subprocess.run(
         [str(ADAPTER), *args],
         cwd=REPO_ROOT,
-        env=env,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-
-
-def _run_public_adapter_with_successful_stderr(
-    tmp_path: Path,
-    stderr_lines: list[str],
-) -> subprocess.CompletedProcess[str]:
-    """Run the public adapter entrypoint against a successful fake check.sh."""
-    project_root = tmp_path / "project"
-    scripts_dir = project_root / "scripts"
-    scripts_dir.mkdir(parents=True)
-    stderr_path = project_root / "dependency.stderr"
-    stderr_path.write_text("\n".join(stderr_lines) + "\n", encoding="utf-8")
-    check_script = scripts_dir / "check.sh"
-    check_script.write_text(
-        "#!/bin/bash\n"
-        "set -Eeuo pipefail\n"
-        "cat \"$PROJECT_CI_TEST_STDERR\" >&2\n",
-        encoding="utf-8",
-    )
-    check_script.chmod(0o755)
-    env = os.environ.copy()
-    env["PROJECT_CI_PROFILE"] = "full"
-    env["PROJECT_CI_TEST_STDERR"] = str(stderr_path)
-    return subprocess.run(
-        [str(ADAPTER), "--run-id", "public-stderr-contract"],
-        cwd=project_root,
         env=env,
         check=False,
         capture_output=True,
@@ -414,81 +375,6 @@ def test_gate_dependency_success_returns_terminal_result() -> None:
     assert "evidence_path= error_class=none" in result.stdout
 
 
-def test_successful_dependency_yq_warning_is_sanitized(tmp_path: Path) -> None:
-    dependency = tmp_path / "dependency.sh"
-    dependency.write_text(
-        "#!/bin/bash\n"
-        f"printf '%s\\n' {shlex.quote(YQ_MERGE_ANCHOR_WARNING)} >&2\n",
-        encoding="utf-8",
-    )
-    dependency.chmod(0o755)
-
-    result = _run_gate_dependency(str(dependency), mode="full")
-    combined = result.stdout + result.stderr
-
-    assert result.returncode == 0
-    assert "status=passed" in result.stdout
-    assert "warning_count=1" in result.stdout
-    assert "cleanup_status=passed" in result.stdout
-    assert "error_class=none" in result.stdout
-    assert "level=warning" in result.stderr
-    assert "result=passed" in result.stderr
-    assert "stderr-lines=1" in result.stderr
-    assert "classes=auth:0,network:0,warning:1,error:0,other:0" in result.stderr
-    assert "redaction=full" in result.stderr
-    assert "level=WARN" not in combined
-    assert "--yaml-fix-merge-anchor-to-spec is false" not in combined
-
-
-def test_public_entrypoint_non_warning_stderr_fails_closed(tmp_path: Path) -> None:
-    cases = [
-        (
-            "auth",
-            ["HTTP 401 Unauthorized while reading private credential"],
-            "classes=auth:1,network:0,warning:0,error:0,other:0",
-        ),
-        (
-            "network",
-            ["DNS timeout while connecting to dependency"],
-            "classes=auth:0,network:1,warning:0,error:0,other:0",
-        ),
-        (
-            "error",
-            ["fatal: dependency failed with error"],
-            "classes=auth:0,network:0,warning:0,error:1,other:0",
-        ),
-        (
-            "other",
-            ["private dependency detail"],
-            "classes=auth:0,network:0,warning:0,error:0,other:1",
-        ),
-        (
-            "mixed-warning-error",
-            [YQ_MERGE_ANCHOR_WARNING.replace('2025."', '2025: fatal failure."')],
-            "classes=auth:0,network:0,warning:0,error:1,other:0",
-        ),
-    ]
-
-    for case_name, stderr_lines, expected_classes in cases:
-        case_tmp_path = tmp_path / case_name
-        result = _run_public_adapter_with_successful_stderr(
-            case_tmp_path,
-            stderr_lines,
-        )
-        combined = result.stdout + result.stderr
-
-        assert result.returncode == 2, case_name
-        assert "status=failed" in result.stdout
-        assert "warning_count=1" in result.stdout
-        assert "error_class=dependency-stderr" in result.stdout
-        assert "result=failed" in result.stderr
-        assert "stderr-lines=" in result.stderr
-        assert expected_classes in result.stderr
-        assert "redaction=full" in result.stderr
-        for raw_line in stderr_lines:
-            assert raw_line not in combined
-
-
 def test_dependency_stderr_is_counted_but_not_replayed(tmp_path: Path) -> None:
     dependency = tmp_path / "dependency.sh"
     dependency.write_text(
@@ -498,12 +384,10 @@ def test_dependency_stderr_is_counted_but_not_replayed(tmp_path: Path) -> None:
     dependency.chmod(0o755)
 
     result = _run_gate_dependency(str(dependency), mode="full")
-    combined = result.stdout + result.stderr
 
     assert result.returncode == 2
-    assert "private dependency detail" not in combined
+    assert "private dependency detail" not in result.stderr
     assert "stderr-lines=1" in result.stderr
-    assert "classes=auth:0,network:0,warning:0,error:0,other:1" in result.stderr
     assert "redaction=full" in result.stderr
     assert "warning_count=1" in result.stdout
     assert "status=failed" in result.stdout

--- a/tests/gates/test_project_ci_cpu_validation.py
+++ b/tests/gates/test_project_ci_cpu_validation.py
@@ -2,26 +2,79 @@
 
 from __future__ import annotations
 
+import json
+import os
+import re
+import signal
 import subprocess
+import time
 from pathlib import Path
-
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ADAPTER = REPO_ROOT / "tools" / "project-ci-cpu-validation.sh"
 
 
-def _resolve_mode(focused_gate: str, project_profile: str) -> subprocess.CompletedProcess[str]:
+def _resolve_mode(
+    focused_gate: str,
+    project_profile: str,
+    project_smoke: str = "",
+) -> subprocess.CompletedProcess[str]:
     """Call only the sourceable selection core without executing project gates."""
     return subprocess.run(
         [
             "/bin/bash",
             "-c",
-            'source "$1"; project_ci_cpu_mode "$2" "$3"',
+            'source "$1"; project_ci_cpu_mode "$2" "$3" "$4"',
             "project-ci-cpu-validation-test",
             str(ADAPTER),
             focused_gate,
             project_profile,
+            project_smoke,
         ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _resolve_gate(
+    focused_gate: str,
+    project_profile: str,
+    project_smoke: str = "",
+) -> subprocess.CompletedProcess[str]:
+    """Call only the sourceable gate resolver without executing project gates."""
+    return subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            'source "$1"; project_ci_cpu_gate "$2" "$3" "$4"',
+            "project-ci-cpu-validation-test",
+            str(ADAPTER),
+            focused_gate,
+            project_profile,
+            project_smoke,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_adapter(
+    *args: str,
+    focused_gate: str = "",
+    project_profile: str = "",
+    project_smoke: str = "",
+) -> subprocess.CompletedProcess[str]:
+    """Run only non-executing adapter controls with explicit selector inputs."""
+    env = os.environ.copy()
+    env["FOCUSED_GATE"] = focused_gate
+    env["PROJECT_CI_PROFILE"] = project_profile
+    env["PROJECT_CI_SMOKE"] = project_smoke
+    return subprocess.run(
+        [str(ADAPTER), *args],
+        cwd=REPO_ROOT,
+        env=env,
         check=False,
         capture_output=True,
         text=True,
@@ -59,12 +112,25 @@ def test_conflicting_focused_and_full_inputs_fail_closed() -> None:
     assert "cannot be combined" in result.stderr
 
 
-def test_focused_profile_without_gate_fails_closed() -> None:
-    result = _resolve_mode("", "focused")
+def test_invalid_focused_gate_identifier_fails_closed() -> None:
+    result = _resolve_mode('unit.all"bad', "focused")
 
     assert result.returncode == 2
     assert result.stdout == ""
-    assert "requires FOCUSED_GATE" in result.stderr
+    assert "bounded gate identifier" in result.stderr
+    assert "Safe next step:" in result.stderr
+
+
+def test_focused_profile_without_gate_defaults_to_unit_all() -> None:
+    result = _resolve_mode("", "focused")
+    gate = _resolve_gate("", "focused")
+
+    assert result.returncode == 0
+    assert result.stdout == "focused\n"
+    assert result.stderr == ""
+    assert gate.returncode == 0
+    assert gate.stdout == "unit.all\n"
+    assert gate.stderr == ""
 
 
 def test_missing_profile_and_gate_fail_closed() -> None:
@@ -73,3 +139,349 @@ def test_missing_profile_and_gate_fail_closed() -> None:
     assert result.returncode == 2
     assert result.stdout == ""
     assert "must be focused or full" in result.stderr
+
+
+def test_help_documents_non_interactive_agent_contract() -> None:
+    result = _run_adapter("--help")
+
+    assert result.returncode == 0
+    assert "Audience: both" in result.stdout
+    for option in (
+        "--dry-run",
+        "--log-format",
+        "--log-level",
+        "--log-file",
+        "--run-id",
+    ):
+        assert option in result.stdout
+    assert result.stderr == ""
+
+
+def test_dry_run_reports_default_focused_gate_without_execution() -> None:
+    result = _run_adapter(
+        "--dry-run",
+        "--log-format",
+        "json",
+        "--run-id",
+        "cpu-contract-1",
+        project_profile="focused",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == (
+        '{"mode":"focused","gate":"unit.all","mutation":false,'
+        '"runId":"cpu-contract-1","status":"planned","warningCount":0,'
+        '"cleanupStatus":"not-required","evidencePath":""}\n'
+    )
+    assert result.stderr == ""
+
+
+def test_unknown_option_fails_with_safe_next_step() -> None:
+    result = _run_adapter("--unknown", project_profile="focused")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "BLOCKER:" in result.stderr
+    assert "Safe next step:" in result.stderr
+
+
+def test_dry_run_rejects_log_file_side_effect(tmp_path: Path) -> None:
+    log_path = tmp_path / "adapter.log"
+
+    result = _run_adapter(
+        "--dry-run",
+        "--log-file",
+        str(log_path),
+        project_profile="focused",
+    )
+
+    assert result.returncode == 2
+    assert not log_path.exists()
+    assert "cannot be combined with --dry-run" in result.stderr
+
+
+def test_exact_cpu_smoke_selector_resolves_one_bounded_mode() -> None:
+    result = _resolve_mode("", "", "project-ci-cpu-validation")
+
+    assert result.returncode == 0
+    assert result.stdout == "smoke\n"
+    assert result.stderr == ""
+
+
+def test_unknown_cpu_smoke_selector_fails_closed() -> None:
+    result = _resolve_mode("", "", "other-smoke")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "unsupported PROJECT_CI_SMOKE" in result.stderr
+
+
+def test_json_log_is_contract_complete_and_appended(tmp_path: Path) -> None:
+    log_path = tmp_path / "adapter.jsonl"
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                'source "$1"; '
+                'project_ci_parse_args --log-format json --log-level debug '
+                '--log-file "$2" --run-id log-1; '
+                'project_ci_log_selection focused unit.all 25'
+            ),
+            "project-ci-cpu-validation-test",
+            str(ADAPTER),
+            str(log_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    event = json.loads(result.stderr)
+    assert json.loads(log_path.read_text(encoding="utf-8")) == event
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", event["timestamp"])
+    assert set(event) == {
+        "timestamp",
+        "level",
+        "runId",
+        "component",
+        "operation",
+        "mode",
+        "event",
+        "attempt",
+        "resource",
+        "result",
+        "elapsedMs",
+        "errorClass",
+        "safeNextStep",
+        "message",
+    }
+    assert event["level"] == "info"
+    assert event["runId"] == "log-1"
+    assert event["component"] == "project-ci-cpu-validation"
+    assert event["operation"] == "validate"
+    assert event["mode"] == "focused"
+    assert event["event"] == "selection"
+    assert event["attempt"] == 1
+    assert event["resource"] == "gate:unit.all"
+    assert event["result"] == "running"
+    assert event["elapsedMs"] == 25
+    assert event["errorClass"] == "none"
+    assert event["safeNextStep"] == ""
+    assert event["message"] == "selected project CI validation"
+
+
+def test_json_blocker_stays_machine_readable() -> None:
+    result = _run_adapter(
+        "--log-format",
+        "json",
+        "--run-id",
+        "log-error",
+        "--unknown",
+        project_profile="focused",
+    )
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    event = json.loads(result.stderr)
+    assert event["level"] == "error"
+    assert event["runId"] == "log-error"
+    assert event["event"] == "blocker"
+    assert event["result"] == "blocked"
+    assert event["errorClass"] == "usage-error"
+    assert event["safeNextStep"]
+    assert event["message"] == "unknown option: --unknown"
+    assert event["authorityChecked"]
+    assert event["observation"] == "unknown option: --unknown"
+    assert event["risk"]
+
+
+def test_log_level_filters_info_event(tmp_path: Path) -> None:
+    log_path = tmp_path / "filtered.jsonl"
+    result = subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                'source "$1"; '
+                'project_ci_parse_args --log-format json --log-level warning '
+                '--log-file "$2" --run-id log-filter; '
+                'project_ci_log_selection focused unit.all 0'
+            ),
+            "project-ci-cpu-validation-test",
+            str(ADAPTER),
+            str(log_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    assert not log_path.exists()
+
+
+def _run_gate_dependency(
+    dependency: str,
+    *,
+    mode: str = "smoke",
+    gate: str = "",
+    log_format: str = "text",
+) -> subprocess.CompletedProcess[str]:
+    command = (
+        'source "$1"; '
+        'project_ci_parse_args --log-format "$2" --run-id gate-test; '
+        'project_ci_run_gate "$3" "$4" "$5" 0'
+    )
+    return subprocess.run(
+        [
+            "/bin/bash",
+            "-c",
+            command,
+            "project-ci-cpu-validation-test",
+            str(ADAPTER),
+            log_format,
+            dependency,
+            mode,
+            gate,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_gate_dependency_failure_returns_terminal_result() -> None:
+    result = _run_gate_dependency("/bin/false", mode="focused", gate="unit.all")
+
+    assert result.returncode == 1
+    assert "status=failed" in result.stdout
+    assert "error_class=gate-failed" in result.stdout
+    assert "result=failed" in result.stderr
+    assert "cleanup_status=passed" in result.stdout
+
+
+def test_gate_dependency_success_returns_terminal_result() -> None:
+    result = _run_gate_dependency("/bin/true", mode="smoke")
+
+    assert result.returncode == 0
+    assert "mode=smoke" in result.stdout
+    assert "status=passed" in result.stdout
+    assert "cleanup_status=passed" in result.stdout
+    assert "evidence_path= error_class=none" in result.stdout
+
+
+def test_dependency_stderr_is_counted_but_not_replayed(tmp_path: Path) -> None:
+    dependency = tmp_path / "dependency.sh"
+    dependency.write_text(
+        "#!/bin/bash\nprintf 'private dependency detail\\n' >&2\n",
+        encoding="utf-8",
+    )
+    dependency.chmod(0o755)
+
+    result = _run_gate_dependency(str(dependency), mode="full")
+
+    assert result.returncode == 2
+    assert "private dependency detail" not in result.stderr
+    assert "stderr-lines=1" in result.stderr
+    assert "redaction=full" in result.stderr
+    assert "warning_count=1" in result.stdout
+    assert "status=failed" in result.stdout
+    assert "error_class=dependency-stderr" in result.stdout
+
+
+def test_json_terminal_result_classifies_dependency_failure() -> None:
+    result = _run_gate_dependency(
+        "/bin/false",
+        mode="focused",
+        gate="unit.all",
+        log_format="json",
+    )
+
+    assert result.returncode == 1
+    terminal = json.loads(result.stdout)
+    events = [json.loads(line) for line in result.stderr.splitlines()]
+    event = next(item for item in events if item["event"] == "terminal")
+    assert terminal["status"] == "failed"
+    assert terminal["errorClass"] == "gate-failed"
+    assert terminal["cleanupStatus"] == "passed"
+    assert event["event"] == "terminal"
+    assert event["errorClass"] == "gate-failed"
+
+
+def test_invalid_run_id_cannot_break_json_blocker() -> None:
+    result = _run_adapter(
+        "--log-format",
+        "json",
+        "--run-id",
+        'bad"value\nnext',
+        project_profile="focused",
+    )
+
+    assert result.returncode == 2
+    event = json.loads(result.stderr)
+    assert event["runId"] == "invalid"
+    assert event["message"] == "--run-id must be a bounded identifier"
+
+
+def test_term_signal_reaps_gate_and_reports_cleanup(tmp_path: Path) -> None:
+    dependency = tmp_path / "blocking-dependency.sh"
+    child_pid_path = tmp_path / "child.pid"
+    dependency.write_text(
+        "#!/bin/bash\n"
+        "printf '%s\\n' \"$$\" >\"$CHILD_PID_PATH\"\n"
+        "while :; do sleep 1; done\n",
+        encoding="utf-8",
+    )
+    dependency.chmod(0o755)
+    env = os.environ.copy()
+    env["TMPDIR"] = str(tmp_path)
+    env["CHILD_PID_PATH"] = str(child_pid_path)
+    process = subprocess.Popen(
+        [
+            "/bin/bash",
+            "-c",
+            (
+                'source "$1"; '
+                'project_ci_parse_args --log-format json --run-id signal-test; '
+                'project_ci_run_gate "$2" full "" 0'
+            ),
+            "project-ci-cpu-validation-test",
+            str(ADAPTER),
+            str(dependency),
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    deadline = time.monotonic() + 5
+    while not child_pid_path.exists() and time.monotonic() < deadline:
+        time.sleep(0.05)
+    assert child_pid_path.exists()
+    child_pid = int(child_pid_path.read_text(encoding="utf-8").strip())
+
+    process.send_signal(signal.SIGTERM)
+    stdout, stderr = process.communicate(timeout=5)
+
+    assert process.returncode == 143
+    terminal = json.loads(stdout)
+    assert terminal["status"] == "failed"
+    assert terminal["errorClass"] == "signal-term"
+    assert terminal["cleanupStatus"] == "passed"
+    events = [json.loads(line) for line in stderr.splitlines()]
+    assert any(event["event"] == "cleanup" for event in events)
+    assert any(event["event"] == "signal" for event in events)
+    assert not list(tmp_path.glob("project-ci-cpu-validation.*"))
+    try:
+        os.kill(child_pid, 0)
+    except ProcessLookupError:
+        child_running = False
+    else:
+        child_running = True
+    assert not child_running

--- a/tests/gates/test_project_ci_cpu_validation.py
+++ b/tests/gates/test_project_ci_cpu_validation.py
@@ -12,6 +12,11 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 ADAPTER = REPO_ROOT / "tools" / "project-ci-cpu-validation.sh"
+YQ_MERGE_ANCHOR_WARNING = (
+    'time=2026-08-30T00:00:00Z level=WARN '
+    'msg="--yaml-fix-merge-anchor-to-spec is false; '
+    'this flag will default to true in late 2025."'
+)
 
 
 def _resolve_mode(
@@ -74,6 +79,37 @@ def _run_adapter(
     return subprocess.run(
         [str(ADAPTER), *args],
         cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_public_adapter_with_successful_stderr(
+    tmp_path: Path,
+    stderr_lines: list[str],
+) -> subprocess.CompletedProcess[str]:
+    """Run the public adapter entrypoint against a successful fake check.sh."""
+    project_root = tmp_path / "project"
+    scripts_dir = project_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    stderr_path = project_root / "dependency.stderr"
+    stderr_path.write_text("\n".join(stderr_lines) + "\n", encoding="utf-8")
+    check_script = scripts_dir / "check.sh"
+    check_script.write_text(
+        "#!/bin/bash\n"
+        "set -Eeuo pipefail\n"
+        "cat \"$PROJECT_CI_TEST_STDERR\" >&2\n",
+        encoding="utf-8",
+    )
+    check_script.chmod(0o755)
+    env = os.environ.copy()
+    env["PROJECT_CI_PROFILE"] = "full"
+    env["PROJECT_CI_TEST_STDERR"] = str(stderr_path)
+    return subprocess.run(
+        [str(ADAPTER), "--run-id", "public-stderr-contract"],
+        cwd=project_root,
         env=env,
         check=False,
         capture_output=True,
@@ -379,7 +415,7 @@ def test_successful_dependency_yq_warning_is_sanitized(tmp_path: Path) -> None:
     dependency = tmp_path / "dependency.sh"
     dependency.write_text(
         "#!/bin/bash\n"
-        "printf 'level=WARN msg=\"yq wrote advisory warning\"\\n' >&2\n",
+        f"printf '%s\\n' '{YQ_MERGE_ANCHOR_WARNING}' >&2\n",
         encoding="utf-8",
     )
     dependency.chmod(0o755)
@@ -398,7 +434,56 @@ def test_successful_dependency_yq_warning_is_sanitized(tmp_path: Path) -> None:
     assert "classes=auth:0,network:0,warning:1,error:0,other:0" in result.stderr
     assert "redaction=full" in result.stderr
     assert "level=WARN" not in combined
-    assert "yq wrote advisory warning" not in combined
+    assert "--yaml-fix-merge-anchor-to-spec is false" not in combined
+
+
+def test_public_entrypoint_non_warning_stderr_fails_closed(tmp_path: Path) -> None:
+    cases = [
+        (
+            "auth",
+            ["HTTP 401 Unauthorized while reading private credential"],
+            "classes=auth:1,network:0,warning:0,error:0,other:0",
+        ),
+        (
+            "network",
+            ["DNS timeout while connecting to dependency"],
+            "classes=auth:0,network:1,warning:0,error:0,other:0",
+        ),
+        (
+            "error",
+            ["fatal: dependency failed with error"],
+            "classes=auth:0,network:0,warning:0,error:1,other:0",
+        ),
+        (
+            "other",
+            ["private dependency detail"],
+            "classes=auth:0,network:0,warning:0,error:0,other:1",
+        ),
+        (
+            "mixed-warning-error",
+            [YQ_MERGE_ANCHOR_WARNING.replace('2025."', '2025: fatal failure."')],
+            "classes=auth:0,network:0,warning:0,error:1,other:0",
+        ),
+    ]
+
+    for case_name, stderr_lines, expected_classes in cases:
+        case_tmp_path = tmp_path / case_name
+        result = _run_public_adapter_with_successful_stderr(
+            case_tmp_path,
+            stderr_lines,
+        )
+        combined = result.stdout + result.stderr
+
+        assert result.returncode == 2, case_name
+        assert "status=failed" in result.stdout
+        assert "warning_count=1" in result.stdout
+        assert "error_class=dependency-stderr" in result.stdout
+        assert "result=failed" in result.stderr
+        assert "stderr-lines=" in result.stderr
+        assert expected_classes in result.stderr
+        assert "redaction=full" in result.stderr
+        for raw_line in stderr_lines:
+            assert raw_line not in combined
 
 
 def test_dependency_stderr_is_counted_but_not_replayed(tmp_path: Path) -> None:

--- a/tools/gate_meta.py
+++ b/tools/gate_meta.py
@@ -207,6 +207,24 @@ def _trusted_include_contract(
     return identities, templates
 
 
+def _trusted_external_jobs(registry: dict) -> dict[str, dict]:
+    """Return concrete jobs supplied by exact trusted provider includes.
+
+    Concrete provider jobs are not present in the consumer YAML before GitLab
+    resolves the include. Their closed-world contract therefore lives beside
+    the immutable include identity and is used for required-job and smoke
+    coverage without copying the provider job into this repository.
+
+    :param registry: parsed gate registry containing ``trusted_includes``.
+    :return: external job contracts keyed by exact job name.
+    """
+    jobs: dict[str, dict] = {}
+    for include in registry.get("trusted_includes") or []:
+        for job in include.get("jobs") or []:
+            jobs[job["name"]] = job
+    return jobs
+
+
 def _check_trusted_includes(
     ci: dict, registry: dict
 ) -> tuple[list[str], dict[str, dict]]:
@@ -350,9 +368,10 @@ def _check_smoke_inventory(registry: dict) -> list[str]:
         failures.append(f"smoke records reference non-required CI jobs: {extra}")
 
     real_jobs = _real_gitlab_jobs(ci)
+    external_jobs = _trusted_external_jobs(registry)
     for record in records:
         job = record["job"]
-        ci_job = real_jobs.get(job)
+        ci_job = real_jobs.get(job) or external_jobs.get(job)
         if ci_job is None:
             failures.append(f"smoke record references missing GitLab job: {job}")
             continue
@@ -409,8 +428,45 @@ def _check_gitlab(registry: dict) -> tuple[list[str], bool]:
     ci = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     runner_tag = registry.get("runner_tag", "homelab-k8s")
     failures, trusted_templates = _check_trusted_includes(ci, registry)
+    trusted_external_jobs = _trusted_external_jobs(registry)
     default_tags = (ci.get("default") or {}).get("tags") or []
     real_jobs = _real_gitlab_jobs(ci)
+    external_names = [
+        job["name"]
+        for include in registry.get("trusted_includes") or []
+        for job in include.get("jobs") or []
+    ]
+    duplicate_external_names = sorted(
+        {name for name in external_names if external_names.count(name) > 1}
+    )
+    if duplicate_external_names:
+        failures.append(
+            f"duplicate trusted external jobs: {duplicate_external_names}"
+        )
+    for name, contract in trusted_external_jobs.items():
+        if name in real_jobs:
+            failures.append(
+                f"gitlab job {name}: local definition shadows a trusted concrete provider job"
+            )
+        if contract.get("required") is not True:
+            failures.append(f"gitlab job {name}: trusted provider job must be required")
+        if contract.get("allowFailure") is not False:
+            failures.append(
+                f"gitlab job {name}: trusted provider job must set allowFailure:false"
+            )
+        if contract.get("mutates") is not False:
+            failures.append(
+                f"gitlab job {name}: mutating concrete provider jobs require "
+                "a local protected wrapper"
+            )
+        if runner_tag not in (contract.get("tags") or []):
+            failures.append(
+                f"gitlab job {name}: trusted provider job is missing runner tag '{runner_tag}'"
+            )
+        if not contract.get("stage") or not contract.get("script"):
+            failures.append(
+                f"gitlab job {name}: trusted provider job lacks analyzable stage or script"
+            )
     for name, job in real_jobs.items():
         if job.get("allow_failure") is True:
             failures.append(f"gitlab job {name}: allow_failure:true is forbidden")
@@ -467,11 +523,18 @@ def _check_gitlab(registry: dict) -> tuple[list[str], bool]:
         failures.append(
             "registry declares no required_jobs while .gitlab-ci.yml exists — the required-jobs "
             "check would silently pass")
+    known_jobs = set(real_jobs) | set(trusted_external_jobs)
     for required in required_jobs:
-        if required not in real_jobs:
+        if required not in known_jobs:
             failures.append(f"required GitLab job missing: {required}")
+    undeclared_external_jobs = sorted(set(trusted_external_jobs) - set(required_jobs))
+    if undeclared_external_jobs:
+        failures.append(
+            "trusted required provider jobs are absent from required_jobs: "
+            f"{undeclared_external_jobs}"
+        )
     for diagnostic in registry.get("diagnostic_jobs") or []:
-        if diagnostic not in real_jobs:
+        if diagnostic not in known_jobs:
             failures.append(f"diagnostic GitLab job missing: {diagnostic}")
     return failures, True
 

--- a/tools/gate_meta.py
+++ b/tools/gate_meta.py
@@ -27,6 +27,13 @@ SMOKE_CLASSES = frozenset({
     "wiring", "offline-component", "ephemeral-integration",
     "protected-live", "recovery", "status-reflection",
 })
+PROJECT_CI_SELECTOR_DENY = (
+    '($FOCUSED_GATE != null && $FOCUSED_GATE != "") || '
+    '$MERGE_PROFILE == "merge" || '
+    '(($PROJECT_CI_PROFILE != null && $PROJECT_CI_PROFILE != "") && '
+    '$PROJECT_CI_PROFILE != "protected") || '
+    '($PROJECT_CI_SMOKE != null && $PROJECT_CI_SMOKE != "")'
+)
 
 
 def _load_registry() -> dict:
@@ -302,9 +309,14 @@ def _protected_template_rules_match(job: dict, protected_when: str) -> bool:
 
     :param job: parsed local wrapper job.
     :param protected_when: required protected-ref behavior from the registry.
-    :return: True only for MR deny, protected-ref action, then terminal deny.
+    :return: True only for project-ci validation selector deny, MR deny,
+        protected-ref action, then terminal deny.
     """
     return (job.get("rules") or []) == [
+        {
+            "if": PROJECT_CI_SELECTOR_DENY,
+            "when": "never",
+        },
         {
             "if": '$CI_PIPELINE_SOURCE == "merge_request_event"',
             "when": "never",

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -442,58 +442,36 @@ project_ci_terminal_result() {
   fi
 }
 
-# Count captured dependency stderr classes without replaying raw content.
-# Arguments: capture path. Environment inputs: none. Stdout: tab-separated
-# total/auth/network/warning/error/other counts. Stderr: none. Exit classes: 0.
-# Side effects and cleanup: none.
-project_ci_stderr_counts() {
+# Classify captured dependency stderr without replaying raw content.
+# Arguments: capture path. Environment inputs: none. Stdout: one sanitized
+# summary. Stderr: none. Exit classes: 0. Side effects and cleanup: none.
+project_ci_stderr_summary() {
   local stderr_file="$1"
 
   awk '
-    BEGIN {
-      auth = network = warning = error = other = total = 0
-    }
+    BEGIN { auth = network = warning = error = other = total = 0 }
     {
       text = tolower($0)
-      is_yq_merge_warning = 0
-      if (text ~ /^time=[^[:space:]]+ level=warn msg="/) {
-        if (text ~ /--yaml-fix-merge-anchor-to-spec is false/) {
-          is_yq_merge_warning = 1
-        }
-      }
       total++
       if (text ~ /(unauthorized|forbidden|credential|password|token|401|403)/) {
         auth++
       } else if (text ~ /(timeout|connection|network|dns|unreachable|reset)/) {
         network++
+      } else if (text ~ /(warning|deprecated)/) {
+        warning++
       } else if (text ~ /(error|failed|failure|fatal)/) {
         error++
-      } else if (is_yq_merge_warning) {
-        warning++
       } else {
         other++
       }
     }
     END {
-      printf "%d\t%d\t%d\t%d\t%d\t%d\n", \
-        total, auth, network, warning, error, other
+      printf "stderr-lines=%d classes=auth:%d,network:%d,", \
+        total, auth, network
+      printf "warning:%d,error:%d,other:%d redaction=full", \
+        warning, error, other
     }
   ' "$stderr_file"
-}
-
-# Render one sanitized stderr classification from the shared count helper.
-# Arguments: capture path. Environment inputs: none. Stdout: one summary.
-# Stderr: none. Exit classes: 0. Side effects and cleanup: none.
-project_ci_stderr_summary() {
-  local stderr_file="$1"
-  local total auth network warning error other
-
-  IFS=$'\t' read -r total auth network warning error other \
-    < <(project_ci_stderr_counts "$stderr_file")
-  printf 'stderr-lines=%d classes=auth:%d,network:%d,' \
-    "$total" "$auth" "$network"
-  printf 'warning:%d,error:%d,other:%d redaction=full' \
-    "$warning" "$error" "$other"
 }
 
 # Execute one selected gate invocation without replaying dependency stderr.
@@ -510,7 +488,6 @@ project_ci_run_gate() {
   local evidence_path=""
   local stderr_file="" cleanup_status=passed
   local elapsed_ms status=0 stderr_lines=0 warning_count=0
-  local auth_lines=0 network_lines=0 warning_lines=0 error_lines=0 other_lines=0
   local diagnostic_summary="stderr-lines=0 redaction=full"
   local result_status=passed error_class=none event_level=info
   local resource=profile:merge
@@ -685,9 +662,7 @@ project_ci_run_gate() {
   child_running=false
   child_pid=""
   diagnostic_summary="$(project_ci_stderr_summary "$stderr_file")"
-  IFS=$'\t' read -r \
-    stderr_lines auth_lines network_lines warning_lines error_lines other_lines \
-    < <(project_ci_stderr_counts "$stderr_file")
+  stderr_lines="$(awk 'END { print NR + 0 }' "$stderr_file")"
   if (( stderr_lines > 0 )); then
     warning_count=1
   fi
@@ -695,20 +670,18 @@ project_ci_run_gate() {
 
   if (( status != 0 )); then
     result_status=failed
-    error_class="gate-failed"
+    error_class=gate-failed
     event_level=error
-  elif (( auth_lines + network_lines + error_lines + other_lines > 0 )); then
+  elif (( stderr_lines > 0 )); then
     status=2
     result_status=failed
-    error_class="dependency-stderr"
+    error_class=dependency-stderr
     event_level=error
   elif [[ "$cleanup_status" != "passed" ]]; then
     status=2
     result_status=failed
-    error_class="cleanup-failed"
+    error_class=cleanup-failed
     event_level=error
-  elif (( warning_lines > 0 )); then
-    event_level=warning
   fi
 
   elapsed_ms=$(( (SECONDS - start_seconds) * 1000 ))

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -458,10 +458,14 @@ project_ci_stderr_counts() {
         auth++
       } else if (text ~ /(timeout|connection|network|dns|unreachable|reset)/) {
         network++
-      } else if (text ~ /(warning|deprecated|level=warn)/) {
-        warning++
       } else if (text ~ /(error|failed|failure|fatal)/) {
         error++
+      } else if (
+        text ~ /^time=[^[:space:]]+ level=warn msg="/ &&
+        text ~ /--yaml-fix-merge-anchor-to-spec is false;/ &&
+        text ~ /this flag will default to true in late 2025\."$/
+      ) {
+        warning++
       } else {
         other++
       }

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Resolve Builder's one CPU resource job to exactly one consumer gate mode.
+# Arguments: focused gate and project CI profile. Stdout: focused|full.
+# Exit classes: 0 valid selection, 2 invalid or ambiguous dispatch.
+# Side effects: none. Idempotency: deterministic for the same inputs.
+project_ci_cpu_mode() {
+  local focused_gate="$1"
+  local project_profile="$2"
+
+  if [[ -n "$focused_gate" ]]; then
+    if [[ -n "$project_profile" && "$project_profile" != "focused" ]]; then
+      printf 'BLOCKER: FOCUSED_GATE cannot be combined with PROJECT_CI_PROFILE=%s\n' \
+        "$project_profile" >&2
+      return 2
+    fi
+    printf 'focused\n'
+    return 0
+  fi
+
+  case "$project_profile" in
+    full)
+      printf 'full\n'
+      ;;
+    focused)
+      printf 'BLOCKER: PROJECT_CI_PROFILE=focused requires FOCUSED_GATE\n' >&2
+      return 2
+      ;;
+    *)
+      printf 'BLOCKER: PROJECT_CI_PROFILE must be focused or full\n' >&2
+      return 2
+      ;;
+  esac
+}
+
+main() {
+  local focused_gate="${FOCUSED_GATE:-}"
+  local project_profile="${PROJECT_CI_PROFILE:-}"
+  local mode
+
+  mode="$(project_ci_cpu_mode "$focused_gate" "$project_profile")" || return "$?"
+  case "$mode" in
+    focused)
+      exec ./scripts/check.sh --profile merge --gate "$focused_gate"
+      ;;
+    full)
+      exec ./scripts/check.sh --profile merge
+      ;;
+    *)
+      printf 'BLOCKER: unsupported CPU validation mode: %s\n' "$mode" >&2
+      return 2
+      ;;
+  esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -452,19 +452,15 @@ project_ci_stderr_counts() {
   awk '
     BEGIN {
       auth = network = warning = error = other = total = 0
-      apostrophe = sprintf("%c", 39)
-      expected_yq_warning = \
-        "level=warn msg=\"--yaml-fix-merge-anchor-to-spec is false; "
-      expected_yq_warning = expected_yq_warning \
-        "causing merge anchors to override the existing values which isn"
-      expected_yq_warning = expected_yq_warning apostrophe \
-        "t to the yaml spec. this flag will default to true in late 2025.\""
     }
     {
       text = tolower($0)
-      yq_warning_text = text
-      sub(/^time=[^[:space:]]+ /, "", yq_warning_text)
-      is_yq_merge_warning = (yq_warning_text == expected_yq_warning)
+      is_yq_merge_warning = 0
+      if (text ~ /^time=[^[:space:]]+ level=warn msg="/) {
+        if (text ~ /--yaml-fix-merge-anchor-to-spec is false/) {
+          is_yq_merge_warning = 1
+        }
+      }
       total++
       if (text ~ /(unauthorized|forbidden|credential|password|token|401|403)/) {
         auth++

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -442,10 +442,11 @@ project_ci_terminal_result() {
   fi
 }
 
-# Classify captured dependency stderr without replaying raw content.
-# Arguments: capture path. Environment inputs: none. Stdout: one sanitized
-# summary. Stderr: none. Exit classes: 0. Side effects and cleanup: none.
-project_ci_stderr_summary() {
+# Count captured dependency stderr classes without replaying raw content.
+# Arguments: capture path. Environment inputs: none. Stdout: tab-separated
+# total/auth/network/warning/error/other counts. Stderr: none. Exit classes: 0.
+# Side effects and cleanup: none.
+project_ci_stderr_counts() {
   local stderr_file="$1"
 
   awk '
@@ -457,7 +458,7 @@ project_ci_stderr_summary() {
         auth++
       } else if (text ~ /(timeout|connection|network|dns|unreachable|reset)/) {
         network++
-      } else if (text ~ /(warning|deprecated)/) {
+      } else if (text ~ /(warning|deprecated|level=warn)/) {
         warning++
       } else if (text ~ /(error|failed|failure|fatal)/) {
         error++
@@ -466,12 +467,25 @@ project_ci_stderr_summary() {
       }
     }
     END {
-      printf "stderr-lines=%d classes=auth:%d,network:%d,", \
-        total, auth, network
-      printf "warning:%d,error:%d,other:%d redaction=full", \
-        warning, error, other
+      printf "%d\t%d\t%d\t%d\t%d\t%d\n", \
+        total, auth, network, warning, error, other
     }
   ' "$stderr_file"
+}
+
+# Render one sanitized stderr classification from the shared count helper.
+# Arguments: capture path. Environment inputs: none. Stdout: one summary.
+# Stderr: none. Exit classes: 0. Side effects and cleanup: none.
+project_ci_stderr_summary() {
+  local stderr_file="$1"
+  local total auth network warning error other
+
+  IFS=$'\t' read -r total auth network warning error other \
+    < <(project_ci_stderr_counts "$stderr_file")
+  printf 'stderr-lines=%d classes=auth:%d,network:%d,' \
+    "$total" "$auth" "$network"
+  printf 'warning:%d,error:%d,other:%d redaction=full' \
+    "$warning" "$error" "$other"
 }
 
 # Execute one selected gate invocation without replaying dependency stderr.
@@ -488,6 +502,7 @@ project_ci_run_gate() {
   local evidence_path=""
   local stderr_file="" cleanup_status=passed
   local elapsed_ms status=0 stderr_lines=0 warning_count=0
+  local auth_lines=0 network_lines=0 warning_lines=0 error_lines=0 other_lines=0
   local diagnostic_summary="stderr-lines=0 redaction=full"
   local result_status=passed error_class=none event_level=info
   local resource=profile:merge
@@ -662,7 +677,9 @@ project_ci_run_gate() {
   child_running=false
   child_pid=""
   diagnostic_summary="$(project_ci_stderr_summary "$stderr_file")"
-  stderr_lines="$(awk 'END { print NR + 0 }' "$stderr_file")"
+  IFS=$'\t' read -r \
+    stderr_lines auth_lines network_lines warning_lines error_lines other_lines \
+    < <(project_ci_stderr_counts "$stderr_file")
   if (( stderr_lines > 0 )); then
     warning_count=1
   fi
@@ -670,18 +687,20 @@ project_ci_run_gate() {
 
   if (( status != 0 )); then
     result_status=failed
-    error_class=gate-failed
+    error_class="gate-failed"
     event_level=error
-  elif (( stderr_lines > 0 )); then
+  elif (( auth_lines + network_lines + error_lines + other_lines > 0 )); then
     status=2
     result_status=failed
-    error_class=dependency-stderr
+    error_class="dependency-stderr"
     event_level=error
   elif [[ "$cleanup_status" != "passed" ]]; then
     status=2
     result_status=failed
-    error_class=cleanup-failed
+    error_class="cleanup-failed"
     event_level=error
+  elif (( warning_lines > 0 )); then
+    event_level=warning
   fi
 
   elapsed_ms=$(( (SECONDS - start_seconds) * 1000 ))

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -480,7 +480,7 @@ project_ci_stderr_summary() {
 # sanitized classified events only. Exit classes: dependency status, or 2 when
 # owned temporary cleanup fails. Side effects: runs the selected read-only gate.
 # Idempotency: delegated to the gate. Cleanup: always removes owned stderr file.
-project_ci_run_gate() (
+project_ci_run_gate() {
   local check_script="$1"
   local mode="$2"
   local gate="$3"
@@ -492,7 +492,29 @@ project_ci_run_gate() (
   local result_status=passed error_class=none event_level=info
   local resource=profile:merge
   local child_pid="" child_running=false
+  local saved_exit_trap saved_hup_trap saved_int_trap saved_term_trap
   local -a gate_args=(--profile merge)
+
+  saved_exit_trap="$(trap -p EXIT)"
+  saved_hup_trap="$(trap -p HUP)"
+  saved_int_trap="$(trap -p INT)"
+  saved_term_trap="$(trap -p TERM)"
+
+  # Restore the caller's trap ownership after normal completion.
+  # Arguments: none. Environment: captured caller traps. Stdout/stderr: none.
+  # Exit classes: 0. Side effects: restores signal/exit handlers.
+  # Idempotency: repeat-safe. Cleanup: releases this function's trap ownership.
+  restore_gate_traps() {
+    local saved_trap
+
+    trap - EXIT HUP INT TERM
+    for saved_trap in \
+      "$saved_exit_trap" "$saved_hup_trap" "$saved_int_trap" "$saved_term_trap"; do
+      if [[ -n "$saved_trap" ]]; then
+        eval "$saved_trap"
+      fi
+    done
+  }
 
   # Remove the function-owned stderr capture and log the action.
   # Arguments: none. Environment: closure state. Stdout: none. Stderr: log.
@@ -562,6 +584,23 @@ project_ci_run_gate() (
     [[ "$termination_result" == "passed" ]]
   }
 
+  # Clean every resource owned by the active gate invocation.
+  # Arguments: none. Environment: closure state. Stdout: none. Stderr: logs.
+  # Exit classes: 0 cleaned, 1 cleanup unproven. Side effects: may terminate the
+  # tracked process group and remove one temp file. Idempotency: safe twice.
+  # Cleanup: this is the aggregate cleanup action.
+  cleanup_gate_runtime() {
+    local runtime_cleanup=passed
+
+    if ! stop_gate_process; then
+      runtime_cleanup=failed
+    fi
+    if ! cleanup_gate_stderr; then
+      runtime_cleanup=failed
+    fi
+    [[ "$runtime_cleanup" == "passed" ]]
+  }
+
   # Convert a received signal into cleanup and a terminal failed result.
   # Arguments: signal name and exit code. Environment: closure state.
   # Stdout: terminal result. Stderr: cleanup/signal logs. Exit: signal class.
@@ -593,13 +632,10 @@ project_ci_run_gate() (
     project_ci_terminal_result \
       "$PROJECT_CI_LOG_FORMAT" "$mode" "$gate" "$PROJECT_CI_RUN_ID" \
       failed "$warning_count" "$cleanup_status" "" "$signal_error"
+    restore_gate_traps
     exit "$signal_exit"
   }
 
-  trap cleanup_gate_stderr EXIT
-  trap 'handle_gate_signal HUP 129' HUP
-  trap 'handle_gate_signal INT 130' INT
-  trap 'handle_gate_signal TERM 143' TERM
   if [[ "$mode" == "focused" ]]; then
     gate_args+=(--gate "$gate")
     resource="gate:$gate"
@@ -610,6 +646,10 @@ project_ci_run_gate() (
       temp-allocation-failed
     return 2
   }
+  trap cleanup_gate_runtime EXIT
+  trap 'handle_gate_signal HUP 129' HUP
+  trap 'handle_gate_signal INT 130' INT
+  trap 'handle_gate_signal TERM 143' TERM
 
   setsid "$check_script" "${gate_args[@]}" 2>"$stderr_file" &
   child_pid=$!
@@ -653,8 +693,9 @@ project_ci_run_gate() (
     "$PROJECT_CI_LOG_FORMAT" "$mode" "$gate" "$PROJECT_CI_RUN_ID" \
     "$result_status" "$warning_count" "$cleanup_status" "$evidence_path" \
     "$error_class"
+  restore_gate_traps
   return "$status"
-)
+}
 
 main() {
   local focused_gate="${FOCUSED_GATE:-}"

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -450,17 +450,21 @@ project_ci_stderr_counts() {
   local stderr_file="$1"
 
   awk '
-    BEGIN { auth = network = warning = error = other = total = 0 }
+    BEGIN {
+      auth = network = warning = error = other = total = 0
+      apostrophe = sprintf("%c", 39)
+      expected_yq_warning = \
+        "level=warn msg=\"--yaml-fix-merge-anchor-to-spec is false; "
+      expected_yq_warning = expected_yq_warning \
+        "causing merge anchors to override the existing values which isn"
+      expected_yq_warning = expected_yq_warning apostrophe \
+        "t to the yaml spec. this flag will default to true in late 2025.\""
+    }
     {
       text = tolower($0)
-      is_yq_merge_warning = 0
-      if (text ~ /^time=[^[:space:]]+ level=warn msg="/) {
-        if (text ~ /--yaml-fix-merge-anchor-to-spec is false;/) {
-          if (text ~ /this flag will default to true in late 2025\."$/) {
-            is_yq_merge_warning = 1
-          }
-        }
-      }
+      yq_warning_text = text
+      sub(/^time=[^[:space:]]+ /, "", yq_warning_text)
+      is_yq_merge_warning = (yq_warning_text == expected_yq_warning)
       total++
       if (text ~ /(unauthorized|forbidden|credential|password|token|401|403)/) {
         auth++

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -1,18 +1,212 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+usage() {
+  printf '%s\n' \
+    'usage: project-ci-cpu-validation.sh [--dry-run]' \
+    '       [--log-format text|json]' \
+    '       [--log-level debug|info|warning|error] [--log-file PATH]' \
+    '       [--run-id ID]' \
+    '' \
+    'Audience: both (CI agents and operators).' \
+    'Run the CPU validation selected by FOCUSED_GATE or PROJECT_CI_PROFILE.' \
+    'PROJECT_CI_PROFILE=focused defaults to the required unit.all gate.'
+}
+
+# Return whether one event level passes the configured threshold.
+# Arguments: event level and configured level. Stdout/stderr: none.
+# Exit classes: 0 enabled, 1 filtered. Side effects and cleanup: none.
+project_ci_log_enabled() {
+  local event_level="$1"
+  local configured_level="$2"
+  local event_rank configured_rank
+
+  case "$event_level" in
+    debug) event_rank=10 ;;
+    info) event_rank=20 ;;
+    warning) event_rank=30 ;;
+    error) event_rank=40 ;;
+    *) return 1 ;;
+  esac
+  case "$configured_level" in
+    debug) configured_rank=10 ;;
+    info) configured_rank=20 ;;
+    warning) configured_rank=30 ;;
+    error) configured_rank=40 ;;
+    *) configured_rank=20 ;;
+  esac
+  (( event_rank >= configured_rank ))
+}
+
+# Emit one contract-complete log event.
+# Arguments: level, mode, event, result, error class, resource, elapsed ms,
+# safe next step, message, and optional blocker authority/observation/risk.
+# Environment: parsed PROJECT_CI_* log controls.
+# Stdout: none. Stderr: one text or JSONL event. Exit classes: 0 success.
+# Side effects: optionally appends to a validated log file. Idempotency: logs
+# are append-only. Cleanup: no temporary resources.
+project_ci_log_event() {
+  local level="$1"
+  local mode="$2"
+  local event="$3"
+  local result="$4"
+  local error_class="$5"
+  local resource="$6"
+  local elapsed_ms="$7"
+  local safe_next_step="$8"
+  local message="${9:-}"
+  local authority_checked="${10:-}"
+  local observation="${11:-}"
+  local risk="${12:-}"
+  local configured_level="${PROJECT_CI_LOG_LEVEL:-info}"
+  local format="${PROJECT_CI_LOG_FORMAT:-text}"
+  local run_id="${PROJECT_CI_RUN_ID:-}"
+  local timestamp record text_format
+
+  project_ci_log_enabled "$level" "$configured_level" || return 0
+  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  if [[ "$format" == "json" ]]; then
+    if ! command -v jq >/dev/null 2>&1; then
+      printf '%s\n' \
+        'BLOCKER: jq is required for machine-readable project CI output' \
+        'Authority checked:' \
+        '- inventory/ci/smoke-tests.yaml requiredTools' \
+        'Observation:' \
+        '- jq is unavailable on the selected execution surface' \
+        'Risk:' \
+        '- JSON output cannot be encoded safely' \
+        'Safe next step:' \
+        '- run this adapter in the declared Builder resource job' >&2
+      return 2
+    fi
+    record="$(jq -cn \
+      --arg timestamp "$timestamp" \
+      --arg level "$level" \
+      --arg runId "$run_id" \
+      --arg mode "$mode" \
+      --arg event "$event" \
+      --arg resource "$resource" \
+      --arg result "$result" \
+      --arg errorClass "$error_class" \
+      --arg safeNextStep "$safe_next_step" \
+      --arg message "$message" \
+      --arg authorityChecked "$authority_checked" \
+      --arg observation "$observation" \
+      --arg risk "$risk" \
+      --argjson elapsedMs "$elapsed_ms" \
+      '{
+        timestamp: $timestamp,
+        level: $level,
+        runId: $runId,
+        component: "project-ci-cpu-validation",
+        operation: "validate",
+        mode: $mode,
+        event: $event,
+        attempt: 1,
+        resource: $resource,
+        result: $result,
+        elapsedMs: $elapsedMs,
+        errorClass: $errorClass,
+        safeNextStep: $safeNextStep,
+        message: $message
+      }
+      + (if $authorityChecked == "" then {} else {
+          authorityChecked: $authorityChecked,
+          observation: $observation,
+          risk: $risk
+        } end)')"
+  else
+    printf -v text_format '%s' \
+      'level=%s run_id=%s component=project-ci-cpu-validation' \
+      ' operation=validate mode=%s event=%s attempt=1 resource=%s' \
+      ' result=%s elapsed_ms=%s error_class=%s'
+    printf -v record "$text_format" \
+      "$level" "$run_id" "$mode" "$event" "$resource" "$result" \
+      "$elapsed_ms" "$error_class"
+    if [[ -n "$message" ]]; then
+      record+=" message=$message"
+    fi
+    if [[ -n "$safe_next_step" ]]; then
+      record+=" safe_next_step=$safe_next_step"
+    fi
+    if [[ -n "$authority_checked" ]]; then
+      record+=" authority_checked=$authority_checked"
+      record+=" observation=$observation risk=$risk"
+    fi
+  fi
+  printf '%s\n' "$record" >&2
+  if [[ "${PROJECT_CI_LOG_FILE_READY:-false}" == true &&
+        -n "${PROJECT_CI_LOG_FILE:-}" ]]; then
+    ( umask 077; printf '%s\n' "$record" >>"$PROJECT_CI_LOG_FILE" )
+  fi
+}
+
+# Emit one mandatory structured blocker.
+# Arguments: message, safe next step, optional error class, authority, and risk.
+# Environment: parsed PROJECT_CI_* log controls. Stdout: none. Stderr: blocker.
+# Exit classes: always 2. Side effects: optional validated log append.
+# Idempotency: deterministic apart from timestamp. Cleanup: none.
+project_ci_blocker() {
+  local message="$1"
+  local safe_next_step="$2"
+  local error_class="${3:-usage-error}"
+  local authority_checked="${4:-standards-binding.yaml and pinned automation contracts}"
+  local risk="${5:-required validation could be selected or reported incorrectly}"
+  local run_id="${PROJECT_CI_RUN_ID:-}"
+
+  if [[ "${PROJECT_CI_LOG_FORMAT:-text}" == "json" ]]; then
+    if [[ ! "$run_id" =~ ^[A-Za-z0-9._:-]{1,128}$ ]]; then
+      PROJECT_CI_RUN_ID=invalid
+    fi
+    project_ci_log_event error selection blocker blocked "$error_class" \
+      selection 0 "$safe_next_step" "$message" "$authority_checked" \
+      "$message" "$risk"
+  else
+    printf 'BLOCKER: %s\n' "$message" >&2
+    printf 'Authority checked:\n- %s\n' "$authority_checked" >&2
+    printf 'Observation:\n- %s\n' "$message" >&2
+    printf 'Risk:\n- %s\n' "$risk" >&2
+    printf 'Safe next step:\n- %s\n' "$safe_next_step" >&2
+  fi
+  return 2
+}
+
 # Resolve Builder's one CPU resource job to exactly one consumer gate mode.
-# Arguments: focused gate and project CI profile. Stdout: focused|full.
+# Arguments: focused gate, project CI profile, and optional smoke selector.
+# Stdout: focused|full|smoke.
 # Exit classes: 0 valid selection, 2 invalid or ambiguous dispatch.
 # Side effects: none. Idempotency: deterministic for the same inputs.
 project_ci_cpu_mode() {
   local focused_gate="$1"
   local project_profile="$2"
+  local project_smoke="${3:-}"
+
+  if [[ -n "$project_smoke" ]]; then
+    if [[ -n "$focused_gate" || -n "$project_profile" ]]; then
+      project_ci_blocker "PROJECT_CI_SMOKE cannot be combined with another selector" \
+        "use exactly one project-ci selector"
+      return 2
+    fi
+    if [[ "$project_smoke" != "project-ci-cpu-validation" ]]; then
+      project_ci_blocker "unsupported PROJECT_CI_SMOKE selection" \
+        "select project-ci-cpu-validation from the smoke inventory"
+      return 2
+    fi
+    printf 'smoke\n'
+    return 0
+  fi
 
   if [[ -n "$focused_gate" ]]; then
+    if [[ ${#focused_gate} -gt 128 ||
+          ! "$focused_gate" =~ ^[a-z0-9]+([._-][a-z0-9]+)*$ ]]; then
+      project_ci_blocker "FOCUSED_GATE must be a bounded gate identifier" \
+        "select a gate id from ./scripts/check.sh --list"
+      return 2
+    fi
     if [[ -n "$project_profile" && "$project_profile" != "focused" ]]; then
-      printf 'BLOCKER: FOCUSED_GATE cannot be combined with PROJECT_CI_PROFILE=%s\n' \
-        "$project_profile" >&2
+      project_ci_blocker \
+        "FOCUSED_GATE cannot be combined with PROJECT_CI_PROFILE=$project_profile" \
+        "use FOCUSED_GATE alone or PROJECT_CI_PROFILE=focused"
       return 2
     fi
     printf 'focused\n'
@@ -24,31 +218,476 @@ project_ci_cpu_mode() {
       printf 'full\n'
       ;;
     focused)
-      printf 'BLOCKER: PROJECT_CI_PROFILE=focused requires FOCUSED_GATE\n' >&2
-      return 2
+      printf 'focused\n'
       ;;
     *)
-      printf 'BLOCKER: PROJECT_CI_PROFILE must be focused or full\n' >&2
+      project_ci_blocker "PROJECT_CI_PROFILE must be focused or full" \
+        "set PROJECT_CI_PROFILE=focused or PROJECT_CI_PROFILE=full"
       return 2
       ;;
   esac
 }
 
+# Resolve the focused gate after the mode has been validated.
+# Arguments: focused gate and project CI profile. Stdout: gate id or empty.
+# Exit classes: 0 valid selection, 2 invalid selection. Side effects: none.
+project_ci_cpu_gate() {
+  local focused_gate="$1"
+  local project_profile="$2"
+  local project_smoke="${3:-}"
+  local mode
+
+  mode="$(project_ci_cpu_mode \
+    "$focused_gate" "$project_profile" "$project_smoke")" || return "$?"
+  if [[ "$mode" != "focused" ]]; then
+    return 0
+  fi
+  printf '%s\n' "${focused_gate:-unit.all}"
+}
+
+# Validate an explicitly requested append-only log target without opening it.
+# Arguments: path. Stdout: none. Stderr: classified blocker on failure.
+# Exit classes: 0 safe target, 2 unsafe target. Side effects and cleanup: none.
+project_ci_validate_log_target() {
+  local log_file="$1"
+
+  if [[ -z "$log_file" ]]; then
+    PROJECT_CI_LOG_FILE_READY=true
+    return 0
+  fi
+  if [[ "$log_file" == *$'\n'* || "$log_file" == *$'\r'* ||
+        -L "$log_file" || ( -e "$log_file" && ! -f "$log_file" ) ]]; then
+    project_ci_blocker "--log-file must name a regular non-symlink file" \
+      "select a regular file in an existing writable directory" log-target-invalid
+    return 2
+  fi
+  if [[ ! -d "$(dirname "$log_file")" ]]; then
+    project_ci_blocker "--log-file parent directory does not exist" \
+      "create the intended directory outside this tool or omit --log-file" \
+      log-target-invalid
+    return 2
+  fi
+  PROJECT_CI_LOG_FILE_READY=true
+}
+
+# Parse the universal non-interactive CLI controls into PROJECT_CI_* globals.
+# Arguments: CLI options. Stdout: none. Exit classes: 0 valid, 2 invalid.
+# Side effects: updates function-scoped process globals only.
+project_ci_parse_args() {
+  PROJECT_CI_DRY_RUN=false
+  PROJECT_CI_HELP=false
+  PROJECT_CI_LOG_FORMAT=text
+  PROJECT_CI_LOG_LEVEL=info
+  PROJECT_CI_LOG_FILE=""
+  PROJECT_CI_LOG_FILE_READY=false
+  PROJECT_CI_RUN_ID="${CI_PIPELINE_ID:-not-provided}"
+
+  while (( $# > 0 )); do
+    case "$1" in
+      --help|-h)
+        PROJECT_CI_HELP=true
+        shift
+        ;;
+      --dry-run)
+        PROJECT_CI_DRY_RUN=true
+        shift
+        ;;
+      --log-format|--log-level|--log-file|--run-id)
+        if (( $# < 2 )); then
+          project_ci_blocker "$1 requires a value" \
+            "rerun with $1 followed by its value"
+          return 2
+        fi
+        case "$1" in
+          --log-format) PROJECT_CI_LOG_FORMAT="$2" ;;
+          --log-level) PROJECT_CI_LOG_LEVEL="$2" ;;
+          --log-file) PROJECT_CI_LOG_FILE="$2" ;;
+          --run-id) PROJECT_CI_RUN_ID="$2" ;;
+        esac
+        shift 2
+        ;;
+      *)
+        project_ci_blocker "unknown option: $1" \
+          "run project-ci-cpu-validation.sh --help"
+        return 2
+        ;;
+    esac
+  done
+
+  case "$PROJECT_CI_LOG_FORMAT" in
+    text|json) ;;
+    *)
+      project_ci_blocker "--log-format must be text or json" \
+        "select --log-format text or --log-format json"
+      return 2
+      ;;
+  esac
+  case "$PROJECT_CI_LOG_LEVEL" in
+    debug|info|warning|error) ;;
+    *)
+      project_ci_blocker \
+        "--log-level must be debug, info, warning, or error" \
+        "select a supported --log-level"
+      return 2
+      ;;
+  esac
+  if [[ -n "$PROJECT_CI_RUN_ID" &&
+        ! "$PROJECT_CI_RUN_ID" =~ ^[A-Za-z0-9._:-]{1,128}$ ]]; then
+    project_ci_blocker "--run-id must be a bounded identifier" \
+      "use 1-128 letters, digits, dots, underscores, colons, or hyphens"
+    return 2
+  fi
+  if [[ "$PROJECT_CI_DRY_RUN" == true && -n "$PROJECT_CI_LOG_FILE" ]]; then
+    project_ci_blocker "--log-file cannot be combined with --dry-run" \
+      "remove --log-file for a side-effect-free plan"
+    return 2
+  fi
+  project_ci_validate_log_target "$PROJECT_CI_LOG_FILE" || return "$?"
+}
+
+# Render one bounded selection record.
+# Arguments: format, mode, gate, run id. Stdout: one text or JSON line.
+# Exit classes: 0. Side effects: none.
+project_ci_selection_record() {
+  local format="$1"
+  local mode="$2"
+  local gate="$3"
+  local run_id="$4"
+  local record
+
+  if [[ "$format" == "json" ]]; then
+    record="$(jq -cn \
+      --arg mode "$mode" \
+      --arg gate "$gate" \
+      --arg runId "$run_id" \
+      '{
+        mode: $mode,
+        gate: $gate,
+        mutation: false,
+        runId: $runId,
+        status: "planned",
+        warningCount: 0,
+        cleanupStatus: "not-required",
+        evidencePath: ""
+      }')"
+    printf '%s\n' "$record"
+  else
+    printf -v record '%s' \
+      "mode=$mode gate=$gate mutation=false run_id=$run_id status=planned" \
+      ' warning_count=0 cleanup_status=not-required evidence_path='
+    printf '%s\n' "$record"
+  fi
+}
+
+# Emit an informational selection record through the configured logger.
+# Arguments: mode, gate, and elapsed milliseconds. Stdout: none.
+# Exit classes: 0. Side effects: optional validated log append. Cleanup: none.
+project_ci_log_selection() {
+  local mode="$1"
+  local gate="$2"
+  local elapsed_ms="$3"
+  local resource="profile:merge"
+
+  if [[ -n "$gate" ]]; then
+    resource="gate:$gate"
+  fi
+  project_ci_log_event info "$mode" selection running none \
+    "$resource" "$elapsed_ms" "" "selected project CI validation"
+}
+
+# Render one terminal adapter result. Builder owns canonical smoke evidence;
+# this consumer reports only the path to the gate evidence it observed.
+# Arguments: format, mode, gate, run id, status, warning count, cleanup status,
+# evidence path, and error class. Stdout: one bounded text or JSON result.
+# Exit classes: 0. Side effects and cleanup: none.
+project_ci_terminal_result() {
+  local format="$1"
+  local mode="$2"
+  local gate="$3"
+  local run_id="$4"
+  local status="$5"
+  local warning_count="$6"
+  local cleanup_status="$7"
+  local evidence_path="$8"
+  local error_class="$9"
+  local result
+
+  if [[ "$format" == "json" ]]; then
+    result="$(jq -cn \
+      --arg mode "$mode" \
+      --arg gate "$gate" \
+      --arg runId "$run_id" \
+      --arg status "$status" \
+      --arg cleanupStatus "$cleanup_status" \
+      --arg evidencePath "$evidence_path" \
+      --arg errorClass "$error_class" \
+      --argjson warningCount "$warning_count" \
+      '{
+        mode: $mode,
+        gate: $gate,
+        mutation: false,
+        runId: $runId,
+        status: $status,
+        warningCount: $warningCount,
+        cleanupStatus: $cleanupStatus,
+        evidencePath: $evidencePath,
+        errorClass: $errorClass
+      }')"
+    printf '%s\n' "$result"
+  else
+    printf '%s%s%s\n' \
+      "mode=$mode gate=$gate mutation=false run_id=$run_id status=$status" \
+      " warning_count=$warning_count cleanup_status=$cleanup_status" \
+      " evidence_path=$evidence_path error_class=$error_class"
+  fi
+}
+
+# Classify captured dependency stderr without replaying raw content.
+# Arguments: capture path. Environment inputs: none. Stdout: one sanitized
+# summary. Stderr: none. Exit classes: 0. Side effects and cleanup: none.
+project_ci_stderr_summary() {
+  local stderr_file="$1"
+
+  awk '
+    BEGIN { auth = network = warning = error = other = total = 0 }
+    {
+      text = tolower($0)
+      total++
+      if (text ~ /(unauthorized|forbidden|credential|password|token|401|403)/) {
+        auth++
+      } else if (text ~ /(timeout|connection|network|dns|unreachable|reset)/) {
+        network++
+      } else if (text ~ /(warning|deprecated)/) {
+        warning++
+      } else if (text ~ /(error|failed|failure|fatal)/) {
+        error++
+      } else {
+        other++
+      }
+    }
+    END {
+      printf "stderr-lines=%d classes=auth:%d,network:%d,", \
+        total, auth, network
+      printf "warning:%d,error:%d,other:%d redaction=full", \
+        warning, error, other
+    }
+  ' "$stderr_file"
+}
+
+# Execute one selected gate invocation without replaying dependency stderr.
+# Arguments: check script, mode, gate, and start time. Environment: configured
+# logger. Stdout: dependency stdout followed by one terminal result. Stderr:
+# sanitized classified events only. Exit classes: dependency status, or 2 when
+# owned temporary cleanup fails. Side effects: runs the selected read-only gate.
+# Idempotency: delegated to the gate. Cleanup: always removes owned stderr file.
+project_ci_run_gate() (
+  local check_script="$1"
+  local mode="$2"
+  local gate="$3"
+  local start_seconds="$4"
+  local evidence_path=""
+  local stderr_file="" cleanup_status=passed
+  local elapsed_ms status=0 stderr_lines=0 warning_count=0
+  local diagnostic_summary="stderr-lines=0 redaction=full"
+  local result_status=passed error_class=none event_level=info
+  local resource=profile:merge
+  local child_pid="" child_running=false
+  local -a gate_args=(--profile merge)
+
+  # Remove the function-owned stderr capture and log the action.
+  # Arguments: none. Environment: closure state. Stdout: none. Stderr: log.
+  # Exit classes: 0 removed/absent, 1 removal failed. Side effects: removes one
+  # owned temporary file. Idempotency: safe twice. Cleanup: this is cleanup.
+  cleanup_gate_stderr() {
+    local cleanup_result=passed cleanup_error=none
+    local cleanup_level=info
+
+    if [[ -z "$stderr_file" || ! -e "$stderr_file" ]]; then
+      return 0
+    fi
+    if ! rm -f -- "$stderr_file"; then
+      cleanup_result=failed
+      cleanup_error=cleanup-failed
+      cleanup_level=error
+      cleanup_status=failed
+    else
+      stderr_file=""
+    fi
+    project_ci_log_event \
+      "$cleanup_level" "$mode" cleanup "$cleanup_result" \
+      "$cleanup_error" dependency-stderr 0 \
+      "rerun in a clean Builder resource job when cleanup fails" \
+      "removed dependency stderr capture"
+    [[ "$cleanup_result" == "passed" ]]
+  }
+
+  # Terminate and reap the active gate process group during cancellation.
+  # Arguments: none. Environment: closure state. Stdout: none. Stderr: log.
+  # Exit classes: 0 stopped/absent, 1 stop unproven. Side effects: terminates
+  # only the tracked process group. Idempotency: safe twice. Cleanup: reaps it.
+  stop_gate_process() {
+    local termination_result=passed termination_error=none
+    local termination_level=info
+    local wait_status=0
+
+    if [[ "$child_running" != true || -z "$child_pid" ]]; then
+      return 0
+    fi
+    if kill -TERM -- "-$child_pid" 2>>"$stderr_file"; then
+      :
+    elif kill -TERM "$child_pid" 2>>"$stderr_file"; then
+      :
+    else
+      termination_result=failed
+      termination_error=cleanup-failed
+      termination_level=error
+    fi
+    if wait "$child_pid" 2>>"$stderr_file"; then
+      wait_status=0
+    else
+      wait_status=$?
+    fi
+    child_running=false
+    child_pid=""
+    if (( wait_status == 127 )); then
+      termination_result=failed
+      termination_error=cleanup-failed
+      termination_level=error
+    fi
+    project_ci_log_event \
+      "$termination_level" "$mode" cleanup \
+      "$termination_result" "$termination_error" gate-process 0 \
+      "inspect Builder job cancellation and retry the exact commit" \
+      "terminated and reaped active gate process group"
+    [[ "$termination_result" == "passed" ]]
+  }
+
+  # Convert a received signal into cleanup and a terminal failed result.
+  # Arguments: signal name and exit code. Environment: closure state.
+  # Stdout: terminal result. Stderr: cleanup/signal logs. Exit: signal class.
+  # Side effects: terminates the tracked gate. Idempotency: one-shot handler.
+  # Cleanup: process group and owned stderr capture are cleaned before exit.
+  handle_gate_signal() {
+    local signal_name="$1"
+    local signal_exit="$2"
+    local process_cleanup=passed signal_error
+
+    stop_gate_process || process_cleanup=failed
+    if [[ -n "$stderr_file" && -f "$stderr_file" ]]; then
+      diagnostic_summary="$(project_ci_stderr_summary "$stderr_file")"
+      stderr_lines="$(awk 'END { print NR + 0 }' "$stderr_file")"
+    fi
+    cleanup_gate_stderr || cleanup_status=failed
+    if [[ "$process_cleanup" != "passed" ]]; then
+      cleanup_status=failed
+    fi
+    if (( stderr_lines > 0 )); then
+      warning_count=1
+    fi
+    signal_error="signal-${signal_name,,}"
+    elapsed_ms=$(( (SECONDS - start_seconds) * 1000 ))
+    project_ci_log_event error "$mode" signal failed "$signal_error" \
+      "$resource" "$elapsed_ms" \
+      "rerun the exact commit after confirming the cancellation cause" \
+      "$diagnostic_summary"
+    project_ci_terminal_result \
+      "$PROJECT_CI_LOG_FORMAT" "$mode" "$gate" "$PROJECT_CI_RUN_ID" \
+      failed "$warning_count" "$cleanup_status" "" "$signal_error"
+    exit "$signal_exit"
+  }
+
+  trap cleanup_gate_stderr EXIT
+  trap 'handle_gate_signal HUP 129' HUP
+  trap 'handle_gate_signal INT 130' INT
+  trap 'handle_gate_signal TERM 143' TERM
+  if [[ "$mode" == "focused" ]]; then
+    gate_args+=(--gate "$gate")
+    resource="gate:$gate"
+  fi
+  stderr_file="$(mktemp "${TMPDIR:-/tmp}/project-ci-cpu-validation.XXXXXX")" || {
+    project_ci_blocker "cannot allocate dependency stderr capture" \
+      "rerun in a Builder resource job with a writable temporary directory" \
+      temp-allocation-failed
+    return 2
+  }
+
+  setsid "$check_script" "${gate_args[@]}" 2>"$stderr_file" &
+  child_pid=$!
+  child_running=true
+  if wait "$child_pid"; then
+    status=0
+  else
+    status=$?
+  fi
+  child_running=false
+  child_pid=""
+  diagnostic_summary="$(project_ci_stderr_summary "$stderr_file")"
+  stderr_lines="$(awk 'END { print NR + 0 }' "$stderr_file")"
+  if (( stderr_lines > 0 )); then
+    warning_count=1
+  fi
+  cleanup_gate_stderr || cleanup_status=failed
+
+  if (( status != 0 )); then
+    result_status=failed
+    error_class=gate-failed
+    event_level=error
+  elif (( stderr_lines > 0 )); then
+    status=2
+    result_status=failed
+    error_class=dependency-stderr
+    event_level=error
+  elif [[ "$cleanup_status" != "passed" ]]; then
+    status=2
+    result_status=failed
+    error_class=cleanup-failed
+    event_level=error
+  fi
+
+  elapsed_ms=$(( (SECONDS - start_seconds) * 1000 ))
+  project_ci_log_event "$event_level" "$mode" terminal "$result_status" \
+    "$error_class" "$resource" "$elapsed_ms" \
+    "inspect Builder canonical evidence for the exact commit" \
+    "$diagnostic_summary"
+  project_ci_terminal_result \
+    "$PROJECT_CI_LOG_FORMAT" "$mode" "$gate" "$PROJECT_CI_RUN_ID" \
+    "$result_status" "$warning_count" "$cleanup_status" "$evidence_path" \
+    "$error_class"
+  return "$status"
+)
+
 main() {
   local focused_gate="${FOCUSED_GATE:-}"
   local project_profile="${PROJECT_CI_PROFILE:-}"
-  local mode
+  local project_smoke="${PROJECT_CI_SMOKE:-}"
+  local mode gate elapsed_ms
+  local start_seconds="$SECONDS"
 
-  mode="$(project_ci_cpu_mode "$focused_gate" "$project_profile")" || return "$?"
+  project_ci_parse_args "$@" || return "$?"
+  if [[ "$PROJECT_CI_HELP" == true ]]; then
+    usage
+    return 0
+  fi
+
+  mode="$(project_ci_cpu_mode \
+    "$focused_gate" "$project_profile" "$project_smoke")" || return "$?"
+  gate="$(project_ci_cpu_gate \
+    "$focused_gate" "$project_profile" "$project_smoke")" || return "$?"
+  if [[ "$PROJECT_CI_DRY_RUN" == true ]]; then
+    project_ci_selection_record \
+      "$PROJECT_CI_LOG_FORMAT" "$mode" "$gate" "$PROJECT_CI_RUN_ID"
+    return 0
+  fi
+  elapsed_ms=$(( (SECONDS - start_seconds) * 1000 ))
+  project_ci_log_selection "$mode" "$gate" "$elapsed_ms" || return "$?"
   case "$mode" in
-    focused)
-      exec ./scripts/check.sh --profile merge --gate "$focused_gate"
-      ;;
-    full)
-      exec ./scripts/check.sh --profile merge
+    focused|full|smoke)
+      project_ci_run_gate \
+        ./scripts/check.sh "$mode" "$gate" "$start_seconds"
       ;;
     *)
-      printf 'BLOCKER: unsupported CPU validation mode: %s\n' "$mode" >&2
+      project_ci_blocker "unsupported CPU validation mode: $mode" \
+        "select focused or full validation"
       return 2
       ;;
   esac

--- a/tools/project-ci-cpu-validation.sh
+++ b/tools/project-ci-cpu-validation.sh
@@ -453,6 +453,14 @@ project_ci_stderr_counts() {
     BEGIN { auth = network = warning = error = other = total = 0 }
     {
       text = tolower($0)
+      is_yq_merge_warning = 0
+      if (text ~ /^time=[^[:space:]]+ level=warn msg="/) {
+        if (text ~ /--yaml-fix-merge-anchor-to-spec is false;/) {
+          if (text ~ /this flag will default to true in late 2025\."$/) {
+            is_yq_merge_warning = 1
+          }
+        }
+      }
       total++
       if (text ~ /(unauthorized|forbidden|credential|password|token|401|403)/) {
         auth++
@@ -460,11 +468,7 @@ project_ci_stderr_counts() {
         network++
       } else if (text ~ /(error|failed|failure|fatal)/) {
         error++
-      } else if (
-        text ~ /^time=[^[:space:]]+ level=warn msg="/ &&
-        text ~ /--yaml-fix-merge-anchor-to-spec is false;/ &&
-        text ~ /this flag will default to true in late 2025\."$/
-      ) {
+      } else if (is_yq_merge_warning) {
         warning++
       } else {
         other++


### PR DESCRIPTION
## Summary

- pin both Builder project-service and CPU resource-job includes to exact revision `1511171608f913833004e29558468d8e481fd947`
- register the concrete `project-ci-cpu-validation` job in the closed-world gate and smoke inventories
- make Builder the sole owner of focused/full CPU dispatch while preserving the existing merge pipeline path
- bind DMTF release, consumer identity, immutable toolbox image, live-test command, and the full publication/deploy/evidence DAG
- add fail-closed tests for exact includes, external-job shadowing, duplicate execution, direct Helm/kubectl bypass, floating simulator tags, and focused/full dispatch selection

## Validation

- `git diff --cached --check`: passed before commit
- mandatory read-only QA: initial two P1 findings resolved in this commit
- local project tests intentionally not run; repository policy requires Internal GitLab/Kubernetes authority
- exact-head Internal GitLab validation must run after provider sync for commit `b5292984aafef43327d3c9ea9c41252db91ceb9f`

## Live provider evidence

The existing-main merge gate passed in Internal GitLab pipeline 992, but live simulator deployment correctly failed closed before publication. The remaining Builder-owned blockers are tracked separately:

- spyroot/builder#291 — bounded namespace bootstrap and project-service credential materialization
- spyroot/builder#293 — confirmed ensure-capability apply returns dry-run
- spyroot/builder#294 — provider evidence can pass without protected live evidence
- spyroot/builder#295 — consumer project token cannot resolve the private Builder include

No direct Helm or kubectl deployment path is introduced by this PR.
